### PR TITLE
Fix(eos_validate_state): ANTA Fix bug when skipping specific tests of AvdTestBGP

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/catalog.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/catalog.py
@@ -3,6 +3,7 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Mapping
 
 from yaml import Dumper, dump, safe_load
@@ -27,6 +28,8 @@ except ImportError:
 
 if TYPE_CHECKING:
     from .avdtestbase import AvdTestBase
+
+LOGGER = logging.getLogger(__name__)
 
 
 class Catalog:
@@ -112,6 +115,8 @@ class Catalog:
             # Check if the whole class is to be skipped
             class_skip_config = get_item(self.skipped_tests, "category", avd_test_class.__name__)
             if class_skip_config is not None and not class_skip_config.get("tests"):
+                msg = f"Skipping all tests of {avd_test_class.__name__} per the `skipped_tests` input variable."
+                LOGGER.info(msg)
                 continue
 
             # Initialize the test class
@@ -120,8 +125,11 @@ class Catalog:
 
             # Remove the individual tests that are to be skipped
             if class_skip_config is not None and (avd_test_class_skipped_tests := class_skip_config.get("tests")) is not None:
+                msg = f"Skipping the following tests of {avd_test_class.__name__} per the `skipped_tests` input variable: "
+                msg += ", ".join(avd_test_class_skipped_tests)
+                LOGGER.info(msg)
                 for anta_tests in generated_tests.values():
-                    anta_tests[:] = [test for test in anta_tests if list(test.keys())[0] not in avd_test_class_skipped_tests]
+                    anta_tests[:] = [test for test in anta_tests if next(iter(test.keys())) not in avd_test_class_skipped_tests]
 
             default_catalog = self.merge_catalogs(default_catalog, generated_tests)
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestrouting.py
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/python_modules/tests/avdtestrouting.py
@@ -90,7 +90,7 @@ class AvdTestBGP(AvdTestBase):
             if safi:
                 address_family["safi"] = safi
 
-            anta_tests.setdefault("bgp", []).append(
+            anta_tests.setdefault(f"{self.anta_module}.bgp", []).append(
                 {
                     "VerifyBGPSpecificPeers": {
                         "address_families": [address_family],
@@ -102,7 +102,7 @@ class AvdTestBGP(AvdTestBase):
         if self.logged_get(key="router_bgp") is None or not self.validate_data(service_routing_protocols_model="multi-agent", logging_level="WARNING"):
             return None
 
-        anta_tests.setdefault("generic", []).append(
+        anta_tests.setdefault(f"{self.anta_module}.generic", []).append(
             {
                 "VerifyRoutingProtocolModel": {
                     "model": "multi-agent",
@@ -134,4 +134,4 @@ class AvdTestBGP(AvdTestBase):
             elif neighbor_peer_group["type"] == "evpn":
                 add_test(description="bgp evpn peer state established (evpn)", afi="evpn", bgp_neighbor_ip=str(bgp_neighbor["ip_address"]))
 
-        return {self.anta_module: anta_tests} if anta_tests.get("bgp") else None
+        return anta_tests if anta_tests.get(f"{self.anta_module}.bgp") else None


### PR DESCRIPTION
## Change Summary

Fix bug when skipping specific tests of AvdTestBGP.

## Related Issue(s)

Fixes #3497 

## Component(s) name

`arista.avd.eos_validate_state` **ANTA**

## Proposed changes
- Change the `test_definition` of `AvdTestBGP` to return a proper dictionary with ANTA module as keys and list of ANTA tests as values (like the other tests)
- Add logging for skipped tests

## How to test

Run validate state in ANTA mode with the following input variable:
```yaml
skipped_tests:
  - category: AvdTestBGP
    tests:
      - VerifyRoutingProtocolModel
```
OR
```yaml
skipped_tests:
  - category: AvdTestBGP
    tests:
      - VerifyBGPSpecificPeers
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
