### PR TITLE
Fix(eos_cli_config_gen): Print config for service_routing_protocols_model ribd

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/service-routing-protocols-model-2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/service-routing-protocols-model-2.md
@@ -1,0 +1,47 @@
+# service-routing-protocols-model-2
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Routing](#routing)
+  - [Service Routing Protocols Model](#service-routing-protocols-model)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | Description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## Routing
+
+### Service Routing Protocols Model
+
+Single agent routing protocol model enabled
+
+```eos
+!
+service routing protocols model ribd
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/service-routing-protocols-model-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/service-routing-protocols-model-2.cfg
@@ -1,0 +1,17 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model ribd
+!
+hostname service-routing-protocols-model-2
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/service-routing-protocols-model-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/service-routing-protocols-model-2.yml
@@ -1,0 +1,2 @@
+#### service-routing-protocols-model ####
+service_routing_protocols_model: ribd

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -141,6 +141,7 @@ router-service-insertion
 router-igmp
 service-routing-configuration-bgp
 service-routing-protocols-model
+service-routing-protocols-model-2
 router-general
 router-traffic-engineering
 sflow

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/service-routing-protocols-model.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/service-routing-protocols-model.j2
@@ -4,7 +4,7 @@
  that can be found in the LICENSE file.
 #}
 {# eos - service routing protocols model #}
-{% if service_routing_protocols_model is arista.avd.defined("multi-agent") %}
+{% if service_routing_protocols_model is arista.avd.defined %}
 !
-service routing protocols model multi-agent
+service routing protocols model {{ service_routing_protocols_model }}
 {% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Print config for service_routing_protocols_model ribd

## Related Issue(s)

Fixes #3507 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added test for ribd.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
