### PR TITLE
Fix(eos_validate_state): ANTA Fix AvdTestBase structured_config objects

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/eos_validate_state_runner.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_validate_state_runner.py
@@ -36,7 +36,7 @@ class AnsibleNoAliasDumper(AnsibleDumper):
 
 
 class ActionModule(ActionBase):
-    # @cprofile
+    # @cprofile()
     def run(self, tmp=None, task_vars=None):
         self._supports_check_mode = True
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/avdtestbase.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/avdtestbase.py
@@ -4,9 +4,9 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
 from functools import cached_property
 from ipaddress import ip_interface
+from typing import Mapping
 
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError, AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import default, get, get_item
@@ -20,18 +20,18 @@ class AvdTestBase:
     Base class for all AVD eos_validate_state tests.
     """
 
-    def __init__(self, device_name: str, hostvars: dict | object):
+    def __init__(self, device_name: str, hostvars: Mapping):
         """
         Initialize the AvdTestBase class.
 
         Args:
             device_name (str): The current device name for which the plugin is being run.
-            hostvars (dict | object): A dictionary that contains a key for each device with a value of the structured_config.
+            hostvars (Mapping): A mapping that contains a key for each device with a value of the structured_config.
                                       When using Ansible, this is the `task_vars['hostvars']` object.
         """
         self.hostvars = hostvars
         self.device_name = device_name
-        self.structured_config = self.get_host_struct_cfg(host=device_name)
+        self.structured_config = self.get_host_structured_config(host=device_name)
 
     def render(self) -> dict:
         """
@@ -46,12 +46,9 @@ class AvdTestBase:
         """
         return getattr(self, "test_definition", None) or {}
 
-    def get_host_struct_cfg(self, host: str) -> dict:
+    def get_host_structured_config(self, host: str) -> Mapping:
         """
-        Retrieves and returns the structured configuration for a specified host.
-
-        The function fetches the structured_config from hostvars. It ensures the returned object is a non-empty
-        dictionary, converting Ansible dictionary-like objects to a standard dictionary if necessary.
+        Get a specified host's structured configuration from the hostvars.
 
         Args:
             host (str): Hostname to retrieve the structured_config.
@@ -60,18 +57,15 @@ class AvdTestBase:
             dict: Structured configuration for the host.
 
         Raises:
-            AristaAvdError: If host is not in hostvars or if its structured_config is not a dictionary or is empty.
+            AristaAvdError: If host is not in hostvars or if its structured_config is not a mapping object.
         """
         if host not in self.hostvars:
             raise AristaAvdError(f"Host '{host}' is missing from the hostvars.")
-        struct_cfg = get(self.hostvars, host, separator="..")
+        struct_cfg = self.hostvars[host]
 
-        # Check if struct_cfg is a dict or behaves like a dict (e.g. Ansible 'hostvars' object)
-        if not isinstance(struct_cfg, (dict, Mapping)):
+        # Check if struct_cfg is a mapping object (e.g. Ansible 'hostvars' object or regular dict)
+        if not isinstance(struct_cfg, Mapping):
             raise AristaAvdError(f"Host '{host}' structured_config is not a dictionary or dictionary-like object.")
-
-        if not isinstance(struct_cfg, dict):
-            struct_cfg = dict(struct_cfg)
 
         return struct_cfg
 
@@ -124,7 +118,7 @@ class AvdTestBase:
             bool: Returns the interface shutdown key's value, or `interface_defaults.ethernet` if not available.
                   Returns False if both are absent, which is the default EOS behavior.
         """
-        host_struct_cfg = self.get_host_struct_cfg(host=host) if host else self.structured_config
+        host_struct_cfg = self.get_host_structured_config(host=host) if host else self.structured_config
         if "Ethernet" in get(interface, "name", ""):
             interface["shutdown"] = default(get(interface, "shutdown"), get(host_struct_cfg, "interface_defaults.ethernet.shutdown"), False)
         else:
