### PR TITLE
Fix(eos_designs): Empty description under network-ports

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -49,6 +49,11 @@ interface Port-Channel42
    switchport
    mlag 42
 !
+interface Port-Channel43
+   no shutdown
+   switchport
+   mlag 43
+!
 interface Port-Channel101
    description MLAG_PEER_network-ports-tests.1_Po101
    no shutdown
@@ -558,6 +563,14 @@ interface Ethernet12
    switchport phone trunk untagged
    switchport mode trunk phone
    switchport
+!
+interface Ethernet51
+   no shutdown
+   channel-group 43 mode active
+!
+interface Ethernet52
+   no shutdown
+   channel-group 43 mode active
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -538,6 +538,26 @@ interface Ethernet14
    no shutdown
    switchport
 !
+interface Ethernet51
+   description 
+   shutdown
+   switchport
+!
+interface Ethernet52
+   description 
+   shutdown
+   switchport
+!
+interface Ethernet53
+   description 
+   shutdown
+   switchport
+!
+interface Ethernet54
+   description 
+   shutdown
+   switchport
+!
 interface Vlan4094
    description MLAG_PEER
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -539,22 +539,18 @@ interface Ethernet14
    switchport
 !
 interface Ethernet51
-   description 
    shutdown
    switchport
 !
 interface Ethernet52
-   description 
    shutdown
    switchport
 !
 interface Ethernet53
-   description 
    shutdown
    switchport
 !
 interface Ethernet54
-   description 
    shutdown
    switchport
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -69,6 +69,10 @@ port_channel_interfaces:
   type: switched
   shutdown: false
   mlag: 42
+- name: Port-Channel43
+  type: switched
+  shutdown: false
+  mlag: 43
 ethernet_interfaces:
 - name: Ethernet10/1
   peer: network-ports-tests.1
@@ -709,6 +713,20 @@ ethernet_interfaces:
   type: port-channel-member
   channel_group:
     id: 42
+    mode: active
+- name: Ethernet51
+  peer_type: network_port
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 43
+    mode: active
+- name: Ethernet52
+  peer_type: network_port
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 43
     mode: active
 mlag_configuration:
   domain_id: mlag

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -669,6 +669,26 @@ ethernet_interfaces:
   description: CONNECTED_ENDPOINT_OVERWRITING_NETWORK_PORT_Eth42
   shutdown: false
   type: switched
+- name: Ethernet51
+  peer_type: network_port
+  description: ''
+  shutdown: true
+  type: switched
+- name: Ethernet52
+  peer_type: network_port
+  description: ''
+  shutdown: true
+  type: switched
+- name: Ethernet53
+  peer_type: network_port
+  description: ''
+  shutdown: true
+  type: switched
+- name: Ethernet54
+  peer_type: network_port
+  description: ''
+  shutdown: true
+  type: switched
 mlag_configuration:
   domain_id: mlag
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -671,22 +671,18 @@ ethernet_interfaces:
   type: switched
 - name: Ethernet51
   peer_type: network_port
-  description: ''
   shutdown: true
   type: switched
 - name: Ethernet52
   peer_type: network_port
-  description: ''
   shutdown: true
   type: switched
 - name: Ethernet53
   peer_type: network_port
-  description: ''
   shutdown: true
   type: switched
 - name: Ethernet54
   peer_type: network_port
-  description: ''
   shutdown: true
   type: switched
 mlag_configuration:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -87,7 +87,7 @@ network_ports:
 
   # Test no description
   - switches:
-    - network-ports-tests.1
+      - network-ports-tests.1
     switch_ports:
       - Ethernet51-54
     enabled: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -91,6 +91,13 @@ network_ports:
     switch_ports:
       - Ethernet51-54
     enabled: false
+  - switches:
+      - network-ports-tests.2
+    switch_ports:
+      - Ethernet51-52
+    port_channel:
+      channel_id: 43
+      mode: "active"
 
 servers:
   - name: CONNECTED_ENDPOINT_OVERWRITING_NETWORK_PORT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -85,6 +85,13 @@ network_ports:
       - Ethernet12
     description: Config overwriting base config
 
+  # Test no description
+  - switches:
+    - network-ports-tests.1
+    switch_ports:
+      - Ethernet51-54
+    enabled: false
+
 servers:
   - name: CONNECTED_ENDPOINT_OVERWRITING_NETWORK_PORT
     adapters:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
@@ -181,4 +181,4 @@ class EthernetInterfacesMixin(UtilsMixin):
         if (flowcontrol_received := get(adapter, "flowcontrol.received")) is not None:
             ethernet_interface["flowcontrol"] = {"received": flowcontrol_received}
 
-        return strip_null_from_data(ethernet_interface)
+        return strip_null_from_data(ethernet_interface, strip_values_tuple=(None, ""))

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/port_channel_interfaces.py
@@ -183,7 +183,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
                 }
             )
 
-        return strip_null_from_data(port_channel_interface)
+        return strip_null_from_data(port_channel_interface, strip_values_tuple=(None, ""))
 
     def _get_port_channel_subinterface_cfg(self, subinterface: dict, adapter: dict, port_channel_subinterface_name: str, channel_group_id: int) -> dict:
         """
@@ -215,4 +215,4 @@ class PortChannelInterfacesMixin(UtilsMixin):
                 "route_target": generate_route_target(short_esi),
             }
 
-        return strip_null_from_data(port_channel_interface)
+        return strip_null_from_data(port_channel_interface, strip_values_tuple=(None, ""))


### PR DESCRIPTION
## Change Summary

Strip empty strings from the rendered structured_config for ethernet_interfaces for connected_endpoints

## Related Issue(s)

Fixes #3443

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Replacing the default tuple for `strip_null_fom_data` with `(None, "")`.
Apply same fix for port-channels where the issue can also be reproduced

## How to test

molecule (first commit shows the issue)

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
