### PR TITLE
Feat(eos_cli_config_gen): add ip verify unicast source to ethernet-, vlan- and port-channel interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -344,6 +344,7 @@ interface Ethernet1
    bgp session tracker ST1
    no switchport
    ip address 172.31.255.1/31
+   ip verify unicast source reachable-via rx
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
    priority-flow-control on

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -364,6 +364,7 @@ interface Port-Channel5
    l2 mtu 8000
    l2 mru 8000
    mlag 5
+   ip verify unicast source reachable-via rx
    storm-control broadcast level 1
    storm-control multicast level 1
    storm-control unknown-unicast level 1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -335,8 +335,8 @@ interface Vlan91
 interface Vlan92
    description SVI Description
    ip proxy-arp
-   ip address 10.10.92.1/24
    ip directed-broadcast
+   ip address 10.10.92.1/24
 !
 interface Vlan110
    description PVLAN Primary with vlan mapping

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -335,8 +335,8 @@ interface Vlan91
 interface Vlan92
    description SVI Description
    ip proxy-arp
-   ip directed-broadcast
    ip address 10.10.92.1/24
+   ip directed-broadcast
 !
 interface Vlan110
    description PVLAN Primary with vlan mapping
@@ -423,6 +423,7 @@ interface Vlan2002
    description SVI Description
    no autostate
    vrf Tenant_B
+   ip verify unicast source reachable-via rx
    isis enable EVPN_UNDERLAY
    ip address virtual 10.2.2.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -16,6 +16,7 @@ interface Ethernet1
    bgp session tracker ST1
    no switchport
    ip address 172.31.255.1/31
+   ip verify unicast source reachable-via rx
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
    priority-flow-control on

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -26,6 +26,7 @@ interface Port-Channel5
    l2 mtu 8000
    l2 mru 8000
    mlag 5
+   ip verify unicast source reachable-via rx
    storm-control broadcast level 1
    storm-control multicast level 1
    storm-control unknown-unicast level 1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -160,8 +160,8 @@ interface Vlan91
 interface Vlan92
    description SVI Description
    ip proxy-arp
-   ip directed-broadcast
    ip address 10.10.92.1/24
+   ip directed-broadcast
 !
 interface Vlan110
    description PVLAN Primary with vlan mapping
@@ -248,6 +248,7 @@ interface Vlan2002
    description SVI Description
    no autostate
    vrf Tenant_B
+   ip verify unicast source reachable-via rx
    isis enable EVPN_UNDERLAY
    ip address virtual 10.2.2.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -160,8 +160,8 @@ interface Vlan91
 interface Vlan92
    description SVI Description
    ip proxy-arp
-   ip address 10.10.92.1/24
    ip directed-broadcast
+   ip address 10.10.92.1/24
 !
 interface Vlan110
    description PVLAN Primary with vlan mapping

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -28,9 +28,7 @@ ethernet_interfaces:
       multiplier: 5
     bgp:
       session_tracker: ST1
-    ip_verify:
-      unicast_source:
-        reachable_via: rx
+    ip_verify_unicast_source_reachable_via: rx
     eos_cli: |
       comment
       Comment created from eos_cli under ethernet_interfaces.Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -28,6 +28,9 @@ ethernet_interfaces:
       multiplier: 5
     bgp:
       session_tracker: ST1
+    ip_verify:
+      unicast_source:
+        reachable_via: rx
     eos_cli: |
       comment
       Comment created from eos_cli under ethernet_interfaces.Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -23,6 +23,9 @@ port_channel_interfaces:
       session_tracker: ST2
     l2_mtu: 8000
     l2_mru: 8000
+    ip_verify:
+      unicast_source:
+        reachable_via: rx
     eos_cli: |
       comment
       Comment created from eos_cli under port_channel_interfaces.Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -23,9 +23,7 @@ port_channel_interfaces:
       session_tracker: ST2
     l2_mtu: 8000
     l2_mru: 8000
-    ip_verify:
-      unicast_source:
-        reachable_via: rx
+    ip_verify_unicast_source_reachable_via: rx
     eos_cli: |
       comment
       Comment created from eos_cli under port_channel_interfaces.Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -16,6 +16,9 @@ vlan_interfaces:
     ip_address_virtual: 10.2.2.1/24
     no_autostate: true
     isis_enable: "EVPN_UNDERLAY"
+    ip_verify:
+      unicast_source:
+        reachable_via: rx
 
   - name: Vlan81
     description: IPv6 Virtual Address

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -16,9 +16,7 @@ vlan_interfaces:
     ip_address_virtual: 10.2.2.1/24
     no_autostate: true
     isis_enable: "EVPN_UNDERLAY"
