### PR TITLE
Fix(eos_cli_config_gen): Reordering router adaptive-virtual-topology / router path-selection

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -17,64 +17,6 @@ service routing protocols model multi-agent
 !
 hostname cv-pathfinder-edge
 !
-router path-selection
-   !
-   path-group INET id 101
-      ipsec profile CP-PROFILE
-      !
-      local interface Ethernet1
-         stun server-profile INET-cv-pathfinder-pathfinder-Ethernet1 INET-cv-pathfinder-pathfinder-Ethernet3
-      !
-      peer dynamic
-      !
-      peer static router-ip 192.168.44.1
-         name cv-pathfinder-pathfinder
-         ipv4 address 10.7.7.7
-         ipv4 address 10.9.9.9
-   !
-   path-group LTE id 102
-      ipsec profile CP-PROFILE
-      !
-      local interface Ethernet3
-      !
-      peer dynamic
-   !
-   path-group MPLS id 100
-      !
-      local interface Ethernet2
-         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
-      !
-      peer dynamic
-      !
-      peer static router-ip 192.168.44.1
-         name cv-pathfinder-pathfinder
-         ipv4 address 172.16.0.1
-   !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-      path-group MPLS
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 42
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
-      path-group INET
-      path-group MPLS
-   !
-   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VIDEO
-      path-group LTE
-      path-group MPLS
-      path-group INET priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VOICE
-      path-group MPLS
-      path-group INET priority 2
-!
 router adaptive-virtual-topology
    topology role edge
    region AVD_Land_East id 43
@@ -145,6 +87,64 @@ router adaptive-virtual-topology
       avt profile PROD-AVT-POLICY-DEFAULT id 1
       avt profile PROD-AVT-POLICY-VOICE id 2
       avt profile PROD-AVT-POLICY-VIDEO id 4
+!
+router path-selection
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+         stun server-profile INET-cv-pathfinder-pathfinder-Ethernet1 INET-cv-pathfinder-pathfinder-Ethernet3
+      !
+      peer dynamic
+      !
+      peer static router-ip 192.168.44.1
+         name cv-pathfinder-pathfinder
+         ipv4 address 10.7.7.7
+         ipv4 address 10.9.9.9
+   !
+   path-group LTE id 102
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet3
+      !
+      peer dynamic
+   !
+   path-group MPLS id 100
+      !
+      local interface Ethernet2
+         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+      !
+      peer dynamic
+      !
+      peer static router-ip 192.168.44.1
+         name cv-pathfinder-pathfinder
+         ipv4 address 172.16.0.1
+   !
+   load-balance policy LB-CONTROL-PLANE-PROFILE
+      path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 42
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      path-group LTE
+      path-group MPLS
+      path-group INET priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VOICE
+      path-group MPLS
+      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -17,54 +17,6 @@ service routing protocols model multi-agent
 !
 hostname cv-pathfinder-pathfinder
 !
-router path-selection
-   peer dynamic source stun
-   !
-   path-group INET id 101
-      ipsec profile CP-PROFILE
-      !
-      local interface Ethernet1
-      !
-      local interface Ethernet3
-   !
-   path-group MPLS id 100
-      !
-      local interface Ethernet2
-   !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-      path-group MPLS
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group Equinix
-      path-group INET
-      path-group MPLS priority 42
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
-      path-group INET
-      path-group MPLS
-   !
-   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VIDEO
-      path-group LTE
-      path-group MPLS
-      path-group INET priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VOICE
-      path-group MPLS
-      path-group INET priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
-      path-group MPLS
-      path-group INET priority 2
-!
 router adaptive-virtual-topology
    topology role pathfinder
    !
@@ -151,6 +103,54 @@ router adaptive-virtual-topology
       avt policy TRANSIT-AVT-POLICY
       avt profile TRANSIT-AVT-POLICY-DEFAULT id 1
       avt profile TRANSIT-AVT-POLICY-VOICE id 42
+!
+router path-selection
+   peer dynamic source stun
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+      !
+      local interface Ethernet3
+   !
+   path-group MPLS id 100
+      !
+      local interface Ethernet2
+   !
+   load-balance policy LB-CONTROL-PLANE-PROFILE
+      path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
+      path-group Equinix
+      path-group INET
+      path-group MPLS priority 42
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      path-group LTE
+      path-group MPLS
+      path-group INET priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VOICE
+      path-group MPLS
+      path-group INET priority 2
+   !
+   load-balance policy LB-TRANSIT-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
+      path-group MPLS
+      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -17,55 +17,6 @@ service routing protocols model multi-agent
 !
 hostname cv-pathfinder-pathfinder1
 !
