### PR TITLE
Fix(eos_validate_state): ANTA Decrease default logging level for tests

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/avdtestbase.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/avdtestbase.py
@@ -163,14 +163,14 @@ class AvdTestBase:
             self.log_skip_message(message=f"Host '{host or self.device_name}' interface '{interface_name}' IP address is unavailable.", logging_level="WARNING")
             return None
 
-    def logged_get(self, key: str, host: str | None = None, logging_level: str = "WARNING"):
+    def logged_get(self, key: str, host: str | None = None, logging_level: str = "INFO"):
         """
         Attempts to retrieve a value associated with a given key from structured_config and logs if it's missing.
 
         Args:
             key (str): The key to retrieve.
             host (str | None): The host from which to retrieve the key. Defaults to the device running the test.
-            logging_level (str): The logging level to use for the log message.
+            logging_level (str): The logging level to use for the log message. Defaults to "INFO".
         """
         host_struct_cfg = self.get_host_structured_config(host=host) if host else self.structured_config
         try:
@@ -185,7 +185,7 @@ class AvdTestBase:
         data_path: str | None = None,
         host: str | None = None,
         required_keys: str | list[str] | None = None,
-        logging_level: str | None = None,
+        logging_level: str = "INFO",
         **kwargs,
     ) -> bool:
         """
@@ -196,8 +196,7 @@ class AvdTestBase:
             data_path (str | None): The data path in dot notation. Used for logging purposes. Index or primary key can be used for lists.
             host (str | None): The host from which data should be retrieved. Defaults to the device running the test.
             required_keys (str | list[str] | None): The keys that are expected to be in the data.
-            logging_level (str): Overwrites all default logging levels within this function.
-                                If not provided, the default logging level is 'WARNING' when a key is missing and 'INFO' when his value is not matching.
+            logging_level (str): The logging level to use for the log message. Defaults to "INFO".
             **kwargs: Expected key-value pairs in the data.
 
         Returns:
@@ -216,10 +215,10 @@ class AvdTestBase:
         for key, value in kwargs.items():
             actual_value = get(data, key)
             if actual_value is None:
-                self.log_skip_message(key=key, value=value, key_path=data_path, is_missing=True, logging_level=logging_level or "WARNING")
+                self.log_skip_message(key=key, value=value, key_path=data_path, is_missing=True, logging_level=logging_level)
                 valid = False
             elif actual_value != value:
-                self.log_skip_message(key=key, value=value, key_path=data_path, is_missing=False, logging_level=logging_level or "INFO")
+                self.log_skip_message(key=key, value=value, key_path=data_path, is_missing=False, logging_level=logging_level)
                 valid = False
 
         # Return False if any of the expected values are missing or not matching
@@ -231,7 +230,7 @@ class AvdTestBase:
             required_keys = [required_keys] if isinstance(required_keys, str) else required_keys
             for key in required_keys:
                 if get(data, key) is None:
-                    self.log_skip_message(key=key, key_path=data_path, is_missing=True, logging_level=logging_level or "WARNING")
+                    self.log_skip_message(key=key, key_path=data_path, is_missing=True, logging_level=logging_level)
                     valid = False
         return valid
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestconnectivity.py
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestconnectivity.py
@@ -29,7 +29,7 @@ class AvdTestP2PIPReachability(AvdTestBase):
         """
         anta_tests = []
 
-        if (ethernet_interfaces := self.logged_get(key="ethernet_interfaces")) is None:
+        if (ethernet_interfaces := self.logged_get(key="ethernet_interfaces", logging_level="WARNING")) is None:
             return None
 
         required_keys = ["name", "peer", "peer_interface", "ip_address"]
@@ -81,7 +81,7 @@ class AvdTestInbandReachability(AvdTestBase):
         """
         anta_tests = []
 
-        if (management_interfaces := self.logged_get(key="management_interfaces")) is None:
+        if (management_interfaces := self.logged_get(key="management_interfaces", logging_level="WARNING")) is None:
             return None
 
         for idx, interface in enumerate(management_interfaces):
@@ -169,7 +169,7 @@ class AvdTestLLDPTopology(AvdTestBase):
         """
         anta_tests = []
 
-        if (ethernet_interfaces := self.logged_get(key="ethernet_interfaces")) is None:
+        if (ethernet_interfaces := self.logged_get(key="ethernet_interfaces", logging_level="WARNING")) is None:
             return None
 
         required_keys = ["name", "peer", "peer_interface"]

--- a/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestinterfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestinterfaces.py
@@ -68,7 +68,7 @@ class AvdTestInterfacesState(AvdTestBase):
                 return "adminDown", "down", description_template.format(state="adminDown")
             return "up", "up", description_template.format(state="up")
 
-        required_keys = ["name", "shutdown", "description"]
+        required_keys = ["name", "shutdown"]
 
         for interface_key, description_template in self.interface_types:
             interfaces = get(self.structured_config, interface_key, [])
@@ -78,7 +78,8 @@ class AvdTestInterfacesState(AvdTestBase):
                 if not self.validate_data(data=interface, data_path=f"{interface_key}.[{idx}]", required_keys=required_keys):
                     continue
                 state, proto, description = generate_test_details(interface, description_template)
-                custom_field = f"{interface['name']} - {interface['description']}"
+                intf_description = interface.get("description")
+                custom_field = interface["name"] if not intf_description else f"{interface['name']} - {intf_description}"
 
                 add_test(str(interface["name"]), state, proto, description, custom_field)
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestmlag.py
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestmlag.py
@@ -23,7 +23,7 @@ class AvdTestMLAG(AvdTestBase):
         Returns:
             test_definition (dict): ANTA test definition.
         """
-        if self.logged_get(key="mlag_configuration", logging_level="INFO") is None:
+        if self.logged_get(key="mlag_configuration") is None:
             return None
 
         anta_tests = [

--- a/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestrouting.py
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestrouting.py
@@ -99,9 +99,7 @@ class AvdTestBGP(AvdTestBase):
                 }
             )
 
-        if self.logged_get(key="router_bgp", logging_level="INFO") is None or not self.validate_data(
-            service_routing_protocols_model="multi-agent", logging_level="WARNING"
-        ):
+        if self.logged_get(key="router_bgp") is None or not self.validate_data(service_routing_protocols_model="multi-agent", logging_level="WARNING"):
             return None
 
         anta_tests.setdefault("generic", []).append(

--- a/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestsecurity.py
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestsecurity.py
@@ -24,7 +24,7 @@ class AvdTestAPIHttpsSSL(AvdTestBase):
             test_definition (dict): ANTA test definition.
         """
         anta_tests = []
-        if (profile := self.logged_get(key="management_api_http..https_ssl_profile", logging_level="INFO")) is None:
+        if (profile := self.logged_get(key="management_api_http..https_ssl_profile")) is None:
             return None
         anta_tests.append({"VerifyAPIHttpsSSL": {"profile": profile}})
 


### PR DESCRIPTION
## Change Summary

Decrease default logging level for tests.

Example output when using `-v` (INFO):
![image](https://github.com/aristanetworks/ansible-avd/assets/63206086/4c5f8399-47bb-4de7-8afe-c1280ebc7f64)

## Related Issue(s)

Fixes #3452

## Component(s) name

`arista.avd.eos_validate_state` **ANTA**

## Proposed changes
All logging functions for tests are now set to INFO by default to avoid unnecessary WARNING logs. Some tests will still emit WARNING logs when needed.

## How to test
`ansible-playbook playbooks/fabric_validate_state.yaml -e use_anta=true`
You can use `-v` to see INFO logs when tests are skipped.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
