### PR TITLE
Fix(eos_designs): Do not KeyError when no path-group is in common with pathfinder

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -1,0 +1,275 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+flow tracking hardware
+   tracker WAN-FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 5000
+      exporter DPI-EXPORTER
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 5000
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname cv-pathfinder-edge-no-common-path-group
+!
+router adaptive-virtual-topology
+   topology role edge
+   region AVD_Land_East id 43
+   zone DEFAULT-ZONE id 1
+   site Site512 id 512
+   !
+   policy DEFAULT-AVT-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-AVT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-AVT-POLICY-DEFAULT
+   !
+   policy DEFAULT-AVT-POLICY-WITH-CP
+      !
+      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
+         avt profile CONTROL-PLANE-PROFILE
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-AVT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-AVT-POLICY-DEFAULT
+   !
+   policy PROD-AVT-POLICY
+      !
+      match application-profile VOICE
+         avt profile PROD-AVT-POLICY-VOICE
+      !
+      match application-profile VIDEO
+         avt profile PROD-AVT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile PROD-AVT-POLICY-DEFAULT
+   !
+   profile CONTROL-PLANE-PROFILE
+      path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   !
+   profile DEFAULT-AVT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
+   !
+   profile PROD-AVT-POLICY-DEFAULT
+      path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
+   !
+   profile PROD-AVT-POLICY-VIDEO
+      path-selection load-balance LB-PROD-AVT-POLICY-VIDEO
+   !
+   profile PROD-AVT-POLICY-VOICE
+      path-selection load-balance LB-PROD-AVT-POLICY-VOICE
+   !
+   vrf default
+      avt policy DEFAULT-AVT-POLICY-WITH-CP
+      avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-AVT-POLICY-VIDEO id 3
+      avt profile CONTROL-PLANE-PROFILE id 254
+   !
+   vrf IT
+      avt policy DEFAULT-AVT-POLICY
+      avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-AVT-POLICY-VIDEO id 3
+   !
+   vrf PROD
+      avt policy PROD-AVT-POLICY
+      avt profile PROD-AVT-POLICY-DEFAULT id 1
+      avt profile PROD-AVT-POLICY-VOICE id 2
+      avt profile PROD-AVT-POLICY-VIDEO id 4
+!
+router path-selection
+   !
+   path-group Satellite id 104
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+      !
+      peer dynamic
+   !
+   load-balance policy LB-CONTROL-PLANE-PROFILE
+      path-group Satellite
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+   !
+   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VIDEO
+   !
+   load-balance policy LB-PROD-AVT-POLICY-VOICE
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance IT
+!
+vrf instance MGMT
+!
+vrf instance PROD
+!
+ip security
+   !
+   ike policy DP-IKE-POLICY
+      local-id 192.168.42.6
+   !
+   ike policy CP-IKE-POLICY
+      local-id 192.168.42.6
+   !
+   sa policy DP-SA-POLICY
+      esp encryption aes128
+      pfs dh-group 14
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes128
+      pfs dh-group 14
+   !
+   profile DP-PROFILE
+      ike-policy DP-IKE-POLICY
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
+      dpd 10 50 clear
+      mode transport
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   key controller
+      profile DP-PROFILE
+!
+interface Dps1
+   description DPS Interface
+   flow tracker hardware WAN-FLOW-TRACKER
+   tcp mss ceiling ipv4 1000
+!
+interface Ethernet1
+   no shutdown
+   no switchport
+   flow tracker hardware WAN-FLOW-TRACKER
+   ip address dhcp
+   dhcp client accept default-route
+!
+interface Loopback0
+   description Router_ID
+   no shutdown
+   ip address 192.168.42.6/32
+!
+interface Vxlan1
+   description cv-pathfinder-edge-no-common-path-group_VTEP
+   vxlan source-interface Loopback0
+   vxlan udp-port 4789
+   vxlan vrf default vni 1
+   vxlan vrf IT vni 100
+   vxlan vrf PROD vni 42
+!
+application traffic recognition
+   !
+   application ipv4 CONTROL-PLANE-APPLICATION
+      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   !
+   application ipv4 CUSTOM-APPLICATION-1
+      source prefix field-set CUSTOM-SRC-PREFIX-1
+      destination prefix field-set CUSTOM-DEST-PREFIX-1
+      protocol tcp
+   !
+   application ipv4 CUSTOM-APPLICATION-2
+      protocol tcp source port field-set TCP-SRC-2 destination port field-set TCP-DEST-2
+   !
+   category VIDEO1
+      application CUSTOM-APPLICATION-2
+      application microsoft-teams
+   !
+   application-profile CONTROL-PLANE-APPLICATION-PROFILE
+      application CONTROL-PLANE-APPLICATION
+   !
+   application-profile VIDEO
+      application CUSTOM-APPLICATION-1
+      application skype
+      category VIDEO1
+   !
+   application-profile VOICE
+      application CUSTOM-VOICE-APPLICATION
+   !
+   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+      192.168.44.1/32
+   !
+   field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
+      6.6.6.0/24
+   !
+   field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
+      42.42.42.0/24
+   !
+   field-set l4-port TCP-DEST-2
+      666, 777
+   !
+   field-set l4-port TCP-SRC-2
+      42
+!
+ip routing
+ip routing vrf IT
+no ip routing vrf MGMT
+ip routing vrf PROD
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 192.168.42.6
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS update-source Loopback0
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.44.1 peer group WAN-OVERLAY-PEERS
+   neighbor 192.168.44.1 description cv-pathfinder-pathfinder
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      path-selection
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -1,8 +1,8 @@
-hostname: cv-pathfinder-pathfinder
+hostname: cv-pathfinder-edge-no-common-path-group
 is_deployed: true
 router_bgp:
   as: '65000'