-    ip_verify:
-      unicast_source:
-        reachable_via: rx
+    ip_verify_unicast_source_reachable_via: rx
 
   - name: Vlan81
     description: IPv6 Virtual Address

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -78,9 +78,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask or "dhcp" |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_secondaries</samp>](## "ethernet_interfaces.[].ip_address_secondaries") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "ethernet_interfaces.[].ip_address_secondaries.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify</samp>](## "ethernet_interfaces.[].ip_verify") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unicast_source</samp>](## "ethernet_interfaces.[].ip_verify.unicast_source") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reachable_via</samp>](## "ethernet_interfaces.[].ip_verify.unicast_source.reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify_unicast_source_reachable_via</samp>](## "ethernet_interfaces.[].ip_verify_unicast_source_reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "ethernet_interfaces.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Install default-route obtained via DHCP |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv4</samp>](## "ethernet_interfaces.[].dhcp_server_ipv4") | Boolean |  |  |  | Enable IPv4 DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv6</samp>](## "ethernet_interfaces.[].dhcp_server_ipv6") | Boolean |  |  |  | Enable IPv6 DHCP server. |
@@ -505,9 +503,7 @@
         ip_address: <str>
         ip_address_secondaries:
           - <str>
-        ip_verify:
-          unicast_source:
-            reachable_via: <str; "any" | "rx">
+        ip_verify_unicast_source_reachable_via: <str; "any" | "rx">
 
         # Install default-route obtained via DHCP
         dhcp_client_accept_default_route: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -78,6 +78,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask or "dhcp" |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_secondaries</samp>](## "ethernet_interfaces.[].ip_address_secondaries") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "ethernet_interfaces.[].ip_address_secondaries.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify</samp>](## "ethernet_interfaces.[].ip_verify") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unicast_source</samp>](## "ethernet_interfaces.[].ip_verify.unicast_source") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reachable_via</samp>](## "ethernet_interfaces.[].ip_verify.unicast_source.reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "ethernet_interfaces.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Install default-route obtained via DHCP |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv4</samp>](## "ethernet_interfaces.[].dhcp_server_ipv4") | Boolean |  |  |  | Enable IPv4 DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv6</samp>](## "ethernet_interfaces.[].dhcp_server_ipv6") | Boolean |  |  |  | Enable IPv6 DHCP server. |
@@ -502,6 +505,9 @@
         ip_address: <str>
         ip_address_secondaries:
           - <str>
+        ip_verify:
+          unicast_source:
+            reachable_via: <str; "any" | "rx">
 
         # Install default-route obtained via DHCP
         dhcp_client_accept_default_route: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -140,9 +140,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].ptp.vlan") | String |  |  |  | VLAN can be 'all' or list of vlans as string |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "port_channel_interfaces.[].ptp.transport") | String |  |  | Valid Values:<br>- <code>ipv4</code><br>- <code>ipv6</code><br>- <code>layer2</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "port_channel_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify</samp>](## "port_channel_interfaces.[].ip_verify") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unicast_source</samp>](## "port_channel_interfaces.[].ip_verify.unicast_source") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reachable_via</samp>](## "port_channel_interfaces.[].ip_verify.unicast_source.reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify_unicast_source_reachable_via</samp>](## "port_channel_interfaces.[].ip_verify_unicast_source_reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_nat</samp>](## "port_channel_interfaces.[].ip_nat") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "port_channel_interfaces.[].ip_nat.destination") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic</samp>](## "port_channel_interfaces.[].ip_nat.destination.dynamic") | List, items: Dictionary |  |  |  |  |
@@ -478,9 +476,7 @@
 
         # IPv4 address/mask
         ip_address: <str>
-        ip_verify:
-          unicast_source:
-            reachable_via: <str; "any" | "rx">
+        ip_verify_unicast_source_reachable_via: <str; "any" | "rx">
         ip_nat:
           destination:
             dynamic:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -140,6 +140,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].ptp.vlan") | String |  |  |  | VLAN can be 'all' or list of vlans as string |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "port_channel_interfaces.[].ptp.transport") | String |  |  | Valid Values:<br>- <code>ipv4</code><br>- <code>ipv6</code><br>- <code>layer2</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "port_channel_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify</samp>](## "port_channel_interfaces.[].ip_verify") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unicast_source</samp>](## "port_channel_interfaces.[].ip_verify.unicast_source") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reachable_via</samp>](## "port_channel_interfaces.[].ip_verify.unicast_source.reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_nat</samp>](## "port_channel_interfaces.[].ip_nat") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "port_channel_interfaces.[].ip_nat.destination") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic</samp>](## "port_channel_interfaces.[].ip_nat.destination.dynamic") | List, items: Dictionary |  |  |  |  |
@@ -475,6 +478,9 @@
 
         # IPv4 address/mask
         ip_address: <str>
+        ip_verify:
+          unicast_source:
+            reachable_via: <str; "any" | "rx">
         ip_nat:
           destination:
             dynamic:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -26,9 +26,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_virtual</samp>](## "vlan_interfaces.[].ip_address_virtual") | String |  |  |  | IPv4_address/Mask |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_virtual_secondaries</samp>](## "vlan_interfaces.[].ip_address_virtual_secondaries") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "vlan_interfaces.[].ip_address_virtual_secondaries.[]") | String |  |  |  | IPv4_address/Mask |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify</samp>](## "vlan_interfaces.[].ip_verify") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unicast_source</samp>](## "vlan_interfaces.[].ip_verify.unicast_source") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reachable_via</samp>](## "vlan_interfaces.[].ip_verify.unicast_source.reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify_unicast_source_reachable_via</samp>](## "vlan_interfaces.[].ip_verify_unicast_source_reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp</samp>](## "vlan_interfaces.[].ip_igmp") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_version</samp>](## "vlan_interfaces.[].ip_igmp_version") | Integer |  |  | Min: 1<br>Max: 3 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "vlan_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  | List of DHCP servers |
@@ -218,9 +216,7 @@
 
             # IPv4_address/Mask
           - <str>
-        ip_verify:
-          unicast_source:
-            reachable_via: <str; "any" | "rx">
+        ip_verify_unicast_source_reachable_via: <str; "any" | "rx">
         ip_igmp: <bool>
         ip_igmp_version: <int; 1-3>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -26,6 +26,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_virtual</samp>](## "vlan_interfaces.[].ip_address_virtual") | String |  |  |  | IPv4_address/Mask |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_virtual_secondaries</samp>](## "vlan_interfaces.[].ip_address_virtual_secondaries") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "vlan_interfaces.[].ip_address_virtual_secondaries.[]") | String |  |  |  | IPv4_address/Mask |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify</samp>](## "vlan_interfaces.[].ip_verify") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unicast_source</samp>](## "vlan_interfaces.[].ip_verify.unicast_source") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reachable_via</samp>](## "vlan_interfaces.[].ip_verify.unicast_source.reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp</samp>](## "vlan_interfaces.[].ip_igmp") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_version</samp>](## "vlan_interfaces.[].ip_igmp_version") | Integer |  |  | Min: 1<br>Max: 3 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "vlan_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  | List of DHCP servers |
@@ -215,6 +218,9 @@
 
             # IPv4_address/Mask
           - <str>
+        ip_verify:
+          unicast_source:
+            reachable_via: <str; "any" | "rx">
         ip_igmp: <bool>
         ip_igmp_version: <int; 1-3>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2882,33 +2882,13 @@
             },
             "title": "IP Address Secondaries"
           },
