### PR TITLE
CI: Stop building python3.9 and start building universal on pre-release

### DIFF
--- a/.github/workflows/container_build_base.yml
+++ b/.github/workflows/container_build_base.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         container_name: [base]
-        python_version: ["3.9", "3.10", "3.11"]
+        python_version: ["3.10", "3.11",  "3.12"]
         include:
-          - python_version: "3.11"
+          - python_version: "3.12"
             container_tags: latest
     with:
       container_name: ${{ matrix.container_name }}

--- a/.github/workflows/container_build_base.yml
+++ b/.github/workflows/container_build_base.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         container_name: [base]
-        python_version: ["3.10", "3.11",  "3.12"]
+        python_version: ["3.10", "3.11", "3.12"]
         include:
           - python_version: "3.12"
             container_tags: latest

--- a/.github/workflows/container_build_dev.yml
+++ b/.github/workflows/container_build_dev.yml
@@ -20,9 +20,9 @@ jobs:
     strategy:
       matrix:
         container_name: [dev]
-        python_version: ["3.9", "3.10", "3.11"]
+        python_version: ["3.10", "3.11",  "3.12"]
         include:
-          - python_version: "3.11"
+          - python_version: "3.12"
             container_tags: latest
     with:
       container_name: ${{ matrix.container_name }}

--- a/.github/workflows/container_build_dev.yml
+++ b/.github/workflows/container_build_dev.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         container_name: [dev]
-        python_version: ["3.10", "3.11",  "3.12"]
+        python_version: ["3.10", "3.11", "3.12"]
         include:
           - python_version: "3.12"
             container_tags: latest

--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -22,9 +22,9 @@ jobs:
     strategy:
       matrix:
         container_name: [universal]
-        python_version: ["3.9", "3.10", "3.11"]
+        python_version: ["3.10", "3.11",  "3.12"]
         include:
-          - python_version: "3.11"
+          - python_version: "3.12"
             container_tags: latest
     with:
       container_name: ${{ matrix.container_name }}

--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -13,7 +13,7 @@ on:
     branches:
       - devel
   release:
-    types: [published]
+    types: [published, prereleased]
 
 jobs:
   build_universal_container:

--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         container_name: [universal]
-        python_version: ["3.10", "3.11",  "3.12"]
+        python_version: ["3.10", "3.11", "3.12"]
         include:
           - python_version: "3.12"
             container_tags: latest


### PR DESCRIPTION
## Change Summary

This change will stop new python3.9 container builds and add 3.12 instead.
On top, container builds must be triggered on pre-release event.

## Component(s) name

containers

## How to test
After merge check that 3.12 container was build.
Also confirm that a new universal container will be created on next AVD pre-release.