### PR TITLE
Feat(eos_cli_config_gen): Set BFD neighbor and per-link in port-channel interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -389,6 +389,8 @@ interface Port-Channel9
    ip address 10.9.2.3/31
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   bfd neighbor 10.1.2.4
+   bfd per-link rfc-7130
 !
 interface Port-Channel10
    description SRV01_bond0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bfd-1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bfd-1.md
@@ -64,6 +64,7 @@ interface Management1
 router bfd
    interval 900 min-rx 900 multiplier 50 default
    multihop interval 300 min-rx 300 multiplier 3
+   local-address 192.168.255.1
    session stats snapshot interval 51
    !
    sbfd

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -51,6 +51,8 @@ interface Port-Channel9
    ip address 10.9.2.3/31
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   bfd neighbor 10.1.2.4
+   bfd per-link rfc-7130
 !
 interface Port-Channel10
    description SRV01_bond0

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bfd-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bfd-1.cfg
@@ -15,6 +15,7 @@ interface Management1
 router bfd
    interval 900 min-rx 900 multiplier 50 default
    multihop interval 300 min-rx 300 multiplier 3
+   local-address 192.168.255.1
    session stats snapshot interval 51
    !
    sbfd

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -130,6 +130,9 @@ port_channel_interfaces:
       interval: 500
       min_rx: 500
       multiplier: 5
+      neighbor: 10.1.2.4
+      per_link:
+        rfc_7130: true
     spanning_tree_guard: root
 
   - name: Port-Channel20

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -132,6 +132,7 @@ port_channel_interfaces:
       multiplier: 5
       neighbor: 10.1.2.4
       per_link:
+        enabled: true
         rfc_7130: true
     spanning_tree_guard: root
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bfd-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bfd-1.yml
@@ -2,6 +2,7 @@
 
 router_bfd:
   interval: 900
