### PR TITLE
Fix(plugins): Remove wrong 3.9 deprecation warning

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -55,16 +55,17 @@ def _validate_python_version(info: dict, result: dict) -> bool:
     if sys.version_info < MIN_PYTHON_SUPPORTED_VERSION:
         display.error(f"Python Version running {running_version} - Minimum Version required is {min_version}", False)
         return False
-    elif sys.version_info[:2] == MIN_PYTHON_SUPPORTED_VERSION:
-        result.setdefault("deprecations", []).append(
-            {
-                "msg": (
-                    f"You are currently running Python {running_version}. The next minor release of AVD after November 6th 2023 will drop support for Python"
-                    f" {min_version} as it will be dropping support for ansible-core<2.14 and ansible-core>=2.14 does not support Python {min_version} as"
-                    " documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix"
-                )
-            }
-        )
+    # Keeping this for next deprecation adjust the message as required
+    # elif sys.version_info[:2] == MIN_PYTHON_SUPPORTED_VERSION:
+    #     result.setdefault("deprecations", []).append(
+    #         {
+    #             "msg": (
+    #                 f"You are currently running Python {running_version}. The next minor release of AVD after November 6th 2023 will drop support for Python"
+    #                 f" {min_version} as it will be dropping support for ansible-core<2.14 and ansible-core>=2.14 does not support Python {min_version} as"
+    #                 " documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix"
+    #             )
+    #         }
+    #     )
 
     return True
 
@@ -187,7 +188,7 @@ def _validate_ansible_version(collection_name: str, running_version: str, info: 
             False,
         )
         return False
-    # TODO remove this once dropping support of ansible-core<2.14 as the previous if will catch it.
+    # Keeping this for next deprecation - set the value of deprecation_specifiers_set when needed and adjust message
     elif not deprecation_specifiers_set.contains(running_version):
         result.setdefault("deprecations", []).append(
             {

--- a/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
+++ b/ansible_collections/arista/avd/tests/unit/action/test_verify_requirements.py
@@ -56,9 +56,9 @@ def test__validate_python_version(mocked_version, expected_return):
         "serial": mocked_version[4],
     }
     assert bool(info["python_path"])
-    if mocked_version[:2] == MIN_PYTHON_SUPPORTED_VERSION:
-        # Check for depreecation of PYTHON 3.8
-        assert len(result["deprecations"]) == 1
+    # if mocked_version[:2] == MIN_PYTHON_SUPPORTED_VERSION:
+    #     # Check for depreecation of PYTHON 3.8
+    #     assert len(result["deprecations"]) == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Change Summary

A warning is currently emitted for user running 3.9 stating deprecation will happen in Nov 2023. This is a leftover mistake and this PR addresses it

## Component(s) name

`plugins`

## How to test

No more warning

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