-router path-selection
-   peer dynamic source stun
-   !
-   path-group INET id 101
-      ipsec profile CP-PROFILE
-      !
-      local interface Ethernet1
-      !
-      peer static router-ip 6.6.6.6
-         name cv-pathfinder-pathfinder3
-         ipv4 address 10.50.50.50
-      !
-      peer static router-ip 192.168.44.3
-         name cv-pathfinder-pathfinder2
-         ipv4 address 10.9.9.9
-   !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group Equinix
-      path-group INET
-      path-group MPLS priority 42
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
-      path-group INET
-      path-group MPLS
-   !
-   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VIDEO
-      path-group LTE
-      path-group MPLS
-      path-group INET priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VOICE
-      path-group MPLS
-      path-group INET priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
-      path-group MPLS
-      path-group INET priority 2
-!
 router adaptive-virtual-topology
    topology role pathfinder
    !
@@ -152,6 +103,55 @@ router adaptive-virtual-topology
       avt policy TRANSIT-AVT-POLICY
       avt profile TRANSIT-AVT-POLICY-DEFAULT id 1
       avt profile TRANSIT-AVT-POLICY-VOICE id 42
+!
+router path-selection
+   peer dynamic source stun
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+      !
+      peer static router-ip 6.6.6.6
+         name cv-pathfinder-pathfinder3
+         ipv4 address 10.50.50.50
+      !
+      peer static router-ip 192.168.44.3
+         name cv-pathfinder-pathfinder2
+         ipv4 address 10.9.9.9
+   !
+   load-balance policy LB-CONTROL-PLANE-PROFILE
+      path-group INET
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
+      path-group Equinix
+      path-group INET
+      path-group MPLS priority 42
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      path-group LTE
+      path-group MPLS
+      path-group INET priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VOICE
+      path-group MPLS
+      path-group INET priority 2
+   !
+   load-balance policy LB-TRANSIT-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
+      path-group MPLS
+      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -17,64 +17,6 @@ service routing protocols model multi-agent
 !
 hostname cv-pathfinder-pathfinder2
 !
-router path-selection
-   peer dynamic source stun
-   !
-   path-group INET id 101
-      ipsec profile CP-PROFILE
-      !
-      local interface Ethernet1
-      !
-      peer static router-ip 6.6.6.6
-         name cv-pathfinder-pathfinder3
-         ipv4 address 10.50.50.50
-      !
-      peer static router-ip 192.168.44.2
-         name cv-pathfinder-pathfinder1
-         ipv4 address 10.8.8.8
-   !
-   path-group MPLS id 100
-      !
-      local interface Ethernet2
-      !
-      peer static router-ip 6.6.6.6
-         name cv-pathfinder-pathfinder3
-         ipv4 address 172.17.17.17
-   !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-      path-group MPLS
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group Equinix
-      path-group INET
-      path-group MPLS priority 42
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
-      path-group INET
-      path-group MPLS
-   !
-   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VIDEO
-      path-group LTE
-      path-group MPLS
-      path-group INET priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VOICE
-      path-group MPLS
-      path-group INET priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
-      path-group MPLS
-      path-group INET priority 2
-!
 router adaptive-virtual-topology
    topology role pathfinder
    !
@@ -161,6 +103,64 @@ router adaptive-virtual-topology
       avt policy TRANSIT-AVT-POLICY
       avt profile TRANSIT-AVT-POLICY-DEFAULT id 1
       avt profile TRANSIT-AVT-POLICY-VOICE id 42
+!
+router path-selection
+   peer dynamic source stun
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+      !
+      peer static router-ip 6.6.6.6
+         name cv-pathfinder-pathfinder3
+         ipv4 address 10.50.50.50
+      !
+      peer static router-ip 192.168.44.2
+         name cv-pathfinder-pathfinder1
+         ipv4 address 10.8.8.8
+   !
+   path-group MPLS id 100
+      !
+      local interface Ethernet2
+      !
+      peer static router-ip 6.6.6.6
+         name cv-pathfinder-pathfinder3
+         ipv4 address 172.17.17.17
+   !
+   load-balance policy LB-CONTROL-PLANE-PROFILE
+      path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
+      path-group Equinix
+      path-group INET
+      path-group MPLS priority 42
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      path-group LTE
+      path-group MPLS
+      path-group INET priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VOICE
+      path-group MPLS
+      path-group INET priority 2
+   !
+   load-balance policy LB-TRANSIT-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
+      path-group MPLS
+      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
@@ -17,64 +17,6 @@ service routing protocols model multi-agent
 !
 hostname cv-pathfinder-transit
 !