-  router_id: 192.168.44.1
+  router_id: 192.168.42.6
   bgp:
     default:
       ipv4_unicast: false
@@ -11,14 +11,6 @@ router_bgp:
     ecmp: 4
   updates:
     wait_install: true
-  bgp_cluster_id: 192.168.44.1
-  listen_ranges:
-  - prefix: 192.168.42.0/24
-    peer_group: WAN-OVERLAY-PEERS
-    remote_as: '65000'
-  - prefix: 192.168.43.0/24
-    peer_group: WAN-OVERLAY-PEERS
-    remote_as: '65000'
   peer_groups:
   - name: WAN-OVERLAY-PEERS
     type: wan
@@ -28,13 +20,10 @@ router_bgp:
     send_community: all
     maximum_routes: 0
     remote_as: '65000'
-    route_reflector_client: true
   address_family_evpn:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    next_hop:
-      resolution_disabled: true
   address_family_ipv4:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
@@ -47,12 +36,9 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-      missing_policy:
-        direction_out_action: deny
     path_selection:
       roles:
-        consumer: true
-        propagator: true
+        producer: true
   address_family_path_selection:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
@@ -62,6 +48,11 @@ router_bgp:
         receive: true
         send:
           any: true
+  neighbors:
+  - ip_address: 192.168.44.1
+    peer_group: WAN-OVERLAY-PEERS
+    peer: cv-pathfinder-pathfinder
+    description: cv-pathfinder-pathfinder
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -74,6 +65,12 @@ spanning_tree:
 vrfs:
 - name: MGMT
   ip_routing: false
+- name: IT
+  tenant: TenantA
+  ip_routing: true
+- name: PROD
+  tenant: TenantA
+  ip_routing: true
 management_api_http:
   enable_vrfs:
   - name: MGMT
@@ -81,33 +78,17 @@ management_api_http:
 ethernet_interfaces:
 - name: Ethernet1
   peer_type: l3_interface
-  ip_address: 10.7.7.7/31
+  ip_address: dhcp
   shutdown: false
   type: routed
-  flow_tracker:
-    hardware: WAN-FLOW-TRACKER
-- name: Ethernet2
-  peer_type: l3_interface
-  ip_address: 172.16.0.1/31
-  shutdown: false
-  type: routed
-  flow_tracker:
-    hardware: WAN-FLOW-TRACKER
-- name: Ethernet3
-  peer_type: l3_interface
-  ip_address: 10.9.9.9/31
-  shutdown: false
-  type: routed
+  dhcp_client_accept_default_route: true
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
   shutdown: false
-  ip_address: 192.168.44.1/32
-static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.7.7.6
+  ip_address: 192.168.42.6/32
 flow_tracking:
   hardware:
     trackers:
@@ -124,9 +105,9 @@ flow_tracking:
 ip_security:
   ike_policies:
   - name: DP-IKE-POLICY
-    local_id: 192.168.44.1
+    local_id: 192.168.42.6
   - name: CP-IKE-POLICY
