### PR TITLE
Doc(eos_cli_config_gen): Add documentation table for Application traffic recognition

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -729,6 +729,12 @@ roles/eos_cli_config_gen/docs/tables/queue-monitor-length.md
 roles/eos_cli_config_gen/docs/tables/queue-monitor-streaming.md
 --8<--
 
+### Application traffic recognition
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/application-traffic-recognition.md
+--8<--
+
 ## Routing
 
 ### ARP


### PR DESCRIPTION
## Change Summary

Adding the table was missed in #3350 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adding the table in QoS section -> happy to change if reviewer prefers to put it in another section

## How to test

Check readthedocs

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
