### PR TITLE
CI(pyavd): Ignore Jinja generated instructions from coverage

### DIFF
--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -72,3 +72,42 @@ profile = "black"
 skip_gitignore = true
 line_length = 160
 known_third_party = ["pyavd"]
+
+[tool.coverage.run]
+branch = true
+parallel = true
+
+[tool.coverage.report]
+# Regexes for lines to exclude from consideration
+exclude_also = [
+    # Have to re-enable the standard pragma
+    "pragma: no cover",
+
+    # Don't complain about missing debug-only code:
+    "def __repr__",
+    "if self\\.debug",
+
+    # Don't complain if tests don't hit defensive assertion code:
+    "raise AssertionError",
+    "raise NotImplementedError",
+
+    # Don't complain if non-runnable code isn't run:
+    "if 0:",
+    "if __name__ == .__main__.:",
+
+    # Don't complain about abstract methods, they aren't run:
+    "@(abc\\.)?abstractmethod",
+
+    # Don't complain about TYPE_CHECKING blocks
+    "if TYPE_CHECKING:",
+
+    # Dont' complain about Jinja2 internalcode
+    # Note that except KeyError is a bid sad..
+    "except KeyError:",
+    "@internalcode",
+    "raise TemplateRuntimeError",
+    "^blocks = {}",
+    "^debug_info =.*",
+]
+
+ignore_errors = true

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -78,36 +78,33 @@ branch = true
 parallel = true
 
 [tool.coverage.report]
+show_missing = true
+fail_under = 89
+include = [
+  "pyavd/*"
+]
 # Regexes for lines to exclude from consideration
 exclude_also = [
     # Have to re-enable the standard pragma
     "pragma: no cover",
-
     # Don't complain about missing debug-only code:
     "def __repr__",
     "if self\\.debug",
-
     # Don't complain if tests don't hit defensive assertion code:
     "raise AssertionError",
     "raise NotImplementedError",
-
     # Don't complain if non-runnable code isn't run:
     "if 0:",
     "if __name__ == .__main__.:",
-
     # Don't complain about abstract methods, they aren't run:
     "@(abc\\.)?abstractmethod",
-
     # Don't complain about TYPE_CHECKING blocks
     "if TYPE_CHECKING:",
-
     # Dont' complain about Jinja2 internalcode
-    # Note that except KeyError is a bid sad..
+    # Note that except KeyError is a bit sad but this is the pattern
     "except KeyError:",
     "@internalcode",
     "raise TemplateRuntimeError",
     "^blocks = {}",
     "^debug_info =.*",
 ]
-
-ignore_errors = true

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -75,7 +75,6 @@ known_third_party = ["pyavd"]
 
 [tool.coverage.run]
 branch = true
-parallel = true
 
 [tool.coverage.report]
 show_missing = true

--- a/python-avd/tox.ini
+++ b/python-avd/tox.ini
@@ -23,7 +23,9 @@ deps =
 extras = mdtoc
 commands =
     make test-dep
-    pytest
+    # posargs allows to run only a specific test using
+    # tox -e <env> -- path/to/my/test::test
+    pytest {posargs}
 
 [testenv:coverage]
 deps =
@@ -33,7 +35,9 @@ deps =
     coverage[toml]
 commands =
     coverage erase
-    coverage run -m pytest
+    # posargs allows to run only a specific test using
+    # tox -e <env> -- path/to/my/test::test
+    coverage run --rcfile=pyproject.toml -m pytest {posargs}
 
 [testenv:report]
 skip_install = true
@@ -41,11 +45,3 @@ deps =
     coverage[toml]
 commands =
     coverage report --rcfile=pyproject.toml
-
-[coverage:report]
-fail_under = 85
-show_missing = true
-include =
-    pyavd/*
-exclude_also =
-    raise NotImplementedError

--- a/python-avd/tox.ini
+++ b/python-avd/tox.ini
@@ -30,7 +30,7 @@ deps =
     pytest
     PyYAML>=6.0.0
     pydantic>=2.3.0
-    coverage
+    coverage[toml]
 commands =
     coverage erase
     coverage run -m pytest
@@ -38,9 +38,9 @@ commands =
 [testenv:report]
 skip_install = true
 deps =
-    coverage
+    coverage[toml]
 commands =
-    coverage report
+    coverage report --rcfile=pyproject.toml
 
 [coverage:report]
 fail_under = 85


### PR DESCRIPTION
## Change Summary

Ignore Jinja2 instructions from coverage report.
Leveraging this: https://coverage.readthedocs.io/en/latest/excluding.html#advanced-exclusion
sadly cannot exclude multilines

## Component(s) name

`pyavd`

## Proposed changes

Added list of exceptions from what Jinja code is generated

## How to test

Let pipeline execute

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