+  local_address: 192.168.255.1
   min_rx: 900
   multiplier: 50
   multihop:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -62,7 +62,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "port_channel_interfaces.[].bfd.interval") | Integer |  |  |  | Interval in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "port_channel_interfaces.[].bfd.min_rx") | Integer |  |  |  | Rate in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "port_channel_interfaces.[].bfd.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor</samp>](## "port_channel_interfaces.[].bfd.neighbor") | String |  |  |  | IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor</samp>](## "port_channel_interfaces.[].bfd.neighbor") | String |  |  |  | IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address (router_bfd.local_address) has to be defined globally on the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;per_link</samp>](## "port_channel_interfaces.[].bfd.per_link") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "port_channel_interfaces.[].bfd.per_link.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rfc_7130</samp>](## "port_channel_interfaces.[].bfd.per_link.rfc_7130") | Boolean |  |  |  |  |
@@ -336,7 +336,7 @@
           min_rx: <int>
           multiplier: <int; 3-50>
 
-          # IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.
+          # IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address (router_bfd.local_address) has to be defined globally on the switch.
           neighbor: <str>
           per_link:
             enabled: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -62,6 +62,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "port_channel_interfaces.[].bfd.interval") | Integer |  |  |  | Interval in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "port_channel_interfaces.[].bfd.min_rx") | Integer |  |  |  | Rate in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "port_channel_interfaces.[].bfd.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor</samp>](## "port_channel_interfaces.[].bfd.neighbor") | String |  |  |  | IPv4 or IPv6 address |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;per_link</samp>](## "port_channel_interfaces.[].bfd.per_link") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rfc_7130</samp>](## "port_channel_interfaces.[].bfd.per_link.rfc_7130") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_policy</samp>](## "port_channel_interfaces.[].service_policy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pbr</samp>](## "port_channel_interfaces.[].service_policy.pbr") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;input</samp>](## "port_channel_interfaces.[].service_policy.pbr.input") | String |  |  |  | Policy Based Routing Policy-map name |
@@ -331,6 +334,11 @@
           # Rate in milliseconds
           min_rx: <int>
           multiplier: <int; 3-50>
+
+          # IPv4 or IPv6 address
+          neighbor: <str>
+          per_link:
+            rfc_7130: <bool>
         service_policy:
           pbr:
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -62,7 +62,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "port_channel_interfaces.[].bfd.interval") | Integer |  |  |  | Interval in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "port_channel_interfaces.[].bfd.min_rx") | Integer |  |  |  | Rate in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "port_channel_interfaces.[].bfd.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor</samp>](## "port_channel_interfaces.[].bfd.neighbor") | String |  |  |  | IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor</samp>](## "port_channel_interfaces.[].bfd.neighbor") | String |  |  |  | IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;per_link</samp>](## "port_channel_interfaces.[].bfd.per_link") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "port_channel_interfaces.[].bfd.per_link.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rfc_7130</samp>](## "port_channel_interfaces.[].bfd.per_link.rfc_7130") | Boolean |  |  |  |  |
@@ -336,7 +336,7 @@
           min_rx: <int>
           multiplier: <int; 3-50>
 
-          # IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.
+          # IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.
           neighbor: <str>
           per_link:
             enabled: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -62,7 +62,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "port_channel_interfaces.[].bfd.interval") | Integer |  |  |  | Interval in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min_rx</samp>](## "port_channel_interfaces.[].bfd.min_rx") | Integer |  |  |  | Rate in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "port_channel_interfaces.[].bfd.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor</samp>](## "port_channel_interfaces.[].bfd.neighbor") | String |  |  |  | IPv4 or IPv6 address |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor</samp>](## "port_channel_interfaces.[].bfd.neighbor") | String |  |  |  | IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;per_link</samp>](## "port_channel_interfaces.[].bfd.per_link") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "port_channel_interfaces.[].bfd.per_link.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rfc_7130</samp>](## "port_channel_interfaces.[].bfd.per_link.rfc_7130") | Boolean |  |  |  |  |
@@ -336,7 +336,7 @@
           min_rx: <int>
           multiplier: <int; 3-50>
 
-          # IPv4 or IPv6 address
+          # IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.
           neighbor: <str>
           per_link:
             enabled: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -64,6 +64,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiplier</samp>](## "port_channel_interfaces.[].bfd.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor</samp>](## "port_channel_interfaces.[].bfd.neighbor") | String |  |  |  | IPv4 or IPv6 address |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;per_link</samp>](## "port_channel_interfaces.[].bfd.per_link") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "port_channel_interfaces.[].bfd.per_link.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rfc_7130</samp>](## "port_channel_interfaces.[].bfd.per_link.rfc_7130") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;service_policy</samp>](## "port_channel_interfaces.[].service_policy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pbr</samp>](## "port_channel_interfaces.[].service_policy.pbr") | Dictionary |  |  |  |  |
@@ -338,6 +339,7 @@
           # IPv4 or IPv6 address
           neighbor: <str>
           per_link:
+            enabled: <bool>
             rfc_7130: <bool>
         service_policy:
           pbr:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bfd.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bfd.md
@@ -9,6 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>router_bfd</samp>](## "router_bfd") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;interval</samp>](## "router_bfd.interval") | Integer |  |  |  | Rate in milliseconds |
+    | [<samp>&nbsp;&nbsp;local_address</samp>](## "router_bfd.local_address") | String |  |  |  | Configure BFD local IP/IPv6 address |
     | [<samp>&nbsp;&nbsp;min_rx</samp>](## "router_bfd.min_rx") | Integer |  |  |  | Rate in milliseconds |
     | [<samp>&nbsp;&nbsp;multiplier</samp>](## "router_bfd.multiplier") | Integer |  |  | Min: 3<br>Max: 50 |  |
     | [<samp>&nbsp;&nbsp;multihop</samp>](## "router_bfd.multihop") | Dictionary |  |  |  |  |
@@ -37,6 +38,9 @@
 
       # Rate in milliseconds
       interval: <int>
+
+      # Configure BFD local IP/IPv6 address
+      local_address: <str>
 
       # Rate in milliseconds
       min_rx: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12236,6 +12236,10 @@
               "per_link": {
                 "type": "object",
                 "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                  },
                   "rfc_7130": {
                     "type": "boolean",
                     "title": "Rfc 7130"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12230,7 +12230,7 @@
               },
               "neighbor": {
                 "type": "string",
-                "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.",
+                "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address (router_bfd.local_address) has to be defined globally on the switch.",
                 "title": "Neighbor"
               },
               "per_link": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12227,6 +12227,25 @@
                 "minimum": 3,
                 "maximum": 50,
                 "title": "Multiplier"
+              },
+              "neighbor": {
+                "type": "string",
+                "description": "IPv4 or IPv6 address",
+                "title": "Neighbor"
+              },
+              "per_link": {
+                "type": "object",
+                "properties": {
+                  "rfc_7130": {
+                    "type": "boolean",
+                    "title": "Rfc 7130"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Per Link"
               }
             },
             "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12230,7 +12230,7 @@
               },
               "neighbor": {
                 "type": "string",
-                "description": "IPv4 or IPv6 address",
+                "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.",
                 "title": "Neighbor"
               },
               "per_link": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -12230,7 +12230,7 @@
               },
               "neighbor": {
                 "type": "string",
-                "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.",
+                "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.",
                 "title": "Neighbor"
               },
               "per_link": {
@@ -15130,6 +15130,11 @@
           "type": "integer",
           "description": "Rate in milliseconds",
           "title": "Interval"
+        },
+        "local_address": {
+          "type": "string",
+          "description": "Configure BFD local IP/IPv6 address",
+          "title": "Local Address"
         },
         "min_rx": {
           "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7257,7 +7257,8 @@ keys:
               max: 50
             neighbor:
               type: str
-              description: IPv4 or IPv6 address
+              description: IPv4 or IPv6 address. When the Port-channel is a L2 interface,
+                a local L3 BFD address has to be defined globally on the switch.
             per_link:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7255,6 +7255,14 @@ keys:
               - str
               min: 3
               max: 50
+            neighbor:
+              type: str
+              description: IPv4 or IPv6 address
+            per_link:
+              type: dict
+              keys:
+                rfc_7130:
+                  type: bool
         service_policy:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7258,7 +7258,7 @@ keys:
             neighbor:
               type: str
               description: IPv4 or IPv6 address. When the Port-channel is a L2 interface,
-                a local L3 BFD address `router_bfd.local_address` has to be defined
+                a local L3 BFD address (router_bfd.local_address) has to be defined
                 globally on the switch.
             per_link:
               type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7261,6 +7261,8 @@ keys:
             per_link:
               type: dict
               keys:
+                enabled:
+                  type: bool
                 rfc_7130:
                   type: bool
         service_policy:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7258,7 +7258,8 @@ keys:
             neighbor:
               type: str
               description: IPv4 or IPv6 address. When the Port-channel is a L2 interface,
-                a local L3 BFD address has to be defined globally on the switch.
+                a local L3 BFD address `router_bfd.local_address` has to be defined
+                globally on the switch.
             per_link:
               type: dict
               keys:
@@ -8971,6 +8972,9 @@ keys:
       interval:
         type: int
         description: Rate in milliseconds
+      local_address:
+        type: str
+        description: Configure BFD local IP/IPv6 address
       min_rx:
         type: int
         description: Rate in milliseconds

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -257,7 +257,7 @@ keys:
               max: 50
             neighbor:
               type: str
-              description: IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.
+              description: IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address (router_bfd.local_address) has to be defined globally on the switch.
             per_link:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -255,6 +255,14 @@ keys:
                 - str
               min: 3
               max: 50
+            neighbor:
+              type: str
+              description: IPv4 or IPv6 address
+            per_link:
+              type: dict
+              keys:
+                rfc_7130:
+                  type: bool
         service_policy:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -261,6 +261,8 @@ keys:
             per_link:
               type: dict
               keys:
+                enabled:
+                  type: bool
                 rfc_7130:
                   type: bool
         service_policy:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -257,7 +257,7 @@ keys:
               max: 50
             neighbor:
               type: str
-              description: IPv4 or IPv6 address
+              description: IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.
             per_link:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -257,7 +257,7 @@ keys:
               max: 50
             neighbor:
               type: str
-              description: IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.
+              description: IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.
             per_link:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bfd.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bfd.schema.yml
@@ -12,6 +12,9 @@ keys:
       interval:
         type: int
         description: Rate in milliseconds
+      local_address:
+        type: str
+        description: Configure BFD local IP/IPv6 address
       min_rx:
         type: int
         description: Rate in milliseconds

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -355,6 +355,14 @@ interface {{ port_channel_interface.name }}
 {%     elif port_channel_interface.bfd.echo is arista.avd.defined(false) %}
    no bfd echo
 {%     endif %}
+{%     if port_channel_interface.bfd.neighbor is arista.avd.defined %}
+   bfd neighbor {{ port_channel_interface.bfd.neighbor }}
+{%     endif %}
+{%     if port_channel_interface.bfd.per_link.rfc_7130 is arista.avd.defined(true) %}
+   bfd per-link rfc-7130
+{%     elif port_channel_interface.bfd.per_link.rfc_7130 is arista.avd.defined(false) %}
+   bfd per-link
+{%     endif %}
 {%     for link_tracking_group in port_channel_interface.link_tracking_groups | arista.avd.natural_sort('name') %}
 {%         if link_tracking_group.name is arista.avd.defined and link_tracking_group.direction is arista.avd.defined %}
    link tracking group {{ link_tracking_group.name }} {{ link_tracking_group.direction }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -358,10 +358,12 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.bfd.neighbor is arista.avd.defined %}
    bfd neighbor {{ port_channel_interface.bfd.neighbor }}
 {%     endif %}
-{%     if port_channel_interface.bfd.per_link.rfc_7130 is arista.avd.defined(true) %}
+{%     if port_channel_interface.bfd.per_link.enabled is arista.avd.defined(true) %}
+{%         if port_channel_interface.bfd.per_link.rfc_7130 is arista.avd.defined(true) %}
    bfd per-link rfc-7130
-{%     elif port_channel_interface.bfd.per_link.rfc_7130 is arista.avd.defined(false) %}
+{%         else %}
    bfd per-link
+{%         endif %}
 {%     endif %}
 {%     for link_tracking_group in port_channel_interface.link_tracking_groups | arista.avd.natural_sort('name') %}
 {%         if link_tracking_group.name is arista.avd.defined and link_tracking_group.direction is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bfd.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bfd.j2
@@ -13,6 +13,9 @@ router bfd
 {%     if router_bfd.multihop.interval is arista.avd.defined and router_bfd.multihop.min_rx is arista.avd.defined and router_bfd.multihop.multiplier is arista.avd.defined  %}
    multihop interval {{ router_bfd.multihop.interval }} min-rx {{ router_bfd.multihop.min_rx }} multiplier {{ router_bfd.multihop.multiplier }}
 {%     endif %}
+{%     if router_bfd.local_address is arista.avd.defined %}
+   local-address {{ router_bfd.local_address }}
+{%     endif %}
 {%     if router_bfd.session_snapshot_interval is arista.avd.defined and router_bfd.session_snapshot_interval < 10 and router_bfd.session_snapshot_interval_dangerous is arista.avd.defined(true, fail_action="error", var_name="router_bfd.session_snapshot_interval_dangerous") %}
    session stats snapshot interval dangerous {{ router_bfd.session_snapshot_interval }}
 {%     elif router_bfd.session_snapshot_interval is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9618,6 +9618,10 @@
                       "per_link": {
                         "type": "object",
                         "properties": {
+                          "enabled": {
+                            "type": "boolean",
+                            "title": "Enabled"
+                          },
                           "rfc_7130": {
                             "type": "boolean",
                             "title": "Rfc 7130"
@@ -15666,6 +15670,10 @@
                       "per_link": {
                         "type": "object",
                         "properties": {
+                          "enabled": {
+                            "type": "boolean",
+                            "title": "Enabled"
+                          },
                           "rfc_7130": {
                             "type": "boolean",
                             "title": "Rfc 7130"

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9612,7 +9612,7 @@
                       },
                       "neighbor": {
                         "type": "string",
-                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.",
+                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.",
                         "title": "Neighbor"
                       },
                       "per_link": {
@@ -15664,7 +15664,7 @@
                       },
                       "neighbor": {
                         "type": "string",
-                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.",
+                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.",
                         "title": "Neighbor"
                       },
                       "per_link": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9612,7 +9612,7 @@
                       },
                       "neighbor": {
                         "type": "string",
-                        "description": "IPv4 or IPv6 address",
+                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.",
                         "title": "Neighbor"
                       },
                       "per_link": {
@@ -15664,7 +15664,7 @@
                       },
                       "neighbor": {
                         "type": "string",
-                        "description": "IPv4 or IPv6 address",
+                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address has to be defined globally on the switch.",
                         "title": "Neighbor"
                       },
                       "per_link": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9612,7 +9612,7 @@
                       },
                       "neighbor": {
                         "type": "string",
-                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.",
+                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address (router_bfd.local_address) has to be defined globally on the switch.",
                         "title": "Neighbor"
                       },
                       "per_link": {
@@ -15664,7 +15664,7 @@
                       },
                       "neighbor": {
                         "type": "string",
-                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address `router_bfd.local_address` has to be defined globally on the switch.",
+                        "description": "IPv4 or IPv6 address. When the Port-channel is a L2 interface, a local L3 BFD address (router_bfd.local_address) has to be defined globally on the switch.",
                         "title": "Neighbor"
                       },
                       "per_link": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9609,6 +9609,25 @@
                         "minimum": 3,
                         "maximum": 50,
                         "title": "Multiplier"
+                      },
+                      "neighbor": {
+                        "type": "string",
+                        "description": "IPv4 or IPv6 address",
+                        "title": "Neighbor"
+                      },
+                      "per_link": {
+                        "type": "object",
+                        "properties": {
+                          "rfc_7130": {
+                            "type": "boolean",
+                            "title": "Rfc 7130"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Per Link"
                       }
                     },
                     "additionalProperties": false,
@@ -15638,6 +15657,25 @@
                         "minimum": 3,
                         "maximum": 50,
                         "title": "Multiplier"
+                      },
+                      "neighbor": {
+                        "type": "string",
+                        "description": "IPv4 or IPv6 address",
+                        "title": "Neighbor"
+                      },
+                      "per_link": {
+                        "type": "object",
+                        "properties": {
+                          "rfc_7130": {
+                            "type": "boolean",
+                            "title": "Rfc 7130"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Per Link"
                       }
                     },
                     "additionalProperties": false,


### PR DESCRIPTION
## Change Summary

Setting BFD neighbor and per-link in port-channel interfaces.
Setting local-address to router_bfd.

## Related Issue(s)

Fixes #3250 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### User Checklist

- [x] Verify the command ordering on EOS

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
