### PR TITLE
Feat(eos_cli_config_gen): Add vxlan_interface.Vxlan1.multicast_headend_replication

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -85,6 +85,7 @@ interface Management1
 interface Vxlan1
    description DC1-LEAF2A_VTEP
    vxlan source-interface Loopback0
+   vxlan multicast headend-replication
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -56,6 +56,7 @@ interface Management1
 | Remote VTEPs EVPN BFD expected minimum incoming rate (min-rx) | 300ms |
 | Remote VTEPs EVPN BFD multiplier | 3 |
 | Remote VTEPs EVPN BFD prefix-list | PL-TEST |
+| Multicast headend-replication | Enabled |
 
 ##### VLAN to VNI, Flood List and Multicast Group Mappings
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vxlan-interface.md
@@ -85,7 +85,6 @@ interface Management1
 interface Vxlan1
    description DC1-LEAF2A_VTEP
    vxlan source-interface Loopback0
-   vxlan multicast headend-replication
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
@@ -105,6 +104,7 @@ interface Vxlan1
    vxlan vlan 110 multicast group 239.9.1.4
    vxlan vlan 112 multicast group 239.9.1.6
    vxlan vrf Tenant_A_OP_Zone multicast group 232.0.0.10
+   vxlan multicast headend-replication
    vxlan encapsulation ipv4
 
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
@@ -15,6 +15,7 @@ interface Management1
 interface Vxlan1
    description DC1-LEAF2A_VTEP
    vxlan source-interface Loopback0
+   vxlan multicast headend-replication
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vxlan-interface.cfg
@@ -15,7 +15,6 @@ interface Management1
 interface Vxlan1
    description DC1-LEAF2A_VTEP
    vxlan source-interface Loopback0
-   vxlan multicast headend-replication
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id
    vxlan udp-port 4789
@@ -35,6 +34,7 @@ interface Vxlan1
    vxlan vlan 110 multicast group 239.9.1.4
    vxlan vlan 112 multicast group 239.9.1.6
    vxlan vrf Tenant_A_OP_Zone multicast group 232.0.0.10
+   vxlan multicast headend-replication
    vxlan encapsulation ipv4
 
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
@@ -5,6 +5,7 @@ vxlan_interface:
     description: DC1-LEAF2A_VTEP
     vxlan:
       source_interface: Loopback0
+      multicast_headend_replication: true
       controller_client:
         enabled: true
       mlag_source_interface: Loopback1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vxlan-interface.yml
@@ -5,7 +5,8 @@ vxlan_interface:
     description: DC1-LEAF2A_VTEP
     vxlan:
       source_interface: Loopback0
-      multicast_headend_replication: true
+      multicast:
+        headend_replication: true
       controller_client:
         enabled: true
       mlag_source_interface: Loopback1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vxlan-interface.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vxlan-interface.md
@@ -12,7 +12,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "vxlan_interface.Vxlan1.description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "vxlan_interface.Vxlan1.vxlan") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.source_interface") | String |  |  |  | Source Interface Name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast_headend_replication</samp>](## "vxlan_interface.Vxlan1.vxlan.multicast_headend_replication") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast</samp>](## "vxlan_interface.Vxlan1.vxlan.multicast") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;headend_replication</samp>](## "vxlan_interface.Vxlan1.vxlan.multicast.headend_replication") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;controller_client</samp>](## "vxlan_interface.Vxlan1.vxlan.controller_client") | Dictionary |  |  |  | Client to CVX Controllers |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "vxlan_interface.Vxlan1.vxlan.controller_client.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.mlag_source_interface") | String |  |  |  |  |
@@ -52,7 +53,8 @@
 
           # Source Interface Name
           source_interface: <str>
-          multicast_headend_replication: <bool>
+          multicast:
+            headend_replication: <bool>
 
           # Client to CVX Controllers
           controller_client:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vxlan-interface.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vxlan-interface.md
@@ -12,6 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "vxlan_interface.Vxlan1.description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "vxlan_interface.Vxlan1.vxlan") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.source_interface") | String |  |  |  | Source Interface Name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast_headend_replication</samp>](## "vxlan_interface.Vxlan1.vxlan.multicast_headend_replication") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;controller_client</samp>](## "vxlan_interface.Vxlan1.vxlan.controller_client") | Dictionary |  |  |  | Client to CVX Controllers |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "vxlan_interface.Vxlan1.vxlan.controller_client.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_source_interface</samp>](## "vxlan_interface.Vxlan1.vxlan.mlag_source_interface") | String |  |  |  |  |
@@ -51,6 +52,7 @@
 
           # Source Interface Name
           source_interface: <str>
+          multicast_headend_replication: <bool>
 
           # Client to CVX Controllers
           controller_client:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -26078,9 +26078,19 @@
                   "description": "Source Interface Name",
                   "title": "Source Interface"
                 },
