### PR TITLE
CI: build avd universal container on pre-release

### DIFF
--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -13,7 +13,7 @@ on:
     branches:
       - devel
   release:
-    types: [published]
+    types: [published, prereleased]
 
 jobs:
   build_universal_container:


### PR DESCRIPTION
## Change Summary

Start building universal container on pre-release.

## Component(s) name

containers

## Proposed changes
trigger CI workflow on `prereleased` event

## How to test
- Create a test repository.
- Add a Github Actions workflow similar to: https://github.com/ankudinov/gh-actions-playground/blob/master/.github/workflows/test-pre-release.yml
- Create pre-release and verify that CI is triggered as expected.

Also check if universal container will be created on the next pre-release.