-    local_id: 192.168.44.1
+    local_id: 192.168.42.6
   sa_policies:
   - name: DP-SA-POLICY
     esp:
@@ -157,8 +138,19 @@ ip_security:
       time: 50
       action: clear
     mode: transport
+  key_controller:
+    profile: DP-PROFILE
 router_adaptive_virtual_topology:
-  topology_role: pathfinder
+  topology_role: edge
+  region:
+    name: AVD_Land_East
+    id: 43
+  zone:
+    name: DEFAULT-ZONE
+    id: 1
+  site:
+    name: Site512
+    id: 512
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
@@ -172,10 +164,6 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
-  - name: TRANSIT-AVT-POLICY-VOICE
-    load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
-  - name: TRANSIT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -202,13 +190,6 @@ router_adaptive_virtual_topology:
       id: 3
     - name: DEFAULT-AVT-POLICY-DEFAULT
       id: 1
-  - name: TRANSIT
-    policy: TRANSIT-AVT-POLICY
-    profiles:
-    - name: TRANSIT-AVT-POLICY-VOICE
-      id: 42
-    - name: TRANSIT-AVT-POLICY-DEFAULT
-      id: 1
   policies:
   - name: PROD-AVT-POLICY
     matches:
@@ -224,12 +205,6 @@ router_adaptive_virtual_topology:
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
       avt_profile: DEFAULT-AVT-POLICY-DEFAULT
-  - name: TRANSIT-AVT-POLICY
-    matches:
-    - application_profile: VOICE
-      avt_profile: TRANSIT-AVT-POLICY-VOICE
-    - application_profile: default
-      avt_profile: TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
     - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
@@ -245,64 +220,22 @@ router_bfd:
     multiplier: 3
 router_path_selection:
   path_groups:
-  - name: INET
-    id: 101
+  - name: Satellite
+    id: 104
     local_interfaces:
     - name: Ethernet1
-    - name: Ethernet3
+    dynamic_peers:
+      enabled: true
     ipsec_profile: CP-PROFILE
-  - name: MPLS
-    id: 100
-    local_interfaces:
-    - name: Ethernet2
-  peer_dynamic_source: stun
   load_balance_policies:
   - name: LB-CONTROL-PLANE-PROFILE
     path_groups:
-    - name: INET
-    - name: MPLS
+    - name: Satellite
   - name: LB-PROD-AVT-POLICY-VOICE
-    path_groups:
-    - name: MPLS
-    - name: INET
-      priority: 2
   - name: LB-PROD-AVT-POLICY-VIDEO
-    path_groups:
-    - name: MPLS
-    - name: LTE
-    - name: INET
-      priority: 2
   - name: LB-PROD-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: INET
-    - name: MPLS
-      priority: 2
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
-    path_groups:
-    - name: MPLS
-    - name: INET
   - name: LB-DEFAULT-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: INET
-    - name: Equinix
-    - name: MPLS
-      priority: 42
-  - name: LB-TRANSIT-AVT-POLICY-VOICE
-    path_groups:
-    - name: MPLS
-    - name: INET
-      priority: 2
-  - name: LB-TRANSIT-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: INET
-    - name: MPLS
-      priority: 2
-stun:
-  server:
-    local_interfaces:
-    - Ethernet1
-    - Ethernet2
-    - Ethernet3
 application_traffic_recognition:
   application_profiles:
   - name: VOICE
@@ -354,8 +287,7 @@ application_traffic_recognition:
       - 6.6.6.0/24
     - name: CONTROL-PLANE-APP-DEST-PREFIXES
       prefix_values:
-      - 192.168.42.0/24
-      - 192.168.43.0/24
+      - 192.168.44.1/32
 dps_interfaces:
 - name: Dps1
   description: DPS Interface
@@ -365,99 +297,46 @@ dps_interfaces:
     hardware: WAN-FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
-    description: cv-pathfinder-pathfinder_VTEP
+    description: cv-pathfinder-edge-no-common-path-group_VTEP
     vxlan:
       udp_port: 4789
       source_interface: Loopback0
       vrfs:
       - name: default
         vni: 1
+      - name: IT
+        vni: 100
+      - name: PROD
+        vni: 42
 metadata:
   cv_tags:
     device_tags:
     - name: Role
