### PR TITLE
Fix(eos_designs): Fix incorrect syntax in EVPN multicast PIM error messages

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-l3-with-pim.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-l3-with-pim.yml
@@ -1,0 +1,45 @@
+type: l3leaf
+underlay_multicast: true
+evpn_multicast: true
+
+l3leaf:
+  defaults:
+    # LOOPBACK AND VTEP MANAGEMENT
+    loopback_ipv4_pool: 10.10.0.0/24
+    vtep_loopback_ipv4_pool: 10.11.0.0/24
+    vtep_loopback: Loopback1
+  nodes:
+    - name: failure-missing-evpn-multicast-l3-with-pim
+      id: 3
+      bgp_as: 65101
+      filter:
+        tags: ['evpn-multicast-pegs']
+
+tenants:
+  - name: FABRIC
+    mac_vrf_vni_base: 10000
+    evpn_l3_multicast:
+      enabled: false
+      evpn_underlay_l3_multicast_group_ipv4_pool: 232.0.0.0/20
+    vrfs:
+      - name: Tenant_A_OP_Zone_MC
+        description: "Tenant_A_OP_Zone"
+        vrf_vni: 10
+        vtep_diagnostic:
+          loopback: 31
+          loopback_ip_range: 10.255.1.0/24
+        svis:
+          - id: 210
+            name: Tenant_A_OP_Zone_1
+            tags: ['evpn-multicast-l3']
+        l3_interfaces:
+          - nodes: [ failure-missing-evpn-multicast-l3-with-pim ]
+            interfaces: [ Ethernet1 ]
+            ip_addresses: [ 10.254.248.0/31 ]
+            descriptions: [ "L3 Link to RPs" ]
+            enabled: true
+            pim:
+              enabled: true
+
+expected_error_message: >-
+  'pim: enabled' set on l3_interface Ethernet1 on failure-missing-evpn-multicast-l3-with-pim requires evpn_l3_multicast: enabled: true under VRF 'Tenant_A_OP_Zone_MC' or Tenant 'FABRIC'

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-l3-with-pim.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-l3-with-pim.yml
@@ -42,4 +42,4 @@ tenants:
               enabled: true
 
 expected_error_message: >-
-  'pim: enabled' set on l3_interface Ethernet1 on failure-missing-evpn-multicast-l3-with-pim requires evpn_l3_multicast: enabled: true under VRF 'Tenant_A_OP_Zone_MC' or Tenant 'FABRIC'
+  'pim: enabled' set on l3_interface 'Ethernet1' on 'failure-missing-evpn-multicast-l3-with-pim' requires evpn_l3_multicast: enabled: true under VRF 'Tenant_A_OP_Zone_MC' or Tenant 'FABRIC'

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-peg-rps.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-peg-rps.yml
@@ -42,4 +42,4 @@ tenants:
               enabled: true
 
 expected_error_message: >-
-  'pim: enabled' set on l3_interface Ethernet1 on failure-missing-evpn-multicast-peg-rps requires at least one RP defined in pim_rp_addresses under VRF 'Tenant_A_OP_Zone_MC' or Tenant 'FABRIC'
+  'pim: enabled' set on l3_interface 'Ethernet1' on 'failure-missing-evpn-multicast-peg-rps' requires at least one RP defined in pim_rp_addresses under VRF 'Tenant_A_OP_Zone_MC' or Tenant 'FABRIC'

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-peg-rps.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-peg-rps.yml
@@ -1,0 +1,45 @@
+type: l3leaf
+underlay_multicast: true
+evpn_multicast: true
+
+l3leaf:
+  defaults:
+    # LOOPBACK AND VTEP MANAGEMENT
+    loopback_ipv4_pool: 10.10.0.0/24
+    vtep_loopback_ipv4_pool: 10.11.0.0/24
+    vtep_loopback: Loopback1
+  nodes:
+    - name: failure-missing-evpn-multicast-peg-rps
+      id: 3
+      bgp_as: 65101
+      filter:
+        tags: ['evpn-multicast-pegs']
+
+tenants:
+  - name: FABRIC
+    mac_vrf_vni_base: 10000
+    evpn_l3_multicast:
+      enabled: true
+      evpn_underlay_l3_multicast_group_ipv4_pool: 232.0.0.0/20
+    vrfs:
+      - name: Tenant_A_OP_Zone_MC
+        description: "Tenant_A_OP_Zone"
+        vrf_vni: 10
+        vtep_diagnostic:
+          loopback: 31
+          loopback_ip_range: 10.255.1.0/24
+        svis:
+          - id: 210
+            name: Tenant_A_OP_Zone_1
+            tags: ['evpn-multicast-l3']
+        l3_interfaces:
+          - nodes: [ failure-missing-evpn-multicast-peg-rps ]
+            interfaces: [ Ethernet1 ]
+            ip_addresses: [ 10.254.248.0/31 ]
+            descriptions: [ "L3 Link to RPs" ]
+            enabled: true
+            pim:
+              enabled: true
+
+expected_error_message: >-
+  'pim: enabled' set on l3_interface Ethernet1 on failure-missing-evpn-multicast-peg-rps requires at least one RP defined in pim_rp_addresses under VRF 'Tenant_A_OP_Zone_MC' or Tenant 'FABRIC'

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -74,6 +74,8 @@ all:
         failure-missing-evpn-vlan-bundle:
         failure-missing-evpn-multicast-l2:
         failure-missing-evpn-multicast-l3:
+        failure-missing-evpn-multicast-l3-with-pim:
+        failure-missing-evpn-multicast-peg-rps:
         failure-duplicate-evpn-vlan-bundle-name:
         ntp-settings-server-vrf-missing-mgmt-ip:
         ntp-settings-server-vrf-missing-inband-mgmt-interface:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ethernet_interfaces.py
@@ -122,14 +122,14 @@ class EthernetInterfacesMixin(UtilsMixin):
                             if get(l3_interface, "pim.enabled"):
                                 if not vrf.get("_evpn_l3_multicast_enabled"):
                                     raise AristaAvdError(
-                                        f"'pim: enabled' set on l3_interface {interface_name} on {self.shared_utils.hostname} requires evpn_l3_multicast:"
+                                        f"'pim: enabled' set on l3_interface '{interface_name}' on '{self.shared_utils.hostname}' requires evpn_l3_multicast:"
                                         f" enabled: true under VRF '{vrf['name']}' or Tenant '{tenant['name']}'"
                                     )
 
                                 if not vrf.get("_pim_rp_addresses"):
                                     raise AristaAvdError(
-                                        f"'pim: enabled' set on l3_interface {interface_name} on {self.shared_utils.hostname} requires at least one RP defined"
-                                        f" in pim_rp_addresses under VRF '{vrf['name']}' or Tenant '{tenant['name']}'"
+                                        f"'pim: enabled' set on l3_interface '{interface_name}' on '{self.shared_utils.hostname}' requires at least one RP"
+                                        f" defined in pim_rp_addresses under VRF '{vrf['name']}' or Tenant '{tenant['name']}'"
                                     )
 
                                 interface["pim"] = {"ipv4": {"sparse_mode": True}}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/ethernet_interfaces.py
@@ -123,13 +123,13 @@ class EthernetInterfacesMixin(UtilsMixin):
                                 if not vrf.get("_evpn_l3_multicast_enabled"):
                                     raise AristaAvdError(
                                         f"'pim: enabled' set on l3_interface {interface_name} on {self.shared_utils.hostname} requires evpn_l3_multicast:"
-                                        f" enabled: true under VRF '{vrf.name}' or Tenant '{tenant.name}'"
+                                        f" enabled: true under VRF '{vrf['name']}' or Tenant '{tenant['name']}'"
                                     )
 
                                 if not vrf.get("_pim_rp_addresses"):
                                     raise AristaAvdError(
                                         f"'pim: enabled' set on l3_interface {interface_name} on {self.shared_utils.hostname} requires at least one RP defined"
-                                        f" in pim_rp_addresses under VRF '{vrf.name}' or Tenant '{tenant.name}'"
+                                        f" in pim_rp_addresses under VRF '{vrf['name']}' or Tenant '{tenant['name']}'"
                                     )
 
                                 interface["pim"] = {"ipv4": {"sparse_mode": True}}


### PR DESCRIPTION
## Change Summary

Mistakenly used Ansible "." syntax for accessing dict keys - should be "[]" in error messages.

## Related Issue(s)

Fixes #3454 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
Molecule negative tests added for this.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
