### PR TITLE
Fix(eos_cli_config_gen): Various fixes for router path-selection & application-traffic-recognition

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
@@ -47,8 +47,8 @@ interface Management1
 
 | Name | Source Prefix | Destination Prefix | Protocols | Protocol Ranges | TCP Source Port Set | TCP Destination Port Set | UDP Source Port Set | UDP Destination Port Set |
 | ---- | ------------- | ------------------ | --------- | --------------- | ------------------- | ------------------------ | ------------------- | ------------------------ |
-| empty-application | - | - |  |  | - | - | - | - |
-| empty-protocols | - | - |  | 21 | - | - | - | - |
+| empty-application | - | - | - | - | - | - | - | - |
+| empty-protocols | - | - | - | 21 | - | - | - | - |
 | user_defined_app1 | src_prefix_set1 | dest_prefix_set1 | udp, tcp | 25 | src_port_set1 | dest_port_set1 | src_port_set2 | dest_port_set2 |
 | user_defined_app2 | src_prefix_set2 | dest_prefix_set2 | pim, icmp, tcp | 21, 7-11 | - | - | - | - |
 
@@ -92,7 +92,7 @@ interface Management1
 | ---- | ----- |
 | dest_port_set1 | 2300-2350 |
 | dest_port_set2 | 3300-3350 |
-| empty-l4-ports |  |
+| empty-l4-ports | - |
 | ordering-test | 101-103, 650, 666 |
 | src_port_set1 | 2400-2500, 2900-3000 |
 | src_port_set2 | 5700-5800, 6500-6600 |
@@ -103,8 +103,8 @@ interface Management1
 | ---- | -------- |
 | dest_prefix_set1 | 2.3.4.0/24 |
 | dest_prefix_set2 | 4.4.4.0/24 |
-| empty-ipv4-prefixes |  |
-| order-test | 6.6.6.6/32<br>192.168.42.0/24<br>192.168.43.0/24 |
+| empty-ipv4-prefixes | - |
+| order-test | 192.168.42.0/24<br>192.168.43.0/24<br>6.6.6.6/32 |
 | src_prefix_set1 | 1.2.3.0/24<br>1.2.5.0/24 |
 | src_prefix_set2 | 2.2.2.0/24<br>3.3.3.0/24 |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
@@ -47,6 +47,8 @@ interface Management1
 
 | Name | Source Prefix | Destination Prefix | Protocols | Protocol Ranges | TCP Source Port Set | TCP Destination Port Set | UDP Source Port Set | UDP Destination Port Set |
 | ---- | ------------- | ------------------ | --------- | --------------- | ------------------- | ------------------------ | ------------------- | ------------------------ |
+| empty-application | - | - |  |  | - | - | - | - |
+| empty-protocols | - | - |  | 21 | - | - | - | - |
 | user_defined_app1 | src_prefix_set1 | dest_prefix_set1 | udp, tcp | 25 | src_port_set1 | dest_port_set1 | src_port_set2 | dest_port_set2 |
 | user_defined_app2 | src_prefix_set2 | dest_prefix_set2 | pim, icmp, tcp | 21, 7-11 | - | - | - | - |
 
@@ -90,6 +92,7 @@ interface Management1
 | ---- | ----- |
 | dest_port_set1 | 2300-2350 |
 | dest_port_set2 | 3300-3350 |
+| empty-l4-ports |  |
 | src_port_set1 | 2400-2500, 2900-3000 |
 | src_port_set2 | 5700-5800, 6500-6600 |
 
@@ -99,6 +102,7 @@ interface Management1
 | ---- | -------- |
 | dest_prefix_set1 | 2.3.4.0/24 |
 | dest_prefix_set2 | 4.4.4.0/24 |
+| empty-ipv4-prefixes |  |
 | src_prefix_set1 | 1.2.3.0/24<br>1.2.5.0/24 |
 | src_prefix_set2 | 2.2.2.0/24<br>3.3.3.0/24 |
 