-                "multicast_headend_replication": {
-                  "type": "boolean",
-                  "title": "Multicast Headend Replication"
+                "multicast": {
+                  "type": "object",
+                  "properties": {
+                    "headend_replication": {
+                      "type": "boolean",
+                      "title": "Headend Replication"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Multicast"
                 },
                 "controller_client": {
                   "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -26078,6 +26078,10 @@
                   "description": "Source Interface Name",
                   "title": "Source Interface"
                 },
+                "multicast_headend_replication": {
+                  "type": "boolean",
+                  "title": "Multicast Headend Replication"
+                },
                 "controller_client": {
                   "type": "object",
                   "description": "Client to CVX Controllers",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -14997,8 +14997,11 @@ keys:
               source_interface:
                 type: str
                 description: Source Interface Name
-              multicast_headend_replication:
-                type: bool
+              multicast:
+                type: dict
+                keys:
+                  headend_replication:
+                    type: bool
               controller_client:
                 type: dict
                 description: Client to CVX Controllers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -14997,6 +14997,8 @@ keys:
               source_interface:
                 type: str
                 description: Source Interface Name
+              multicast_headend_replication:
+                type: bool
               controller_client:
                 type: dict
                 description: Client to CVX Controllers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
@@ -20,8 +20,11 @@ keys:
               source_interface:
                 type: str
                 description: Source Interface Name
-              multicast_headend_replication:
-                type: bool
+              multicast:
+                type: dict
+                keys:
+                  headend_replication:
+                    type: bool
               controller_client:
                 type: dict
                 description: Client to CVX Controllers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vxlan_interface.schema.yml
@@ -20,6 +20,8 @@ keys:
               source_interface:
                 type: str
                 description: Source Interface Name
+              multicast_headend_replication:
+                type: bool
               controller_client:
                 type: dict
                 description: Client to CVX Controllers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vxlan-interface.j2
@@ -60,6 +60,11 @@
 | Remote VTEPs EVPN BFD prefix-list | {{ vxlan_interface.Vxlan1.vxlan.bfd_vtep_evpn.prefix_list }} |
 {%         endif %}
 {%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.multicast.headend_replication is arista.avd.defined(true) %}
+| Multicast headend-replication | Enabled |
+{%     elif vxlan_interface.Vxlan1.vxlan.multicast.headend_replication is arista.avd.defined(false) %}
+| Multicast headend-replication | Disabled |
+{%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.vlans is arista.avd.defined %}
 
 ##### VLAN to VNI, Flood List and Multicast Group Mappings

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -14,6 +14,9 @@ interface Vxlan1
 {%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
    vxlan source-interface {{ vxlan_interface.Vxlan1.vxlan.source_interface }}
 {%     endif %}
+{%     if vxlan_interface.Vxlan1.vxlan.multicast_headend_replication is arista.avd.defined(true) %}
+   vxlan multicast headend-replication
+{%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.controller_client.enabled is arista.avd.defined(true) %}
    vxlan controller-client
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -14,9 +14,6 @@ interface Vxlan1
 {%     if vxlan_interface.Vxlan1.vxlan.source_interface is arista.avd.defined %}
    vxlan source-interface {{ vxlan_interface.Vxlan1.vxlan.source_interface }}
 {%     endif %}
-{%     if vxlan_interface.Vxlan1.vxlan.multicast_headend_replication is arista.avd.defined(true) %}
-   vxlan multicast headend-replication
-{%     endif %}
 {%     if vxlan_interface.Vxlan1.vxlan.controller_client.enabled is arista.avd.defined(true) %}
    vxlan controller-client
 {%     endif %}
@@ -79,6 +76,9 @@ interface Vxlan1
 {%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort('name') if vrf.multicast_group is arista.avd.defined %}
    vxlan vrf {{ vrf.name }} multicast group {{ vrf.multicast_group }}
 {%     endfor %}
+{%     if vxlan_interface.Vxlan1.vxlan.multicast_headend_replication is arista.avd.defined(true) %}
+   vxlan multicast headend-replication
+{%     endif %}
 {%     if  vxlan_interface.Vxlan1.eos_cli is arista.avd.defined %}
    {{ vxlan_interface.Vxlan1.eos_cli | indent(3, false) }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vxlan-interface.j2
@@ -76,7 +76,7 @@ interface Vxlan1
 {%     for vrf in vxlan_interface.Vxlan1.vxlan.vrfs | arista.avd.natural_sort('name') if vrf.multicast_group is arista.avd.defined %}
    vxlan vrf {{ vrf.name }} multicast group {{ vrf.multicast_group }}
 {%     endfor %}
-{%     if vxlan_interface.Vxlan1.vxlan.multicast_headend_replication is arista.avd.defined(true) %}
+{%     if vxlan_interface.Vxlan1.vxlan.multicast.headend_replication is arista.avd.defined(true) %}
    vxlan multicast headend-replication
 {%     endif %}
 {%     if  vxlan_interface.Vxlan1.eos_cli is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Add headend_replication to vxlan_interface.Vxlan1

## Related Issue(s)

Fixes #3095

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist
### User Checklist

- [x] Verify the command ordering on EOS

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