-      value: pathfinder
-    - name: PathfinderSet
-      value: PATHFINDERS
+      value: edge
+    - name: Region
+      value: AVD_Land_East
+    - name: Zone
+      value: DEFAULT-ZONE
+    - name: Site
+      value: Site512
     interface_tags:
     - interface: Ethernet1
       tags:
       - name: Type
         value: wan
       - name: Carrier
-        value: Bouygues_Telecom
+        value: Inmrasat
       - name: Circuit
-        value: '777'
-    - interface: Ethernet2
-      tags:
-      - name: Type
-        value: wan
-      - name: Carrier
-        value: Colt
-      - name: Circuit
-        value: '10000'
-    - interface: Ethernet3
-      tags:
-      - name: Type
-        value: wan
-      - name: Carrier
-        value: Another-ISP
-      - name: Circuit
-        value: '999'
+        value: S512
   cv_pathfinder:
-    role: pathfinder
-    vtep_ip: 192.168.44.1
+    role: edge
+    vtep_ip: 192.168.42.6
+    region: AVD_Land_East
+    zone: DEFAULT-ZONE
+    site: Site512
     interfaces:
     - name: Ethernet1
-      carrier: Bouygues_Telecom
-      pathgroup: INET
-      public_ip: 10.7.7.7
-    - name: Ethernet2
-      carrier: Colt
-      pathgroup: MPLS
-      public_ip: 172.16.0.1
-    - name: Ethernet3
-      carrier: Another-ISP
-      pathgroup: INET
-      public_ip: 10.9.9.9
-    pathgroups:
-    - name: MPLS
-      carriers:
-      - name: Colt
-      - name: ATT-MPLS
-    - name: INET
-      carriers:
-      - name: Comcast
-      - name: ATT
-      - name: Bouygues_Telecom
-      - name: SFR
-      - name: Orange
-      - name: Another-ISP
-    - name: LTE
-      carriers:
-      - name: Comcast-5G
-    - name: Equinix
-    - name: Satellite
-      carriers:
-      - name: Inmrasat
-    regions:
-    - name: AVD_Land_West
-      id: 42
-      zones:
-      - name: DEFAULT-ZONE
-        id: 1
-        sites:
-        - name: Site422
-          id: 422
-          location:
-            address: Somewhere
-    - name: AVD_Land_East
-      id: 43
-      zones:
-      - name: DEFAULT-ZONE
-        id: 1
-        sites:
-        - name: Site511
-          id: 511
-        - name: Site512
-          id: 512
+      carrier: Inmrasat
+      pathgroup: Satellite
+    pathfinders:
+    - vtep_ip: 192.168.44.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -425,6 +425,9 @@ metadata:
       carriers:
       - name: Comcast-5G
     - name: Equinix
+    - name: Satellite
+      carriers:
+      - name: Inmrasat
     regions:
     - name: AVD_Land_West
       id: 42
@@ -444,3 +447,5 @@ metadata:
         sites:
         - name: Site511
           id: 511
+        - name: Site512
+          id: 512

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -455,6 +455,9 @@ metadata:
       carriers:
       - name: Comcast-5G
     - name: Equinix
+    - name: Satellite
+      carriers:
+      - name: Inmrasat
     regions:
     - name: AVD_Land_West
       id: 42
@@ -474,3 +477,5 @@ metadata:
         sites:
         - name: Site511
           id: 511
+        - name: Site512
+          id: 512

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -18,6 +18,8 @@ cv_pathfinder_regions:
     sites:
       - name: Site511
         id: 511
+      - name: Site512
+        id: 512
 
 bgp_peer_groups:
   wan_overlay_peers:
@@ -45,7 +47,7 @@ default_node_types:
       - "cv-pathfinder-transit"
   - node_type: wan_edge
     match_hostnames:
-      - "cv-pathfinder-edge"
+      - "cv-pathfinder-edge.*"
 
 wan_edge:
   defaults:
@@ -72,6 +74,16 @@ wan_edge:
           wan_circuit_id: AF830
           ip: 172.20.20.20/31
           connected_to_pathfinder: False
+    - name: cv-pathfinder-edge-no-common-path-group
+      cv_pathfinder_region: AVD_Land_East
+      cv_pathfinder_site: Site512
+      id: 6
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: Inmrasat
+          wan_circuit_id: S512
+          set_default_route: true
+          ip: dhcp
 
 wan_transit:
   defaults:
@@ -145,6 +157,8 @@ wan_path_groups:
     id: 102
   - name: Equinix
     id: 103
+  - name: Satellite
+    id: 104
 
 wan_carriers:
   - name: Comcast
@@ -165,6 +179,8 @@ wan_carriers:
     path_group: MPLS
   - name: Comcast-5G
     path_group: LTE
+  - name: Inmrasat
+    path_group: Satellite
 
 tenants:
   - name: TenantA

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -292,6 +292,7 @@ all:
             CV_PATHFINDER_TESTS:
               hosts:
                 cv-pathfinder-edge:
+                cv-pathfinder-edge-no-common-path-group:
                 cv-pathfinder-transit:
                 cv-pathfinder-pathfinder:
               children:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -185,7 +185,7 @@ class WanMixin:
 
         if interface["ip"] == "dhcp":
             raise AristaAvdError(
-                f"The IP address for WAN interface '{interface['name']}' on Route Server '{self.hostname}' is set 'dhcp'."
+                f"The IP address for WAN interface '{interface['name']}' on Route Server '{self.hostname}' is set to 'dhcp'. "
                 "Clients need to peer with a static IP which must be set under the 'wan_route_servers.path_groups.interfaces' key."
             )
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -30,12 +30,12 @@ The intention is to support both a single [AutoVPN design](https://www.arista.co
 4. The default VRF is being configured by default on all WAN devices with a `vni_id` of 1. To override this, it is necessary to configure the `default` VRF in a tenant in `network_services`.
 5. When configuring HA on a site, the path-group ID `65535` is reserved for the path-group called `LAN_HA`.
 6. The policies definition works as follow:
-    - The policies are defined under `wan_virtual_topologies.policies`. For AutoVPN mode, the policies are configured under `router path-selection`, for CV Pathfinder, they are configured under `router adaptive-virtual-topology`.
-    - A policy is composed of a list of `application_virtual_topologies` and one `default_virtual_topology`.
-    - The `application_virtual_topologies` entries and the `default_virtual_topology` key are used to create the policy match statement, the AVT profile (when `wan_mode` is CV Pathfinder) and the load balancing policy.
-    - The `default_virtual_topology` is used as the default match in the policy.  To prevent configuring it, the `drop_unmatched` boolean must be set to `true` otherwise, at least one `path-group` must be configured or AVD will raise an error.
-    - Policies are assigned to VRFs using the list `wan_virtual_topologies.vrfs`. A policy can be reused in multiple VRFs.
-    - AVD requires that a policy is assigned for the `default` VRF policy. An extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `CONTROL-PLANE-APPLICATION-PROFILE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
+     - The policies are defined under `wan_virtual_topologies.policies`. For AutoVPN mode, the policies are configured under `router path-selection`, for CV Pathfinder, they are configured under `router adaptive-virtual-topology`.
+     - A policy is composed of a list of `application_virtual_topologies` and one `default_virtual_topology`.
+     - The `application_virtual_topologies` entries and the `default_virtual_topology` key are used to create the policy match statement, the AVT profile (when `wan_mode` is CV Pathfinder) and the load balancing policy.
+     - The `default_virtual_topology` is used as the default match in the policy.  To prevent configuring it, the `drop_unmatched` boolean must be set to `true` otherwise, at least one `path-group` must be configured or AVD will raise an error.
+     - Policies are assigned to VRFs using the list `wan_virtual_topologies.vrfs`. A policy can be reused in multiple VRFs.
+     - AVD requires that a policy is assigned for the `default` VRF policy. An extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `CONTROL-PLANE-APPLICATION-PROFILE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
 
 ## Known limitations
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_path_selection.py
@@ -116,7 +116,7 @@ class RouterPathSelectionMixin(UtilsMixin):
 
         static_peers = []
         for wan_route_server, data in self.shared_utils.filtered_wan_route_servers.items():
-            if (path_group := get_item(data["wan_path_groups"], "name", path_group_name)) is not None:
+            if (path_group := get_item(get(data, "wan_path_groups", default=[]), "name", path_group_name)) is not None:
                 ipv4_addresses = []
 
                 for interface_dict in get(path_group, "interfaces", required=True):


### PR DESCRIPTION
## Change Summary

Fix KeyError found 

## Related Issue(s)

Fixes #3511 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

* use `get` instead of dict key access
* add molecule test
* fix doc (not related)
* fix typo in error message (not related)

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
