### PR TITLE
Fix: Minor container fixes

### DIFF
--- a/containers/base/.devcontainer/Dockerfile
+++ b/containers/base/.devcontainer/Dockerfile
@@ -7,6 +7,8 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     make \
     git \
+    # xz-utils required for docker import to work
+    xz-utils \
     && rm -rf /var/lib/apt/lists/* \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean

--- a/containers/dev/.devcontainer/Dockerfile
+++ b/containers/dev/.devcontainer/Dockerfile
@@ -14,3 +14,5 @@ ENTRYPOINT [ "/bin/entrypoint.sh" ]
 # Switch user to given USERNAME otherwise Ansible will be installed as root.
 USER ${USERNAME}
 ENV PATH=$PATH:/home/${USERNAME}/.local/bin
+# make sure that path required to mount Ansible collection exists
+RUN mkdir -p /home/${USERNAME}/.ansible/collections/ansible_collections/arista/avd

--- a/containers/universal/.devcontainer/Dockerfile
+++ b/containers/universal/.devcontainer/Dockerfile
@@ -13,4 +13,6 @@ ENV PATH=$PATH:/home/${USERNAME}/.local/bin
 # Install Ansible AVD collection.
 RUN pip3 install "${ANSIBLE_CORE_VERSION}" \
     && ansible-galaxy collection install ${ANSIBLE_INSTALL_LOCATION} \
-    && pip3 install -r /home/${USERNAME}/.ansible/collections/ansible_collections/arista/avd/requirements.txt
+    && pip3 install -r /home/${USERNAME}/.ansible/collections/ansible_collections/arista/avd/requirements.txt \
+    # install community.general to support callback plugins in ansible.cfg, etc.
+    && ansible-galaxy collection install community.general


### PR DESCRIPTION
## Change Summary

This PR adds xz-utils to the base container, that is required for Docker import to work when D-in-D is installed.
It also adds `/home/${USER}/.ansible/collections/ansible_collections/arista/avd` explicitly to `dev` image, as otherwise mount to non-existing path can fail in some environments.

## Component(s) name

containers

## How to test

Merge to rebuild containers. Pull and check that xz-utils are installed.
The best way to test for mount issues to non-existing path is to start Codespace for AVD PR and check if AVD collection was installed successfully.
Once `base` is re-build, `dev` and `universal` builds must be triggered manually to get xz-utils.
