### PR TITLE
Feat: Avd install for codespaces

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,8 +1,0 @@
-ARG VARIANT="3.8-v2.0"
-FROM avdteam/base:${VARIANT}
-
-WORKDIR /workspace
-VOLUME ["/workspace"]
-
-USER avd
-RUN rm -f /home/avd/.gitconfig

--- a/containers/dev/.devcontainer/entrypoint.sh
+++ b/containers/dev/.devcontainer/entrypoint.sh
@@ -1,43 +1,37 @@
 #!/bin/bash
 
-AVD_DEV_REQ_FILE="${HOME}/.ansible/collections/ansible_collections/arista/avd/requirements-dev.txt"
 USERNAME=$(whoami)
+AVD_COLLECTION_PATH="${HOME}/.ansible/collections/ansible_collections/arista/avd"
+CONTAINER_WORKSPACE=$(git rev-parse --show-toplevel)
+CONTAINER_WSF_AVD_PATH=${CONTAINER_WORKSPACE}/ansible_collections/arista/avd
 
-# Install ansible if not yet installed and avd collection is locally mounted.
-ansible --version &> /dev/null ||  if [ -f $AVD_DEV_REQ_FILE ]; then
-  sudo chown -R ${USERNAME} ${HOME}/.ansible
-  ANSIBLE_CORE_VERSION=$(cat ${AVD_DEV_REQ_FILE}| grep ansible-core)
-  pip3 install "${ANSIBLE_CORE_VERSION}"
-  ansible-galaxy collection install -r ${HOME}/.ansible/collections/ansible_collections/arista/avd/collections.yml
-  pip3 install -r ${HOME}/.ansible/collections/ansible_collections/arista/avd/requirements.txt
-  pip3 install -r ${HOME}/.ansible/collections/ansible_collections/arista/avd/requirements-dev.txt
-fi
-
-# Install Ansible based on any AVD git branch (or its fork).
-# The ANSIBLE_INSTALL_LOCATION_FORMAT must be "git+https://github.com/${AVD_GITHUB_REPO}.git#/ansible_collections/arista/avd/,${AVD_BRANCH_NAME}".
-# AVD_GITHUB_REPO and AVD_BRANCH_NAME must be defined for ANSIBLE_INSTALL_LOCATION_FORMAT to be crafted successfully.
-ansible --version &> /dev/null ||  if ! [ -z "${AVD_GITHUB_REPO}" ] && ! [ -z "${AVD_BRANCH_NAME}" ]; then
+# if collection is already mounted, it will be used to install the requirements
+# there is no need to install AVD collection for this case as it's already mounted to the correct location
+if [ -f ${AVD_COLLECTION_PATH}/requirements.txt ] && [ -f ${AVD_COLLECTION_PATH}/requirements-dev.txt ] ; then
+  sudo chown -R ${USERNAME} ${HOME}/.ansible  # make sure mounted path is owned by container user and not root
+  ANSIBLE_CORE_VERSION=$(cat ${AVD_COLLECTION_PATH}/requirements-dev.txt | grep ansible-core)
+# if env variables are set - use git
+elif ! [ -z "${AVD_GITHUB_REPO}" ] && ! [ -z "${AVD_BRANCH_NAME}" ]; then
   ANSIBLE_CORE_VERSION=$(curl -s https://raw.githubusercontent.com/${AVD_GITHUB_REPO}/${AVD_BRANCH_NAME}/ansible_collections/arista/avd/requirements-dev.txt | grep ansible-core)
-  pip3 install "${ANSIBLE_CORE_VERSION}"
-  ansible-galaxy collection install git+https://github.com/${AVD_GITHUB_REPO}.git#/ansible_collections/arista/avd/,${AVD_BRANCH_NAME}
-  pip3 install -r ${HOME}/.ansible/collections/ansible_collections/arista/avd/requirements.txt
-  pip3 install -r ${HOME}/.ansible/collections/ansible_collections/arista/avd/requirements-dev.txt
-fi
-
+  AVD_INSTALL_PATH="git+https://github.com/${AVD_GITHUB_REPO}.git#/ansible_collections/arista/avd/,${AVD_BRANCH_NAME}"
 # In some cases AVD can not be correctly mounted, for ex. when running dev container as Codespace
 # In that case if collection is available in the container workspace, it will be installed from there
-CONTAINER_WORKSPACE=$(git rev-parse --show-toplevel)
-AVD_DEV_REQ_FILE_ALT="${CONTAINER_WORKSPACE}/ansible_collections/arista/avd/requirements-dev.txt"
-ansible --version &> /dev/null ||  if [ -f $AVD_DEV_REQ_FILE_ALT ]; then
-  sudo chown -R ${USERNAME} ${HOME}/.ansible
-  ANSIBLE_CORE_VERSION=$(cat ${AVD_DEV_REQ_FILE_ALT}| grep ansible-core)
-  pip3 install "${ANSIBLE_CORE_VERSION}"
-  ansible-galaxy collection install ${CONTAINER_WORKSPACE}/ansible_collections/arista/avd/
-  ansible-galaxy collection install -r ${CONTAINER_WORKSPACE}/ansible_collections/arista/avd/collections.yml
-  pip3 install -r ${CONTAINER_WORKSPACE}/ansible_collections/arista/avd/requirements.txt
-  pip3 install -r ${CONTAINER_WORKSPACE}/ansible_collections/arista/avd/requirements-dev.txt
+elif [ -f ${CONTAINER_WSF_AVD_PATH}/requirements.txt ] && [ -f ${CONTAINER_WSF_AVD_PATH}/requirements-dev.txt ] ; then
+  ANSIBLE_CORE_VERSION=$(cat ${CONTAINER_WSF_AVD_PATH}/requirements-dev.txt | grep ansible-core)
+  AVD_INSTALL_PATH="${CONTAINER_WSF_AVD_PATH}/"
 fi
 
+# install ansible core and requirements
+if ! [ -z "${ANSIBLE_CORE_VERSION}" ]; then
+  pip3 install "${ANSIBLE_CORE_VERSION}"
+  if ! [ -z "${AVD_INSTALL_PATH}" ]; then
+    ansible-galaxy collection install ${AVD_INSTALL_PATH}
+  fi
+  ansible-galaxy collection install -r ${AVD_COLLECTION_PATH}/collections.yml
+  pip3 install -r ${AVD_COLLECTION_PATH}/requirements.txt -r ${AVD_COLLECTION_PATH}/requirements-dev.txt
+fi
+
+# if ansible installation failed for whatever reason - raise an error
 ansible --version &> /dev/null ||  (echo "ERROR: Failed to install Ansible and collections." >&2; exit 1)
 
 # Execute command from docker cli if any.


### PR DESCRIPTION
## Change Summary

This PR add support for AVD installation inside Codespaces.
Currently mount fails due to: https://github.com/orgs/community/discussions/85658
As a workaround, `dev` image `entrypoint.sh` will get additional logic to install AVD directly from the workspace.

## Component(s) name

`containers`

## How to test
Once AVD dev image will be re-build after merge, start Github Codespace on any PR and check:
- ansible --version
- ansible-galaxy collection list

It should be also possible to "unpack" AVD examples and build configs in every example directory.