@@ -160,7 +154,7 @@ class AvdTestBase:
         Returns:
             str | None: IP address of the host interface or None if unavailable.
         """
-        host_struct_cfg = self.get_host_struct_cfg(host=host) if host else self.structured_config
+        host_struct_cfg = self.get_host_structured_config(host=host) if host else self.structured_config
         try:
             peer_interfaces = get(host_struct_cfg, interface_model, required=True)
             peer_interface = get_item(peer_interfaces, "name", interface_name, required=True)
@@ -174,13 +168,13 @@ class AvdTestBase:
         Attempts to retrieve a value associated with a given key from structured_config and logs if it's missing.
 
         Args:
-            key (str): The key to retrieve.
+            key (str): The key to retrieve. Supports dot-notation like "foo.bar" to do deeper lookups.
             host (str | None): The host from which to retrieve the key. Defaults to the device running the test.
             logging_level (str): The logging level to use for the log message.
         """
-        host_struct_cfg = self.get_host_struct_cfg(host=host) if host else self.structured_config
+        host_struct_cfg = self.get_host_structured_config(host=host) if host else self.structured_config
         try:
-            return get(host_struct_cfg, key, required=True, separator="..")
+            return get(host_struct_cfg, key, required=True)
         except AristaAvdMissingVariableError:
             self.log_skip_message(key=key, logging_level=logging_level)
             return None
@@ -215,7 +209,7 @@ class AvdTestBase:
             In this case, the function will log a warning message because the key 'c' with value '3' is not found,
             and it will return False as the data doesn't meet all validation requirements.
         """
-        data = data or (self.get_host_struct_cfg(host=host) if host else self.structured_config)
+        data = data or (self.get_host_structured_config(host=host) if host else self.structured_config)
         valid = True
 
         # Check the expected key/value pairs first

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/avdtestbase.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/avdtestbase.py
@@ -168,13 +168,13 @@ class AvdTestBase:
         Attempts to retrieve a value associated with a given key from structured_config and logs if it's missing.
 
         Args:
-            key (str): The key to retrieve. Supports dot-notation like "foo.bar" to do deeper lookups.
+            key (str): The key to retrieve.
             host (str | None): The host from which to retrieve the key. Defaults to the device running the test.
             logging_level (str): The logging level to use for the log message.
         """
         host_struct_cfg = self.get_host_structured_config(host=host) if host else self.structured_config
         try:
-            return get(host_struct_cfg, key, required=True)
+            return get(host_struct_cfg, key, required=True, separator="..")
         except AristaAvdMissingVariableError:
             self.log_skip_message(key=key, logging_level=logging_level)
             return None

--- a/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestsecurity.py
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestsecurity.py
@@ -24,7 +24,7 @@ class AvdTestAPIHttpsSSL(AvdTestBase):
             test_definition (dict): ANTA test definition.
         """
         anta_tests = []
-        if (profile := self.logged_get(key="management_api_http..https_ssl_profile", logging_level="INFO")) is None:
+        if (profile := self.logged_get(key="management_api_http.https_ssl_profile", logging_level="INFO")) is None:
             return None
         anta_tests.append({"VerifyAPIHttpsSSL": {"profile": profile}})
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestsecurity.py
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestsecurity.py
@@ -24,7 +24,7 @@ class AvdTestAPIHttpsSSL(AvdTestBase):
             test_definition (dict): ANTA test definition.
         """
         anta_tests = []
-        if (profile := self.logged_get(key="management_api_http.https_ssl_profile", logging_level="INFO")) is None:
+        if (profile := self.logged_get(key="management_api_http..https_ssl_profile", logging_level="INFO")) is None:
             return None
         anta_tests.append({"VerifyAPIHttpsSSL": {"profile": profile}})
 


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Re-adding some changes of commit https://github.com/aristanetworks/ansible-avd/pull/3407/commits/8f6284513db8c6cb3792428e9cb3dc4aedcb7cbd that was lost in commit https://github.com/aristanetworks/ansible-avd/pull/3407/commits/f8212433005631735550b14d2998c8cc70ccf97a of PR #3407

Fixing other issues. See Proposed changes below.
## Related Issue(s)

N/A

## Component(s) name

`arista.avd.eos_validate_state` **ANTA Mode**

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->
- Changed `get_host_struct_cfg` method name to `get_host_structured_config` for clarity
- Fixed the commented `cprofile()`
- Used `Mapping` from typing
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
