### PR TITLE
Refactor: Update black and isort libraries

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,13 +73,13 @@ repos:
   #   -   id: autopep8
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort
         name: Check for changes when running isort on all python files
 
   - repo: https://github.com/psf/black
-    rev: 22.8.0
+    rev: 23.12.1
     hooks:
       - id: black
         name: Check for changes when running Black on all python files

--- a/ansible_collections/arista/avd/docs/contribution/style-guide.md
+++ b/ansible_collections/arista/avd/docs/contribution/style-guide.md
@@ -15,8 +15,8 @@ As AVD is an Ansible collection, we're required to follow guidelines from the of
 Furthermore, the CI Pipeline (& pre-commit) for AVD enforces the following:
 
 - Maximum line length of 160
-- [Black](https://black.readthedocs.io/en/stable/index.html) version 22.8.0
-- [isort](https://pycqa.github.io/isort/) version 5.12.0
+- [Black](https://black.readthedocs.io/en/stable/index.html) version 23.12.1
+- [isort](https://pycqa.github.io/isort/) version 5.13.2
 - [Flake-8](https://flake8.pycqa.org/en/4.0.1/index.html) version 4.0.1
 - [pylint](https://pylint.pycqa.org/en/2.6/) version 2.6.0
 

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -16,8 +16,8 @@ md-toc>=7.1.0
 natsort
 jsonschema>=4.5.1,<4.18
 deepmerge>=1.1.0
-isort==5.12.0
-black==22.8.0
+isort==5.13.2
+black==23.12.1
 ansible-doc-extractor>=0.1.10
 tox
 pydantic>=2.3.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,6 @@
 [tool.black]
 line-length = 160
 
-# Default in black is "false", but the code generator for Pydantic needs this forced.
-skip-string-normalization = false
-
-# Version is locked to 22.8.0 where preview features are all something we like.
-# If the version is changed later, we have to reconsider preview.
-preview = true
-
 [tool.isort]
 profile = "black"
 skip_gitignore = true

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -60,13 +60,6 @@ optional-dependencies = {"mdtoc" = { file = ["requirements-mdtoc.txt"] }}
 [tool.black]
 line-length = 160
 
-# Default in black is "false", but the code generator for Pydantic needs this forced.
-skip-string-normalization = false
-
-# Version is locked to 22.8.0 where preview features are all something we like.
-# If the version is changed later, we have to reconsider preview.
-preview = true
-
 [tool.isort]
 profile = "black"
 skip_gitignore = true


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Update pinned `black` and `isort` libraries to be compatible with future dependency `aristaproto`.

Since we move from `black` 22 -> 23 we can remove preview.