-          "ip_verify": {
-            "type": "object",
-            "properties": {
-              "unicast_source": {
-                "type": "object",
-                "properties": {
-                  "reachable_via": {
-                    "type": "string",
-                    "enum": [
-                      "any",
-                      "rx"
-                    ],
-                    "title": "Reachable Via"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "Unicast Source"
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {
-              "^_.+$": {}
-            },
-            "title": "IP Verify"
+          "ip_verify_unicast_source_reachable_via": {
+            "type": "string",
+            "enum": [
+              "any",
+              "rx"
+            ],
+            "title": "IP Verify Unicast Source Reachable Via"
           },
           "dhcp_client_accept_default_route": {
             "type": "boolean",
@@ -12802,33 +12782,13 @@
             "description": "IPv4 address/mask",
             "title": "IP Address"
           },
-          "ip_verify": {
-            "type": "object",
-            "properties": {
-              "unicast_source": {
-                "type": "object",
-                "properties": {
-                  "reachable_via": {
-                    "type": "string",
-                    "enum": [
-                      "any",
-                      "rx"
-                    ],
-                    "title": "Reachable Via"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "Unicast Source"
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {
-              "^_.+$": {}
-            },
-            "title": "IP Verify"
+          "ip_verify_unicast_source_reachable_via": {
+            "type": "string",
+            "enum": [
+              "any",
+              "rx"
+            ],
+            "title": "IP Verify Unicast Source Reachable Via"
           },
           "ip_nat": {
             "type": "object",
@@ -24863,33 +24823,13 @@
             },
             "title": "IP Address Virtual Secondaries"
           },
-          "ip_verify": {
-            "type": "object",
-            "properties": {
-              "unicast_source": {
-                "type": "object",
-                "properties": {
-                  "reachable_via": {
-                    "type": "string",
-                    "enum": [
-                      "any",
-                      "rx"
-                    ],
-                    "title": "Reachable Via"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "Unicast Source"
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {
-              "^_.+$": {}
-            },
-            "title": "IP Verify"
+          "ip_verify_unicast_source_reachable_via": {
+            "type": "string",
+            "enum": [
+              "any",
+              "rx"
+            ],
+            "title": "IP Verify Unicast Source Reachable Via"
           },
           "ip_igmp": {
             "type": "boolean",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2882,6 +2882,34 @@
             },
             "title": "IP Address Secondaries"
           },
+          "ip_verify": {
+            "type": "object",
+            "properties": {
+              "unicast_source": {
+                "type": "object",
+                "properties": {
+                  "reachable_via": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "rx"
+                    ],
+                    "title": "Reachable Via"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Unicast Source"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "IP Verify"
+          },
           "dhcp_client_accept_default_route": {
             "type": "boolean",
             "description": "Install default-route obtained via DHCP",
@@ -12773,6 +12801,34 @@
             "type": "string",
             "description": "IPv4 address/mask",
             "title": "IP Address"
+          },
+          "ip_verify": {
+            "type": "object",
+            "properties": {
+              "unicast_source": {
+                "type": "object",
+                "properties": {
+                  "reachable_via": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "rx"
+                    ],
+                    "title": "Reachable Via"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Unicast Source"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "IP Verify"
           },
           "ip_nat": {
             "type": "object",
@@ -24806,6 +24862,34 @@
               "description": "IPv4_address/Mask"
             },
             "title": "IP Address Virtual Secondaries"
+          },
+          "ip_verify": {
+            "type": "object",
+            "properties": {
+              "unicast_source": {
+                "type": "object",
+                "properties": {
+                  "reachable_via": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "rx"
+                    ],
+                    "title": "Reachable Via"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Unicast Source"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "IP Verify"
           },
           "ip_igmp": {
             "type": "boolean",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1974,6 +1974,17 @@ keys:
           type: list
           items:
             type: str
+        ip_verify:
+          type: dict
+          keys:
+            unicast_source:
+              type: dict
+              keys:
+                reachable_via:
+                  type: str
+                  valid_values:
+                  - any
+                  - rx
         dhcp_client_accept_default_route:
           type: bool
           description: Install default-route obtained via DHCP
@@ -7600,6 +7611,17 @@ keys:
         ip_address:
           type: str
           description: IPv4 address/mask
+        ip_verify:
+          type: dict
+          keys:
+            unicast_source:
+              type: dict
+              keys:
+                reachable_via:
+                  type: str
+                  valid_values:
+                  - any
+                  - rx
         ip_nat:
           type: dict
           $ref: eos_cli_config_gen#/$defs/interface_ip_nat
@@ -14388,6 +14410,17 @@ keys:
           items:
             type: str
             description: IPv4_address/Mask
+        ip_verify:
+          type: dict
+          keys:
+            unicast_source:
+              type: dict
+              keys:
+                reachable_via:
+                  type: str
+                  valid_values:
+                  - any
+                  - rx
         ip_igmp:
           type: bool
         ip_igmp_version:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1974,17 +1974,11 @@ keys:
           type: list
           items:
             type: str
-        ip_verify:
-          type: dict
-          keys:
-            unicast_source:
-              type: dict
-              keys:
-                reachable_via:
-                  type: str
-                  valid_values:
-                  - any
-                  - rx
+        ip_verify_unicast_source_reachable_via:
+          type: str
+          valid_values:
+          - any
+          - rx
         dhcp_client_accept_default_route:
           type: bool
           description: Install default-route obtained via DHCP
@@ -7611,17 +7605,11 @@ keys:
         ip_address:
           type: str
           description: IPv4 address/mask
-        ip_verify:
-          type: dict
-          keys:
-            unicast_source:
-              type: dict
-              keys:
-                reachable_via:
-                  type: str
-                  valid_values:
-                  - any
-                  - rx
+        ip_verify_unicast_source_reachable_via:
+          type: str
+          valid_values:
+          - any
+          - rx
         ip_nat:
           type: dict
           $ref: eos_cli_config_gen#/$defs/interface_ip_nat
@@ -14410,17 +14398,11 @@ keys:
           items:
             type: str
             description: IPv4_address/Mask
-        ip_verify:
-          type: dict
-          keys:
-            unicast_source:
-              type: dict
-              keys:
-                reachable_via:
-                  type: str
-                  valid_values:
-                  - any
-                  - rx
+        ip_verify_unicast_source_reachable_via:
+          type: str
+          valid_values:
+          - any
+          - rx
         ip_igmp:
           type: bool
         ip_igmp_version:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -276,6 +276,17 @@ keys:
           type: list
           items:
             type: str
+        ip_verify:
+          type: dict
+          keys:
+            unicast_source:
+              type: dict
+              keys:
+                reachable_via:
+                  type: str
+                  valid_values:
+                    - any
+                    - rx
         dhcp_client_accept_default_route:
           type: bool
           description: Install default-route obtained via DHCP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -276,17 +276,11 @@ keys:
           type: list
           items:
             type: str
-        ip_verify:
-          type: dict
-          keys:
-            unicast_source:
-              type: dict
-              keys:
-                reachable_via:
-                  type: str
-                  valid_values:
-                    - any
-                    - rx
+        ip_verify_unicast_source_reachable_via:
+          type: str
+          valid_values:
+            - any
+            - rx
         dhcp_client_accept_default_route:
           type: bool
           description: Install default-route obtained via DHCP

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -580,6 +580,17 @@ keys:
         ip_address:
           type: str
           description: IPv4 address/mask
+        ip_verify:
+          type: dict
+          keys:
+            unicast_source:
+              type: dict
+              keys:
+                reachable_via:
+                  type: str
+                  valid_values:
+                    - any
+                    - rx
         ip_nat:
           type: dict
           $ref: "eos_cli_config_gen#/$defs/interface_ip_nat"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -580,17 +580,11 @@ keys:
         ip_address:
           type: str
           description: IPv4 address/mask
-        ip_verify:
-          type: dict
-          keys:
-            unicast_source:
-              type: dict
-              keys:
-                reachable_via:
-                  type: str
-                  valid_values:
-                    - any
-                    - rx
+        ip_verify_unicast_source_reachable_via:
+          type: str
+          valid_values:
+            - any
+            - rx
         ip_nat:
           type: dict
           $ref: "eos_cli_config_gen#/$defs/interface_ip_nat"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -68,6 +68,17 @@ keys:
           items:
             type: str
             description: IPv4_address/Mask
+        ip_verify:
+          type: dict
+          keys:
+            unicast_source:
+              type: dict
+              keys:
+                reachable_via:
+                  type: str
+                  valid_values:
+                    - any
+                    - rx
         ip_igmp:
           type: bool
         ip_igmp_version:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -68,17 +68,11 @@ keys:
           items:
             type: str
             description: IPv4_address/Mask
-        ip_verify:
-          type: dict
-          keys:
-            unicast_source:
-              type: dict
-              keys:
-                reachable_via:
-                  type: str
-                  valid_values:
-                    - any
-                    - rx
+        ip_verify_unicast_source_reachable_via:
+          type: str
+          valid_values:
+            - any
+            - rx
         ip_igmp:
           type: bool
         ip_igmp_version:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -341,6 +341,13 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.ip_address is arista.avd.defined("dhcp") and ethernet_interface.dhcp_client_accept_default_route is arista.avd.defined(true) %}
    dhcp client accept default-route
 {%     endif %}
+{%     if ethernet_interface.ip_verify is arista.avd.defined %}
+{%         if ethernet_interface.ip_verify.unicast_source is arista.avd.defined %}
+{%             if ethernet_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
+   ip verify unicast source reachable-via {{ ethernet_interface.ip_verify.unicast_source.reachable_via }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
 {%     if ethernet_interface.bfd.interval is arista.avd.defined and
           ethernet_interface.bfd.min_rx is arista.avd.defined and
           ethernet_interface.bfd.multiplier is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -341,8 +341,8 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.ip_address is arista.avd.defined("dhcp") and ethernet_interface.dhcp_client_accept_default_route is arista.avd.defined(true) %}
    dhcp client accept default-route
 {%     endif %}
-{%     if ethernet_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
-   ip verify unicast source reachable-via {{ ethernet_interface.ip_verify.unicast_source.reachable_via }}
+{%     if ethernet_interface.ip_verify_unicast_source_reachable_via is arista.avd.defined %}
+   ip verify unicast source reachable-via {{ ethernet_interface.ip_verify_unicast_source_reachable_via }}
 {%     endif %}
 {%     if ethernet_interface.bfd.interval is arista.avd.defined and
           ethernet_interface.bfd.min_rx is arista.avd.defined and

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -341,12 +341,8 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.ip_address is arista.avd.defined("dhcp") and ethernet_interface.dhcp_client_accept_default_route is arista.avd.defined(true) %}
    dhcp client accept default-route
 {%     endif %}
-{%     if ethernet_interface.ip_verify is arista.avd.defined %}
-{%         if ethernet_interface.ip_verify.unicast_source is arista.avd.defined %}
-{%             if ethernet_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
+{%     if ethernet_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
    ip verify unicast source reachable-via {{ ethernet_interface.ip_verify.unicast_source.reachable_via }}
-{%             endif %}
-{%         endif %}
 {%     endif %}
 {%     if ethernet_interface.bfd.interval is arista.avd.defined and
           ethernet_interface.bfd.min_rx is arista.avd.defined and

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -226,8 +226,8 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.ip_address is arista.avd.defined %}
    ip address {{ port_channel_interface.ip_address }}
 {%     endif %}
-{%     if port_channel_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
-   ip verify unicast source reachable-via {{ port_channel_interface.ip_verify.unicast_source.reachable_via }}
+{%     if port_channel_interface.ip_verify_unicast_source_reachable_via is arista.avd.defined %}
+   ip verify unicast source reachable-via {{ port_channel_interface.ip_verify_unicast_source_reachable_via }}
 {%     endif %}
 {%     if port_channel_interface.ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -226,6 +226,13 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.ip_address is arista.avd.defined %}
    ip address {{ port_channel_interface.ip_address }}
 {%     endif %}
+{%     if port_channel_interface.ip_verify is arista.avd.defined %}
+{%         if port_channel_interface.ip_verify.unicast_source is arista.avd.defined %}
+{%             if port_channel_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
+   ip verify unicast source reachable-via {{ port_channel_interface.ip_verify.unicast_source.reachable_via }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
 {%     if port_channel_interface.ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -226,12 +226,8 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.ip_address is arista.avd.defined %}
    ip address {{ port_channel_interface.ip_address }}
 {%     endif %}
-{%     if port_channel_interface.ip_verify is arista.avd.defined %}
-{%         if port_channel_interface.ip_verify.unicast_source is arista.avd.defined %}
-{%             if port_channel_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
+{%     if port_channel_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
    ip verify unicast source reachable-via {{ port_channel_interface.ip_verify.unicast_source.reachable_via }}
-{%             endif %}
-{%         endif %}
 {%     endif %}
 {%     if port_channel_interface.ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -39,9 +39,6 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
 {%     endif %}
-{%     if vlan_interface.ip_directed_broadcast is arista.avd.defined(true) %}
-   ip directed-broadcast
-{%     endif %}
 {%     if vlan_interface.ip_address is arista.avd.defined %}
    ip address {{ vlan_interface.ip_address }}
 {%         if vlan_interface.ip_address_secondaries is arista.avd.defined %}
@@ -49,6 +46,16 @@ interface {{ vlan_interface.name }}
    ip address {{ ip_address_secondary }} secondary
 {%             endfor %}
 {%         endif %}
+{%     endif %}
+{%     if vlan_interface.ip_verify is arista.avd.defined %}
+{%         if vlan_interface.ip_verify.unicast_source is arista.avd.defined %}
+{%             if vlan_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
+   ip verify unicast source reachable-via {{ vlan_interface.ip_verify.unicast_source.reachable_via }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
+{%     if vlan_interface.ip_directed_broadcast is arista.avd.defined(true) %}
+   ip directed-broadcast
 {%     endif %}
 {%     for ip_helper in vlan_interface.ip_helpers | arista.avd.natural_sort('ip_helper') %}
 {%         set ip_helper_cli = "ip helper-address " ~ ip_helper.ip_helper %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -39,6 +39,9 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
 {%     endif %}
+{%     if vlan_interface.ip_directed_broadcast is arista.avd.defined(true) %}
+   ip directed-broadcast
+{%     endif %}
 {%     if vlan_interface.ip_address is arista.avd.defined %}
    ip address {{ vlan_interface.ip_address }}
 {%         if vlan_interface.ip_address_secondaries is arista.avd.defined %}
@@ -47,11 +50,8 @@ interface {{ vlan_interface.name }}
 {%             endfor %}
 {%         endif %}
 {%     endif %}
-{%     if vlan_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
-   ip verify unicast source reachable-via {{ vlan_interface.ip_verify.unicast_source.reachable_via }}
-{%     endif %}
-{%     if vlan_interface.ip_directed_broadcast is arista.avd.defined(true) %}
-   ip directed-broadcast
+{%     if vlan_interface.ip_verify_unicast_source_reachable_via is arista.avd.defined %}
+   ip verify unicast source reachable-via {{ vlan_interface.ip_verify_unicast_source_reachable_via }}
 {%     endif %}
 {%     for ip_helper in vlan_interface.ip_helpers | arista.avd.natural_sort('ip_helper') %}
 {%         set ip_helper_cli = "ip helper-address " ~ ip_helper.ip_helper %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -47,12 +47,8 @@ interface {{ vlan_interface.name }}
 {%             endfor %}
 {%         endif %}
 {%     endif %}
-{%     if vlan_interface.ip_verify is arista.avd.defined %}
-{%         if vlan_interface.ip_verify.unicast_source is arista.avd.defined %}
-{%             if vlan_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
+{%     if vlan_interface.ip_verify.unicast_source.reachable_via is arista.avd.defined %}
    ip verify unicast source reachable-via {{ vlan_interface.ip_verify.unicast_source.reachable_via }}
-{%             endif %}
-{%         endif %}
 {%     endif %}
 {%     if vlan_interface.ip_directed_broadcast is arista.avd.defined(true) %}
    ip directed-broadcast

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5962,6 +5962,34 @@
                 },
                 "title": "IP Address Secondaries"
               },
+              "ip_verify": {
+                "type": "object",
+                "properties": {
+                  "unicast_source": {
+                    "type": "object",
+                    "properties": {
+                      "reachable_via": {
+                        "type": "string",
+                        "enum": [
+                          "any",
+                          "rx"
+                        ],
+                        "title": "Reachable Via"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Unicast Source"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP Verify"
+              },
               "dhcp_client_accept_default_route": {
                 "type": "boolean",
                 "description": "Install default-route obtained via DHCP",
@@ -10156,6 +10184,34 @@
                     "description": "IPv4 address/mask",
                     "title": "IP Address"
                   },
+                  "ip_verify": {
+                    "type": "object",
+                    "properties": {
+                      "unicast_source": {
+                        "type": "object",
+                        "properties": {
+                          "reachable_via": {
+                            "type": "string",
+                            "enum": [
+                              "any",
+                              "rx"
+                            ],
+                            "title": "Reachable Via"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unicast Source"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "IP Verify"
+                  },
                   "ip_nat": {
                     "type": "object",
                     "properties": {
@@ -11172,6 +11228,34 @@
                   "type": "string"
                 },
                 "title": "IP Address Secondaries"
+              },
+              "ip_verify": {
+                "type": "object",
+                "properties": {
+                  "unicast_source": {
+                    "type": "object",
+                    "properties": {
+                      "reachable_via": {
+                        "type": "string",
+                        "enum": [
+                          "any",
+                          "rx"
+                        ],
+                        "title": "Reachable Via"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Unicast Source"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP Verify"
               },
               "dhcp_client_accept_default_route": {
                 "type": "boolean",
@@ -16169,6 +16253,34 @@
                     "description": "IPv4 address/mask",
                     "title": "IP Address"
                   },
+                  "ip_verify": {
+                    "type": "object",
+                    "properties": {
+                      "unicast_source": {
+                        "type": "object",
+                        "properties": {
+                          "reachable_via": {
+                            "type": "string",
+                            "enum": [
+                              "any",
+                              "rx"
+                            ],
+                            "title": "Reachable Via"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Unicast Source"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "IP Verify"
+                  },
                   "ip_nat": {
                     "type": "object",
                     "properties": {
@@ -17185,6 +17297,34 @@
                   "type": "string"
                 },
                 "title": "IP Address Secondaries"
+              },
+              "ip_verify": {
+                "type": "object",
+                "properties": {
+                  "unicast_source": {
+                    "type": "object",
+                    "properties": {
+                      "reachable_via": {
+                        "type": "string",
+                        "enum": [
+                          "any",
+                          "rx"
+                        ],
+                        "title": "Reachable Via"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Unicast Source"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP Verify"
               },
               "dhcp_client_accept_default_route": {
                 "type": "boolean",
@@ -20755,6 +20895,34 @@
                       },
                       "title": "IP Address Virtual Secondaries"
                     },
+                    "ip_verify": {
+                      "type": "object",
+                      "properties": {
+                        "unicast_source": {
+                          "type": "object",
+                          "properties": {
+                            "reachable_via": {
+                              "type": "string",
+                              "enum": [
+                                "any",
+                                "rx"
+                              ],
+                              "title": "Reachable Via"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Unicast Source"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "IP Verify"
+                    },
                     "ip_igmp": {
                       "type": "boolean",
                       "title": "IP IGMP"
@@ -22391,6 +22559,34 @@
                   "description": "IPv4_address/Mask"
                 },
                 "title": "IP Address Virtual Secondaries"
+              },
+              "ip_verify": {
+                "type": "object",
+                "properties": {
+                  "unicast_source": {
+                    "type": "object",
+                    "properties": {
+                      "reachable_via": {
+                        "type": "string",
+                        "enum": [
+                          "any",
+                          "rx"
+                        ],
+                        "title": "Reachable Via"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Unicast Source"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP Verify"
               },
               "ip_igmp": {
                 "type": "boolean",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5962,33 +5962,13 @@
                 },
                 "title": "IP Address Secondaries"
               },
-              "ip_verify": {
-                "type": "object",
-                "properties": {
-                  "unicast_source": {
-                    "type": "object",
-                    "properties": {
-                      "reachable_via": {
-                        "type": "string",
-                        "enum": [
-                          "any",
-                          "rx"
-                        ],
-                        "title": "Reachable Via"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^_.+$": {}
-                    },
-                    "title": "Unicast Source"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "IP Verify"
+              "ip_verify_unicast_source_reachable_via": {
+                "type": "string",
+                "enum": [
+                  "any",
+                  "rx"
+                ],
+                "title": "IP Verify Unicast Source Reachable Via"
               },
               "dhcp_client_accept_default_route": {
                 "type": "boolean",
@@ -10184,33 +10164,13 @@
                     "description": "IPv4 address/mask",
                     "title": "IP Address"
                   },
-                  "ip_verify": {
-                    "type": "object",
-                    "properties": {
-                      "unicast_source": {
-                        "type": "object",
-                        "properties": {
-                          "reachable_via": {
-                            "type": "string",
-                            "enum": [
-                              "any",
-                              "rx"
-                            ],
-                            "title": "Reachable Via"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "patternProperties": {
-                          "^_.+$": {}
-                        },
-                        "title": "Unicast Source"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^_.+$": {}
-                    },
-                    "title": "IP Verify"
+                  "ip_verify_unicast_source_reachable_via": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "rx"
+                    ],
+                    "title": "IP Verify Unicast Source Reachable Via"
                   },
                   "ip_nat": {
                     "type": "object",
@@ -11229,33 +11189,13 @@
                 },
                 "title": "IP Address Secondaries"
               },
-              "ip_verify": {
-                "type": "object",
-                "properties": {
-                  "unicast_source": {
-                    "type": "object",
-                    "properties": {
-                      "reachable_via": {
-                        "type": "string",
-                        "enum": [
-                          "any",
-                          "rx"
-                        ],
-                        "title": "Reachable Via"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^_.+$": {}
-                    },
-                    "title": "Unicast Source"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "IP Verify"
+              "ip_verify_unicast_source_reachable_via": {
+                "type": "string",
+                "enum": [
+                  "any",
+                  "rx"
+                ],
+                "title": "IP Verify Unicast Source Reachable Via"
               },
               "dhcp_client_accept_default_route": {
                 "type": "boolean",
@@ -16253,33 +16193,13 @@
                     "description": "IPv4 address/mask",
                     "title": "IP Address"
                   },
-                  "ip_verify": {
-                    "type": "object",
-                    "properties": {
-                      "unicast_source": {
-                        "type": "object",
-                        "properties": {
-                          "reachable_via": {
-                            "type": "string",
-                            "enum": [
-                              "any",
-                              "rx"
-                            ],
-                            "title": "Reachable Via"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "patternProperties": {
-                          "^_.+$": {}
-                        },
-                        "title": "Unicast Source"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^_.+$": {}
-                    },
-                    "title": "IP Verify"
+                  "ip_verify_unicast_source_reachable_via": {
+                    "type": "string",
+                    "enum": [
+                      "any",
+                      "rx"
+                    ],
+                    "title": "IP Verify Unicast Source Reachable Via"
                   },
                   "ip_nat": {
                     "type": "object",
@@ -17298,33 +17218,13 @@
                 },
                 "title": "IP Address Secondaries"
               },
-              "ip_verify": {
-                "type": "object",
-                "properties": {
-                  "unicast_source": {
-                    "type": "object",
-                    "properties": {
-                      "reachable_via": {
-                        "type": "string",
-                        "enum": [
-                          "any",
-                          "rx"
-                        ],
-                        "title": "Reachable Via"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^_.+$": {}
-                    },
-                    "title": "Unicast Source"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "IP Verify"
+              "ip_verify_unicast_source_reachable_via": {
+                "type": "string",
+                "enum": [
+                  "any",
+                  "rx"
+                ],
+                "title": "IP Verify Unicast Source Reachable Via"
               },
               "dhcp_client_accept_default_route": {
                 "type": "boolean",
@@ -20895,33 +20795,13 @@
                       },
                       "title": "IP Address Virtual Secondaries"
                     },
-                    "ip_verify": {
-                      "type": "object",
-                      "properties": {
-                        "unicast_source": {
-                          "type": "object",
-                          "properties": {
-                            "reachable_via": {
-                              "type": "string",
-                              "enum": [
-                                "any",
-                                "rx"
-                              ],
-                              "title": "Reachable Via"
-                            }
-                          },
-                          "additionalProperties": false,
-                          "patternProperties": {
-                            "^_.+$": {}
-                          },
-                          "title": "Unicast Source"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {
-                        "^_.+$": {}
-                      },
-                      "title": "IP Verify"
+                    "ip_verify_unicast_source_reachable_via": {
+                      "type": "string",
+                      "enum": [
+                        "any",
+                        "rx"
+                      ],
+                      "title": "IP Verify Unicast Source Reachable Via"
                     },
                     "ip_igmp": {
                       "type": "boolean",
@@ -22560,33 +22440,13 @@
                 },
                 "title": "IP Address Virtual Secondaries"
               },
-              "ip_verify": {
-                "type": "object",
-                "properties": {
-                  "unicast_source": {
-                    "type": "object",
-                    "properties": {
-                      "reachable_via": {
-                        "type": "string",
-                        "enum": [
-                          "any",
-                          "rx"
-                        ],
-                        "title": "Reachable Via"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^_.+$": {}
-                    },
-                    "title": "Unicast Source"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "IP Verify"
+              "ip_verify_unicast_source_reachable_via": {
+                "type": "string",
+                "enum": [
+                  "any",
+                  "rx"
+                ],
+                "title": "IP Verify Unicast Source Reachable Via"
               },
               "ip_igmp": {
                 "type": "boolean",


### PR DESCRIPTION

## Change Summary

Add ip verify unicast source to ethernet-, vlan- and port-channel interfaces

## Related Issue(s)

Fixes #2880


## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### User Checklist

- [x] Verify the ordering on EOS switch

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