-router path-selection
-   !
-   path-group INET id 101
-      ipsec profile CP-PROFILE
-      !
-      local interface Ethernet1
-         stun server-profile INET-cv-pathfinder-pathfinder-Ethernet1 INET-cv-pathfinder-pathfinder-Ethernet3
-      !
-      peer dynamic
-      !
-      peer static router-ip 192.168.44.1
-         name cv-pathfinder-pathfinder
-         ipv4 address 10.7.7.7
-         ipv4 address 10.9.9.9
-   !
-   path-group MPLS id 100
-      !
-      local interface Ethernet2
-         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
-      !
-      peer dynamic
-      !
-      peer static router-ip 192.168.44.1
-         name cv-pathfinder-pathfinder
-         ipv4 address 172.16.0.1
-   !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-      path-group MPLS
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 42
-   !
-   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
-      path-group INET
-      path-group MPLS
-   !
-   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VIDEO
-      path-group MPLS
-      path-group INET priority 2
-   !
-   load-balance policy LB-PROD-AVT-POLICY-VOICE
-      path-group MPLS
-      path-group INET priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-DEFAULT
-      path-group INET
-      path-group MPLS priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
-      path-group MPLS
-      path-group INET priority 2
-!
 router adaptive-virtual-topology
    topology role transit region
    region AVD_Land_West id 42
@@ -164,6 +106,64 @@ router adaptive-virtual-topology
       avt policy TRANSIT-AVT-POLICY
       avt profile TRANSIT-AVT-POLICY-DEFAULT id 1
       avt profile TRANSIT-AVT-POLICY-VOICE id 42
+!
+router path-selection
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+         stun server-profile INET-cv-pathfinder-pathfinder-Ethernet1 INET-cv-pathfinder-pathfinder-Ethernet3
+      !
+      peer dynamic
+      !
+      peer static router-ip 192.168.44.1
+         name cv-pathfinder-pathfinder
+         ipv4 address 10.7.7.7
+         ipv4 address 10.9.9.9
+   !
+   path-group MPLS id 100
+      !
+      local interface Ethernet2
+         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+      !
+      peer dynamic
+      !
+      peer static router-ip 192.168.44.1
+         name cv-pathfinder-pathfinder
+         ipv4 address 172.16.0.1
+   !
+   load-balance policy LB-CONTROL-PLANE-PROFILE
+      path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 42
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      path-group MPLS
+      path-group INET priority 2
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VOICE
+      path-group MPLS
+      path-group INET priority 2
+   !
+   load-balance policy LB-TRANSIT-AVT-POLICY-DEFAULT
+      path-group INET
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
+      path-group MPLS
+      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos-intended-config.j2
@@ -90,6 +90,10 @@
 {% include 'eos/domain-list.j2' %}
 {# Object Tracking #}
 {% include 'eos/trackers.j2' %}
+{# router adaptive-virtual-topology #}
+{% include 'eos/router-adaptive-virtual-topology.j2' %}
+{# router l2-vpn #}
+{% include 'eos/router-l2-vpn.j2' %}
 {# router path-selection #}
 {% include 'eos/router-path-selection.j2' %}
 {# ntp #}
@@ -102,10 +106,6 @@
 {% include 'eos/radius-servers.j2' %}
 {# radius server #}
 {% include 'eos/radius-server.j2' %}
-{# router adaptive-virtual-topology #}
-{% include 'eos/router-adaptive-virtual-topology.j2' %}
-{# router l2-vpn #}
-{% include 'eos/router-l2-vpn.j2' %}
 {# sflow #}
 {% include 'eos/sflow.j2' %}
 {# redundancy #}


### PR DESCRIPTION
## Change Summary

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

put `router adaptive-virtual-topology` and `router l2-vpn` before `router path-selection`

## How to test

Check things in CLI (EOS 4.31)

```
!
router adaptive-virtual-topology
   zone 42 id 42
!
router l2-vpn
   arp learning bridged
!
router path-selection
   peer dynamic source stun
   !
```

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