@@ -107,6 +111,11 @@ interface Management1
 ```eos
 !
 application traffic recognition
+   !
+   application ipv4 empty-application
+   !
+   application ipv4 empty-protocols
+      protocol 21
    !
    application ipv4 user_defined_app1
       source prefix field-set src_prefix_set1
@@ -156,6 +165,8 @@ application traffic recognition
    field-set ipv4 prefix dest_prefix_set2
       4.4.4.0/24
    !
+   field-set ipv4 prefix empty-ipv4-prefixes
+   !
    field-set ipv4 prefix src_prefix_set1
       1.2.3.0/24 1.2.5.0/24
    !
@@ -167,6 +178,8 @@ application traffic recognition
    !
    field-set l4-port dest_port_set2
       3300-3350
+   !
+   field-set l4-port empty-l4-ports
    !
    field-set l4-port src_port_set1
       2400-2500, 2900-3000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
@@ -93,6 +93,7 @@ interface Management1
 | dest_port_set1 | 2300-2350 |
 | dest_port_set2 | 3300-3350 |
 | empty-l4-ports |  |
+| ordering-test | 101-103, 650, 666 |
 | src_port_set1 | 2400-2500, 2900-3000 |
 | src_port_set2 | 5700-5800, 6500-6600 |
 
@@ -103,6 +104,7 @@ interface Management1
 | dest_prefix_set1 | 2.3.4.0/24 |
 | dest_prefix_set2 | 4.4.4.0/24 |
 | empty-ipv4-prefixes |  |
+| order-test | 6.6.6.6/32<br>192.168.42.0/24<br>192.168.43.0/24 |
 | src_prefix_set1 | 1.2.3.0/24<br>1.2.5.0/24 |
 | src_prefix_set2 | 2.2.2.0/24<br>3.3.3.0/24 |
 
@@ -167,6 +169,9 @@ application traffic recognition
    !
    field-set ipv4 prefix empty-ipv4-prefixes
    !
+   field-set ipv4 prefix order-test
+      192.168.42.0/24 192.168.43.0/24 6.6.6.6/32
+   !
    field-set ipv4 prefix src_prefix_set1
       1.2.3.0/24 1.2.5.0/24
    !
@@ -180,6 +185,9 @@ application traffic recognition
       3300-3350
    !
    field-set l4-port empty-l4-ports
+   !
+   field-set l4-port ordering-test
+      101-103, 650, 666
    !
    field-set l4-port src_port_set1
       2400-2500, 2900-3000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-path-selection.md
@@ -114,6 +114,7 @@ interface Management1
 
 | Policy Name | Jitter (ms) | Latency (ms) | Loss Rate (%) | Path Groups (priority) | Lowest Hop Count |
 | ----------- | ----------- | ------------ | ------------- | ---------------------- | ---------------- |
+| LB-EMPTY | - | - | - |  | False |
 | LB-P-1 | - | - | 17 | PG-5 (1)<br>PG-2 (42)<br>PG-4 (42)<br>PG-3 (666) | True |
 | LB-P-2 | 666 | 42 | 42.42 | PG-1 (1)<br>PG-3 (1) | False |
 
@@ -200,6 +201,8 @@ router path-selection
    path-group PG-3 id 888
    !
    path-group PG-4
+   !
+   load-balance policy LB-EMPTY
    !
    load-balance policy LB-P-1
       hop count lowest

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
@@ -14,6 +14,11 @@ interface Management1
 !
 application traffic recognition
    !
+   application ipv4 empty-application
+   !
+   application ipv4 empty-protocols
+      protocol 21
+   !
    application ipv4 user_defined_app1
       source prefix field-set src_prefix_set1
       destination prefix field-set dest_prefix_set1
@@ -62,6 +67,8 @@ application traffic recognition
    field-set ipv4 prefix dest_prefix_set2
       4.4.4.0/24
    !
+   field-set ipv4 prefix empty-ipv4-prefixes
+   !
    field-set ipv4 prefix src_prefix_set1
       1.2.3.0/24 1.2.5.0/24
    !
@@ -73,6 +80,8 @@ application traffic recognition
    !
    field-set l4-port dest_port_set2
       3300-3350
+   !
+   field-set l4-port empty-l4-ports
    !
    field-set l4-port src_port_set1
       2400-2500, 2900-3000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
@@ -69,6 +69,9 @@ application traffic recognition
    !
    field-set ipv4 prefix empty-ipv4-prefixes
    !
+   field-set ipv4 prefix order-test
+      192.168.42.0/24 192.168.43.0/24 6.6.6.6/32
+   !
    field-set ipv4 prefix src_prefix_set1
       1.2.3.0/24 1.2.5.0/24
    !
@@ -82,6 +85,9 @@ application traffic recognition
       3300-3350
    !
    field-set l4-port empty-l4-ports
+   !
+   field-set l4-port ordering-test
+      101-103, 650, 666
    !
    field-set l4-port src_port_set1
       2400-2500, 2900-3000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-path-selection.cfg
@@ -54,6 +54,8 @@ router path-selection
    !
    path-group PG-4
    !
+   load-balance policy LB-EMPTY
+   !
    load-balance policy LB-P-1
       hop count lowest
       loss-rate 17

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
@@ -34,6 +34,11 @@ application_traffic_recognition:
       - name: dest_port_set2
         port_values:
           - 3300-3350
+      - name: ordering-test
+        port_values:
+          - 666
+          - 101-103
+          - 650
       - name: empty-l4-ports
     ipv4_prefixes:
       - name: src_prefix_set1
@@ -50,6 +55,11 @@ application_traffic_recognition:
       - name: dest_prefix_set2
         prefix_values:
           - 4.4.4.0/24
+      - name: order-test
+        prefix_values:
+          - 192.168.42.0/24
+          - 6.6.6.6/32
+          - 192.168.43.0/24
       - name: empty-ipv4-prefixes
   applications:
     ipv4_applications:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
@@ -34,6 +34,7 @@ application_traffic_recognition:
       - name: dest_port_set2
         port_values:
           - 3300-3350
+      - name: empty-l4-ports
     ipv4_prefixes:
       - name: src_prefix_set1
         prefix_values:
@@ -49,8 +50,13 @@ application_traffic_recognition:
       - name: dest_prefix_set2
         prefix_values:
           - 4.4.4.0/24
+      - name: empty-ipv4-prefixes
   applications:
     ipv4_applications:
+      - name: empty-application
+      - name: empty-protocols
+        protocol_ranges:
+          - "21"
       - name: user_defined_app2
         protocols:
           - pim

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-path-selection.yml
@@ -91,6 +91,7 @@ router_path_selection:
           priority: 42
         - name: PG-2
           priority: 42
+    - name: LB-EMPTY
   policies:
     # Out of order to test sorting
     - name: DPS-P-2

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/application-traffic-recognition.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/application-traffic-recognition.j2
@@ -23,8 +23,8 @@
 {%                 set tcp_dest_port = application.tcp_dest_port_set_name | arista.avd.default("-") %}
 {%                 set udp_src_port = application.udp_src_port_set_name | arista.avd.default("-") %}
 {%                 set udp_dest_port = application.udp_dest_port_set_name | arista.avd.default("-") %}
-{%                 set protocol_ranges = ", ".join(application.protocol_ranges) | arista.avd.default("-") %}
-{%                 set protocol = ", ".join(application.protocols) | arista.avd.default("-") %}
+{%                 set protocol_ranges = ", ".join(application.protocol_ranges | arista.avd.default([])) | arista.avd.default("-") %}
+{%                 set protocol = ", ".join(application.protocols | arista.avd.default([])) | arista.avd.default("-") %}
 | {{ application.name }} | {{ src_prefix }} | {{ dest_prefix }} | {{ protocol }} | {{ protocol_ranges }} | {{ tcp_src_port }} | {{ tcp_dest_port }} | {{ udp_src_port }} | {{ udp_dest_port }} |
 {%             endfor %}
 {%         endif %}
@@ -79,8 +79,7 @@
 | Name | Ports |
 | ---- | ----- |
 {%             for port_set in application_traffic_recognition.field_sets.l4_ports | arista.avd.natural_sort('name') %}
-{%                 do port_set.port_values.sort() %}
-| {{ port_set.name }} | {{ port_set.port_values | arista.avd.default([]) | join(', ') }} |
+| {{ port_set.name }} | {{ port_set.port_values | arista.avd.natural_sort | join(', ') }} |
 {%             endfor %}
 {%         endif %}
 {%         if application_traffic_recognition.field_sets.ipv4_prefixes is arista.avd.defined %}
@@ -90,8 +89,7 @@
 | Name | Prefixes |
 | ---- | -------- |
 {%             for prefix_set in application_traffic_recognition.field_sets.ipv4_prefixes | arista.avd.natural_sort('name') %}
-{%                 do prefix_set.prefix_values.sort() %}
-| {{ prefix_set.name }} | {{ prefix_set.prefix_values | arista.avd.default([]) | join('<br>') }} |
+| {{ prefix_set.name }} | {{ prefix_set.prefix_values | arista.avd.natural_sort | join('<br>') }} |
 {%             endfor %}
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/application-traffic-recognition.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/application-traffic-recognition.j2
@@ -23,8 +23,8 @@
 {%                 set tcp_dest_port = application.tcp_dest_port_set_name | arista.avd.default("-") %}
 {%                 set udp_src_port = application.udp_src_port_set_name | arista.avd.default("-") %}
 {%                 set udp_dest_port = application.udp_dest_port_set_name | arista.avd.default("-") %}
-{%                 set protocol_ranges = ", ".join(application.protocol_ranges | arista.avd.default([])) | arista.avd.default("-") %}
-{%                 set protocol = ", ".join(application.protocols | arista.avd.default([])) | arista.avd.default("-") %}
+{%                 set protocol_ranges = ", ".join(application.protocol_ranges | arista.avd.default(["-"])) %}
+{%                 set protocol = ", ".join(application.protocols | arista.avd.default(["-"])) %}
 | {{ application.name }} | {{ src_prefix }} | {{ dest_prefix }} | {{ protocol }} | {{ protocol_ranges }} | {{ tcp_src_port }} | {{ tcp_dest_port }} | {{ udp_src_port }} | {{ udp_dest_port }} |
 {%             endfor %}
 {%         endif %}
@@ -79,7 +79,7 @@
 | Name | Ports |
 | ---- | ----- |
 {%             for port_set in application_traffic_recognition.field_sets.l4_ports | arista.avd.natural_sort('name') %}
-| {{ port_set.name }} | {{ port_set.port_values | arista.avd.natural_sort | join(', ') }} |
+| {{ port_set.name }} | {{ port_set.port_values | arista.avd.default(["-"]) | arista.avd.natural_sort | join(', ') }} |
 {%             endfor %}
 {%         endif %}
 {%         if application_traffic_recognition.field_sets.ipv4_prefixes is arista.avd.defined %}
@@ -89,7 +89,7 @@
 | Name | Prefixes |
 | ---- | -------- |
 {%             for prefix_set in application_traffic_recognition.field_sets.ipv4_prefixes | arista.avd.natural_sort('name') %}
-| {{ prefix_set.name }} | {{ prefix_set.prefix_values | arista.avd.natural_sort | join('<br>') }} |
+| {{ prefix_set.name }} | {{ prefix_set.prefix_values | arista.avd.default(["-"]) | sort | join('<br>') }} |
 {%             endfor %}
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-path-selection.j2
@@ -85,11 +85,7 @@
 {%             set latency = load_balance_policy.latency | arista.avd.default("-") %}
 {%             set loss_rate = load_balance_policy.loss_rate | arista.avd.default("-") %}
 {%             set path_groups_list = [] %}
-{# TODO remove inplace update once Ansible 2.13 is dropped and use groupby default instead #}
-{%             for path_group in load_balance_policy.path_groups | arista.avd.default([]) %}
-{%                 do path_group.update({"_priority": path_group.priority | arista.avd.default(1)}) %}
-{%             endfor %}
-{%             for priority, entries in load_balance_policy.path_groups | groupby("_priority") %}
+{%             for priority, entries in load_balance_policy.path_groups | arista.avd.default([]) | groupby("priority", default=1) %}
 {%                 for entry in entries | arista.avd.natural_sort("name") %}
 {%                     do path_groups_list.append(entry.name ~ " (" ~ priority ~ ")") %}
 {%                 endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/application-traffic-recognition.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/application-traffic-recognition.j2
@@ -78,18 +78,20 @@ application traffic recognition
 {%     if application_traffic_recognition.field_sets is arista.avd.defined %}
 {%         for prefix_set in application_traffic_recognition.field_sets.ipv4_prefixes | arista.avd.natural_sort('name') %}
 {%             if prefix_set.name is arista.avd.defined %}
-{%                 do prefix_set.prefix_values.sort() %}
    !
    field-set ipv4 prefix {{ prefix_set.name }}
-      {{ prefix_set.prefix_values | join(" ") }}
+{%                 if prefix_set.prefix_values is arista.avd.defined %}
+      {{ prefix_set.prefix_values | arista.avd.natural_sort | join(" ") }}
+{%                 endif %}
 {%             endif %}
 {%         endfor %}
 {%         for port_set in application_traffic_recognition.field_sets.l4_ports | arista.avd.natural_sort('name') %}
 {%             if port_set.name is arista.avd.defined %}
-{%                 do port_set.port_values.sort() %}
    !
    field-set l4-port {{ port_set.name }}
-      {{ port_set.port_values | join(", ") }}
+{%                 if port_set.port_values is arista.avd.defined %}
+      {{ port_set.port_values | arista.avd.natural_sort | join(", ") }}
+{%                 endif %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/application-traffic-recognition.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/application-traffic-recognition.j2
@@ -81,7 +81,7 @@ application traffic recognition
    !
    field-set ipv4 prefix {{ prefix_set.name }}
 {%                 if prefix_set.prefix_values is arista.avd.defined %}
-      {{ prefix_set.prefix_values | arista.avd.natural_sort | join(" ") }}
+      {{ prefix_set.prefix_values | arista.avd.default([]) | sort | join(" ") }}
 {%                 endif %}
 {%             endif %}
 {%         endfor %}


### PR DESCRIPTION
## Change Summary

Some fixes in Jinja2 templates for empty lists that were overlooked

## Related Issue(s)

Discovered while testing trailblazer

## Component(s) name

`arista.avd.eos_cli_config_gen`

## How to test

molecule tests

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
