### PR TITLE
Doc: rename repo ansible-avd -> avd

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -3,12 +3,12 @@
     "mounts": [
         "source=${localWorkspaceFolder}/ansible_collections/arista/avd,target=/home/avd/.ansible/collections/ansible_collections/arista/avd,type=bind"
     ],
-    "image": "ghcr.io/aristanetworks/ansible-avd/dev:python3.11",
+    "image": "ghcr.io/aristanetworks/avd/dev:python3.11",
     // The AVD collection can also be installed from any git branch.
     // Comment mount section if this is the case.
     //
     // "containerEnv": {
-    //     "AVD_GITHUB_REPO": "aristanetworks/ansible-avd",
+    //     "AVD_GITHUB_REPO": "aristanetworks/avd",
     //     "AVD_BRANCH_NAME": "devel"
     // },
     // Run entrypoint script manually as it's ignored by dev container CLI otherwise.

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -32,4 +32,4 @@ Fixes #<ISSUE ID>
 - [ ] My code has been rebased from devel before I start
 - [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
 - [ ] My change requires a change to the documentation and documentation have been updated accordingly.
-- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
+- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)

--- a/.github/changelog.sh
+++ b/.github/changelog.sh
@@ -192,7 +192,7 @@ function display-release {
     case "$output" in
     raw) printf "$hash" ;;
     text) printf "\e[33m$hash\e[0m" ;; # red
-    md) printf "[\`$hash\`](https://github.com/aristanetworks/ansible-avd/commit/$hash)" ;;
+    md) printf "[\`$hash\`](https://github.com/aristanetworks/avd/commit/$hash)" ;;
     esac
   }
 
@@ -262,7 +262,7 @@ function display-release {
     # In text mode, highlight (#<issue>) and dim text between `backticks`
     text) sed -E $'s|#([0-9]+)|\e[32m#\\1\e[0m|g;s|`([^`]+)`|`\e[2m\\1\e[0m`|g' <<< "$subject" ;;
     # In markdown mode, link to (#<issue>) issues
-    md) sed -E 's|#([0-9]+)|[#\1](https://github.com/aristanetworks/ansible-avd/issues/\1)|g' <<< "$subject" ;;
+    md) sed -E 's|#([0-9]+)|[#\1](https://github.com/aristanetworks/avd/issues/\1)|g' <<< "$subject" ;;
     esac
   }
 
@@ -368,7 +368,7 @@ function main {
     # If $since is not specified:
     # 1) try to find the version used before updating
     # 2) try to find the first version tag before $until
-    since=$(command git config --get ansible-avd.lastVersion 2>/dev/null) || \
+    since=$(command git config --get avd.lastVersion 2>/dev/null) || \
     since=$(command git describe --abbrev=0 --tags "$until^" 2>/dev/null) || \
     unset since
   elif [[ "$since" = --all ]]; then

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -32,4 +32,4 @@ Fixes #<ISSUE ID>
 - [ ] My code has been rebased from devel before I start
 - [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
 - [ ] My change requires a change to the documentation and documentation have been updated accordingly.
-- [ ] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
+- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)

--- a/.github/workflows/container_build_base.yml
+++ b/.github/workflows/container_build_base.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build_base:
-    if: github.repository == 'aristanetworks/ansible-avd'
+    if: github.repository == 'aristanetworks/avd'
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:

--- a/.github/workflows/container_build_dev.yml
+++ b/.github/workflows/container_build_dev.yml
@@ -15,7 +15,7 @@ on:
 
 jobs:
   build_dev_container:
-    if: github.repository == 'aristanetworks/ansible-avd'
+    if: github.repository == 'aristanetworks/avd'
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:

--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -17,7 +17,7 @@ on:
 
 jobs:
   build_universal_container:
-    if: github.repository == 'aristanetworks/ansible-avd'
+    if: github.repository == 'aristanetworks/avd'
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:

--- a/.github/workflows/devel-push.yml
+++ b/.github/workflows/devel-push.yml
@@ -1,6 +1,6 @@
 ---
 # This workflow is conditionned to only run on the main repo
-# aristanetworks/ansible-avd and not on forks
+# aristanetworks/avd and not on forks
 # cf - https://github.com/actions/runner/issues/859
 # TODO - revisist if a feature is ever published
 name: "Devel Code Management"
@@ -28,7 +28,7 @@ jobs:
       docs: ${{ steps.filter.outputs.docs }}
     if: |
       github.event_name != 'workflow_dispatch' &&
-      github.repository == 'aristanetworks/ansible-avd'
+      github.repository == 'aristanetworks/avd'
     steps:
       - uses: actions/checkout@v3
       - uses: dorny/paths-filter@v2
@@ -94,7 +94,7 @@ jobs:
     #   * either there is a file change
     #   * or it is a manually triggered workflow on devel
     if: |
-      github.repository == 'aristanetworks/ansible-avd' &&
+      github.repository == 'aristanetworks/avd' &&
       (needs.file-changes.outputs.requirements == 'true' ||
        (github.ref == 'refs/heads/devel' && github.event_name == 'workflow_dispatch'))
     steps:

--- a/.github/workflows/installation-test.yml
+++ b/.github/workflows/installation-test.yml
@@ -7,7 +7,7 @@ jobs:
     name: 'One liner installation'
     runs-on: ubuntu-20.04
     container: avdteam/base:3.8-v2.0
-    if: github.repository == 'aristanetworks/ansible-avd'
+    if: github.repository == 'aristanetworks/avd'
     steps:
       - uses: actions/checkout@v3
       - name: Execute one-liner installation

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
-    if: github.repository == 'aristanetworks/ansible-avd'
+    if: github.repository == 'aristanetworks/avd'
     steps:
       # Issue stale management
     - uses: actions/stale@v6

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # Arista Validated Designs
 
-![Arista AVD](https://img.shields.io/badge/Arista-AVD%20Automation-blue) ![collection version](https://img.shields.io/github/v/release/aristanetworks/ansible-avd) ![License](https://img.shields.io/github/license/aristanetworks/ansible-avd)
+![Arista AVD](https://img.shields.io/badge/Arista-AVD%20Automation-blue) ![collection version](https://img.shields.io/github/v/release/aristanetworks/avd) ![License](https://img.shields.io/github/license/aristanetworks/avd)
 
 <center><img src="ansible_collections/arista/avd/media/avd-logo.png" alt="Arista AVD Overview" width="800"/></center>
 
@@ -45,13 +45,13 @@ AVD Documentation:
 
 ## Ask a question
 
-Support for this `arista.avd` collection is provided by the community directly in this repository. If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/ansible-avd/discussions).
+Support for this `arista.avd` collection is provided by the community directly in this repository. If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/avd/discussions).
 
 ## Contributing
 
 Contributing pull requests are gladly welcomed for this repository. If you are planning a big change, please start a discussion first to make sure we'll be able to merge it. Please see [contribution guide](./ansible_collections/arista/avd/docs/contribution/overview.md) for additional details.
 
-You can also open an [issue](https://github.com/aristanetworks/ansible-avd/issues) to report any problems or submit requests for enhancements.
+You can also open an [issue](https://github.com/aristanetworks/avd/issues) to report any problems or submit requests for enhancements.
 
 ## License
 

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -67,7 +67,7 @@ See the section "Ansible Collection Plugins" on the menu to the left.
 
 ## Ask a question
 
-Support for the `arista.avd` collection is provided by the community directly in this repository. If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/ansible-avd/discussions).
+Support for the `arista.avd` collection is provided by the community directly in this repository. If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/avd/discussions).
 
 ### Official Arista support
 
@@ -77,8 +77,8 @@ AVD version 4.x releases with full support from Arista TAC. If your organization
 
 Contributing pull requests are gladly welcomed for this repository. If you are planning a big change, please start a discussion first to make sure we'll be able to merge it. Please see [contribution guide](https://avd.arista.com/stable/docs/contribution/overview.html) for additional details.
 
-You can also open an [issue](https://github.com/aristanetworks/ansible-avd/issues) to report any problems or submit enhancements.
+You can also open an [issue](https://github.com/aristanetworks/avd/issues) to report any problems or submit enhancements.
 
 ## License
 
-The project is published under [Apache 2.0 License](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/LICENSE)
+The project is published under [Apache 2.0 License](https://github.com/aristanetworks/avd/blob/devel/ansible_collections/arista/avd/LICENSE)

--- a/ansible_collections/arista/avd/changelogs/README.md
+++ b/ansible_collections/arista/avd/changelogs/README.md
@@ -26,13 +26,13 @@
     - converts
 
       ```md
-      * Fix(eos_designs): Fix schema for BGP peers to allow shutdown key by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3100
+      * Fix(eos_designs): Fix schema for BGP peers to allow shutdown key by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3100
       ```
 
     - to
 
       ```md
-      - Fix(eos_designs) - Fix schema for BGP peers to allow shutdown key (https://github.com/aristanetworks/ansible-avd/pull/3100)
+      - Fix(eos_designs) - Fix schema for BGP peers to allow shutdown key (https://github.com/aristanetworks/avd/pull/3100)
       ```
 
 - Copy the fragment to `changelogs/fragments_backup` *before* generating the changelog

--- a/ansible_collections/arista/avd/docs/_overrides/main.html
+++ b/ansible_collections/arista/avd/docs/_overrides/main.html
@@ -9,7 +9,7 @@
 {% set title = config.site_name ~ " - " ~ page.title | striptags %}
 {% endif %}
 
-{% set image = 'https://raw.githubusercontent.com/aristanetworks/ansible-avd/devel/ansible_collections/arista/avd/media/avd-logo.png' %}
+{% set image = 'https://raw.githubusercontent.com/aristanetworks/avd/devel/ansible_collections/arista/avd/media/avd-logo.png' %}
 
 <!-- Open graph meta tags -->
 <meta property="og:type" content="website" />

--- a/ansible_collections/arista/avd/docs/containers/overview.md
+++ b/ansible_collections/arista/avd/docs/containers/overview.md
@@ -53,7 +53,7 @@ If you want to use a specific AVD release, use the following `devcontainer.json`
 ```json
 {
     "name": "AVD Universal",
-    "image": "ghcr.io/aristanetworks/ansible-avd/universal:python3.11-avd-v4.4.0"
+    "image": "ghcr.io/aristanetworks/avd/universal:python3.11-avd-v4.4.0"
 }
 ```
 
@@ -64,9 +64,9 @@ If you want to test specific AVD branch or fork without making any changes, use 
 ```json
 {
     "name": "AVD Development",
-    "image": "ghcr.io/aristanetworks/ansible-avd/dev:python3.11",
+    "image": "ghcr.io/aristanetworks/avd/dev:python3.11",
     "containerEnv": {
-        "AVD_GITHUB_REPO": "aristanetworks/ansible-avd",
+        "AVD_GITHUB_REPO": "aristanetworks/avd",
         "AVD_BRANCH_NAME": "devel"
     },
     // Run entrypoint script manually as it's ignored by dev container CLI otherwise.

--- a/ansible_collections/arista/avd/docs/contribution/development.md
+++ b/ansible_collections/arista/avd/docs/contribution/development.md
@@ -8,13 +8,13 @@
 
 ## Overview
 
-Two methods can be used to get Ansible up and running quickly with all the requirements to leverage ansible-avd: a Python Virtual Environment or a Docker container.
+Two methods can be used to get Ansible up and running quickly with all the requirements to leverage AVD: a Python Virtual Environment or a Docker container.
 
 The best way to use the development files is to copy them to the root directory where your repositories are cloned. For example, see the file/folder structure below.
 
 ```shell
 ├── git_projects
-│   ├── ansible-avd
+│   ├── avd
 │   ├── ansible-cvp
 │   ├── netdevops-examples
 |   ├── <YOUR OWN TESTING REPOSITORY>
@@ -44,13 +44,13 @@ Since the AVD Docker image is now automatically published on [**docker-hub**](ht
 ```shell
 # Start development stack
 $ make start
-docker-compose -f ansible-avd/development/docker-compose.yml up -d
+docker-compose -f avd/development/docker-compose.yml up -d
 Recreating development_ansible_1    ... done
 Recreating development_webdoc_cvp_1 ... done
 Recreating development_webdoc_avd_1 ... done
 
 # List containers started with stack
-$ docker-compose -f ansible-avd/development/docker-compose.yml ps
+$ docker-compose -f avd/development/docker-compose.yml ps
         Name                       Command               State           Ports
 -----------------------------------------------------------------------------
 ansible_avd   /bin/sh -c while true; do  ...   Up
@@ -59,7 +59,7 @@ webdoc_cvp    sh -c pip install -r ansib ...   Up      0.0.0.0:8001->8000/tcp
 
 # Get a shell with ansible (if not in shell from previous command)
 $ make dev-run
-docker-compose -f ansible-avd/development/docker-compose.yml exec ansible zsh
+docker-compose -f avd/development/docker-compose.yml exec ansible zsh
 Agent pid 52
 ➜  /projects
 
@@ -74,8 +74,8 @@ $ curl -s http://127.0.0.1:8000 | head -n 10
 
 # Stop development stack
 $ make dev-stop
-docker-compose -f ansible-avd/development/docker-compose.yml kill &&\
-        docker-compose -f ansible-avd/development/docker-compose.yml rm -f
+docker-compose -f avd/development/docker-compose.yml kill &&\
+        docker-compose -f avd/development/docker-compose.yml rm -f
 Killing development_ansible_1 ... done
 Killing development_webdoc_1  ... done
 Going to remove development_ansible_1, development_webdoc_1
@@ -87,7 +87,7 @@ Removing development_webdoc_1  ... done
 
 ### Pre-commit hook
 
-[pre-commit](https://github.com/aristanetworks/ansible-avd/blob/devel/.pre-commit-config.yaml) can run standard hooks on every commit to automatically point out issues in code such as missing semicolons, trailing whitespace, and debug statements. Pointing these issues out before code review allows a code reviewer to focus on the architecture of a change while not wasting time with trivial style nitpicks.
+[pre-commit](https://github.com/aristanetworks/avd/blob/devel/.pre-commit-config.yaml) can run standard hooks on every commit to automatically point out issues in code such as missing semicolons, trailing whitespace, and debug statements. Pointing these issues out before code review allows a code reviewer to focus on the architecture of a change while not wasting time with trivial style nitpicks.
 
 Repository implements the following hooks:
 
@@ -96,15 +96,15 @@ Repository implements the following hooks:
 - `check-yaml`: Checks that all YAML files are valid.
 - `check-added-large-files`: Check if no large file is included in the repository.
 - `check-merge-conflict`: Validate there is no `MERGE` syntax related to an invalid merge process.
-- `pylint`: Run Python linting with settings defined in [pylintrc](https://github.com/aristanetworks/ansible-avd/blob/devel/pylintrc).
-- `yamllint`: Validate all YAML files using configuration from [yamllintrc](https://github.com/aristanetworks/ansible-avd/blob/devel/.github/yamllintrc).
+- `pylint`: Run Python linting with settings defined in [pylintrc](https://github.com/aristanetworks/avd/blob/devel/pylintrc).
+- `yamllint`: Validate all YAML files using configuration from [yamllintrc](https://github.com/aristanetworks/avd/blob/devel/.github/yamllintrc).
 - `ansible-lint`: Validate YAML files with Ansible proven practices, patters, and behaviors.
 - `Flake8`: Style guide enforcement for Python code base.
 - `markdownlint-cli`: Validates markdown files for common errors as referenced [here](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md).
 
 #### Installation
 
-`pre-commit` is part of [**development requirements**](https://github.com/aristanetworks/ansible-avd/blob/devel/development/requirements-dev.txt). To install, run `pip command` in **ansible-avd** folder:
+`pre-commit` is part of [**development requirements**](https://github.com/aristanetworks/avd/blob/devel/development/requirements-dev.txt). To install, run `pip command` in **avd** folder:
 
 ```shell
 $ pip install -r development/requirements-dev.txt

--- a/ansible_collections/arista/avd/docs/contribution/getting-started.md
+++ b/ansible_collections/arista/avd/docs/contribution/getting-started.md
@@ -13,7 +13,7 @@
 
 ## Pull requests
 
-- **Before** you start working on a pull request, open an issue and discuss your ideas with the **ansible-avd** maintainers. This will help prevent wasting time on something we might be unable to implement. When suggesting a new feature, ensure it will be consistent with all work already in progress.
+- **Before** you start working on a pull request, open an issue and discuss your ideas with the **AVD** maintainers. This will help prevent wasting time on something we might be unable to implement. When suggesting a new feature, ensure it will be consistent with all work already in progress.
 
 - Any pull request which *doesn't* relate to an accepted issue will not be approved.
 
@@ -34,13 +34,13 @@ Adhering to the following process is the best way to get your work merged:
 
   ```bash
   # Clone your fork of the repo into the current directory
-  git clone https://github.com/<your-username>/ansible-avd
+  git clone https://github.com/<your-username>/avd
 
   # Navigate to the newly cloned directory
-  cd ansible-avd
+  cd avd
 
   # Assign the original repo to a remote called "upstream"
-  git remote add upstream https://github.com/aristanetworks/ansible-avd.git
+  git remote add upstream https://github.com/aristanetworks/avd.git
   ```
 
 - If you cloned a while ago, get the latest changes from upstream:
@@ -70,4 +70,4 @@ Adhering to the following process is the best way to get your work merged:
   git push origin <topic-branch-name>
   ```
 
-- [Open a Pull Request](https://github.com/aristanetworks/ansible-avd/pulls) with a clear title, description, and following the template.
+- [Open a Pull Request](https://github.com/aristanetworks/avd/pulls) with a clear title, description, and following the template.

--- a/ansible_collections/arista/avd/docs/contribution/overview.md
+++ b/ansible_collections/arista/avd/docs/contribution/overview.md
@@ -6,7 +6,7 @@
 
 # Arista Validated Design Development
 
-**Arista Validated Design (AVD)** is maintained as a [GitHub project](https://github.com/aristanetworks/ansible-avd) under the Apache 2 license. Users are encouraged to submit GitHub issues for feature requests and bug reports.
+**Arista Validated Design (AVD)** is maintained as a [GitHub project](https://github.com/aristanetworks/avd) under the Apache 2 license. Users are encouraged to submit GitHub issues for feature requests and bug reports.
 
 ## Governance
 
@@ -36,8 +36,8 @@ Communication among the contributors should always occur via public channels. Th
 
 #### GitHub
 
-- [GitHub issues](https://github.com/aristanetworks/ansible-avd/issues) - All feature requests, bug reports, and other substantial changes should be documented in an issue.
-- [GitHub discussions](https://github.com/aristanetworks/ansible-avd/discussions) - The preferred forum for general discussion and support issues. Ideal for shaping a feature request before submitting an issue.
+- [GitHub issues](https://github.com/aristanetworks/avd/issues) - All feature requests, bug reports, and other substantial changes should be documented in an issue.
+- [GitHub discussions](https://github.com/aristanetworks/avd/discussions) - The preferred forum for general discussion and support issues. Ideal for shaping a feature request before submitting an issue.
 
 GitHub's discussions are the best place to get help or propose rough ideas for new functionality. Their integration with GitHub allows cross-referencing and converting posts to issues as needed. Below are some examples of categories used for discussions:
 
@@ -76,15 +76,15 @@ Contributing pull requests are gladly welcomed for this repository. If you are p
 #### Branching model
 
 - The **`devel`** branch corresponds to the release actively under development.
-- The [release tags](https://github.com/aristanetworks/ansible-avd/tags) correspond to stable releases.
+- The [release tags](https://github.com/aristanetworks/avd/tags) correspond to stable releases.
 - Fork the repository and create a branch based on **`devel`** to set up a dev environment if you want to open a PR.
-- See the ansible-avd release for information about active branches.
+- See the AVD release for information about active branches.
 
 #### Reporting Bugs
 
-- First, ensure that you're running the [latest stable version](https://github.com/aristanetworks/ansible-avd/releases) of AVD. If you're running an older version, it's possible that the bug has already been fixed.
+- First, ensure that you're running the [latest stable version](https://github.com/aristanetworks/avd/releases) of AVD. If you're running an older version, it's possible that the bug has already been fixed.
 
-- Next, check the GitHub [issues list](https://github.com/aristanetworks/ansible-avd/issues) to see if the bug you've found has already been reported. If you think you may be experiencing a reported issue that hasn't already been resolved, please click "add a reaction" in the top right corner of the issue and add a thumbs up (+1). Also, add a comment describing how it's affecting your installation. This will allow us to prioritize bugs based on how many users are affected.
+- Next, check the GitHub [issues list](https://github.com/aristanetworks/avd/issues) to see if the bug you've found has already been reported. If you think you may be experiencing a reported issue that hasn't already been resolved, please click "add a reaction" in the top right corner of the issue and add a thumbs up (+1). Also, add a comment describing how it's affecting your installation. This will allow us to prioritize bugs based on how many users are affected.
 
 - When submitting an issue, please be as descriptive as possible. Be sure to provide all information requests in the issue template, including:
 
@@ -100,7 +100,7 @@ Contributing pull requests are gladly welcomed for this repository. If you are p
 
 #### Feature Requests
 
-- First, check the GitHub [issues list](https://github.com/aristanetworks/ansible-avd/issues) and [Discussions](https://github.com/aristanetworks/ansible-avd/discussions) to see if the feature you're requesting is already listed. If the feature you'd like to see has already been requested and is open, click "add a reaction" in the top right corner of the issue and add a thumbs up (+1). This ensures that the issue has a better chance of receiving attention. Also, feel free to add a comment with any additional justification for the feature. However, note that comments with no substance other than a "+1" will be deleted. Please use GitHub's reactions feature to indicate your support.
+- First, check the GitHub [issues list](https://github.com/aristanetworks/avd/issues) and [Discussions](https://github.com/aristanetworks/avd/discussions) to see if the feature you're requesting is already listed. If the feature you'd like to see has already been requested and is open, click "add a reaction" in the top right corner of the issue and add a thumbs up (+1). This ensures that the issue has a better chance of receiving attention. Also, feel free to add a comment with any additional justification for the feature. However, note that comments with no substance other than a "+1" will be deleted. Please use GitHub's reactions feature to indicate your support.
 
 - Before filing a new feature request, consider starting with a GitHub Discussion. The feedback you receive there will help validate and shape the proposed feature before filing a formal issue. Suppose the feature request isn't accepted into the *current* or *near-term* backlog. In that case, it will get converted to a discussion anyway.
 

--- a/ansible_collections/arista/avd/docs/contribution/setup-environment.md
+++ b/ansible_collections/arista/avd/docs/contribution/setup-environment.md
@@ -6,14 +6,14 @@
 
 # Setup Ansible AVD Environment
 
-Two methods can be used to get Ansible up and running quickly with all the requirements to leverage **ansible-avd**:
+Two methods can be used to get Ansible up and running quickly with all the requirements to leverage **arista.avd**:
 A Python Virtual Environment or [Docker container](https://hub.docker.com/repository/docker/avdteam/base).
 
 In both scenarios, this document will leverage the git approach to create a local environment with collections installed in their respective folders and additional folders for all your content. All examples will be based on the following folder structure:
 
 ```shell
 ├── git_projects
-│   ├── ansible-avd
+│   ├── avd
 │   ├── ansible-cvp
 │   ├── ansible-avd-cloudvision-demo
 │   ├── Makefile
@@ -35,25 +35,25 @@ $ git config --global user.email johndoe@example.com
 
 ## Create a local folder structure
 
-To build a local folder structure, you manually run all the following commands to git clone [ansible-avd](https://github.com/aristanetworks/ansible-avd), [ansible-cvp collection](https://github.com/aristanetworks/ansible-cvp) and a [repository with demo content](https://github.com/arista-netdevops-community/ansible-avd-cloudvision-demo)
+To build a local folder structure, you manually run all the following commands to git clone [avd](https://github.com/aristanetworks/avd), [ansible-cvp collection](https://github.com/aristanetworks/ansible-cvp) and a [repository with demo content](https://github.com/arista-netdevops-community/ansible-avd-cloudvision-demo)
 
-In addition to these three git clones, you can also deploy a [Makefile](https://github.com/aristanetworks/ansible-avd/blob/devel/development/Makefile) built to provide some shortcuts we will discuss in a second stage.
+In addition to these three git clones, you can also deploy a [Makefile](https://github.com/aristanetworks/avd/blob/devel/development/Makefile) built to provide some shortcuts we will discuss in a second stage.
 
 ```shell
 $ mkdir git_projects
 
 $ cd git_projects
 
-$ git clone https://github.com/aristanetworks/ansible-avd.git
+$ git clone https://github.com/aristanetworks/avd.git
 $ git clone https://github.com/aristanetworks/ansible-cvp.git
 $ git clone https://github.com/arista-netdevops-community/ansible-avd-cloudvision-demo.git
 
 # Copy Makefile at the root position
-$ cp ansible-avd/development/Makefile ./
+$ cp avd/development/Makefile ./
 $ make start
 ```
 
-Or you can use a one-liner script available in ansible-avd repository to create this structure for you. This script accomplishes the following actions:
+Or you can use a one-liner script available in avd repository to create this structure for you. This script accomplishes the following actions:
 
 - Create a local folder for development
 - Instantiate a local git repository (no remote)
@@ -87,11 +87,11 @@ This approach will leverage a Docker container to provide all the AVD requiremen
 
 This approach will make the run process easier as all libraries are pre-configured in the container, and you can continue to use your preferred text editor to edit and build your content.
 
-Considering you have deployed [Makefile](https://github.com/aristanetworks/ansible-avd/blob/devel/development/Makefile) described in the previous section, all the outputs will provide native Docker command and the Make command.
+Considering you have deployed [Makefile](https://github.com/aristanetworks/avd/blob/devel/development/Makefile) described in the previous section, all the outputs will provide native Docker command and the Make command.
 
 ### AVD environment commands
 
-When using the installation script to create your own AVD environment, a [`Makefile`](https://github.com/aristanetworks/ansible-avd/blob/devel/development/Makefile) is deployed under `./ansible-arista` to automate some common commands:
+When using the installation script to create your own AVD environment, a [`Makefile`](https://github.com/aristanetworks/avd/blob/devel/development/Makefile) is deployed under `./ansible-arista` to automate some common commands:
 
 ```shell
 make <your command>
@@ -110,13 +110,13 @@ make <your command>
 
 ```shell
 $ make ansible-upgrade ANSIBLE_VERSION=2.10.7
-docker-compose -f ansible-avd/development/docker-compose.yml exec -u avd ansible pip install --user --upgrade ansible==2.10.7
+docker-compose -f avd/development/docker-compose.yml exec -u avd ansible pip install --user --upgrade ansible==2.10.7
 Collecting ansible==2.10.7
   Downloading ansible-2.10.7.tar.gz (14.2 MB)
      |████████████████████████████████| 14.2 MB 475 kB/s
 ...
 $ make shell
-docker-compose -f ansible-avd/development/docker-compose.yml exec -u avd ansible zsh
+docker-compose -f avd/development/docker-compose.yml exec -u avd ansible zsh
 
 Agent pid 109
 ➜  /projects ansible --version
@@ -203,7 +203,7 @@ Then you can move to your content folder as the structure remains the same:
 
 ```shell
 ➜  /projects ls -l
-drwxr-xr-x 24 root root  768 Sep  4 15:47 ansible-avd
+drwxr-xr-x 24 root root  768 Sep  4 15:47 avd
 drwxr-xr-x 24 root root  768 Sep  4 15:47 ansible-cvp
 drwxr-xr-x 24 root root  768 Sep  4 15:47 ansible-avd-cloudvision-demo
 drwxr-xr-x 24 root root  768 Sep  4 15:47 Makefile
@@ -246,11 +246,11 @@ bd6eece0221e: Downloading [===================>                               ] 
 036c486feecb: Waiting
 ```
 
-Your environment is now ready, and you can start to build your project leveraging ansible-avd and ansible-cvp collections.
+Your environment is now ready, and you can start to build your project leveraging arista.avd and arista.cvp Ansible collections.
 
 ## Using Python 3 Virtual Environment feature
 
-This section describes how to configure Python to run the ansible-AVD.
+This section describes how to configure Python to run AVD.
 
 As a requirement, we consider python3 as the default Python interpreter and pip3 as the package manager for python3. Some differences can be spotted depending on your operating system and how they package Python.
 
@@ -274,6 +274,6 @@ $ virtualenv -p python3 .venv
 $ source .venv/bin/activate
 
 # Install Python requirements
-$ pip3 install -r ansible-avd/ansible_collections/arista/avd/requirements.txt
+$ pip3 install -r avd/ansible_collections/arista/avd/requirements.txt
 ...
 ```

--- a/ansible_collections/arista/avd/docs/contribution/setup-git.md
+++ b/ansible_collections/arista/avd/docs/contribution/setup-git.md
@@ -24,7 +24,7 @@ cd avd
 
 ### Update your `ansible.cfg`
 
-In your project, update your `ansible.cfg` file to point **collection_paths** to your local version of avd
+In your project, update your `ansible.cfg` file to point **collection_paths** to your local version of the `arista.avd` collection
 
 - Get the full path to your newly cloned AVD repository.
 

--- a/ansible_collections/arista/avd/docs/contribution/setup-git.md
+++ b/ansible_collections/arista/avd/docs/contribution/setup-git.md
@@ -16,15 +16,15 @@ In this setup, the Git repository will be used by Ansible as a collection. It's 
 
 ```shell
 # Clone repository
-git clone https://github.com/aristanetworks/ansible-avd.git
+git clone https://github.com/aristanetworks/avd.git
 
 # Move to git folder
-cd ansible-avd
+cd avd
 ```
 
 ### Update your `ansible.cfg`
 
-In your project, update your `ansible.cfg` file to point **collection_paths** to your local version of ansible-avd
+In your project, update your `ansible.cfg` file to point **collection_paths** to your local version of avd
 
 - Get the full path to your newly cloned AVD repository.
 
@@ -52,8 +52,8 @@ This approach uses an Ansible collection package built from the current Git vers
 ### Clone repository
 
 ```shell
-git clone https://github.com/aristanetworks/ansible-avd.git
-cd ansible-avd
+git clone https://github.com/aristanetworks/avd.git
+cd avd
 ```
 
 ### Build and install collection

--- a/ansible_collections/arista/avd/docs/contribution/style-guide.md
+++ b/ansible_collections/arista/avd/docs/contribution/style-guide.md
@@ -6,7 +6,7 @@
 
 # AVD Coding Style
 
-This page lists guidelines for developing Python code or Jinja2 templates in the AVD context. These rules apply to creating or updating any Python or Jinja2 file available in a `aristanetworks/ansible-avd` repository.
+This page lists guidelines for developing Python code or Jinja2 templates in the AVD context. These rules apply to creating or updating any Python or Jinja2 file available in a `aristanetworks/avd` repository.
 
 ## Python code style
 
@@ -22,10 +22,10 @@ Furthermore, the CI Pipeline (& pre-commit) for AVD enforces the following:
 
 Configurations for the above tools can be found in:
 
-- [pyproject.toml](https://github.com/aristanetworks/ansible-avd/blob/devel/pyproject.toml)
-- [.pre-commit-config.yaml](https://github.com/aristanetworks/ansible-avd/blob/devel/.pre-commit-config.yaml)
-- [.flake8](https://github.com/aristanetworks/ansible-avd/blob/devel/.flake8)
-- [pylintrc](https://github.com/aristanetworks/ansible-avd/blob/devel/pylintrc)
+- [pyproject.toml](https://github.com/aristanetworks/avd/blob/devel/pyproject.toml)
+- [.pre-commit-config.yaml](https://github.com/aristanetworks/avd/blob/devel/.pre-commit-config.yaml)
+- [.flake8](https://github.com/aristanetworks/avd/blob/devel/.flake8)
+- [pylintrc](https://github.com/aristanetworks/avd/blob/devel/pylintrc)
 
 ## Jinja2 Syntax guidelines
 

--- a/ansible_collections/arista/avd/docs/getting-started/intro-to-ansible-and-avd.md
+++ b/ansible_collections/arista/avd/docs/getting-started/intro-to-ansible-and-avd.md
@@ -52,14 +52,14 @@ Ansible can run on almost anything, but in production scenarios, Ansible is typi
 ## What is the arista.avd collection?
 
 [Arista.avd](https://galaxy.ansible.com/arista/avd) is an Ansible collection for Arista Validated Designs. It's maintained by
-Arista and accepts third-party contributions on GitHub at [aristanetworks/ansible-avd](https://github.com/aristanetworks/ansible-avd).
+Arista and accepts third-party contributions on GitHub at [aristanetworks/avd](https://github.com/aristanetworks/avd).
 
 While Ansible is the core automation engine, AVD is an Ansible Collection described above. It provides roles, modules, and plugins
 that allows the user to generate and deploy best-practice configurations to a layer three leaf-spine network.
 
 ![Figure: Arista Leaf Spine topology](../_media/getting-started/ansible-avd.png)
 
-The illustration above shows the AVD collection as a box with a red background on the right-hand side.
+The illustration above shows the arista.avd collection as a box with a red background on the right-hand side.
 
 When designing an EVPN/VXLAN L3LS fabric, you don't need to spend hours reading through the [Arista Design and Deployment Guides](https://www.arista.com/en/solutions/design-guides). Instead, the AVD collection will implement those rules and guidelines.
 

--- a/ansible_collections/arista/avd/docs/installation/collection-installation.md
+++ b/ansible_collections/arista/avd/docs/installation/collection-installation.md
@@ -49,7 +49,7 @@ You can specify multiple range identifiers which are split by `,`. For example, 
 ### Install latest `devel` version from AVD GitHub
 
 ```shell
-ansible-galaxy collection install git+https://github.com/aristanetworks/ansible-avd.git#/ansible_collections/arista/avd/,devel
+ansible-galaxy collection install git+https://github.com/aristanetworks/avd.git#/ansible_collections/arista/avd/,devel
 ```
 
 !!! note
@@ -111,7 +111,7 @@ pip3 install -r ${ARISTA_AVD_DIR}/arista/avd/requirements.txt
 If the collection is cloned from GitHub, we can reference the requirements file directly:
 
 ```shell
-pip3 install -r ansible-avd/ansible_collections/arista/avd/requirements.txt
+pip3 install -r avd/ansible_collections/arista/avd/requirements.txt
 ```
 
 !!! warning

--- a/ansible_collections/arista/avd/docs/pyavd.md
+++ b/ansible_collections/arista/avd/docs/pyavd.md
@@ -18,7 +18,7 @@ Supported features:
 - Generation of device configuration.
 - Generation of device documentation.
 
-Feedback is very welcome. Please use [GitHub discussions](https://github.com/aristanetworks/ansible-avd/discussions).
+Feedback is very welcome. Please use [GitHub discussions](https://github.com/aristanetworks/avd/discussions).
 
 ## Functions overview
 

--- a/ansible_collections/arista/avd/docs/release-notes/1.0.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/1.0.x.md
@@ -24,7 +24,7 @@ Provides minor enhancements and fixes.
 - eos_config_deploy_cvp
 
 !!! info
-    For detailed information please see the [release tag](https://github.com/aristanetworks/ansible-avd/releases/tag/v1.0.2)
+    For detailed information please see the [release tag](https://github.com/aristanetworks/avd/releases/tag/v1.0.2)
 
 ## Release 1.0.1
 
@@ -41,7 +41,7 @@ Provides minor enhancements and fixes.
 - eos_cli_config_gen
 
 !!! info
-    For detailed information please see the [release tag](https://github.com/aristanetworks/ansible-avd/releases/tag/v1.0.1)
+    For detailed information please see the [release tag](https://github.com/aristanetworks/avd/releases/tag/v1.0.1)
 
 ## Release 1.0.0
 
@@ -64,4 +64,4 @@ Initial release of Ansible AVD
 - inventory_to_container
 
 !!! info
-    For detailed information please see the [release tag](https://github.com/aristanetworks/ansible-avd/releases/tag/v1.0.0)
+    For detailed information please see the [release tag](https://github.com/aristanetworks/avd/releases/tag/v1.0.0)

--- a/ansible_collections/arista/avd/docs/release-notes/1.1.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/1.1.x.md
@@ -26,7 +26,7 @@ Provides enhancements and bug fixes to the following roles:
 - eos_cli_config_gen
 
 !!! info
-    For detailed information please see the [release tag](https://github.com/aristanetworks/ansible-avd/releases/tag/v1.1.2)
+    For detailed information please see the [release tag](https://github.com/aristanetworks/avd/releases/tag/v1.1.2)
 
 ## Release 1.1.1
 
@@ -39,7 +39,7 @@ Provides enhancements and bug fixes to the following roles:
 - eos_validate_state
 
 !!! info
-    For detailed information please see the [release tag](https://github.com/aristanetworks/ansible-avd/releases/tag/v1.1.1)
+    For detailed information please see the [release tag](https://github.com/aristanetworks/avd/releases/tag/v1.1.1)
 
 ## Release 1.1.0
 
@@ -129,4 +129,4 @@ router_bgp:
 ```
 
 !!! info
-    For detailed information please see the [release tag](https://github.com/aristanetworks/ansible-avd/releases/tag/v1.1.0)
+    For detailed information please see the [release tag](https://github.com/aristanetworks/avd/releases/tag/v1.1.0)

--- a/ansible_collections/arista/avd/docs/release-notes/2.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/2.x.x.md
@@ -464,4 +464,4 @@ New default setting origin to incomplete on routes received from MLAG iBGP peer 
 - [dhcp_provisioner](https://www.avd.sh/en/latest/roles/dhcp_provisioner/): Build and deploy a DHCP configuration file to support Zero Touch Provisioning with Arista EOS devices.
 
 !!! info
-    For detailed information please see the release tags: [2.0.0](https://github.com/aristanetworks/ansible-avd/releases/tag/v2.0.0)
+    For detailed information please see the release tags: [2.0.0](https://github.com/aristanetworks/avd/releases/tag/v2.0.0)

--- a/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/3.x.x.md
@@ -24,25 +24,25 @@
 
 #### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Ensure unique VRF names in schemas (#2878) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/3037)
+- Fix(eos_cli_config_gen): Ensure unique VRF names in schemas (#2878) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/3037)
 
 #### Fixed issues in eos_designs
 
-- Fix(eos_designs): Remove EVPN related config if VRF 'default' is not EVPN enabled (#2888) by @Shivani-chourasiya in (https://github.com/aristanetworks/ansible-avd/pull/3041)
-- Fix(eos_designs): bgp_mesh_pes (#2899) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/3038)
-- Fix(eos_designs): Ignore "overlay_routing_protocol_address_family: ipv6" on l2leaf (#2955) by @Vibhu-gslab in (https://github.com/aristanetworks/ansible-avd/pull/3043)
+- Fix(eos_designs): Remove EVPN related config if VRF 'default' is not EVPN enabled (#2888) by @Shivani-chourasiya in (https://github.com/aristanetworks/avd/pull/3041)
+- Fix(eos_designs): bgp_mesh_pes (#2899) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/3038)
+- Fix(eos_designs): Ignore "overlay_routing_protocol_address_family: ipv6" on l2leaf (#2955) by @Vibhu-gslab in (https://github.com/aristanetworks/avd/pull/3043)
 
 #### Fixed issues in eos_config_deploy_cvp
 
-- Fix(eos_config_deploy_cvp): Avoid duplicate AVD configlet (#3124) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/3166)
+- Fix(eos_config_deploy_cvp): Avoid duplicate AVD configlet (#3124) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/3166)
 
 #### Other Fixed issues
 
-- Fix: Cap requirement on jsonschema in 3.8.x train by @gmuloc in (https://github.com/aristanetworks/ansible-avd/pull/3160)
+- Fix: Cap requirement on jsonschema in 3.8.x train by @gmuloc in (https://github.com/aristanetworks/avd/pull/3160)
 
 ### Documentation
 
-- Doc: update links to specific version by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/3039)
+- Doc: update links to specific version by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/3039)
 
 ## Release 3.8.6
 
@@ -50,19 +50,19 @@
 
 #### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Fix typo in router-bgp.j2 (#2753) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/2817)
+- Fix(eos_cli_config_gen): Fix typo in router-bgp.j2 (#2753) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/2817)
 
 #### Fixed issues in eos_designs
 
-- Doc: Fix typo in custom structured configuration documentation example (#2807) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/2821)
-- Doc(plugins): Fix plugin name in BGP example (#2601) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/2818)
-- Fix: Description key not considered with connected endpoints (#2745) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/2816)
-- Fix(eos_designs): Invalid defaults for ipvpn_gateway domain IDs (#2739) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/2820)
-- Revert(eos_designs): Duplicate checks for VRFs by @ClausHolbechArista in (https://github.com/aristanetworks/ansible-avd/pull/2811)
+- Doc: Fix typo in custom structured configuration documentation example (#2807) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/2821)
+- Doc(plugins): Fix plugin name in BGP example (#2601) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/2818)
+- Fix: Description key not considered with connected endpoints (#2745) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/2816)
+- Fix(eos_designs): Invalid defaults for ipvpn_gateway domain IDs (#2739) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/2820)
+- Revert(eos_designs): Duplicate checks for VRFs by @ClausHolbechArista in (https://github.com/aristanetworks/avd/pull/2811)
 
 #### Other Fixed issues
 
-- Bump(requirements): ansible.utils to ">=2.9.0" (#2740) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/2819)
+- Bump(requirements): ansible.utils to ">=2.9.0" (#2740) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/2819)
 
 ## Release 3.8.5
 
@@ -70,14 +70,14 @@
 
 #### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Checks for missing "vlans" key on access port-channel (#2701) by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/2731
+- Fix(eos_cli_config_gen): Checks for missing "vlans" key on access port-channel (#2701) by @jonxstill in https://github.com/aristanetworks/avd/pull/2731
 
 #### Fixed issues in eos_designs
 
-- Fix(eos_designs): network services vlan interfaces ospf authentication message-digest (#2727) by @philippebureau in https://github.com/aristanetworks/ansible-avd/pull/2730
-- Fix(eos_designs): Change IP addressing templates from ansible netcommon to ansible.utils (#2677) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2732
-- Fix(eos_designs): Avoid configuring trunk-group twice on mlag peer-link if using the same name (#2658) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2735
-- Fix(eos_designs): Configure "ip routing ipv6 interface vrf X" for RFC5549 (#2660) by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2733
+- Fix(eos_designs): network services vlan interfaces ospf authentication message-digest (#2727) by @philippebureau in https://github.com/aristanetworks/avd/pull/2730
+- Fix(eos_designs): Change IP addressing templates from ansible netcommon to ansible.utils (#2677) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2732
+- Fix(eos_designs): Avoid configuring trunk-group twice on mlag peer-link if using the same name (#2658) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2735
+- Fix(eos_designs): Configure "ip routing ipv6 interface vrf X" for RFC5549 (#2660) by @gmuloc in https://github.com/aristanetworks/avd/pull/2733
 
 ## Release 3.8.4
 
@@ -85,15 +85,15 @@
 
 #### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Min value on local_users privilege (#2617) by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2618
-- Fix(eos_cli_config_gen): Fix documentation template for flow tracking (#2636) by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2642
-- Fix(eos_cli_config_gen): Update radius-server and radius-servers to match EOS behavior (#2615) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2644
+- Fix(eos_cli_config_gen): Min value on local_users privilege (#2617) by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2618
+- Fix(eos_cli_config_gen): Fix documentation template for flow tracking (#2636) by @chetryan in https://github.com/aristanetworks/avd/pull/2642
+- Fix(eos_cli_config_gen): Update radius-server and radius-servers to match EOS behavior (#2615) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2644
 
 #### Fixed issues in eos_designs
 
-- Fix(eos_designs): Duplicate route-maps generated when using underlay_filter_peer_as: true (#2612) by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2640
-- Fix(eos_designs): Handle overlapping vlan numbers with filter.only_in_use and trunkgroups (#2628) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2641
-- Fix(eos_designs): Configure ptp to use the system mac (#2647) by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2648
+- Fix(eos_designs): Duplicate route-maps generated when using underlay_filter_peer_as: true (#2612) by @gmuloc in https://github.com/aristanetworks/avd/pull/2640
+- Fix(eos_designs): Handle overlapping vlan numbers with filter.only_in_use and trunkgroups (#2628) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2641
+- Fix(eos_designs): Configure ptp to use the system mac (#2647) by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2648
 
 ## Release 3.8.3
 
@@ -101,12 +101,12 @@
 
 #### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Update schema for storm_control levels to support int or float (#2562) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2583
-- Fix(eos_cli_config_gen): Update schema for logging (#2553) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2582
+- Fix(eos_cli_config_gen): Update schema for storm_control levels to support int or float (#2562) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2583
+- Fix(eos_cli_config_gen): Update schema for logging (#2553) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2582
 
 #### Fixed issues in eos_designs
 
-- Fix(eos_designs): Ensure proper formatting of raised errors by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2580
+- Fix(eos_designs): Ensure proper formatting of raised errors by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2580
 
 ## Release 3.8.2
 
@@ -114,19 +114,19 @@
 
 #### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Fix the router_multicast vrfs indentation (#2476) by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2527
-- Fix(eos_cli_config_gen): Correct schema min values for terminal length/width (#2481) by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2528
-- Fix(eos_cli_config_gen): Add variable protection for router_bgp.as in doc template (#2503) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2535
-- Fix(eos_cli_config_gen): Relax schema for maintenance unit profile (#2492) by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2532
+- Fix(eos_cli_config_gen): Fix the router_multicast vrfs indentation (#2476) by @tgodaA in https://github.com/aristanetworks/avd/pull/2527
+- Fix(eos_cli_config_gen): Correct schema min values for terminal length/width (#2481) by @emilarista in https://github.com/aristanetworks/avd/pull/2528
+- Fix(eos_cli_config_gen): Add variable protection for router_bgp.as in doc template (#2503) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2535
+- Fix(eos_cli_config_gen): Relax schema for maintenance unit profile (#2492) by @gmuloc in https://github.com/aristanetworks/avd/pull/2532
 
 #### Fixed issues in eos_designs
 
-- Fix(eos_designs): Fix error with dotted hostname, l2leaf and mlag (#2502) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2534
-- Fix(eos_designs): Correct range_expand behaviour with .0 4byte ASNs (#2529) by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/2541
+- Fix(eos_designs): Fix error with dotted hostname, l2leaf and mlag (#2502) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2534
+- Fix(eos_designs): Correct range_expand behaviour with .0 4byte ASNs (#2529) by @jonxstill in https://github.com/aristanetworks/avd/pull/2541
 
 #### Documentation
 
-- Doc: Fix typo in plugins README.md (#2495) by @pvinci-arista in https://github.com/aristanetworks/ansible-avd/pull/2533
+- Doc: Fix typo in plugins README.md (#2495) by @pvinci-arista in https://github.com/aristanetworks/avd/pull/2533
 
 ## Release 3.8.1
 
@@ -134,32 +134,32 @@
 
 #### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Update Schema for OSPF maximum paths from 32 to 128 (#2424) by @RyanM-Aristain https://github.com/aristanetworks/ansible-avd/pull/2435
-- Fix(eos_cli_config_gen): Workaround for router-general EOS CLI issue (#2408) by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2436
+- Fix(eos_cli_config_gen): Update Schema for OSPF maximum paths from 32 to 128 (#2424) by @RyanM-Aristain https://github.com/aristanetworks/avd/pull/2435
+- Fix(eos_cli_config_gen): Workaround for router-general EOS CLI issue (#2408) by @tgodaA in https://github.com/aristanetworks/avd/pull/2436
 
 #### Fixed issues in eos_designs
 
-- Fix(eos_designs): Detect duplicate VLAN, VRF, VNI within network_services (#2411) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2449
-- Fix(eos_designs): Renders lacp fallback when port-channel mode is passive by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2452
-- Fix(eos_designs): vtep_vvtep_ip doesn't generate any config (#2442) by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2455
-- Fix(eos_designs): Fix issue with hardware_counters python code (#2447) by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2454
-- Fix(eos_designs) - Remove speed from port-channel interfaces (#2463) by @carlbuchmann in (https://github.com/aristanetworks/ansible-avd/pull/2465)
+- Fix(eos_designs): Detect duplicate VLAN, VRF, VNI within network_services (#2411) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2449
+- Fix(eos_designs): Renders lacp fallback when port-channel mode is passive by @gmuloc in https://github.com/aristanetworks/avd/pull/2452
+- Fix(eos_designs): vtep_vvtep_ip doesn't generate any config (#2442) by @emilarista in https://github.com/aristanetworks/avd/pull/2455
+- Fix(eos_designs): Fix issue with hardware_counters python code (#2447) by @gmuloc in https://github.com/aristanetworks/avd/pull/2454
+- Fix(eos_designs) - Remove speed from port-channel interfaces (#2463) by @carlbuchmann in (https://github.com/aristanetworks/avd/pull/2465)
 
 #### Fixed issues in eos_snapshot
 
-- Fix(eos_snapshot): eos snapshot produces incorrect json and yaml output (#2426 & #2439) by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2434
-- Fix(eos_snapshot): Conditional in tasks are not honored and support for limit (#2457) by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2460
+- Fix(eos_snapshot): eos snapshot produces incorrect json and yaml output (#2426 & #2439) by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2434
+- Fix(eos_snapshot): Conditional in tasks are not honored and support for limit (#2457) by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2460
 
 ### Update for Requirements
 
-- Bump: Support additional ansible-core versions 2.13 and 2.14 by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2433
+- Bump: Support additional ansible-core versions 2.13 and 2.14 by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2433
 
 ## Release 3.8.0
 
 - Version 3.8.0 includes input data validation for `eos_cli_config_gen` based on data model schemas.
   By default data issues will be reported as warnings and will not block the playbook. See details [here](../../roles/eos_cli_config_gen/docs/role-configuration.md#input-variables-validation-settings).
 
-  Please report any problems on [Github discussions](https://github.com/aristanetworks/ansible-avd/discussions/categories/data-model-schemas),
+  Please report any problems on [Github discussions](https://github.com/aristanetworks/avd/discussions/categories/data-model-schemas),
   if it seems like the schema is wrong or too restrictive. Other feedback is also most welcome.
 
 ### Changes to requirements
@@ -179,131 +179,131 @@
 
 #### Fixed issues in eos_cli_config_gen
 
-- Optimize(eos_cli_config_gen): Remove lower method on boolean variables by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2007
-- Fix(eos_cli_config_gen): documentation failure when enable isis on vlan-interface by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2076
-- Fix(eos_designs,eos_cli_config_gen): Fix ipv6_address_virtual and ipv6_virtual_router by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2141
-- Fix(eos_cli_config_gen): Updates to schema for policy_maps by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2177
-- Fix(eos_cli_config_gen): make description, ip and gateway optional for management_interfaces by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2224
-- Fix(eos_cli_config_gen): Add convert_types to router ospf area id schema (#2391) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2402
-- Fix(eos_cli_config_gen): Render LLDP commands on ethernet_interfaces also for port-channel members (#2386) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2405
+- Optimize(eos_cli_config_gen): Remove lower method on boolean variables by @tgodaA in https://github.com/aristanetworks/avd/pull/2007
+- Fix(eos_cli_config_gen): documentation failure when enable isis on vlan-interface by @gmuloc in https://github.com/aristanetworks/avd/pull/2076
+- Fix(eos_designs,eos_cli_config_gen): Fix ipv6_address_virtual and ipv6_virtual_router by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2141
+- Fix(eos_cli_config_gen): Updates to schema for policy_maps by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2177
+- Fix(eos_cli_config_gen): make description, ip and gateway optional for management_interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/2224
+- Fix(eos_cli_config_gen): Add convert_types to router ospf area id schema (#2391) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2402
+- Fix(eos_cli_config_gen): Render LLDP commands on ethernet_interfaces also for port-channel members (#2386) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2405
 
 #### Fixed issues in eos_designs
 
-- Fix(eos_designs): Fix the router_isis redistribute_routes connected by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2001
-- Fix(eos_designs): remove the need for mgmt_gateway by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/1931
-- Fix(eos_designs): Missing defined check for enable_trunk_groups by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2038
-- Fix(eos_designs): Fix core_interfaces ISIS logic by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2078
-- Fix(eos_designs): fix wrong type being returned for mac_address_table aging-time by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2103
-- Fix(eos_designs): `filter.only_vlans_in_use` did not configure vlans used by `network_ports` by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2104
-- Fix(eos_designs): BGP Default Originate produced invalid key for route-map by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2108
-- Fix(eos_designs,eos_cli_config_gen): Fix ipv6_address_virtual and ipv6_virtual_router by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2141
-- Fix(eos_designs): allow ':' in the description for network_ports by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2225
-- Fix(eos_designs): Create mgmt interface even if no gateway is set by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2246
-- Fix(eos_designs): Python import error for AristaAvdMissingVariableError by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2295
-- Fix(eos_designs): Avoid configuring "vxlan virtual-router encapsulation mac-address mlag-system-id" when not applicable by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2325
-- Fix(eos_designs): Create MLAG peer-group when needed for non-BGP underlays by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2316
-- Fix(eos_designs): Minor issues in new PTP feature by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/2331
-- Fix(eos_designs): PTP documentation not linked from mkdocs.yml by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/2334
-- Fix(eos_designs): force inband_management_vlan as integer by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2345
-- Fix(eos_designs): Remove j2caching since it is unstable between versions by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2351
-- Fix(eos_designs): Replace sorted with natural_sort in overlay/utils.py (#2374) by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2375
-- Fix(eos_designs): overlay_rd_type with inline jinja generates incorrect config (#2393) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2403
+- Fix(eos_designs): Fix the router_isis redistribute_routes connected by @tgodaA in https://github.com/aristanetworks/avd/pull/2001
+- Fix(eos_designs): remove the need for mgmt_gateway by @gmuloc in https://github.com/aristanetworks/avd/pull/1931
+- Fix(eos_designs): Missing defined check for enable_trunk_groups by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2038
+- Fix(eos_designs): Fix core_interfaces ISIS logic by @emilarista in https://github.com/aristanetworks/avd/pull/2078
+- Fix(eos_designs): fix wrong type being returned for mac_address_table aging-time by @gmuloc in https://github.com/aristanetworks/avd/pull/2103
+- Fix(eos_designs): `filter.only_vlans_in_use` did not configure vlans used by `network_ports` by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2104
+- Fix(eos_designs): BGP Default Originate produced invalid key for route-map by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2108
+- Fix(eos_designs,eos_cli_config_gen): Fix ipv6_address_virtual and ipv6_virtual_router by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2141
+- Fix(eos_designs): allow ':' in the description for network_ports by @gmuloc in https://github.com/aristanetworks/avd/pull/2225
+- Fix(eos_designs): Create mgmt interface even if no gateway is set by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2246
+- Fix(eos_designs): Python import error for AristaAvdMissingVariableError by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2295
+- Fix(eos_designs): Avoid configuring "vxlan virtual-router encapsulation mac-address mlag-system-id" when not applicable by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2325
+- Fix(eos_designs): Create MLAG peer-group when needed for non-BGP underlays by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2316
+- Fix(eos_designs): Minor issues in new PTP feature by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/2331
+- Fix(eos_designs): PTP documentation not linked from mkdocs.yml by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/2334
+- Fix(eos_designs): force inband_management_vlan as integer by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2345
+- Fix(eos_designs): Remove j2caching since it is unstable between versions by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2351
+- Fix(eos_designs): Replace sorted with natural_sort in overlay/utils.py (#2374) by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2375
+- Fix(eos_designs): overlay_rd_type with inline jinja generates incorrect config (#2393) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2403
 
 #### Other Fixed issues
 
-- Fix: Remove ansible-test enforced GPL3 header from modules by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2010
-- Fix: Create MLAG port-channels with network_ports data model by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2011
-- Fix: pr labeler action by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2051
-- Fix: Update json schema by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2099
-- Fix: Ensure get.avd.sh make script sets the correct UID by @jorisc90 in https://github.com/aristanetworks/ansible-avd/pull/2210
-- Fix: schema auto generated documentation and json schema by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2251
-- Fix(eos_validate_state): Always create directory for reports by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2261
-- Fix: File permissions for documentation and schema tasks by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2292
-- Fix: Incorrect table rendering for L2LS by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/2318
-- Fix(eos_validate_state): Handle missing  interfaces, MLAG and BGP peers by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2330
-- Fix: Logging buffered default level not required (#2364) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2372
-- Fix(plugins): Fix bgp_utils for ansible-test sanity and update requirements (#2401) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2406
+- Fix: Remove ansible-test enforced GPL3 header from modules by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2010
+- Fix: Create MLAG port-channels with network_ports data model by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2011
+- Fix: pr labeler action by @gmuloc in https://github.com/aristanetworks/avd/pull/2051
+- Fix: Update json schema by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2099
+- Fix: Ensure get.avd.sh make script sets the correct UID by @jorisc90 in https://github.com/aristanetworks/avd/pull/2210
+- Fix: schema auto generated documentation and json schema by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2251
+- Fix(eos_validate_state): Always create directory for reports by @chetryan in https://github.com/aristanetworks/avd/pull/2261
+- Fix: File permissions for documentation and schema tasks by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2292
+- Fix: Incorrect table rendering for L2LS by @JulioPDX in https://github.com/aristanetworks/avd/pull/2318
+- Fix(eos_validate_state): Handle missing  interfaces, MLAG and BGP peers by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2330
+- Fix: Logging buffered default level not required (#2364) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2372
+- Fix(plugins): Fix bgp_utils for ansible-test sanity and update requirements (#2401) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2406
 
 ### Documentation
 
-- Doc(eos_designs): specify that id must be unique within a node_type by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2014
-- Doc: L2LS Example by @mthiel117 in https://github.com/aristanetworks/ansible-avd/pull/1992
-- Doc(eos_designs): Fix snmp_settings.compute_v3_user_localized_key typo by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2072
-- Doc: L3LS Example and Mkdoc Updates by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/2055
-- Doc: Add Guillaume Mulocher to Maintainers by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2100
-- Doc: Fix incorrect key names for custom mlag interface descriptions by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2235
-- Doc: Remove display_name from schema generated docs by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2248
-- Doc: Exclude test files from site build, enable twitter, update links by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/2238
-- Doc: Campus Example by @mthiel117 in https://github.com/aristanetworks/ansible-avd/pull/2191
-- Doc: Role diagram support for light and dark modes by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/2272
-- Doc(eos_cli_config_gen): Add LACP to key_to_display_name plugin by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2293
-- Doc: Refactor landing page and installation guide by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/2306
-- Doc(eos_designs): Addition of L2LS documentation by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/2305
-- Doc: Fix code block, update variable information by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/2339
-- Doc: Fix Images in Campus Fabric Example by @mthiel117 in https://github.com/aristanetworks/ansible-avd/pull/2348
-- Doc(eos_cli_config_gen): Fix documentation for cvx.peer_hosts by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2358
+- Doc(eos_designs): specify that id must be unique within a node_type by @gmuloc in https://github.com/aristanetworks/avd/pull/2014
+- Doc: L2LS Example by @mthiel117 in https://github.com/aristanetworks/avd/pull/1992
+- Doc(eos_designs): Fix snmp_settings.compute_v3_user_localized_key typo by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2072
+- Doc: L3LS Example and Mkdoc Updates by @JulioPDX in https://github.com/aristanetworks/avd/pull/2055
+- Doc: Add Guillaume Mulocher to Maintainers by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2100
+- Doc: Fix incorrect key names for custom mlag interface descriptions by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2235
+- Doc: Remove display_name from schema generated docs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2248
+- Doc: Exclude test files from site build, enable twitter, update links by @JulioPDX in https://github.com/aristanetworks/avd/pull/2238
+- Doc: Campus Example by @mthiel117 in https://github.com/aristanetworks/avd/pull/2191
+- Doc: Role diagram support for light and dark modes by @JulioPDX in https://github.com/aristanetworks/avd/pull/2272
+- Doc(eos_cli_config_gen): Add LACP to key_to_display_name plugin by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2293
+- Doc: Refactor landing page and installation guide by @JulioPDX in https://github.com/aristanetworks/avd/pull/2306
+- Doc(eos_designs): Addition of L2LS documentation by @JulioPDX in https://github.com/aristanetworks/avd/pull/2305
+- Doc: Fix code block, update variable information by @JulioPDX in https://github.com/aristanetworks/avd/pull/2339
+- Doc: Fix Images in Campus Fabric Example by @mthiel117 in https://github.com/aristanetworks/avd/pull/2348
+- Doc(eos_cli_config_gen): Fix documentation for cvx.peer_hosts by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2358
 
 ### New Features and enhancements
 
 #### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen): Add support for sub-route-map and continue in route-maps by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/1850
-- Feat(eos_cli_config_gen): add support for SSL profile cipher-list by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2000
-- Feat(eos_cli_config_gen): Support mcs cvx server commands by @sugetha24 in https://github.com/aristanetworks/ansible-avd/pull/1985
-- Feat(eos_cli_config_gen): Support for MCS client commands by @sugetha24 in https://github.com/aristanetworks/ansible-avd/pull/1999
-- Feat(eos_cli_config_gen): Add shutdown knob to MCS client commands by @sugetha24 in https://github.com/aristanetworks/ansible-avd/pull/2009
-- Feat(eos_cli_config_gen): Support for setting queue-monitor length cpu thresholds by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2012
-- Feat(eos_cli_config_gen): Add support for mtu under management interface by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2080
-- Feat(eos_cli_config_gen): add cvconfig flag to TerminAttr by @perimore in https://github.com/aristanetworks/ansible-avd/pull/2217
-- Feat(eos_cli_config_gen): Support no queue-monitor length notifying by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2253
-- Feat(eos_cli_config_gen): Add various config options for Sflow by @ccsnw in https://github.com/aristanetworks/ansible-avd/pull/2249
-- Feat(eos_designs,eos_cli_config_gen): Add "disabled" option to "local_users" by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/2257
-- Feat(eos_cli_config_gen): Add key_type for ntp.authentication_keys by @philippebureau in https://github.com/aristanetworks/ansible-avd/pull/2258
-- Feat(eos_cli_config_gen): Add "bfd" key to router_pim_sparse_mode by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/2262
-- Feat(eos_cli_config_gen): Add flow tracking sampled support by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2270
-- Feat(eos_cli_config_gen): Add tunnel interface functionality by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2260
-- Feat(eos_cli_config_gen): Add schema for ntp by @KonikaChaurasiya-GSLab in https://github.com/aristanetworks/ansible-avd/pull/2151
-- Feat(eos_cli_config_gen): Source-interface for management cvx by @sugetha24 in https://github.com/aristanetworks/ansible-avd/pull/2294
-- Feat(eos_cli_config_gen):  Add macsec commands by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/2286
-- Feat(eos_cli_config_gen): Fix macsec template by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/2297
-- Feat(eos_cli_config_gen): Add support for EVPN multicast ipv4 AF transit by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/2277
-- Feat(eos_cli_config_gen): MAC address on management interfaces by @sugetha24 in https://github.com/aristanetworks/ansible-avd/pull/2275
-- Feat(eos_cli_config_gen): Support route_reflector_client key on BGP neighbors by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2298
-- Feat(eos_cli_config_gen): Add graceful-restart support for router_bgp by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2296
-- Feat(eos_cli_config_gen): Add Router MSDP Data Model by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2278
-- Feat(eos_cli_config_gen, eos_designs): Support Track BFD in static routes by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2320
-- Feat(eos_cli_config_gen): Support access-lists & options on rp addresses by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2355
+- Feat(eos_cli_config_gen): Add support for sub-route-map and continue in route-maps by @emilarista in https://github.com/aristanetworks/avd/pull/1850
+- Feat(eos_cli_config_gen): add support for SSL profile cipher-list by @gmuloc in https://github.com/aristanetworks/avd/pull/2000
+- Feat(eos_cli_config_gen): Support mcs cvx server commands by @sugetha24 in https://github.com/aristanetworks/avd/pull/1985
+- Feat(eos_cli_config_gen): Support for MCS client commands by @sugetha24 in https://github.com/aristanetworks/avd/pull/1999
+- Feat(eos_cli_config_gen): Add shutdown knob to MCS client commands by @sugetha24 in https://github.com/aristanetworks/avd/pull/2009
+- Feat(eos_cli_config_gen): Support for setting queue-monitor length cpu thresholds by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2012
+- Feat(eos_cli_config_gen): Add support for mtu under management interface by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2080
+- Feat(eos_cli_config_gen): add cvconfig flag to TerminAttr by @perimore in https://github.com/aristanetworks/avd/pull/2217
+- Feat(eos_cli_config_gen): Support no queue-monitor length notifying by @tgodaA in https://github.com/aristanetworks/avd/pull/2253
+- Feat(eos_cli_config_gen): Add various config options for Sflow by @ccsnw in https://github.com/aristanetworks/avd/pull/2249
+- Feat(eos_designs,eos_cli_config_gen): Add "disabled" option to "local_users" by @gusmb in https://github.com/aristanetworks/avd/pull/2257
+- Feat(eos_cli_config_gen): Add key_type for ntp.authentication_keys by @philippebureau in https://github.com/aristanetworks/avd/pull/2258
+- Feat(eos_cli_config_gen): Add "bfd" key to router_pim_sparse_mode by @gusmb in https://github.com/aristanetworks/avd/pull/2262
+- Feat(eos_cli_config_gen): Add flow tracking sampled support by @gmuloc in https://github.com/aristanetworks/avd/pull/2270
+- Feat(eos_cli_config_gen): Add tunnel interface functionality by @gmuloc in https://github.com/aristanetworks/avd/pull/2260
+- Feat(eos_cli_config_gen): Add schema for ntp by @KonikaChaurasiya-GSLab in https://github.com/aristanetworks/avd/pull/2151
+- Feat(eos_cli_config_gen): Source-interface for management cvx by @sugetha24 in https://github.com/aristanetworks/avd/pull/2294
+- Feat(eos_cli_config_gen):  Add macsec commands by @gusmb in https://github.com/aristanetworks/avd/pull/2286
+- Feat(eos_cli_config_gen): Fix macsec template by @gusmb in https://github.com/aristanetworks/avd/pull/2297
+- Feat(eos_cli_config_gen): Add support for EVPN multicast ipv4 AF transit by @jonxstill in https://github.com/aristanetworks/avd/pull/2277
+- Feat(eos_cli_config_gen): MAC address on management interfaces by @sugetha24 in https://github.com/aristanetworks/avd/pull/2275
+- Feat(eos_cli_config_gen): Support route_reflector_client key on BGP neighbors by @emilarista in https://github.com/aristanetworks/avd/pull/2298
+- Feat(eos_cli_config_gen): Add graceful-restart support for router_bgp by @gmuloc in https://github.com/aristanetworks/avd/pull/2296
+- Feat(eos_cli_config_gen): Add Router MSDP Data Model by @emilarista in https://github.com/aristanetworks/avd/pull/2278
+- Feat(eos_cli_config_gen, eos_designs): Support Track BFD in static routes by @tgodaA in https://github.com/aristanetworks/avd/pull/2320
+- Feat(eos_cli_config_gen): Support access-lists & options on rp addresses by @tgodaA in https://github.com/aristanetworks/avd/pull/2355
 
 #### New features and enhancements in eos_designs
 
-- Feat(eos_designs): Auto BGP ASN by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/1948
-- Feat(eos_designs): Support for Static Flood Lists, HER by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1982
-- Feat(eos_designs): Support structured config under network services svis and l2vlans for bgp commands by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/1947
-- Feat(eos_designs): Support for custom naming of trunk groups by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2021
-- Feat(eos_designs): Support static_routes for default vrf  under network-services by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1986
-- Feat(eos_designs): Optional underlay eBGP filtering of paths with peer's ASN by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2030
-- Feat(eos_designs): Add channel_id for endpoints by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2070
-- Feat(eos_designs): Support the ip_virtual_router_addresses and ip_address_virtual under the same svi by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2239
-- Feat(eos_designs): Add support for setting node_type by matching regexes against the hostname by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/2266
-- Feat(eos_designs): Support for PTP configuration based on best practices by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/1916
-- Feat(eos_designs): Add support for system mac address derived engine ID by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2289
-- Feat(eos_designs): Add support for multiple descriptions for l3_interfaces by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2291
-- Feat(eos_designs): EVPN to MPLS-VPN Gateway Overlay Support by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2209
-- Feat(eos_designs): EVPN Multicast L3 (OISM) Support by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/2276
-- Feat(eos_cli_config_gen,eos_designs): Support Track BFD in static routes by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2320
-- Feat(eos_designs): Adding 7020R to plattform settings by @tweippert in https://github.com/aristanetworks/ansible-avd/pull/2356
+- Feat(eos_designs): Auto BGP ASN by @jonxstill in https://github.com/aristanetworks/avd/pull/1948
+- Feat(eos_designs): Support for Static Flood Lists, HER by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1982
+- Feat(eos_designs): Support structured config under network services svis and l2vlans for bgp commands by @tgodaA in https://github.com/aristanetworks/avd/pull/1947
+- Feat(eos_designs): Support for custom naming of trunk groups by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2021
+- Feat(eos_designs): Support static_routes for default vrf  under network-services by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1986
+- Feat(eos_designs): Optional underlay eBGP filtering of paths with peer's ASN by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2030
+- Feat(eos_designs): Add channel_id for endpoints by @chetryan in https://github.com/aristanetworks/avd/pull/2070
+- Feat(eos_designs): Support the ip_virtual_router_addresses and ip_address_virtual under the same svi by @tgodaA in https://github.com/aristanetworks/avd/pull/2239
+- Feat(eos_designs): Add support for setting node_type by matching regexes against the hostname by @jonxstill in https://github.com/aristanetworks/avd/pull/2266
+- Feat(eos_designs): Support for PTP configuration based on best practices by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/1916
+- Feat(eos_designs): Add support for system mac address derived engine ID by @gmuloc in https://github.com/aristanetworks/avd/pull/2289
+- Feat(eos_designs): Add support for multiple descriptions for l3_interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/2291
+- Feat(eos_designs): EVPN to MPLS-VPN Gateway Overlay Support by @emilarista in https://github.com/aristanetworks/avd/pull/2209
+- Feat(eos_designs): EVPN Multicast L3 (OISM) Support by @jonxstill in https://github.com/aristanetworks/avd/pull/2276
+- Feat(eos_cli_config_gen,eos_designs): Support Track BFD in static routes by @tgodaA in https://github.com/aristanetworks/avd/pull/2320
+- Feat(eos_designs): Adding 7020R to plattform settings by @tweippert in https://github.com/aristanetworks/avd/pull/2356
 
 #### Other new features and enhancements
 
-- Feat: Schemas for input validation and documentation by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1888
-- Feat(plugins): Add schema support for secondary_key by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2034
-- Feat(plugins): New arista.avd.include_vars plugin by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2040
-- Feat(plugins): AVD to JSON Schema Converter by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2090
-- Feat(plugins,eos_cli_config_gen): add bgp_encrypt filter bgp password by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2207
-- Feat(eos_validate_state): custom fan & pwr states by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2222
-- Feat(eos_validate_state): skip lldp topology for shutdown by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2221
-- Feat(plugins): Add schema support for auto-conversion of floats by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2247
-- Feat: Add peer hosts to CVX by @sugetha24 in https://github.com/aristanetworks/ansible-avd/pull/2281
+- Feat: Schemas for input validation and documentation by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1888
+- Feat(plugins): Add schema support for secondary_key by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2034
+- Feat(plugins): New arista.avd.include_vars plugin by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2040
+- Feat(plugins): AVD to JSON Schema Converter by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2090
+- Feat(plugins,eos_cli_config_gen): add bgp_encrypt filter bgp password by @gmuloc in https://github.com/aristanetworks/avd/pull/2207
+- Feat(eos_validate_state): custom fan & pwr states by @chetryan in https://github.com/aristanetworks/avd/pull/2222
+- Feat(eos_validate_state): skip lldp topology for shutdown by @chetryan in https://github.com/aristanetworks/avd/pull/2221
+- Feat(plugins): Add schema support for auto-conversion of floats by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2247
+- Feat: Add peer hosts to CVX by @sugetha24 in https://github.com/aristanetworks/avd/pull/2281
 
 ## Release 3.7.0
 
@@ -316,79 +316,79 @@
 
 #### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): add vlan.vni var is defined by @lermilov in https://github.com/aristanetworks/ansible-avd/pull/1919
-- Fix(eos_cli_config_gen): print the vlans in alphabetical order for `router bgp` by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/1925
-- Fix(eos_cli_config_gen): Rendering of dot1x cli by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1924
-- Fix(eos_cli_config_gen): Re-add seperator between VRF and non-VRF config by @ccsnw in https://github.com/aristanetworks/ansible-avd/pull/1961
+- Fix(eos_cli_config_gen): add vlan.vni var is defined by @lermilov in https://github.com/aristanetworks/avd/pull/1919
+- Fix(eos_cli_config_gen): print the vlans in alphabetical order for `router bgp` by @gmuloc in https://github.com/aristanetworks/avd/pull/1925
+- Fix(eos_cli_config_gen): Rendering of dot1x cli by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1924
+- Fix(eos_cli_config_gen): Re-add seperator between VRF and non-VRF config by @ccsnw in https://github.com/aristanetworks/avd/pull/1961
 
 #### Fixed issues in eos_designs
 
-- Fix(eos_designs): fix logic for underlay_multicast by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1940
-- Fix(eos_designs): fix the Loopback0 interface description by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/1955
-- Fix(eos_designs): Resolve inline jinja in fabric_name by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1967
-- Fix(eos_designs): Correct underlay routing for overlay_routing_protocol: "none" by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1970
-- Fix(eos_designs): Remove unneeded mlag ibgp vlan for vrf default by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1968
-- Fix(eos_designs): Only configure EVPN filtering on EVPN nodes by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1969
-- Fix(eos_designs): only create igmp snooping querier configuration on l3 devices by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1978
-- Fix(eos_designs): Missing IGP no-passive for single MLAG VLAN by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1974
-- Fix(eos_designs): return the missing node_type in error by @pvinci-arista in https://github.com/aristanetworks/ansible-avd/pull/1981
+- Fix(eos_designs): fix logic for underlay_multicast by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1940
+- Fix(eos_designs): fix the Loopback0 interface description by @tgodaA in https://github.com/aristanetworks/avd/pull/1955
+- Fix(eos_designs): Resolve inline jinja in fabric_name by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1967
+- Fix(eos_designs): Correct underlay routing for overlay_routing_protocol: "none" by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1970
+- Fix(eos_designs): Remove unneeded mlag ibgp vlan for vrf default by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1968
+- Fix(eos_designs): Only configure EVPN filtering on EVPN nodes by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1969
+- Fix(eos_designs): only create igmp snooping querier configuration on l3 devices by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1978
+- Fix(eos_designs): Missing IGP no-passive for single MLAG VLAN by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1974
+- Fix(eos_designs): return the missing node_type in error by @pvinci-arista in https://github.com/aristanetworks/avd/pull/1981
 
 #### Other Fixed issues
 
-- Fix: typos by @matthewgottlieb in https://github.com/aristanetworks/ansible-avd/pull/1957
+- Fix: typos by @matthewgottlieb in https://github.com/aristanetworks/avd/pull/1957
 
 ### Documentation
 
-- Doc(eos_designs): Add documentation for mlag_ibgp_origin_incomplete by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1904
-- Doc: Add proper installation guide links on README by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/1915
-- Doc: Update AVD Core team by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1920
-- Doc: AVD beginner TOI update to be consistent with AVD examples by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/1908
-- Doc: Minor fixes in getting-started docs by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/1934
-- Doc(eos_designs): change adapters.mode to Optional by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/1937
-- Doc: Minor doc changes by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/1935
-- Doc: (eos_snapshot): fix var name in input example by @matthewgottlieb in https://github.com/aristanetworks/ansible-avd/pull/1960
-- Doc: mkdoc updates with layouts, font, material theme, and syntax highlighting by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/1951
-- Doc: refactoring by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/1952
-- Doc: Heading Updates by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/1991
+- Doc(eos_designs): Add documentation for mlag_ibgp_origin_incomplete by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1904
+- Doc: Add proper installation guide links on README by @tgodaA in https://github.com/aristanetworks/avd/pull/1915
+- Doc: Update AVD Core team by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1920
+- Doc: AVD beginner TOI update to be consistent with AVD examples by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/1908
+- Doc: Minor fixes in getting-started docs by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/1934
+- Doc(eos_designs): change adapters.mode to Optional by @gmuloc in https://github.com/aristanetworks/avd/pull/1937
+- Doc: Minor doc changes by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/1935
+- Doc: (eos_snapshot): fix var name in input example by @matthewgottlieb in https://github.com/aristanetworks/avd/pull/1960
+- Doc: mkdoc updates with layouts, font, material theme, and syntax highlighting by @JulioPDX in https://github.com/aristanetworks/avd/pull/1951
+- Doc: refactoring by @JulioPDX in https://github.com/aristanetworks/avd/pull/1952
+- Doc: Heading Updates by @JulioPDX in https://github.com/aristanetworks/avd/pull/1991
 
 ### New Features and enhancements
 
 #### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen): BGP VPN-IPv4/v6 SAFI route-map and match failure discard by @sengarth in https://github.com/aristanetworks/ansible-avd/pull/1851
-- Feat(eos_cli_config_gen): add ip helper to Ethernet interface by @pvinci-arista in https://github.com/aristanetworks/ansible-avd/pull/1844
-- Feat(eos_cli_config_gen): add support for logging event congestion-drops by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/1933
-- Feat(eos_cli_config_gen): Enhance support for PTP monitoring by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/1921
-- Feat(eos_cli_config_gen): router bgp link-bandwidth by @marcusmcpeek in https://github.com/aristanetworks/ansible-avd/pull/1950
-- Feat(eos_cli_config_gen): Support multicast routing under ethernet and vlan interfaces by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/1959
+- Feat(eos_cli_config_gen): BGP VPN-IPv4/v6 SAFI route-map and match failure discard by @sengarth in https://github.com/aristanetworks/avd/pull/1851
+- Feat(eos_cli_config_gen): add ip helper to Ethernet interface by @pvinci-arista in https://github.com/aristanetworks/avd/pull/1844
+- Feat(eos_cli_config_gen): add support for logging event congestion-drops by @gmuloc in https://github.com/aristanetworks/avd/pull/1933
+- Feat(eos_cli_config_gen): Enhance support for PTP monitoring by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/1921
+- Feat(eos_cli_config_gen): router bgp link-bandwidth by @marcusmcpeek in https://github.com/aristanetworks/avd/pull/1950
+- Feat(eos_cli_config_gen): Support multicast routing under ethernet and vlan interfaces by @tgodaA in https://github.com/aristanetworks/avd/pull/1959
 
 #### New features and enhancements in eos_designs
 
-- Feat(eos_designs):  knob to enable multicast in underlay by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1899
-- Feat(eos_designs): Single-Active EVPN Multihoming by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/1864
-- Feat(eos_designs): Add support for trunk_groups by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1826
-- Feat(eos_designs): BGP peer groups in VRFs by @xaviramon in https://github.com/aristanetworks/ansible-avd/pull/1663
-- Feat(eos_designs): Add network_ports data model for large scale port configurations by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1910
-- Feat(eos_designs): Support automatic BGP peer groups without nodes by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/1914
-- Feat(eos_designs): Support for structured_config on bgp_peer_groups by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1905
-- Feat(eos_designs): Automatic uplink/downlink/mlag peer-link allocation by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/1758
-- Feat(eos_designs): Native dot1x support for connected_endpoints by @mthiel117 in https://github.com/aristanetworks/ansible-avd/pull/1932
-- Feat(eos_designs): Fabric EVPN multicast by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1922
-- Feat(eos_designs): Support different ipv4 pool for mlag ibgp peerings by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/1819
-- Feat(eos_designs): Add none as a valid value for underlay and underlay protocol by @mthiel117 in https://github.com/aristanetworks/ansible-avd/pull/1939
-- Refactor(eos_designs)!: MPLS Peer Logic by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1906
-- Feat(eos_designs): Add l2ls default node type key and template by @mthiel117 in https://github.com/aristanetworks/ansible-avd/pull/1938
-- Feat(eos_designs): Support all keys with svi_profiles by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1941
-- Feat(eos_designs): igmp querier in network services by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1958
-- Feat(eos_designs): support switch_id and offset in rd admin subfield by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1977
-- Feat(eos_designs): Support Pure L2 Spine in L2LS by @mthiel117 in https://github.com/aristanetworks/ansible-avd/pull/1983
-- Feat(eos_designs): evpn l2 multicast in network services by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/1907
-- Feat(eos_designs): Only configure vlans in use by connected endpoints or downstream L2 switches by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1821
-- Feat(eos_designs): custom_templates_extra_vars by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/1989
+- Feat(eos_designs):  knob to enable multicast in underlay by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1899
+- Feat(eos_designs): Single-Active EVPN Multihoming by @jonxstill in https://github.com/aristanetworks/avd/pull/1864
+- Feat(eos_designs): Add support for trunk_groups by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1826
+- Feat(eos_designs): BGP peer groups in VRFs by @xaviramon in https://github.com/aristanetworks/avd/pull/1663
+- Feat(eos_designs): Add network_ports data model for large scale port configurations by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1910
+- Feat(eos_designs): Support automatic BGP peer groups without nodes by @tgodaA in https://github.com/aristanetworks/avd/pull/1914
+- Feat(eos_designs): Support for structured_config on bgp_peer_groups by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1905
+- Feat(eos_designs): Automatic uplink/downlink/mlag peer-link allocation by @jonxstill in https://github.com/aristanetworks/avd/pull/1758
+- Feat(eos_designs): Native dot1x support for connected_endpoints by @mthiel117 in https://github.com/aristanetworks/avd/pull/1932
+- Feat(eos_designs): Fabric EVPN multicast by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1922
+- Feat(eos_designs): Support different ipv4 pool for mlag ibgp peerings by @tgodaA in https://github.com/aristanetworks/avd/pull/1819
+- Feat(eos_designs): Add none as a valid value for underlay and underlay protocol by @mthiel117 in https://github.com/aristanetworks/avd/pull/1939
+- Refactor(eos_designs)!: MPLS Peer Logic by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1906
+- Feat(eos_designs): Add l2ls default node type key and template by @mthiel117 in https://github.com/aristanetworks/avd/pull/1938
+- Feat(eos_designs): Support all keys with svi_profiles by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1941
+- Feat(eos_designs): igmp querier in network services by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1958
+- Feat(eos_designs): support switch_id and offset in rd admin subfield by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1977
+- Feat(eos_designs): Support Pure L2 Spine in L2LS by @mthiel117 in https://github.com/aristanetworks/avd/pull/1983
+- Feat(eos_designs): evpn l2 multicast in network services by @carlbuchmann in https://github.com/aristanetworks/avd/pull/1907
+- Feat(eos_designs): Only configure vlans in use by connected endpoints or downstream L2 switches by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1821
+- Feat(eos_designs): custom_templates_extra_vars by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/1989
 
 #### Other new features and enhancements
 
-- Feat: Add AVD Example single-dc-l3ls by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/1849
+- Feat: Add AVD Example single-dc-l3ls by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/1849
 
 ## Release 3.6.0
 
@@ -533,7 +533,7 @@
 
 ## Release 3.4.0
 
-Notable changes are listed below. For a complete list of changes see the [Release](https://github.com/aristanetworks/ansible-avd/releases/tag/v3.4.0) on GitHub.
+Notable changes are listed below. For a complete list of changes see the [Release](https://github.com/aristanetworks/avd/releases/tag/v3.4.0) on GitHub.
 
 ### Data model modifications (non-breaking)
 

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -32,132 +32,132 @@ See the full list of requirements in the [installation guide](../installation/co
 
 Detailed changes:
 
-- Bump: Update Ansible and Python requirements by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3295
-- Bump: ansible collection dependencies by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3410
+- Bump: Update Ansible and Python requirements by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3295
+- Bump: ansible collection dependencies by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3410
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen): Wrong CLI template for some ip_security options by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3263
-- Fix(eos_cli_config_gen): STUN server supports multiple local interfaces by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3266
-- Fix(eos_cli_config_gen): l2_mtu under port_channel_interfaces by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3291
-- Fix(eos_cli_config_gen): correct logging event storm-control unter interface ethernet by @kmueller68 in https://github.com/aristanetworks/ansible-avd/pull/3303
-- Fix(eos_cli_config_gen): Missing password key in router_bgp.neighbors.items by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3326
-- Fix(eos_cli_config_gen): Add device documentation for phone VLAN features by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/3329
-- Fix(eos_cli_config_gen): Correct syntax for "redistribute bgp" in router bgp by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3369
-- Fix(eos_cli_config_gen): Merge flow_tracking tables by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/3396
-- Fix(eos_cli_config_gen): Fix radius attribute 32 format option. by @Chr1stophP in https://github.com/aristanetworks/ansible-avd/pull/3413
-- Fix(eos_cli_config_gen): Hide ip-security shared-key from device documentation by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3411
-- Fix(eos_cli_config_gen): Add line delimiter at beginning of ip access-list cli by @kmueller68 in https://github.com/aristanetworks/ansible-avd/pull/3403
-- Fix(eos_cli_config_gen): Render switchport mode for all modes for Port-channels by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3429
-- Fix(eos_cli_config_gen): MAC Security key fallback configured even if set to false  by @bjmeuer in https://github.com/aristanetworks/ansible-avd/pull/3437
+- Fix(eos_cli_config_gen): Wrong CLI template for some ip_security options by @gmuloc in https://github.com/aristanetworks/avd/pull/3263
+- Fix(eos_cli_config_gen): STUN server supports multiple local interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/3266
+- Fix(eos_cli_config_gen): l2_mtu under port_channel_interfaces by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3291
+- Fix(eos_cli_config_gen): correct logging event storm-control unter interface ethernet by @kmueller68 in https://github.com/aristanetworks/avd/pull/3303
+- Fix(eos_cli_config_gen): Missing password key in router_bgp.neighbors.items by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3326
+- Fix(eos_cli_config_gen): Add device documentation for phone VLAN features by @jonxstill in https://github.com/aristanetworks/avd/pull/3329
+- Fix(eos_cli_config_gen): Correct syntax for "redistribute bgp" in router bgp by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3369
+- Fix(eos_cli_config_gen): Merge flow_tracking tables by @chetryan in https://github.com/aristanetworks/avd/pull/3396
+- Fix(eos_cli_config_gen): Fix radius attribute 32 format option. by @Chr1stophP in https://github.com/aristanetworks/avd/pull/3413
+- Fix(eos_cli_config_gen): Hide ip-security shared-key from device documentation by @gmuloc in https://github.com/aristanetworks/avd/pull/3411
+- Fix(eos_cli_config_gen): Add line delimiter at beginning of ip access-list cli by @kmueller68 in https://github.com/aristanetworks/avd/pull/3403
+- Fix(eos_cli_config_gen): Render switchport mode for all modes for Port-channels by @gmuloc in https://github.com/aristanetworks/avd/pull/3429
+- Fix(eos_cli_config_gen): MAC Security key fallback configured even if set to false  by @bjmeuer in https://github.com/aristanetworks/avd/pull/3437
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs): Inherited structured_config on multiple SVIs. by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3298
-- Fix(eos_designs): Handling empty vars in network services by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/3314
-- Fix(eos_designs): Incorect type for bpg remote_as by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3313
-- Fix(eos_designs): Include ISIS interfaces in fabric docs if any device uses ISIS by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3345
-- Fix(eos_designs): Correct logic for VRF RD/RT overrides by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3434
+- Fix(eos_designs): Inherited structured_config on multiple SVIs. by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3298
+- Fix(eos_designs): Handling empty vars in network services by @emilarista in https://github.com/aristanetworks/avd/pull/3314
+- Fix(eos_designs): Incorect type for bpg remote_as by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3313
+- Fix(eos_designs): Include ISIS interfaces in fabric docs if any device uses ISIS by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3345
+- Fix(eos_designs): Correct logic for VRF RD/RT overrides by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3434
 
 ### Fixed issues in both eos_designs and eos_cli_config_gen
 
-- Fix(eos_cli_config_gen, eos_designs): BGP VRF Prefix-lists not allowed outside of AF by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3358
-- Fix(eos_cli_config_gen,eos_designs): Accept numeric ACL names by @pmprado in https://github.com/aristanetworks/ansible-avd/pull/3363
+- Fix(eos_cli_config_gen, eos_designs): BGP VRF Prefix-lists not allowed outside of AF by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3358
+- Fix(eos_cli_config_gen,eos_designs): Accept numeric ACL names by @pmprado in https://github.com/aristanetworks/avd/pull/3363
 
 ### Other Fixed issues
 
-- Fix(eos_validate_state): ANTA Add a check to AvdTestLLDPTopology for shutdown interfaces by @carl-baillargeon in https://github.com/aristanetworks/ansible-avd/pull/3234
-- Fix(cvp_configlet_upload): Use correct var for tasks manipulation by @titom73 in https://github.com/aristanetworks/ansible-avd/pull/3337
-- Fix(eos_validate_state): ANTA Add conditions to skip tests if a device is not deployed by @carl-baillargeon in https://github.com/aristanetworks/ansible-avd/pull/3272
-- Fix(eos_config_deploy_cvp): share tags from parent to dependent tasks. by @arista-matt in https://github.com/aristanetworks/ansible-avd/pull/3333
-- Fix: Change dev container image by @ankudinov in https://github.com/aristanetworks/ansible-avd/pull/3378
-- Fix(eos_validate_state): ANTA Adding support for FQDN Ansible hosts and fix errors when shutdown and description keys are missing by @carl-baillargeon in https://github.com/aristanetworks/ansible-avd/pull/3407
+- Fix(eos_validate_state): ANTA Add a check to AvdTestLLDPTopology for shutdown interfaces by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/3234
+- Fix(cvp_configlet_upload): Use correct var for tasks manipulation by @titom73 in https://github.com/aristanetworks/avd/pull/3337
+- Fix(eos_validate_state): ANTA Add conditions to skip tests if a device is not deployed by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/3272
+- Fix(eos_config_deploy_cvp): share tags from parent to dependent tasks. by @arista-matt in https://github.com/aristanetworks/avd/pull/3333
+- Fix: Change dev container image by @ankudinov in https://github.com/aristanetworks/avd/pull/3378
+- Fix(eos_validate_state): ANTA Adding support for FQDN Ansible hosts and fix errors when shutdown and description keys are missing by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/3407
 
 ### Documentation
 
-- Doc: add CVaaS Regional URLs by @noredistribution in https://github.com/aristanetworks/ansible-avd/pull/3243
-- Doc: Fix missing flow_tracking table by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3307
-- Doc: Fix missing tables in eos_cli_config_gen by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3308
-- Doc(eos_designs): svi_profiles do not support tags by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3319
-- Doc: Improve role defaults documentation by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3320
-- Doc: Improve schema generated docs by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3321
-- Doc(eos_cli_config_gen): Fix table for router AVT by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3341
-- Doc: Improve search by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3340
-- Doc(eos_cli_config_gen): Changed syslog hostname description by @pmprado in https://github.com/aristanetworks/ansible-avd/pull/3353
-- Doc: Fix doc generation by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3405
+- Doc: add CVaaS Regional URLs by @noredistribution in https://github.com/aristanetworks/avd/pull/3243
+- Doc: Fix missing flow_tracking table by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3307
+- Doc: Fix missing tables in eos_cli_config_gen by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3308
+- Doc(eos_designs): svi_profiles do not support tags by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3319
+- Doc: Improve role defaults documentation by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3320
+- Doc: Improve schema generated docs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3321
+- Doc(eos_cli_config_gen): Fix table for router AVT by @gmuloc in https://github.com/aristanetworks/avd/pull/3341
+- Doc: Improve search by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3340
+- Doc(eos_cli_config_gen): Changed syslog hostname description by @pmprado in https://github.com/aristanetworks/avd/pull/3353
+- Doc: Fix doc generation by @gmuloc in https://github.com/aristanetworks/avd/pull/3405
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen): Add ethernet interface dhcp server config by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3231
-- Feat(eos_cli_config_gen): Add support for qos map exp by @philippebureau in https://github.com/aristanetworks/ansible-avd/pull/3204
-- Feat(eos_cli_config_gen): Support of next_hop_unchanged under EVPN address family by @mmaaloul in https://github.com/aristanetworks/ansible-avd/pull/3232
-- Feat(eos_cli_config_gen): Implement management-ssh client-alive by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3265
-- Feat(eos_cli_config_gen): Add knob to define port in GNMI transport grpc by @philippebureau in https://github.com/aristanetworks/ansible-avd/pull/3245
-- Feat(eos_cli_config_gen): support for mlag peer-link requests disabled under dhcp_relay by @kmueller68 in https://github.com/aristanetworks/ansible-avd/pull/3262
-- Feat(eos_cli_config_gen): Add other valid_values for event-handler trigger 'on-boot' by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3264
-- Feat(eos_cli_config_gen): Add additional-path for evpn address-family peer-groups by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3278
-- Feat(eos_cli_config_gen): LLDP for Management interfaces by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3277
-- Feat(eos_cli_config_gen): Implement speed for management interfaces by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3284
-- Feat(eos_cli_config_gen): Support for "agents" config by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3282
-- Feat(eos_cli_config_gen): Add router path-selection feature by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3203
-- Feat(eos_cli_config_gen): Add enabled flag to router traffic-engineering by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3280
-- Feat(eos_cli_config_gen): Add mtu to Dps interfaces by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3274
-- Feat(eos_cli_config_gen): Deprecate daemon_terminattr.cvcompression by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3275
-- Feat(eos_cli_config_gen): Add ARP static entries by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3288
-- Feat(eos_cli_config_gen): Implement platform sfe cpu allocation maximum by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3287
-- Feat(eos_cli_config_gen): router adaptive-virtual-topology by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3237
-- Feat(eos_cli_config_gen): Add WRED support by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/3192
-- Feat(eos_cli_config_gen): Implement NAT profiles + ethernet interfaces CLI by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3294
-- Feat(eos_cli_config_gen): Implement VRRP for ethernet interfaces by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3276
-- Feat(eos_cli_config_gen): Add hardware_offload feature to flow_tracking.sampled by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/3318
-- Feat(eos_cli_config_gen): Extend CLI model for ip_security by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/3312
-- Feat(eos_cli_config_gen): Adding options for path-selection lb policies by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3334
-- Feat(eos_cli_config_gen): Extend sbfd for initiator measurement round-trip by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/3347
-- Feat(eos_cli_config_gen): implement global ip dhcp snooping by @kmueller68 in https://github.com/aristanetworks/ansible-avd/pull/3323
-- Feat(eos_cli_config_gen): Add profile and policy in adaptive-virtual-topology by @harshitk-arista in https://github.com/aristanetworks/ansible-avd/pull/3351
-- Feat(eos_cli_config_gen): Add support for logging format rfc5424 by @durd in https://github.com/aristanetworks/ansible-avd/pull/3386
-- Feat(eos_cli_config_gen): Improve generated documentation by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3377
-- Feat(eos_cli_config_gen): Add options to stun client and server by @harshitk-arista in https://github.com/aristanetworks/ansible-avd/pull/3383
-- Feat(eos_cli_config_gen): Adding application traffic recognition model by @amitsagar-arsita in https://github.com/aristanetworks/ansible-avd/pull/3350
-- Feat(eos_cli_config_gen): Add CRL support for management security by @harshitk-arista in https://github.com/aristanetworks/ansible-avd/pull/3420
-- Feat(eos_cli_config_gen): Support Sand MDB Profiles by @pmprado in https://github.com/aristanetworks/ansible-avd/pull/3372
+- Feat(eos_cli_config_gen): Add ethernet interface dhcp server config by @gmuloc in https://github.com/aristanetworks/avd/pull/3231
+- Feat(eos_cli_config_gen): Add support for qos map exp by @philippebureau in https://github.com/aristanetworks/avd/pull/3204
+- Feat(eos_cli_config_gen): Support of next_hop_unchanged under EVPN address family by @mmaaloul in https://github.com/aristanetworks/avd/pull/3232
+- Feat(eos_cli_config_gen): Implement management-ssh client-alive by @gmuloc in https://github.com/aristanetworks/avd/pull/3265
+- Feat(eos_cli_config_gen): Add knob to define port in GNMI transport grpc by @philippebureau in https://github.com/aristanetworks/avd/pull/3245
+- Feat(eos_cli_config_gen): support for mlag peer-link requests disabled under dhcp_relay by @kmueller68 in https://github.com/aristanetworks/avd/pull/3262
+- Feat(eos_cli_config_gen): Add other valid_values for event-handler trigger 'on-boot' by @gmuloc in https://github.com/aristanetworks/avd/pull/3264
+- Feat(eos_cli_config_gen): Add additional-path for evpn address-family peer-groups by @gmuloc in https://github.com/aristanetworks/avd/pull/3278
+- Feat(eos_cli_config_gen): LLDP for Management interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/3277
+- Feat(eos_cli_config_gen): Implement speed for management interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/3284
+- Feat(eos_cli_config_gen): Support for "agents" config by @gmuloc in https://github.com/aristanetworks/avd/pull/3282
+- Feat(eos_cli_config_gen): Add router path-selection feature by @gmuloc in https://github.com/aristanetworks/avd/pull/3203
+- Feat(eos_cli_config_gen): Add enabled flag to router traffic-engineering by @gmuloc in https://github.com/aristanetworks/avd/pull/3280
+- Feat(eos_cli_config_gen): Add mtu to Dps interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/3274
+- Feat(eos_cli_config_gen): Deprecate daemon_terminattr.cvcompression by @gmuloc in https://github.com/aristanetworks/avd/pull/3275
+- Feat(eos_cli_config_gen): Add ARP static entries by @gmuloc in https://github.com/aristanetworks/avd/pull/3288
+- Feat(eos_cli_config_gen): Implement platform sfe cpu allocation maximum by @gmuloc in https://github.com/aristanetworks/avd/pull/3287
+- Feat(eos_cli_config_gen): router adaptive-virtual-topology by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3237
+- Feat(eos_cli_config_gen): Add WRED support by @chetryan in https://github.com/aristanetworks/avd/pull/3192
+- Feat(eos_cli_config_gen): Implement NAT profiles + ethernet interfaces CLI by @gmuloc in https://github.com/aristanetworks/avd/pull/3294
+- Feat(eos_cli_config_gen): Implement VRRP for ethernet interfaces by @gmuloc in https://github.com/aristanetworks/avd/pull/3276
+- Feat(eos_cli_config_gen): Add hardware_offload feature to flow_tracking.sampled by @tgodaA in https://github.com/aristanetworks/avd/pull/3318
+- Feat(eos_cli_config_gen): Extend CLI model for ip_security by @gusmb in https://github.com/aristanetworks/avd/pull/3312
+- Feat(eos_cli_config_gen): Adding options for path-selection lb policies by @gmuloc in https://github.com/aristanetworks/avd/pull/3334
+- Feat(eos_cli_config_gen): Extend sbfd for initiator measurement round-trip by @chetryan in https://github.com/aristanetworks/avd/pull/3347
+- Feat(eos_cli_config_gen): implement global ip dhcp snooping by @kmueller68 in https://github.com/aristanetworks/avd/pull/3323
+- Feat(eos_cli_config_gen): Add profile and policy in adaptive-virtual-topology by @harshitk-arista in https://github.com/aristanetworks/avd/pull/3351
+- Feat(eos_cli_config_gen): Add support for logging format rfc5424 by @durd in https://github.com/aristanetworks/avd/pull/3386
+- Feat(eos_cli_config_gen): Improve generated documentation by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3377
+- Feat(eos_cli_config_gen): Add options to stun client and server by @harshitk-arista in https://github.com/aristanetworks/avd/pull/3383
+- Feat(eos_cli_config_gen): Adding application traffic recognition model by @amitsagar-arsita in https://github.com/aristanetworks/avd/pull/3350
+- Feat(eos_cli_config_gen): Add CRL support for management security by @harshitk-arista in https://github.com/aristanetworks/avd/pull/3420
+- Feat(eos_cli_config_gen): Support Sand MDB Profiles by @pmprado in https://github.com/aristanetworks/avd/pull/3372
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs): Support for PIM RP access_list_name under VRFs and Tenants by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/3201
-- Feat(eos_designs): Support PTP on MLAG peer-link by @jrecchia1029 in https://github.com/aristanetworks/ansible-avd/pull/3040
-- Feat(eos_designs): Added the is_deployed knob to the structured_config by @carl-baillargeon in https://github.com/aristanetworks/ansible-avd/pull/3241
-- Feat(eos_designs): Support for underlay uplink_switch_interface_speed by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/3256
-- Feat(eos_designs): Add `default_mgmt_method` to be used later in new management settings. by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3328
-- Feat(eos_designs): Port-channel ID knob for uplinks with type "port-channel" by @bjmeuer in https://github.com/aristanetworks/ansible-avd/pull/3176
-- Feat(eos_designs): Add uplink_type at nodes level by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3385
-- Feat(eos_designs): Improve custom python class API for interface descriptions by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3311
-- Feat(eos_designs): Phone VLAN support for endpoints by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/3317
-- Feat(eos_designs): Add RD and RT override for VRFs by @bjmeuer in https://github.com/aristanetworks/ansible-avd/pull/3419
-- Feat(eos_designs): Add ntp_settings by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3293
+- Feat(eos_designs): Support for PIM RP access_list_name under VRFs and Tenants by @jonxstill in https://github.com/aristanetworks/avd/pull/3201
+- Feat(eos_designs): Support PTP on MLAG peer-link by @jrecchia1029 in https://github.com/aristanetworks/avd/pull/3040
+- Feat(eos_designs): Added the is_deployed knob to the structured_config by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/3241
+- Feat(eos_designs): Support for underlay uplink_switch_interface_speed by @jonxstill in https://github.com/aristanetworks/avd/pull/3256
+- Feat(eos_designs): Add `default_mgmt_method` to be used later in new management settings. by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3328
+- Feat(eos_designs): Port-channel ID knob for uplinks with type "port-channel" by @bjmeuer in https://github.com/aristanetworks/avd/pull/3176
+- Feat(eos_designs): Add uplink_type at nodes level by @gmuloc in https://github.com/aristanetworks/avd/pull/3385
+- Feat(eos_designs): Improve custom python class API for interface descriptions by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3311
+- Feat(eos_designs): Phone VLAN support for endpoints by @jonxstill in https://github.com/aristanetworks/avd/pull/3317
+- Feat(eos_designs): Add RD and RT override for VRFs by @bjmeuer in https://github.com/aristanetworks/avd/pull/3419
+- Feat(eos_designs): Add ntp_settings by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3293
 
 ### New features and enhancement in both eos_designs and eos_cli_config_gen
 
-- Feat(eos_cli_config_gen,eos_designs): Add support for 'l2 mru' by @m-rhode in https://github.com/aristanetworks/ansible-avd/pull/3164
-- Feat(eos_designs,eos_cli_config_gen): Add metadata.platform to structured configuration by @dlobato in https://github.com/aristanetworks/ansible-avd/pull/3421
+- Feat(eos_cli_config_gen,eos_designs): Add support for 'l2 mru' by @m-rhode in https://github.com/aristanetworks/avd/pull/3164
+- Feat(eos_designs,eos_cli_config_gen): Add metadata.platform to structured configuration by @dlobato in https://github.com/aristanetworks/avd/pull/3421
 
 ### Other new features and enhancements
 
-- Feat: AVD dev containers by @ankudinov in https://github.com/aristanetworks/ansible-avd/pull/3179
-- Feat(eos_validate_state): ANTA Add eAPI HTTPS SSL profile test by @MaheshGSLAB in https://github.com/aristanetworks/ansible-avd/pull/3357
-- Feat(eos_validate_state): ANTA New action plugin to generate the reports by @carl-baillargeon in https://github.com/aristanetworks/ansible-avd/pull/3352
+- Feat: AVD dev containers by @ankudinov in https://github.com/aristanetworks/avd/pull/3179
+- Feat(eos_validate_state): ANTA Add eAPI HTTPS SSL profile test by @MaheshGSLAB in https://github.com/aristanetworks/avd/pull/3357
+- Feat(eos_validate_state): ANTA New action plugin to generate the reports by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/3352
 
 ### PyAVD Changes
 
-- Feat(pyavd): Adding "path" attribute to validation_errors and deprecation_warnings. by @Shivani-gslab in https://github.com/aristanetworks/ansible-avd/pull/3255
-- Bump(pyavd): Move PyAVD out of beta by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3433
+- Feat(pyavd): Adding "path" attribute to validation_errors and deprecation_warnings. by @Shivani-gslab in https://github.com/aristanetworks/avd/pull/3255
+- Bump(pyavd): Move PyAVD out of beta by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3433
 
 ### Other Changes
 
-- Refactor(eos_designs): Remove EVPN limitation for underlay_filter_peer_as by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/3207
-- Refactor(eos_designs): Add testcases for ipaddressing and move it to plugin utils by @Vibhu-gslab in https://github.com/aristanetworks/ansible-avd/pull/2410
-- Refactor(eos_designs): Optimize conversion of structured config outputs by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3240
-- Refactor(eos_designs): Reorder BGP address family rendering for overlay module by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3393
+- Refactor(eos_designs): Remove EVPN limitation for underlay_filter_peer_as by @emilarista in https://github.com/aristanetworks/avd/pull/3207
+- Refactor(eos_designs): Add testcases for ipaddressing and move it to plugin utils by @Vibhu-gslab in https://github.com/aristanetworks/avd/pull/2410
+- Refactor(eos_designs): Optimize conversion of structured config outputs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3240
+- Refactor(eos_designs): Reorder BGP address family rendering for overlay module by @gmuloc in https://github.com/aristanetworks/avd/pull/3393
 
 ## Release 4.4.0
 
@@ -173,15 +173,15 @@ Detailed changes:
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen) - under maximum_paths, ecmp field is not required by @mmaaloul in https://github.com/aristanetworks/ansible-avd/pull/3111
-- Fix(eos_cli_config_gen) - ip http client source interfaces cli not generated by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3180
-- Fix(eos_cli_config_gen) - Correct schema for class-maps vlans and cos options by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3215
-- Fix(eos_cli_config_gen) - Correct max TTL values for ip_access_lists and ptp by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3225
-- Fix(eos_cli_config_gen) - Remove requirement for MACSec license and FIPS by @xaviramon in https://github.com/aristanetworks/ansible-avd/pull/3239
+- Fix(eos_cli_config_gen) - under maximum_paths, ecmp field is not required by @mmaaloul in https://github.com/aristanetworks/avd/pull/3111
+- Fix(eos_cli_config_gen) - ip http client source interfaces cli not generated by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3180
+- Fix(eos_cli_config_gen) - Correct schema for class-maps vlans and cos options by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3215
+- Fix(eos_cli_config_gen) - Correct max TTL values for ip_access_lists and ptp by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3225
+- Fix(eos_cli_config_gen) - Remove requirement for MACSec license and FIPS by @xaviramon in https://github.com/aristanetworks/avd/pull/3239
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs) - Configuration of PTP for port-channel uplinks by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3112
+- Fix(eos_designs) - Configuration of PTP for port-channel uplinks by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3112
 
   L2leaf switches were included in the original implementation of PTP for a fabric, but configuration for the port-channel uplinks were missed. This fix adds the missing configuration for the uplinks of l2 leaf switches.
 
@@ -197,59 +197,59 @@ Detailed changes:
               enable: false
       ```
 
-- Fix(eos_designs) - removed min and max value from vrf_id by @karnag3 in https://github.com/aristanetworks/ansible-avd/pull/3130
-- Fix(eos_designs) - Configure evpn_ebgp_gateway_multihop for ipvpn_gateway EBGP peers by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3205
-- Fix(eos_designs) - change speed group value from int to str by @philippebureau in https://github.com/aristanetworks/ansible-avd/pull/3235
-- Fix(eos_designs) - Improve evpn_multicast error handling by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/3195
+- Fix(eos_designs) - removed min and max value from vrf_id by @karnag3 in https://github.com/aristanetworks/avd/pull/3130
+- Fix(eos_designs) - Configure evpn_ebgp_gateway_multihop for ipvpn_gateway EBGP peers by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3205
+- Fix(eos_designs) - change speed group value from int to str by @philippebureau in https://github.com/aristanetworks/avd/pull/3235
+- Fix(eos_designs) - Improve evpn_multicast error handling by @jonxstill in https://github.com/aristanetworks/avd/pull/3195
 
 ### Other Fixed issues
 
-- Fix - ip reachability test with l3dge endpoint not managed by AVD by @spangoli-arista in https://github.com/aristanetworks/ansible-avd/pull/3140
-- Fix(eos_config_deploy_cvp) - Avoid duplicate AVD configlet by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3124
-- Fix(plugins) - Raise AnsibleFilterError when range is invalid by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3163
-- Fix(eos_validate_state) - ANTA VerifyRoutingProtocolModel now only run if there is BGP configuration by @carl-baillargeon in https://github.com/aristanetworks/ansible-avd/pull/3212
+- Fix - ip reachability test with l3dge endpoint not managed by AVD by @spangoli-arista in https://github.com/aristanetworks/avd/pull/3140
+- Fix(eos_config_deploy_cvp) - Avoid duplicate AVD configlet by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3124
+- Fix(plugins) - Raise AnsibleFilterError when range is invalid by @gmuloc in https://github.com/aristanetworks/avd/pull/3163
+- Fix(eos_validate_state) - ANTA VerifyRoutingProtocolModel now only run if there is BGP configuration by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/3212
 
 ### Documentation
 
-- Doc - Add updated requirements for jsonschema in 4.2.0 by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3157
-- Doc - Custom templates docs by @andsouth44 in https://github.com/aristanetworks/ansible-avd/pull/3150
-- Doc - Reorder schema tables with dynamic keys first by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3216
-- Doc - Update AVD project maintainers by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3196
-- Doc(eos_designs) - Clarify evpn_multicast required for evpn_l2/l3_multicast by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/3156
-- Doc(eos_cli_config_gen) - Fix spacing in router-bgp documentation template by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3197
+- Doc - Add updated requirements for jsonschema in 4.2.0 by @gmuloc in https://github.com/aristanetworks/avd/pull/3157
+- Doc - Custom templates docs by @andsouth44 in https://github.com/aristanetworks/avd/pull/3150
+- Doc - Reorder schema tables with dynamic keys first by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3216
+- Doc - Update AVD project maintainers by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3196
+- Doc(eos_designs) - Clarify evpn_multicast required for evpn_l2/l3_multicast by @jonxstill in https://github.com/aristanetworks/avd/pull/3156
+- Doc(eos_cli_config_gen) - Fix spacing in router-bgp documentation template by @gmuloc in https://github.com/aristanetworks/avd/pull/3197
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen) - Support of a global tacacs timeout by @mmaaloul in https://github.com/aristanetworks/ansible-avd/pull/3173
-- Feat(eos_cli_config_gen) - Support STUN by @burnyd in https://github.com/aristanetworks/ansible-avd/pull/3147
-- Feat(eos_cli_config_gen) - Add ECN Support by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2770
-- Feat(eos_cli_config_gen) - Implement next-hop resolution disabled for evpn address-family by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3218
-- Feat(eos_cli_config_gen) - Add IPv4 and IPv6 SR-TE address families by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3217
-- Feat(eos_cli_config_gen) - Support of route-target route-map for BGP VRFs by @mmaaloul in https://github.com/aristanetworks/ansible-avd/pull/3222
-- Feat(eos_cli_config_gen) - Add support for BGP link-state address-family by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3211
-- Feat(eos_cli_config_gen) - Ethernet interfaces ip address dhcp support by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3229
-- Feat(eos_cli_config_gen) - Add ip security by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3194
-- Feat(eos_cli_config_gen) - Support path-selection bgp address-family by @burnyd in https://github.com/aristanetworks/ansible-avd/pull/3151
-- Feat(eos_cli_config_gen) - Add 'router service-insertion' CLI by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3220
-- Feat(eos_cli_config_gen) - Add Dps1 interface by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3198
-- Feat(eos_cli_config_gen) - add system l1 support by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3221
-- Feat(eos_cli_config_gen) - Add support for flow tracking hardware by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3199
+- Feat(eos_cli_config_gen) - Support of a global tacacs timeout by @mmaaloul in https://github.com/aristanetworks/avd/pull/3173
+- Feat(eos_cli_config_gen) - Support STUN by @burnyd in https://github.com/aristanetworks/avd/pull/3147
+- Feat(eos_cli_config_gen) - Add ECN Support by @chetryan in https://github.com/aristanetworks/avd/pull/2770
+- Feat(eos_cli_config_gen) - Implement next-hop resolution disabled for evpn address-family by @gmuloc in https://github.com/aristanetworks/avd/pull/3218
+- Feat(eos_cli_config_gen) - Add IPv4 and IPv6 SR-TE address families by @gmuloc in https://github.com/aristanetworks/avd/pull/3217
+- Feat(eos_cli_config_gen) - Support of route-target route-map for BGP VRFs by @mmaaloul in https://github.com/aristanetworks/avd/pull/3222
+- Feat(eos_cli_config_gen) - Add support for BGP link-state address-family by @gmuloc in https://github.com/aristanetworks/avd/pull/3211
+- Feat(eos_cli_config_gen) - Ethernet interfaces ip address dhcp support by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3229
+- Feat(eos_cli_config_gen) - Add ip security by @gmuloc in https://github.com/aristanetworks/avd/pull/3194
+- Feat(eos_cli_config_gen) - Support path-selection bgp address-family by @burnyd in https://github.com/aristanetworks/avd/pull/3151
+- Feat(eos_cli_config_gen) - Add 'router service-insertion' CLI by @gmuloc in https://github.com/aristanetworks/avd/pull/3220
+- Feat(eos_cli_config_gen) - Add Dps1 interface by @gmuloc in https://github.com/aristanetworks/avd/pull/3198
+- Feat(eos_cli_config_gen) - add system l1 support by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3221
+- Feat(eos_cli_config_gen) - Add support for flow tracking hardware by @gmuloc in https://github.com/aristanetworks/avd/pull/3199
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs) - Support multiple descriptions in connected_endpoint adapters by @pvinci-arista in https://github.com/aristanetworks/ansible-avd/pull/2966
-- Feat(eos_designs) - VTEP override option on node-definitions by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/3133
-- Feat(eos_designs) - Add default_interface_mtu and feature_support.per_interface_mtu by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3128
-- Feat(eos_designs) - Enhance SNMP support by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3083
-- Feat(eos_designs) - EVPN vlan-aware-bundle option for l2vlan  by @bjmeuer in https://github.com/aristanetworks/ansible-avd/pull/3075
-- Feat(eos_designs) - Build AVD topology from CloudVision I&T Studio data by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3223
+- Feat(eos_designs) - Support multiple descriptions in connected_endpoint adapters by @pvinci-arista in https://github.com/aristanetworks/avd/pull/2966
+- Feat(eos_designs) - VTEP override option on node-definitions by @emilarista in https://github.com/aristanetworks/avd/pull/3133
+- Feat(eos_designs) - Add default_interface_mtu and feature_support.per_interface_mtu by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3128
+- Feat(eos_designs) - Enhance SNMP support by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3083
+- Feat(eos_designs) - EVPN vlan-aware-bundle option for l2vlan  by @bjmeuer in https://github.com/aristanetworks/avd/pull/3075
+- Feat(eos_designs) - Build AVD topology from CloudVision I&T Studio data by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3223
 
 ### Other new features and enhancements
 
-- Feat - Support inline comments in requirements.txt by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3125
-- Feat(plugins) - Add deprecation for ansible-core<2.14 and python 3.8 by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3187
-- Feat(eos_validate_state) - Add ANTA integration to eos_validate_state role by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3171
-- Feat(eos_config_deploy_cvp) - Add support for device_inventory_mode by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2561
+- Feat - Support inline comments in requirements.txt by @gmuloc in https://github.com/aristanetworks/avd/pull/3125
+- Feat(plugins) - Add deprecation for ansible-core<2.14 and python 3.8 by @gmuloc in https://github.com/aristanetworks/avd/pull/3187
+- Feat(eos_validate_state) - Add ANTA integration to eos_validate_state role by @gmuloc in https://github.com/aristanetworks/avd/pull/3171
+- Feat(eos_config_deploy_cvp) - Add support for device_inventory_mode by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2561
 
 ## Release 4.3.0
 
@@ -259,38 +259,38 @@ Detailed changes:
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs) - Fix schema for BGP peers to allow shutdown key by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3100
-- Fix(eos_designs) - Don't require "mlag_peer_l3_ipv4_pool" with full rfc5549 by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3106
-- Fix(eos_designs) - Ensure consistent ordering of underlay route-maps by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3105
+- Fix(eos_designs) - Fix schema for BGP peers to allow shutdown key by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3100
+- Fix(eos_designs) - Don't require "mlag_peer_l3_ipv4_pool" with full rfc5549 by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3106
+- Fix(eos_designs) - Ensure consistent ordering of underlay route-maps by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3105
 
 ### Documentation
 
-- Doc - Insert license header in all source files by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3092
-- Doc - Minor typo fixes on internal notes documentation by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/3093
-- Doc - avd to cvaas by @kgiusti4130 in https://github.com/aristanetworks/ansible-avd/pull/3089
-- Doc - Add license header to YAML source files. by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3099
+- Doc - Insert license header in all source files by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3092
+- Doc - Minor typo fixes on internal notes documentation by @JulioPDX in https://github.com/aristanetworks/avd/pull/3093
+- Doc - avd to cvaas by @kgiusti4130 in https://github.com/aristanetworks/avd/pull/3089
+- Doc - Add license header to YAML source files. by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3099
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen) - add dot1x unauthorized access/native vlan membership egress to ethernet interfaces by @kmueller68 in https://github.com/aristanetworks/ansible-avd/pull/3073
-- Feat(eos_cli_config_gen) - Allow TCAM profile local file configuration by @xaviramon in https://github.com/aristanetworks/ansible-avd/pull/2833
-- Feat(eos_cli_config_gen) - Add support for "include leaked" under BGP redistribution by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3071
-- Feat(eos_cli_config_gen) - Add Trident MMU queue by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2835
-- Feat(eos_cli_config_gen) - Add priority flow control to qos profile by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2796
-- Feat(eos_cli_config_gen) - Add support for ftp/tftp/telnet client source interfaces by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/3080
-- Feat(eos_cli_config_gen) - Support accounting logging by @colinmacgiolla in https://github.com/aristanetworks/ansible-avd/pull/3091
+- Feat(eos_cli_config_gen) - add dot1x unauthorized access/native vlan membership egress to ethernet interfaces by @kmueller68 in https://github.com/aristanetworks/avd/pull/3073
+- Feat(eos_cli_config_gen) - Allow TCAM profile local file configuration by @xaviramon in https://github.com/aristanetworks/avd/pull/2833
+- Feat(eos_cli_config_gen) - Add support for "include leaked" under BGP redistribution by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3071
+- Feat(eos_cli_config_gen) - Add Trident MMU queue by @chetryan in https://github.com/aristanetworks/avd/pull/2835
+- Feat(eos_cli_config_gen) - Add priority flow control to qos profile by @chetryan in https://github.com/aristanetworks/avd/pull/2796
+- Feat(eos_cli_config_gen) - Add support for ftp/tftp/telnet client source interfaces by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/3080
+- Feat(eos_cli_config_gen) - Support accounting logging by @colinmacgiolla in https://github.com/aristanetworks/avd/pull/3091
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs) - Add control for redistribution of MLAG peering subnet by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3069
-- Feat(eos_designs) - Validation of structured_config by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3077
-- Feat(eos_designs) - Add support for setting source-interfaces for management protocols by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3072
+- Feat(eos_designs) - Add control for redistribution of MLAG peering subnet by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3069
+- Feat(eos_designs) - Validation of structured_config by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3077
+- Feat(eos_designs) - Add support for setting source-interfaces for management protocols by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3072
 
 ### Other Changes
 
-- Bump - Add support for Ansible 2.15.x by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3070
-- Refactor(eos_designs) - Deprecate cvp_instance_ip in favor of cvp_instance_ips by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/3028
-- Refactor(eos_designs) - Optimize connected endpoints temp data storage by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3094
+- Bump - Add support for Ansible 2.15.x by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3070
+- Refactor(eos_designs) - Deprecate cvp_instance_ip in favor of cvp_instance_ips by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/3028
+- Refactor(eos_designs) - Optimize connected endpoints temp data storage by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3094
 
 ## Release 4.2.0
 
@@ -301,89 +301,89 @@ Detailed changes:
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen) - Force domain_identifier to be a string by @hamptonmoore in https://github.com/aristanetworks/ansible-avd/pull/2997
-- Fix(eos_cli_config_gen) - Fixing management_api_http.protocol_https_certificate error by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/3023
-- Fix(eos_cli_config_gen) - Relax schema for empty prefix-lists by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/3008
-- Fix(eos_cli_config_gen) - Fix router_isis.instance schema by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/3050
-- Fix(eos_cli_config_gen) - Support vars on play via `vars` or `vars_files` by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2999
+- Fix(eos_cli_config_gen) - Force domain_identifier to be a string by @hamptonmoore in https://github.com/aristanetworks/avd/pull/2997
+- Fix(eos_cli_config_gen) - Fixing management_api_http.protocol_https_certificate error by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/3023
+- Fix(eos_cli_config_gen) - Relax schema for empty prefix-lists by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/3008
+- Fix(eos_cli_config_gen) - Fix router_isis.instance schema by @tgodaA in https://github.com/aristanetworks/avd/pull/3050
+- Fix(eos_cli_config_gen) - Support vars on play via `vars` or `vars_files` by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2999
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs) - Incorrect type for ospf.area in network services keys by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2998
-- Fix(eos_designs) - Duplicate neighbor_interfaces in rfc5549 design when multiple uplinks to the same Spine by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3054
+- Fix(eos_designs) - Incorrect type for ospf.area in network services keys by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2998
+- Fix(eos_designs) - Duplicate neighbor_interfaces in rfc5549 design when multiple uplinks to the same Spine by @gmuloc in https://github.com/aristanetworks/avd/pull/3054
 
 ### Other Fixed issues
 
-- Fix(eos_config_deploy_cvp) - device_filter is not behaving correctly if input is a string by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/3046
+- Fix(eos_config_deploy_cvp) - device_filter is not behaving correctly if input is a string by @gmuloc in https://github.com/aristanetworks/avd/pull/3046
 
 ### Documentation
 
-- Doc(eos_designs, eos_cli_config_gen) - Various doc improvements by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/3001
+- Doc(eos_designs, eos_cli_config_gen) - Various doc improvements by @carlbuchmann in https://github.com/aristanetworks/avd/pull/3001
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen) - Generate sFlow egress commands by @xaviramon in https://github.com/aristanetworks/ansible-avd/pull/2767
-- Feat(eos_cli_config_gen) - add support for password complexity policies by @hamptonmoore in https://github.com/aristanetworks/ansible-avd/pull/2991
-- Feat(eos_cli_config_gen) - Add global logging event storm-control by @kmueller68 in https://github.com/aristanetworks/ansible-avd/pull/2994
-- Feat(eos_cli_config_gen) - Flow tracking table size by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2838
-- Feat(eos_cli_config_gen) - ECN Propagation by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2841
-- Feat(eos_cli_config_gen) - Add support for eos_cli under router_ospf process ids by @KyleMui in https://github.com/aristanetworks/ansible-avd/pull/3035
+- Feat(eos_cli_config_gen) - Generate sFlow egress commands by @xaviramon in https://github.com/aristanetworks/avd/pull/2767
+- Feat(eos_cli_config_gen) - add support for password complexity policies by @hamptonmoore in https://github.com/aristanetworks/avd/pull/2991
+- Feat(eos_cli_config_gen) - Add global logging event storm-control by @kmueller68 in https://github.com/aristanetworks/avd/pull/2994
+- Feat(eos_cli_config_gen) - Flow tracking table size by @chetryan in https://github.com/aristanetworks/avd/pull/2838
+- Feat(eos_cli_config_gen) - ECN Propagation by @chetryan in https://github.com/aristanetworks/avd/pull/2841
+- Feat(eos_cli_config_gen) - Add support for eos_cli under router_ospf process ids by @KyleMui in https://github.com/aristanetworks/avd/pull/3035
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs) - Fabric IP Addressing MLAG same_subnet addressing algorithm by @hamptonmoore in https://github.com/aristanetworks/ansible-avd/pull/2987
-- Feat(eos_designs) - Adding structured_config to l3_edge P2P_links by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/3017
-- Feat(eos_designs) - Sflow configuration at fabric level by @xaviramon in https://github.com/aristanetworks/ansible-avd/pull/2775
+- Feat(eos_designs) - Fabric IP Addressing MLAG same_subnet addressing algorithm by @hamptonmoore in https://github.com/aristanetworks/avd/pull/2987
+- Feat(eos_designs) - Adding structured_config to l3_edge P2P_links by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/3017
+- Feat(eos_designs) - Sflow configuration at fabric level by @xaviramon in https://github.com/aristanetworks/avd/pull/2775
 
 ### New features and enhancement in both eos_designs and eos_cli_config_gen
 
-- Feat(eos_designs,eos_cli_config_gen) - Add hostname to structured configuration by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3016
+- Feat(eos_designs,eos_cli_config_gen) - Add hostname to structured configuration by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3016
 
 ### Other new features and enhancements
 
-- Feat(plugins) - Make setting of switch fact optional for yaml_templates_to_facts by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3022
-- Feat(dhcp_provisioner) - Adding support for automatic dict_to_list conversion in ztp_configuration template by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/3012
+- Feat(plugins) - Make setting of switch fact optional for yaml_templates_to_facts by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3022
+- Feat(dhcp_provisioner) - Adding support for automatic dict_to_list conversion in ztp_configuration template by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/3012
 
 ### Other Changes
 
-- Refactor(eos_designs) - Combine core_interfaces and l3_edge python_modules by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/3003
-- Refactor - Adjust pyavd API and requirements by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/3018
-- Refactor(eos_designs) - Using common method for raising duplicate detection error in python_modules by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/3033
-- Refactor(eos_designs) - Deprecating port_channel.short_esi under connected_endpoints by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/3027
+- Refactor(eos_designs) - Combine core_interfaces and l3_edge python_modules by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/3003
+- Refactor - Adjust pyavd API and requirements by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/3018
+- Refactor(eos_designs) - Using common method for raising duplicate detection error in python_modules by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/3033
+- Refactor(eos_designs) - Deprecating port_channel.short_esi under connected_endpoints by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/3027
 
 ## Release 4.1.0
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs) - Schema validation for connected endpoints not executed by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2984
-- Fix(eos_designs) - Sort internal objects for consistent output by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2988
+- Fix(eos_designs) - Schema validation for connected endpoints not executed by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2984
+- Fix(eos_designs) - Sort internal objects for consistent output by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2988
 
 ### Other Fixed issues
 
-- Fix(cvp_configlet_upload) - Add requirements checks by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2990
+- Fix(cvp_configlet_upload) - Add requirements checks by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2990
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen) - Add comments to queue by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2864
-- Feat(eos_cli_config_gen) - Add OSPF default_information_originate options by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/2896
-- Feat(eos_cli_config_gen) - Add trust and chain certificate by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2804
+- Feat(eos_cli_config_gen) - Add comments to queue by @chetryan in https://github.com/aristanetworks/avd/pull/2864
+- Feat(eos_cli_config_gen) - Add OSPF default_information_originate options by @gusmb in https://github.com/aristanetworks/avd/pull/2896
+- Feat(eos_cli_config_gen) - Add trust and chain certificate by @tgodaA in https://github.com/aristanetworks/avd/pull/2804
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs) - Add support for POE settings under connected endpoints by @jrecchia1029 in https://github.com/aristanetworks/ansible-avd/pull/2975
-- Feat(eos_designs) - Enhance RD/RT assignments options by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2893
-- Feat(eos_designs) - Compact MLAG allocations #2903 by @hamptonmoore in https://github.com/aristanetworks/ansible-avd/pull/2946
-- Feat(eos_designs) - Make BFD configurable under bgp_peer_groups by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2890
-- Feat(eos_designs) - Support setting "ptp.auto_clock_identity: false" as group/hostvar by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/2815
-- Feat(eos_designs) - Support for underlay_multicast RPs and Anycast-RP by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2846
+- Feat(eos_designs) - Add support for POE settings under connected endpoints by @jrecchia1029 in https://github.com/aristanetworks/avd/pull/2975
+- Feat(eos_designs) - Enhance RD/RT assignments options by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2893
+- Feat(eos_designs) - Compact MLAG allocations #2903 by @hamptonmoore in https://github.com/aristanetworks/avd/pull/2946
+- Feat(eos_designs) - Make BFD configurable under bgp_peer_groups by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2890
+- Feat(eos_designs) - Support setting "ptp.auto_clock_identity: false" as group/hostvar by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/2815
+- Feat(eos_designs) - Support for underlay_multicast RPs and Anycast-RP by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2846
 
 ### Other new features and enhancements
 
-- Feat: pyavd alpha by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2989
+- Feat: pyavd alpha by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2989
 
 ### Other Changes
 
-- Refactor(eos_cli_config_gen) - Minor adjustments to prepare for pyavd by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2986
+- Refactor(eos_cli_config_gen) - Minor adjustments to prepare for pyavd by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2986
 
 ## Release 4.0.0
 
@@ -454,7 +454,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#non-
 
 Pull request:
 
-- Feat(eos_designs, eos_cli_config_gen)! - Remove default "switchport" and remove logic from eos_cli_config_gen by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2430
+- Feat(eos_designs, eos_cli_config_gen)! - Remove default "switchport" and remove logic from eos_cli_config_gen by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2430
 
 #### Require queue_monitor_length.enabled
 
@@ -466,7 +466,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#requ
 
 Pull request:
 
-- Refactor(eos_cli_config_gen)! - Require queue_monitor_length.enabled to be set by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/2429
+- Refactor(eos_cli_config_gen)! - Require queue_monitor_length.enabled to be set by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/2429
 
 #### Disabling IGMP Snooping globally no longer blocks other IGMP snooping configuration
 
@@ -478,7 +478,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#new-
 
 Pull request:
 
-- Feat(eos_designs)! - Remove default value from mlag_peer_link_allowed_vlans by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2845
+- Feat(eos_designs)! - Remove default value from mlag_peer_link_allowed_vlans by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2845
 
 #### New required vlan_interfaces.[].ip_attached_host_route_export.enabled key
 
@@ -491,7 +491,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#new-
 
 Pull request:
 
-- Refactor(eos_cli_config_gen)! - Require `enabled - true` under `vlan_interfaces.[].ip_attached_host_route_export` by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2773
+- Refactor(eos_cli_config_gen)! - Require `enabled - true` under `vlan_interfaces.[].ip_attached_host_route_export` by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2773
 
 #### New data model for BGP VRF address-families
 
@@ -517,7 +517,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#hard
 
 Pull requests:
 
-- Feat(eos_cli_config_gen)! - Change Hardware Counter model by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2695
+- Feat(eos_cli_config_gen)! - Change Hardware Counter model by @gmuloc in https://github.com/aristanetworks/avd/pull/2695
 
 #### `eos_cli_config_gen` sanitized device documentation
 
@@ -568,7 +568,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#ip-a
 
 Pull request:
 
-- Fix(eos_designs)! - Prevent configuration of IP routing on l2leaf by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2684
+- Fix(eos_designs)! - Prevent configuration of IP routing on l2leaf by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2684
 
 #### BGP is no longer configured on irrelevant nodes
 
@@ -579,7 +579,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#bgp-
 
 Pull request:
 
-- Fix(eos_designs)! - Remove BGP rendering on irrelevant nodes by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2774
+- Fix(eos_designs)! - Remove BGP rendering on irrelevant nodes by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2774
 
 #### Link-local IPv6 addressing is implicitly enabled when configuring IPv6 Anycast IP
 
@@ -620,8 +620,8 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#bgp-
 
 Pull requests:
 
-- Feat(eos_designs)! - fabric variable for bgp default ipv4 unicast by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2799
-- Feat(eos_designs)! - Platform and Fabric variables to adjust update wait-for-convergence and update wait-install by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2855
+- Feat(eos_designs)! - fabric variable for bgp default ipv4 unicast by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2799
+- Feat(eos_designs)! - Platform and Fabric variables to adjust update wait-for-convergence and update wait-install by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2855
 
 #### Change in default MTU for point-to-point ethernet interfaces
 
@@ -631,7 +631,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#p2p-
 
 Pull request:
 
-- Feat(eos_designs)! - Change p2p_uplinks_mtu default value from 9000 to 9214 by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2844
+- Feat(eos_designs)! - Change p2p_uplinks_mtu default value from 9000 to 9214 by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2844
 
 #### Change in behavior in core_interfaces variables
 
@@ -664,7 +664,7 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#chan
 
 Pull request:
 
-- Feat(eos_designs)! - Enhance inband management configuration options by @pvinci-arista in https://github.com/aristanetworks/ansible-avd/pull/2712
+- Feat(eos_designs)! - Enhance inband management configuration options by @pvinci-arista in https://github.com/aristanetworks/avd/pull/2712
 
 #### Several internal switch.* facts and avd_switch_facts have been removed
 
@@ -791,7 +791,7 @@ The `v3` modules are mostly compatible with the `v1` modules with a few known ga
 
 Pull request:
 
-- Bump(cvp_configlet_upload,eos_config_deploy_cvp)! - Update the default `cv_collection` from `v1` to `v3` by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2882
+- Bump(cvp_configlet_upload,eos_config_deploy_cvp)! - Update the default `cv_collection` from `v1` to `v3` by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2882
 
 #### Change upper case CVP roles and module vars to lower case
 
@@ -825,7 +825,7 @@ CVP_VARS -> cvp_vars
 
 Pull request:
 
-- Fix! - Change uppercase CVP role vars to lower case by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2504
+- Fix! - Change uppercase CVP role vars to lower case by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2504
 
 #### Changes to inventory to CloudVision containers
 
@@ -838,161 +838,161 @@ See details in the [Porting guide for AVD 4.x.x](../porting-guides/4.x.x.md#inve
 
 Pull request:
 
-- Feat(eos_config_deploy_cvp)! - Support for dynamic inventories by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2395
+- Feat(eos_config_deploy_cvp)! - Support for dynamic inventories by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2395
 
 ### Fixed issues in eos_cli_config_gen
 
-- Fix(eos_cli_config_gen) - Render LLDP commands on ethernet_interfaces also for port-channel members by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2386
-- Fix(eos_cli_config_gen) - Workaround for router-general EOS CLI issue by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2408
-- Fix(eos_cli_config_gen) - Fix the router_multicast vrfs indentation by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2476
-- Fix(eos_cli_config_gen) - Update radius-server and radius-servers to match EOS behavior by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2615
-- Fix(eos_cli_config_gen) - Fix documentation template for flow tracking by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2636
-- Fix(eos_cli_config_gen) - Checks for missing "vlans" key on access port-channel by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/2701
-- Fix(eos_cli_config_gen) - Fix typo in router-bgp.j2 by @adietrich-ussignal in https://github.com/aristanetworks/ansible-avd/pull/2753
-- Fix(eos_cli_config_gen) - Ensure unique VRF names in schemas by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2878
-- Fix - Logging buffered default level not required by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2364
-- Fix - add guard to dot1x mac_based_authentication by @pvinci-arista in https://github.com/aristanetworks/ansible-avd/pull/2764
+- Fix(eos_cli_config_gen) - Render LLDP commands on ethernet_interfaces also for port-channel members by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2386
+- Fix(eos_cli_config_gen) - Workaround for router-general EOS CLI issue by @tgodaA in https://github.com/aristanetworks/avd/pull/2408
+- Fix(eos_cli_config_gen) - Fix the router_multicast vrfs indentation by @tgodaA in https://github.com/aristanetworks/avd/pull/2476
+- Fix(eos_cli_config_gen) - Update radius-server and radius-servers to match EOS behavior by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2615
+- Fix(eos_cli_config_gen) - Fix documentation template for flow tracking by @chetryan in https://github.com/aristanetworks/avd/pull/2636
+- Fix(eos_cli_config_gen) - Checks for missing "vlans" key on access port-channel by @jonxstill in https://github.com/aristanetworks/avd/pull/2701
+- Fix(eos_cli_config_gen) - Fix typo in router-bgp.j2 by @adietrich-ussignal in https://github.com/aristanetworks/avd/pull/2753
+- Fix(eos_cli_config_gen) - Ensure unique VRF names in schemas by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2878
+- Fix - Logging buffered default level not required by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2364
+- Fix - add guard to dot1x mac_based_authentication by @pvinci-arista in https://github.com/aristanetworks/avd/pull/2764
 
 ### Fixed issues in eos_designs
 
-- Fix(eos_designs) - Handle overlapping VLAN names for l2vlans and vlan-aware-bundles by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2388
-- Fix(eos_designs) - overlay_rd_type with inline jinja generates incorrect config by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2393
-- Fix(eos_designs) - Detect duplicate VLAN, VRF, VNI within network_services by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2411
-- Fix(eos_designs) - Renders lacp fallback when port-channel mode is passive by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2448
-- Fix(eos_designs) - vtep_vvtep_ip doesn't generate any config by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2442
-- Fix(eos_designs) - Fix issue with hardware_counters python code by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2447
-- Fix(eos_designs) - remove speed from port-channel interfaces by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2463
-- Fix(eos_designs) - Fix error with dotted hostname, l2leaf and mlag by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2502
-- Fix(eos_designs) - Correct range_expand behaviour with .0 4byte ASNs by @jonxstill in https://github.com/aristanetworks/ansible-avd/pull/2529
-- Fix(eos_designs) - Duplicate route-maps generated when using underlay_filter_peer_as - true by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2612
-- Fix(eos_designs) - Handle overlapping vlan numbers with filter.only_in_use and trunkgroups by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2628
-- Fix(eos_designs) - Configure ptp to use the system mac by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2647
-- Fix(eos_designs) - Avoid configuring trunk-group twice on mlag peer-link if using the same name by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2658
-- Fix(eos_designs) - Duplicate port-channels in structured-config for network-ports by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2651
-- Fix(eos_designs) - Raise correct error message for duplicate port-channels by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2674
-- Fix(eos_designs) - Configure "ip routing ipv6 interface vrf X" for RFC5549 by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2660
-- Fix(eos_designs) - Add support for her and cvx in default_overlay_routing_protocol by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2717
-- Fix(eos_designs) - network services vlan interfaces ospf authentication message-digest by @philippebureau in https://github.com/aristanetworks/ansible-avd/pull/2727
-- Fix(eos_designs) - Invalid defaults for ipvpn_gateway domain IDs by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2739
-- Fix(eos_designs) - Fix wrong error message for duplicates network_ports by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2756
-- Fix(eos_designs) - Configure "ipv6 enable" on SVIs with Anycast IPv6 by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2784
-- Fix(eos_designs) - Change authentication method and token path for on-prem token auth by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2800
-- Fix(eos_designs) - Re-add the possibility to overwrite network_ports by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2766
-- Fix(eos_designs) - Remove EVPN related config if VRF 'default' is not EVPN enabled by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2888
-- Fix(eos_designs) - bgp_mesh_pes by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2899
-- Fix(eos_designs) - Support 4.0 data models in Connected Endpoints docs by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2915
-- Fix(eos_designs) - Ensure deterministic behavior when defining the same VRF in multiple Tenants by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2900
-- Fix(eos_designs) - eBGP rfc5549 creates invalid configuration for MLAG scenarios by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2950
-- Fix(eos_designs) - Ignore "overlay_routing_protocol_address_family - ipv6" on l2leaf by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2955
-- Refactor(eos_designs) - Change description for port-channel members to be the physical peer interface instead of port-channel by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/2949
-- Fix - Description key not considered with connected endpoints by @pvinci-arista in https://github.com/aristanetworks/ansible-avd/pull/2745
+- Fix(eos_designs) - Handle overlapping VLAN names for l2vlans and vlan-aware-bundles by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2388
+- Fix(eos_designs) - overlay_rd_type with inline jinja generates incorrect config by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2393
+- Fix(eos_designs) - Detect duplicate VLAN, VRF, VNI within network_services by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2411
+- Fix(eos_designs) - Renders lacp fallback when port-channel mode is passive by @gmuloc in https://github.com/aristanetworks/avd/pull/2448
+- Fix(eos_designs) - vtep_vvtep_ip doesn't generate any config by @emilarista in https://github.com/aristanetworks/avd/pull/2442
+- Fix(eos_designs) - Fix issue with hardware_counters python code by @gmuloc in https://github.com/aristanetworks/avd/pull/2447
+- Fix(eos_designs) - remove speed from port-channel interfaces by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2463
+- Fix(eos_designs) - Fix error with dotted hostname, l2leaf and mlag by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2502
+- Fix(eos_designs) - Correct range_expand behaviour with .0 4byte ASNs by @jonxstill in https://github.com/aristanetworks/avd/pull/2529
+- Fix(eos_designs) - Duplicate route-maps generated when using underlay_filter_peer_as - true by @gmuloc in https://github.com/aristanetworks/avd/pull/2612
+- Fix(eos_designs) - Handle overlapping vlan numbers with filter.only_in_use and trunkgroups by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2628
+- Fix(eos_designs) - Configure ptp to use the system mac by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2647
+- Fix(eos_designs) - Avoid configuring trunk-group twice on mlag peer-link if using the same name by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2658
+- Fix(eos_designs) - Duplicate port-channels in structured-config for network-ports by @gmuloc in https://github.com/aristanetworks/avd/pull/2651
+- Fix(eos_designs) - Raise correct error message for duplicate port-channels by @gmuloc in https://github.com/aristanetworks/avd/pull/2674
+- Fix(eos_designs) - Configure "ip routing ipv6 interface vrf X" for RFC5549 by @gmuloc in https://github.com/aristanetworks/avd/pull/2660
+- Fix(eos_designs) - Add support for her and cvx in default_overlay_routing_protocol by @gmuloc in https://github.com/aristanetworks/avd/pull/2717
+- Fix(eos_designs) - network services vlan interfaces ospf authentication message-digest by @philippebureau in https://github.com/aristanetworks/avd/pull/2727
+- Fix(eos_designs) - Invalid defaults for ipvpn_gateway domain IDs by @emilarista in https://github.com/aristanetworks/avd/pull/2739
+- Fix(eos_designs) - Fix wrong error message for duplicates network_ports by @gmuloc in https://github.com/aristanetworks/avd/pull/2756
+- Fix(eos_designs) - Configure "ipv6 enable" on SVIs with Anycast IPv6 by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2784
+- Fix(eos_designs) - Change authentication method and token path for on-prem token auth by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2800
+- Fix(eos_designs) - Re-add the possibility to overwrite network_ports by @gmuloc in https://github.com/aristanetworks/avd/pull/2766
+- Fix(eos_designs) - Remove EVPN related config if VRF 'default' is not EVPN enabled by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2888
+- Fix(eos_designs) - bgp_mesh_pes by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2899
+- Fix(eos_designs) - Support 4.0 data models in Connected Endpoints docs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2915
+- Fix(eos_designs) - Ensure deterministic behavior when defining the same VRF in multiple Tenants by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2900
+- Fix(eos_designs) - eBGP rfc5549 creates invalid configuration for MLAG scenarios by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2950
+- Fix(eos_designs) - Ignore "overlay_routing_protocol_address_family - ipv6" on l2leaf by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2955
+- Refactor(eos_designs) - Change description for port-channel members to be the physical peer interface instead of port-channel by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/2949
+- Fix - Description key not considered with connected endpoints by @pvinci-arista in https://github.com/aristanetworks/avd/pull/2745
 
 ### Other Fixed issues
 
-- Fix(eos_snapshot) - eos snapshot produces incorrect json and yaml output by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2426
-- Fix(eos_snapshot) - Only collect cli-text commands when "text" or "markdown" are selected by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2439
-- Fix(eos_snapshot) - Conditional in tasks are not honored and support for limit by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2457
+- Fix(eos_snapshot) - eos snapshot produces incorrect json and yaml output by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2426
+- Fix(eos_snapshot) - Only collect cli-text commands when "text" or "markdown" are selected by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2439
+- Fix(eos_snapshot) - Conditional in tasks are not honored and support for limit by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2457
 
 ### Documentation
 
-- Doc - Add a warning to upgrade the python reqs when upgrading AVD by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2498
-- Doc(eos_designs) - Dual DC example by @xaviramon in https://github.com/aristanetworks/ansible-avd/pull/2326
-- Doc(eos_designs) - Size recommendations for mlag_peer ip pools by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2599
-- Doc(eos_cli_config_gen) - Deprecate old keys under gNMI by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2876
-- Doc(eos_designs,eos_cli_config_gen) - Add missing deprecation warnings by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2957
-- Doc(eos_designs) - ISIS-LDP IPVPN Topology Example by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2759
-- Doc - Updating the landing page, move the collection below AVD umbrella by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/2587
-- Doc - Update Single DC L3LS example by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/2803
-- Doc - Update Dual DC L3LS example by @xaviramon in https://github.com/aristanetworks/ansible-avd/pull/2904
+- Doc - Add a warning to upgrade the python reqs when upgrading AVD by @gmuloc in https://github.com/aristanetworks/avd/pull/2498
+- Doc(eos_designs) - Dual DC example by @xaviramon in https://github.com/aristanetworks/avd/pull/2326
+- Doc(eos_designs) - Size recommendations for mlag_peer ip pools by @emilarista in https://github.com/aristanetworks/avd/pull/2599
+- Doc(eos_cli_config_gen) - Deprecate old keys under gNMI by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2876
+- Doc(eos_designs,eos_cli_config_gen) - Add missing deprecation warnings by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2957
+- Doc(eos_designs) - ISIS-LDP IPVPN Topology Example by @emilarista in https://github.com/aristanetworks/avd/pull/2759
+- Doc - Updating the landing page, move the collection below AVD umbrella by @JulioPDX in https://github.com/aristanetworks/avd/pull/2587
+- Doc - Update Single DC L3LS example by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/2803
+- Doc - Update Dual DC L3LS example by @xaviramon in https://github.com/aristanetworks/avd/pull/2904
 
 ### New features and enhancements in eos_cli_config_gen
 
-- Feat(eos_cli_config_gen) - Add eos_cli key to management_interfaces by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/2379
-- Feat(eos_cli_config_gen) - Add arp learning bridged by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2383
-- Feat(eos_cli_config_gen) - Add support for load-interval on Ethernet Interfaces by @RyanM-Arista in https://github.com/aristanetworks/ansible-avd/pull/2428
-- Feat(eos_cli_config_gen) - Trim documentation output to only show configured sections by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2357
-- Feat(eos_cli_config_gen) - Extend aaa_accounting with options for dot1x by @dmilyt in https://github.com/aristanetworks/ansible-avd/pull/2450
-- Feat(eos_cli_config_gen) - Support encapsulation for EVPN peer groups by @wnagele in https://github.com/aristanetworks/ansible-avd/pull/2540
-- Feat(eos_cli_config_gen) - Add aaa authorization policy and dynamic by @tgodaA in https://github.com/aristanetworks/ansible-avd/pull/2440
-- Feat(eos_cli_config_gen) - Add Sflow config for ethernet and port_channel interfaces by @UchihaItachiSama in https://github.com/aristanetworks/ansible-avd/pull/1805
-- Feat(eos_cli_config_gen) - Support ND parameters inside router_l2_vpn the same as ARP by @wnagele in https://github.com/aristanetworks/ansible-avd/pull/2538
-- Feat(eos_cli_config_gen) - add event-handler trigger "on-startup-config" by @bjmeuer in https://github.com/aristanetworks/ansible-avd/pull/2486
-- Feat(eos_cli_config_gen) - Add 'route_reflector_client' key to BGP neighbor in VRF by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/2551
-- Feat(eos_cli_config_gen) - CVX Client non-default VRF support by @UchihaItachiSama in https://github.com/aristanetworks/ansible-avd/pull/2545
-- Feat(eos_cli_config_gen) - Add support for shell for local users by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2581
-- Feat(eos_cli_config_gen) - Add support for as-path options for BGP neighbors by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/2591
-- Feat(eos_cli_config_gen) - extend ethernet_interface with dot1x eapol authentication_failure_falback by @dmilyt in https://github.com/aristanetworks/ansible-avd/pull/2482
-- Feat(eos_cli_config_gen) - extend radius_servers with attribute 32 include in access and dynamic-authorization by @dmilyt in https://github.com/aristanetworks/ansible-avd/pull/2523
-- Feat(eos_cli_config_gen) - Add support for passive BGP neighbor by @gusmb in https://github.com/aristanetworks/ansible-avd/pull/2568
-- Feat(eos_cli_config_gen) - Add ipv6 dhcp relay to vlan/ethernet-interfaces by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2585
-- Feat(eos_cli_config_gen) - extend dot1x with radius av-pair and mac based authentication. by @dmilyt in https://github.com/aristanetworks/ansible-avd/pull/2446
-- Feat(eos_cli_config_gen) - Deprecation of 'vlan_interfaces.ipv6_address_virtual' (singular) by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2613
-- Feat(eos_cli_config_gen) - add cvsourceintf flag to TerminAttr by @noredistribution in https://github.com/aristanetworks/ansible-avd/pull/2620
-- Feat(eos_cli_config_gen) - Global IP Locking Configuration Options by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2560
-- Feat(eos_cli_config_gen) - Add support for CVX as VXLAN controller by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2657
-- Feat(eos_cli_config_gen) - Enable redistribution of leaked (static, connected, bgp) routes into OSPF by @carl-baillargeon in https://github.com/aristanetworks/ansible-avd/pull/2639
-- Feat(eos_cli_config_gen) - Add address locking options on ethernet interfaces by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2564
-- Feat(eos_cli_config_gen) - Add support for BGP session tracking by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2659
-- Feat(eos_cli_config_gen) - add certs method to cvauth in TerminAttr by @noredistribution in https://github.com/aristanetworks/ansible-avd/pull/2699
-- Feat(eos_cli_config_gen) - New improved ip_name_servers and deprecate name_server by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2738
-- Feat(eos_cli_config_gen) - Add support for PoE configurations by @jrecchia1029 in https://github.com/aristanetworks/ansible-avd/pull/2690
-- Feat(eos_cli_config_gen) - L2 Protocol Forwarding by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2676
-- Feat(eos_cli_config_gen) - Allow configuration of IGMP snooping features even if globally disabled by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2686
-- Feat(eos_cli_config_gen) - Add support for grpc-tunnel by @adietrich-ussignal in https://github.com/aristanetworks/ansible-avd/pull/2696
-- Feat(eos_cli_config_gen) - Add global IP NAT support by @kornoa in https://github.com/aristanetworks/ansible-avd/pull/2747
-- Feat(eos_cli_config_gen) - Add support for bgp default ipv4-unicast under router bgp by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2789
-- Feat(eos_cli_config_gen) - Add support for "ip_igmp_version" under "vlan_interfaces" by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2792
-- Feat(eos_cli_config_gen) - Add ethernet_interfaces logging event options by @kornoa in https://github.com/aristanetworks/ansible-avd/pull/2783
-- Feat(eos_cli_config_gen) - Add service-policy qos by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2793
-- Feat(eos_cli_config_gen) - Default queue-monitor thresholds by @chetryan in https://github.com/aristanetworks/ansible-avd/pull/2794
-- Feat(eos_cli_config_gen) - Add port-channel esi and rt deprecation warnings by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2443
-- Feat(eos_cli_config_gen) - Add interface IP NAT support by @kornoa in https://github.com/aristanetworks/ansible-avd/pull/2750
-- Feat(eos_cli_config_gen) - Add capability to hide passwords and keys in generated doc and conf by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2806
-- Feat(eos_cli_config_gen) - add options tagged and untagged phone to switchport phone trunk for ethernet interfaces by @kmueller68 in https://github.com/aristanetworks/ansible-avd/pull/2832
-- Feat(eos_cli_config_gen) - BGP RR preserve-attributes by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2879
-- Refactor(eos_cli_config_gen, eos_designs) - Improve BGP VRF Address Families Model by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2808
-- Refactor(eos_cli_config_gen) - Add guards for missing name for hardware_counters legacy syntax by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2741
-- Refactor(eos_cli_config_gen,eos_designs) - Deprecate isis_af_defaults and address_family knobs by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2630
-- Refactor(eos_cli_config_gen) - Deprecate uppercase `MIB_family_name` in favor of `mib_family_name` by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2772
-- Refactor(eos_designs, eos_cli_config_gen) - BGP VRF peer group options, global context ipv6 multicast and flowspec by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2976
+- Feat(eos_cli_config_gen) - Add eos_cli key to management_interfaces by @gusmb in https://github.com/aristanetworks/avd/pull/2379
+- Feat(eos_cli_config_gen) - Add arp learning bridged by @tgodaA in https://github.com/aristanetworks/avd/pull/2383
+- Feat(eos_cli_config_gen) - Add support for load-interval on Ethernet Interfaces by @RyanM-Arista in https://github.com/aristanetworks/avd/pull/2428
+- Feat(eos_cli_config_gen) - Trim documentation output to only show configured sections by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2357
+- Feat(eos_cli_config_gen) - Extend aaa_accounting with options for dot1x by @dmilyt in https://github.com/aristanetworks/avd/pull/2450
+- Feat(eos_cli_config_gen) - Support encapsulation for EVPN peer groups by @wnagele in https://github.com/aristanetworks/avd/pull/2540
+- Feat(eos_cli_config_gen) - Add aaa authorization policy and dynamic by @tgodaA in https://github.com/aristanetworks/avd/pull/2440
+- Feat(eos_cli_config_gen) - Add Sflow config for ethernet and port_channel interfaces by @UchihaItachiSama in https://github.com/aristanetworks/avd/pull/1805
+- Feat(eos_cli_config_gen) - Support ND parameters inside router_l2_vpn the same as ARP by @wnagele in https://github.com/aristanetworks/avd/pull/2538
+- Feat(eos_cli_config_gen) - add event-handler trigger "on-startup-config" by @bjmeuer in https://github.com/aristanetworks/avd/pull/2486
+- Feat(eos_cli_config_gen) - Add 'route_reflector_client' key to BGP neighbor in VRF by @gusmb in https://github.com/aristanetworks/avd/pull/2551
+- Feat(eos_cli_config_gen) - CVX Client non-default VRF support by @UchihaItachiSama in https://github.com/aristanetworks/avd/pull/2545
+- Feat(eos_cli_config_gen) - Add support for shell for local users by @gmuloc in https://github.com/aristanetworks/avd/pull/2581
+- Feat(eos_cli_config_gen) - Add support for as-path options for BGP neighbors by @gusmb in https://github.com/aristanetworks/avd/pull/2591
+- Feat(eos_cli_config_gen) - extend ethernet_interface with dot1x eapol authentication_failure_falback by @dmilyt in https://github.com/aristanetworks/avd/pull/2482
+- Feat(eos_cli_config_gen) - extend radius_servers with attribute 32 include in access and dynamic-authorization by @dmilyt in https://github.com/aristanetworks/avd/pull/2523
+- Feat(eos_cli_config_gen) - Add support for passive BGP neighbor by @gusmb in https://github.com/aristanetworks/avd/pull/2568
+- Feat(eos_cli_config_gen) - Add ipv6 dhcp relay to vlan/ethernet-interfaces by @emilarista in https://github.com/aristanetworks/avd/pull/2585
+- Feat(eos_cli_config_gen) - extend dot1x with radius av-pair and mac based authentication. by @dmilyt in https://github.com/aristanetworks/avd/pull/2446
+- Feat(eos_cli_config_gen) - Deprecation of 'vlan_interfaces.ipv6_address_virtual' (singular) by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2613
+- Feat(eos_cli_config_gen) - add cvsourceintf flag to TerminAttr by @noredistribution in https://github.com/aristanetworks/avd/pull/2620
+- Feat(eos_cli_config_gen) - Global IP Locking Configuration Options by @emilarista in https://github.com/aristanetworks/avd/pull/2560
+- Feat(eos_cli_config_gen) - Add support for CVX as VXLAN controller by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2657
+- Feat(eos_cli_config_gen) - Enable redistribution of leaked (static, connected, bgp) routes into OSPF by @carl-baillargeon in https://github.com/aristanetworks/avd/pull/2639
+- Feat(eos_cli_config_gen) - Add address locking options on ethernet interfaces by @emilarista in https://github.com/aristanetworks/avd/pull/2564
+- Feat(eos_cli_config_gen) - Add support for BGP session tracking by @gmuloc in https://github.com/aristanetworks/avd/pull/2659
+- Feat(eos_cli_config_gen) - add certs method to cvauth in TerminAttr by @noredistribution in https://github.com/aristanetworks/avd/pull/2699
+- Feat(eos_cli_config_gen) - New improved ip_name_servers and deprecate name_server by @gmuloc in https://github.com/aristanetworks/avd/pull/2738
+- Feat(eos_cli_config_gen) - Add support for PoE configurations by @jrecchia1029 in https://github.com/aristanetworks/avd/pull/2690
+- Feat(eos_cli_config_gen) - L2 Protocol Forwarding by @emilarista in https://github.com/aristanetworks/avd/pull/2676
+- Feat(eos_cli_config_gen) - Allow configuration of IGMP snooping features even if globally disabled by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2686
+- Feat(eos_cli_config_gen) - Add support for grpc-tunnel by @adietrich-ussignal in https://github.com/aristanetworks/avd/pull/2696
+- Feat(eos_cli_config_gen) - Add global IP NAT support by @kornoa in https://github.com/aristanetworks/avd/pull/2747
+- Feat(eos_cli_config_gen) - Add support for bgp default ipv4-unicast under router bgp by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2789
+- Feat(eos_cli_config_gen) - Add support for "ip_igmp_version" under "vlan_interfaces" by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2792
+- Feat(eos_cli_config_gen) - Add ethernet_interfaces logging event options by @kornoa in https://github.com/aristanetworks/avd/pull/2783
+- Feat(eos_cli_config_gen) - Add service-policy qos by @chetryan in https://github.com/aristanetworks/avd/pull/2793
+- Feat(eos_cli_config_gen) - Default queue-monitor thresholds by @chetryan in https://github.com/aristanetworks/avd/pull/2794
+- Feat(eos_cli_config_gen) - Add port-channel esi and rt deprecation warnings by @emilarista in https://github.com/aristanetworks/avd/pull/2443
+- Feat(eos_cli_config_gen) - Add interface IP NAT support by @kornoa in https://github.com/aristanetworks/avd/pull/2750
+- Feat(eos_cli_config_gen) - Add capability to hide passwords and keys in generated doc and conf by @gmuloc in https://github.com/aristanetworks/avd/pull/2806
+- Feat(eos_cli_config_gen) - add options tagged and untagged phone to switchport phone trunk for ethernet interfaces by @kmueller68 in https://github.com/aristanetworks/avd/pull/2832
+- Feat(eos_cli_config_gen) - BGP RR preserve-attributes by @emilarista in https://github.com/aristanetworks/avd/pull/2879
+- Refactor(eos_cli_config_gen, eos_designs) - Improve BGP VRF Address Families Model by @emilarista in https://github.com/aristanetworks/avd/pull/2808
+- Refactor(eos_cli_config_gen) - Add guards for missing name for hardware_counters legacy syntax by @gmuloc in https://github.com/aristanetworks/avd/pull/2741
+- Refactor(eos_cli_config_gen,eos_designs) - Deprecate isis_af_defaults and address_family knobs by @emilarista in https://github.com/aristanetworks/avd/pull/2630
+- Refactor(eos_cli_config_gen) - Deprecate uppercase `MIB_family_name` in favor of `mib_family_name` by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2772
+- Refactor(eos_designs, eos_cli_config_gen) - BGP VRF peer group options, global context ipv6 multicast and flowspec by @emilarista in https://github.com/aristanetworks/avd/pull/2976
 
 ### New features and enhancements in eos_designs
 
-- Feat(eos_designs) - Add per MACVRF EVPN domain scope by @MitchV85 in https://github.com/aristanetworks/ansible-avd/pull/2347
-- Feat(eos_designs) - Add schema validation to eos_designs action plugins by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2350
-- Feat(eos_designs) - Support for custom masks in l3_edge ip pools by @philippebureau in https://github.com/aristanetworks/ansible-avd/pull/2466
-- Feat(eos_designs) - User defined description on management interface by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2500
-- Feat(eos_designs) - User defined descriptions on l3_edge and core_interfaces by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2499
-- Feat(eos_designs) - Uplink native vlan for l2 switches by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2522
-- Feat(eos_designs) - Only require 'virtual_router_mac_address' when using VARP or anycast IP on SVIs by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2485
-- Feat(eos_designs) - Allow disabling filtering on redist connected in underlay bgp by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2586
-- Feat(eos_designs) - Add support for overlay_routing_protocol CVX by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2600
-- Feat(eos_designs) - Add Ipv6 management variables by @emilarista in https://github.com/aristanetworks/ansible-avd/pull/2335
-- Feat(eos_designs) - Support for custom masks in core_interfaces ip pools by @philippebureau in https://github.com/aristanetworks/ansible-avd/pull/2469
-- Feat(eos_designs) - Improve CVX Overlay support by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2656
-- Feat(eos_designs) - Add support for serial_number by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2645
-- Feat(eos_designs) - Add support for TerminAttr token-secure auth for on-premise CV by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2685
-- Feat(eos_designs) - Allow to redistribute connected routes under OSPF by @mpergament in https://github.com/aristanetworks/ansible-avd/pull/2762
-- Feat(eos_designs) - Add support for setting "mlag_domain_id" by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2791
-- Feat(eos_designs) - Allow LACP timers configuration under connected_endpoints by @xaviramon in https://github.com/aristanetworks/ansible-avd/pull/2809
-- Feat(eos_designs) - update PTP syntax "enable" -> "enabled" by @nielsjlarsen in https://github.com/aristanetworks/ansible-avd/pull/2776
-- Feat(eos_designs) - use proper structured config knobs for bgp maximum paths by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2868
-- Feat(eos_designs) - Fabric variable to set bgp distance by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2869
-- Doc(eos_designs) - Add connected_endpoints fabric documentation by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2458
-- Refactor(eos_designs) - Use python for all default interface descriptions by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2490
-- Refactor(eos_designs) - Change default native vlan name by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2563
-- Refactor(eos_designs) - Relax requirement for 'id' if not used by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2661
-- Cut - Remove globally defined defaults for underlay_routing_protocol and overlay_routing_protocol variables by @carlbuchmann in https://github.com/aristanetworks/ansible-avd/pull/2691
-- Refactor(eos_designs) - Move default variables to python instead of role defaults. by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2760
-- Refactor(eos_designs) - Remove vxlan_vlan_aware_bundles in favor of evpn_vlan_aware_bundles by @Shivani-chourasiya in https://github.com/aristanetworks/ansible-avd/pull/2865
+- Feat(eos_designs) - Add per MACVRF EVPN domain scope by @MitchV85 in https://github.com/aristanetworks/avd/pull/2347
+- Feat(eos_designs) - Add schema validation to eos_designs action plugins by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2350
+- Feat(eos_designs) - Support for custom masks in l3_edge ip pools by @philippebureau in https://github.com/aristanetworks/avd/pull/2466
+- Feat(eos_designs) - User defined description on management interface by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2500
+- Feat(eos_designs) - User defined descriptions on l3_edge and core_interfaces by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2499
+- Feat(eos_designs) - Uplink native vlan for l2 switches by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2522
+- Feat(eos_designs) - Only require 'virtual_router_mac_address' when using VARP or anycast IP on SVIs by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2485
+- Feat(eos_designs) - Allow disabling filtering on redist connected in underlay bgp by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2586
+- Feat(eos_designs) - Add support for overlay_routing_protocol CVX by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2600
+- Feat(eos_designs) - Add Ipv6 management variables by @emilarista in https://github.com/aristanetworks/avd/pull/2335
+- Feat(eos_designs) - Support for custom masks in core_interfaces ip pools by @philippebureau in https://github.com/aristanetworks/avd/pull/2469
+- Feat(eos_designs) - Improve CVX Overlay support by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2656
+- Feat(eos_designs) - Add support for serial_number by @gmuloc in https://github.com/aristanetworks/avd/pull/2645
+- Feat(eos_designs) - Add support for TerminAttr token-secure auth for on-premise CV by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2685
+- Feat(eos_designs) - Allow to redistribute connected routes under OSPF by @mpergament in https://github.com/aristanetworks/avd/pull/2762
+- Feat(eos_designs) - Add support for setting "mlag_domain_id" by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2791
+- Feat(eos_designs) - Allow LACP timers configuration under connected_endpoints by @xaviramon in https://github.com/aristanetworks/avd/pull/2809
+- Feat(eos_designs) - update PTP syntax "enable" -> "enabled" by @nielsjlarsen in https://github.com/aristanetworks/avd/pull/2776
+- Feat(eos_designs) - use proper structured config knobs for bgp maximum paths by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2868
+- Feat(eos_designs) - Fabric variable to set bgp distance by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2869
+- Doc(eos_designs) - Add connected_endpoints fabric documentation by @gmuloc in https://github.com/aristanetworks/avd/pull/2458
+- Refactor(eos_designs) - Use python for all default interface descriptions by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2490
+- Refactor(eos_designs) - Change default native vlan name by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2563
+- Refactor(eos_designs) - Relax requirement for 'id' if not used by @gmuloc in https://github.com/aristanetworks/avd/pull/2661
+- Cut - Remove globally defined defaults for underlay_routing_protocol and overlay_routing_protocol variables by @carlbuchmann in https://github.com/aristanetworks/avd/pull/2691
+- Refactor(eos_designs) - Move default variables to python instead of role defaults. by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2760
+- Refactor(eos_designs) - Remove vxlan_vlan_aware_bundles in favor of evpn_vlan_aware_bundles by @Shivani-chourasiya in https://github.com/aristanetworks/avd/pull/2865
 
 ### Other new features and enhancements
 
-- Feat(plugins) - Add schema driven deprecation warnings by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2369
-- Feat(plugins) - Automatic requirements check by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2015
-- Feat(plugins) - Add arista.avd.batch_template action plugin by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2593
-- Feat(plugins) - Add OSPF pasword type 7 to encrypt/decrypt filters by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2626
-- Feat(plugins) - Update schema validation to ignore any key starting with underscore by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2689
-- Feat(eos_config_deploy_cvp) - Option for deploying using serial number as identifier by @ClausHolbechArista in https://github.com/aristanetworks/ansible-avd/pull/2718
-- Feat(plugins) - Add arista.avd.global_vars plugin by @gmuloc in https://github.com/aristanetworks/ansible-avd/pull/2751
-- Refactor(eos_cli_config_gen,eos_designs) - Remove multiple H1 headings by @JulioPDX in https://github.com/aristanetworks/ansible-avd/pull/2632
+- Feat(plugins) - Add schema driven deprecation warnings by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2369
+- Feat(plugins) - Automatic requirements check by @gmuloc in https://github.com/aristanetworks/avd/pull/2015
+- Feat(plugins) - Add arista.avd.batch_template action plugin by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2593
+- Feat(plugins) - Add OSPF pasword type 7 to encrypt/decrypt filters by @gmuloc in https://github.com/aristanetworks/avd/pull/2626
+- Feat(plugins) - Update schema validation to ignore any key starting with underscore by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2689
+- Feat(eos_config_deploy_cvp) - Option for deploying using serial number as identifier by @ClausHolbechArista in https://github.com/aristanetworks/avd/pull/2718
+- Feat(plugins) - Add arista.avd.global_vars plugin by @gmuloc in https://github.com/aristanetworks/avd/pull/2751
+- Refactor(eos_cli_config_gen,eos_designs) - Remove multiple H1 headings by @JulioPDX in https://github.com/aristanetworks/avd/pull/2632

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -41,13 +41,13 @@ dependencies:
     "ansible.utils": ">=3.0.0"
 
 # The URL of the originating SCM repository
-repository: https://github.com/aristanetworks/ansible-avd
+repository: https://github.com/aristanetworks/avd
 
 # The URL to any online docs
-documentation: https://www.avd.sh/
+documentation: https://avd.arista.com
 
 # The URL to the homepage of the collection/project
-homepage: https://www.avd.sh/
+homepage: https://avd.arista.com
 
 # The URL to the collection issue tracker
-issues: https://github.com/aristanetworks/ansible-avd/issues
+issues: https://github.com/aristanetworks/avd/issues

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/avdtestbase.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/avdtestbase.py
@@ -253,7 +253,7 @@ class AvdTestBase:
                 - "loopback0_mapping": a list of tuples where each tuple contains a hostname and its Loopback0 IP address.
                 - "vtep_mapping": a list of tuples where each tuple contains a hostname and its VTEP IP address if `Vxlan1` is the source_interface.
 
-        # FIXME @cbaillar: Need to refactor this: https://github.com/aristanetworks/ansible-avd/issues/3304
+        # FIXME @cbaillar: Need to refactor this: https://github.com/aristanetworks/avd/issues/3304
         """
         results = {"loopback0_mapping": [], "vtep_mapping": []}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/README.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/README.md
@@ -138,7 +138,7 @@ Role configuration settings can be set either as regular inventory variables or 
 
 ## vEOS-LAB Know Caveats and Recommendations
 
-- vEOS-LAB is a great tool to learn and test ansible-avd automation framework. This is the primary tool leveraged by Arista Ansible Team for development and testing efforts.
+- vEOS-LAB is a great tool to learn and test the AVD automation framework. This is the primary tool leveraged by Arista Ansible Team for development and testing efforts.
 - vEOS-lab enables you to create and run replicas of physical networks within a risk-free virtual environment.
 - Virtual networks created with vEOS-lab can be used for network modeling, planning for new services, or validating new features and functionality for the installed network.
 - vEOS-lab isn't a network simulator but the exact EOS implementation that runs on the hardware platforms.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/cloudvision-tags-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/cloudvision-tags-preview.md
@@ -16,7 +16,7 @@ title: Generate Cloudvision Tags with eos_designs - Preview
 
     Everything is subject to change, is not supported and may not be complete.
 
-    If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/ansible-avd/discussions)
+    If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/avd/discussions)
 
 `arista.avd.eos_designs` can generate CloudVision Tags that can be applied to interfaces and/or devices. These tags can be used on CloudVision for during Topology view generation,
 or used in searches/filters to select devices based on tags values.
@@ -39,13 +39,13 @@ generate_cv_tags:
   topology_hints: true
 ```
 
-| Hint Tag Name | Description | Source of information |
-| ------------- | ----------- |---------------------- |
-| `topology_hint_type` | Indicates whether the node is a leaf, spine, core device etc. | `cv_tags_topology_type` if set, else `node_type_keys.[].cv_tags_topology_type`. |
-| `topology_hint_fabric` | The overall fabric that the devices pertains to. Useful for multi-fabric deployments. | `fabric_name` |
-| `topology_hint_datacenter` | The datacenter to which the devices belongs. Helpful for multi-dc deployments. | `dc_name` |
-| `topology_hint_pod` | The pod to which the devices belongs. | `pod_name` |
-| `topology_hint_rack` | The physical rack in which the device is located. | `rack` defined on `node` or `node_group` |
+| Hint Tag Name              | Description                                                                           | Source of information                                                           |
+| -------------------------- | ------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- |
+| `topology_hint_type`       | Indicates whether the node is a leaf, spine, core device etc.                         | `cv_tags_topology_type` if set, else `node_type_keys.[].cv_tags_topology_type`. |
+| `topology_hint_fabric`     | The overall fabric that the devices pertains to. Useful for multi-fabric deployments. | `fabric_name`                                                                   |
+| `topology_hint_datacenter` | The datacenter to which the devices belongs. Helpful for multi-dc deployments.        | `dc_name`                                                                       |
+| `topology_hint_pod`        | The pod to which the devices belongs.                                                 | `pod_name`                                                                      |
+| `topology_hint_rack`       | The physical rack in which the device is located.                                     | `rack` defined on `node` or `node_group`                                        |
 
 ## CloudVision Custom Tags
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -16,7 +16,7 @@ title: Ansible Collection Role eos_designs - WAN preview
 
     Everything is subject to change, is not supported and may not be complete.
 
-    If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/ansible-avd/discussions)
+    If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/avd/discussions)
 
 ## Overview
 
@@ -87,11 +87,11 @@ The intention is to support both a single [AutoVPN design](https://www.arista.co
 
 The following table indicates the settings:
 
-| Node Type Key      | Underlay Router | Uplink Type | Default EVPN Role  | L2 Network Services | L3 Network Services | VTEP | MLAG Support | Connected Endpoints | Defaut WAN Role | Default CV Pathfinder Role |
-| ------------------ | --------------- | ------------ | ----------------- | ------------------- | ------------------- | ---- | ------------ | ------------------- | --------------- | -------------------------- |
-| wan_rr             | ✅              | p2p          | server            | ✘                   | ✅                  | ✘    | ✘            | ✘                   | server          | pathfinder                 |
-| wan_edge           | ✅              | p2p          | client            | ✘                   | ✅                  | ✘    | ✘            | ✘                   | client          | edge                       |
-| wan_transit        | ✅              | p2p          | client            | ✘                   | ✅                  | ✘    | ✘            | ✘                   | client          | transit region             |
+| Node Type Key | Underlay Router | Uplink Type | Default EVPN Role | L2 Network Services | L3 Network Services | VTEP | MLAG Support | Connected Endpoints | Defaut WAN Role | Default CV Pathfinder Role |
+| ------------- | --------------- | ----------- | ----------------- | ------------------- | ------------------- | ---- | ------------ | ------------------- | --------------- | -------------------------- |
+| wan_rr        | ✅               | p2p         | server            | ✘                   | ✅                   | ✘    | ✘            | ✘                   | server          | pathfinder                 |
+| wan_edge      | ✅               | p2p         | client            | ✘                   | ✅                   | ✘    | ✘            | ✘                   | client          | edge                       |
+| wan_transit   | ✅               | p2p         | client            | ✘                   | ✅                   | ✘    | ✘            | ✘                   | client          | transit region             |
 
 All these node types are defined with `default_underlay_routing_protocol: none` and `default_overlay_routing_protocol: ibgp`.
 
@@ -167,18 +167,18 @@ roles/eos_designs/docs/tables/node-type-key-wan-configuration.md
 
 #### Device Tags
 
-| Tag Name | Source of information |
-| -------- | --------------------- |
-| `Region` | `cv_pathfinder_region` if `cv_pathfinder_role` is set but not `pathfinder` |
-| `Zone` | `DEFAULT-ZONE` if `cv_pathfinder_role` is set but not `pathfinder` |
-| `Site` | `cv_pathfinder_site` if `cv_pathfinder_role` is set but not `pathfinder` |
+| Tag Name        | Source of information                                                                 |
+| --------------- | ------------------------------------------------------------------------------------- |
+| `Region`        | `cv_pathfinder_region` if `cv_pathfinder_role` is set but not `pathfinder`            |
+| `Zone`          | `DEFAULT-ZONE` if `cv_pathfinder_role` is set but not `pathfinder`                    |
+| `Site`          | `cv_pathfinder_site` if `cv_pathfinder_role` is set but not `pathfinder`              |
 | `PathfinderSet` | name of `node_group` or default `PATHFINDERS` if `cv_pathfinder_role` is `pathfinder` |
-| `Role` | `cv_pathfinder_role` if set |
+| `Role`          | `cv_pathfinder_role` if set                                                           |
 
 #### Interface Tags
 
-| Hint Tag Name | Source of information |
-| ------------- | --------------------- |
-| `Type` | `lan` or `wan` if `cv_pathfinder_role` is set |
-| `Carrier` | `wan_carrier` if `cv_pathfinder_role` is set and this is a WAN interface |
-| `Circuit` | `wan_circiot_id` if `cv_pathfinder_role` is set and this is a LAN interface |
+| Hint Tag Name | Source of information                                                       |
+| ------------- | --------------------------------------------------------------------------- |
+| `Type`        | `lan` or `wan` if `cv_pathfinder_role` is set                               |
+| `Carrier`     | `wan_carrier` if `cv_pathfinder_role` is set and this is a WAN interface    |
+| `Circuit`     | `wan_circiot_id` if `cv_pathfinder_role` is set and this is a LAN interface |

--- a/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
@@ -12,7 +12,7 @@ title: Ansible Collection Role eos_valudate_state - Preview Integration with ANT
 
 !!! warning
     eos_validate_state intergration with ANTA is in preview. Everything is subject to change.
-    If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/ansible-avd/discussions)
+    If you have any questions, please leverage the GitHub [discussions board](https://github.com/aristanetworks/avd/discussions)
 
 ## Overview
 
@@ -41,7 +41,7 @@ title: Ansible Collection Role eos_valudate_state - Preview Integration with ANT
 
 ## Expected changes
 
-- You should expect faster execution, and if not please report on the GitHub [discussions board](https://github.com/aristanetworks/ansible-avd/discussions)
+- You should expect faster execution, and if not please report on the GitHub [discussions board](https://github.com/aristanetworks/avd/discussions)
 - Hardware tests are now collapsed.
 - Some description of tests have been updated to be more precise.
 - Sorting of the test results is now done per device as opposed to per category.

--- a/contributing.md
+++ b/contributing.md
@@ -4,13 +4,13 @@
   ~ that can be found in the LICENSE file.
   -->
 
-# Contribute to Arista ansible-avd collection
+# Contribute to the AVD Project
 
 <!-- @import "[TOC]" {cmd="toc" depthFrom=1 depthTo=6 orderedList=false} -->
 
 <!-- code_chunk_output -->
 
-- [Contribute to Arista ansible-avd collection](#contribute-to-arista-ansible-avd-collection)
+- [Contribute to the AVD Project](#contribute-to-the-avd-project)
   - [Reporting Bugs](#reporting-bugs)
   - [Feature Requests](#feature-requests)
   - [Using the issue tracker](#using-the-issue-tracker)
@@ -29,11 +29,11 @@ patches and features.
 
 ## Reporting Bugs
 
-- First, ensure that you've installed the [latest stable version](https://github.com/aristanetworks/ansible-avd/releases)
-of **ansible-avd**. If you're running an older version, it's possible that the bug has
+- First, ensure that you've installed the [latest stable version](https://github.com/aristanetworks/avd/releases)
+of **arista.avd** or **PyAVD**. If you're running an older version, it's possible that the bug has
 already been fixed.
 
-- Next, check the GitHub [issues list](https://github.com/aristanetworks/ansible-avd/issues)
+- Next, check the GitHub [issues list](https://github.com/aristanetworks/avd/issues)
 to see if the bug you've found has already been reported. If you think you may
 be experiencing a reported issue that hasn't already been resolved, please
 click "add a reaction" in the top right corner of the issue and add a thumbs
@@ -43,12 +43,12 @@ affected.
 
 - If you haven't found an existing issue that describes your suspected bug, **do not** file an issue until you
 have received confirmation that it is in fact a bug. Invalid issues are very
-distracting and slow the pace at which **ansible-avd** is developed.
+distracting and slow the pace at which **AVD** is developed.
 
 - When submitting an issue, please be as descriptive as possible. Be sure to
 include:
 
-  - The environment in which **ansible-avd** is running
+  - The environment in which **AVD** is running
   - The exact steps that can be taken to reproduce the issue (if applicable)
   - Any error messages generated
   - Screenshots (if applicable)
@@ -63,7 +63,7 @@ your issue.
 
 ## Feature Requests
 
-- First, check the GitHub [issues list](https://github.com/aristanetworks/ansible-avd/issues)
+- First, check the GitHub [issues list](https://github.com/aristanetworks/avd/issues)
 to see if the feature you're requesting is already listed. (Be sure to search
 closed issues as well, since some feature requests have been rejected.) If the
 feature you'd like to see has already been requested and is open, click "add a
@@ -86,8 +86,7 @@ implemented. Overly broad feature requests will be closed.
 following:
 
   - A detailed description of the proposed functionality
-  - A use case for the feature; who would use it and what value it would add
-      to **ansible-avd**
+  - A use case for the feature; who would use it and what value it would add to **AVD**
   - A rough description of changes necessary
   - Any third-party libraries or other resources which would be involved
 
@@ -114,7 +113,7 @@ requests**](#pull-requests), but please respect the following restrictions:
 ## Pull requests
 
 - Be sure to open an issue **before** starting work on a pull request, and
-discuss your idea with the **ansible-avd** maintainers before beginning work. This will
+discuss your idea with the **AVD** maintainers before beginning work. This will
 help prevent wasting time on something that might we might not be able to
 implement. When suggesting a new feature, also make sure it won't conflict with
 any work that's already in progress.
@@ -144,13 +143,13 @@ merged:
 
    ```bash
    # Clone your fork of the repo into the current directory
-   git clone https://github.com/<your-username>/ansible-avd
+   git clone https://github.com/<your-username>/avd
 
    # Navigate to the newly cloned directory
-   cd ansible-avd
+   cd avd
 
    # Assign the original repo to a remote called "upstream"
-   git remote add upstream https://github.com/aristanetworks/ansible-avd.git
+   git remote add upstream https://github.com/aristanetworks/avd.git
    ```
 
 - If you cloned a while ago, get the latest changes from upstream:
@@ -185,5 +184,5 @@ merged:
    git push origin <topic-branch-name>
    ```
 
-- [Open a Pull Request](https://github.com/aristanetworks/ansible-avd/pulls)
+- [Open a Pull Request](https://github.com/aristanetworks/avd/pulls)
     with a clear title and description.

--- a/development/Makefile
+++ b/development/Makefile
@@ -13,8 +13,8 @@ VSCODE_CONTAINER = $(VSCODE_CONTAINER_NAME):$(VSCODE_DOCKER_TAG)
 # To change it: make vscode VSCODE_PORT=<port to use>
 VSCODE_PORT ?= 8080
 # Path to compose stack -- should not be changed
-COMPOSE_FILE ?= ansible-avd/development/docker-compose.yml
-COMPOSE_ENV_FILE ?= ansible-avd/development/docker-stack.env
+COMPOSE_FILE ?= avd/development/docker-compose.yml
+COMPOSE_ENV_FILE ?= avd/development/docker-stack.env
 # Option to pass custom requirements and custom ansible version to provision in container
 PIP_REQ ?=
 ANSIBLE_VERSION ?=
@@ -45,10 +45,10 @@ help: ## Display help message
 .PHONY: update
 update: ## Get latest version of AVD runner and MKDOCs server
 	docker pull $(CONTAINER_NAME):$(DOCKER_TAG) && \
-	docker-compose -f ansible-avd/development/docker-compose.yml pull
+	docker-compose -f avd/development/docker-compose.yml pull
 
 .PHONY: run
-run: ## Run ansible-avd container
+run: ## Run avd container
 	docker pull $(CONTAINER) && \
 	docker run --rm -it \
 		-e AVD_REQUIREMENTS=$(PIP_REQ) \
@@ -141,5 +141,5 @@ check-cvp-404: ## Check local 404 links for AVD documentation
 
 .PHONY: refresh
 refresh: ## Refresh Makefile with new version from AVD
-	cp ansible-avd/development/Makefile Makefile
+	cp avd/development/Makefile Makefile
 	@echo "Makefile updated from AVD repository"

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,7 +6,7 @@ copyright: Copyright &copy; 2019 - 2023 Arista Networks
 
 # Repository information
 repo_name: AVD on Github
-repo_url: https://github.com/aristanetworks/ansible-avd
+repo_url: https://github.com/aristanetworks/avd
 
 # Configuration
 use_directory_urls: false
@@ -50,7 +50,7 @@ theme:
 extra:
   social:
     - icon: fontawesome/brands/github-alt
-      link: https://github.com/aristanetworks/ansible-avd
+      link: https://github.com/aristanetworks/avd
     - icon: fontawesome/brands/twitter
       link: https://twitter.com/AristaNetworks
     - icon: fontawesome/solid/globe

--- a/python-avd/README.md
+++ b/python-avd/README.md
@@ -14,4 +14,4 @@ See [avd.arista.com](https://avd.arista.com/stable/docs/pyavd.html) for details.
 
 Copyright (c) 2023-2024 Arista Networks, Inc.
 
-The project is published under [Apache 2.0 License](https://github.com/aristanetworks/ansible-avd/blob/devel/ansible_collections/arista/avd/LICENSE)
+The project is published under [Apache 2.0 License](https://github.com/aristanetworks/avd/blob/devel/ansible_collections/arista/avd/LICENSE)

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -21,7 +21,7 @@ requires-python = ">=3.10"
 
 [project.urls]
 homepage = "https://avd.arista.com"
-repository = "https://github.com/aristanetworks/ansible-avd"
+repository = "https://github.com/aristanetworks/avd"
 
 [build-system]
 requires = [

--- a/python-avd/scripts/export_test_vars.yml
+++ b/python-avd/scripts/export_test_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Playbook to export vars from ansible-avd molecule scenarios
+# Ansible Playbook to export vars from avd molecule scenarios
 # Must load inventory from file in source molecule scenario
 # Must give destination path as extra-var like "-e testdir=eos_designs_unit_tests"
 

--- a/python-avd/scripts/export_test_vars.yml
+++ b/python-avd/scripts/export_test_vars.yml
@@ -1,6 +1,6 @@
 ---
 
-# Ansible Playbook to export vars from avd molecule scenarios
+# Ansible Playbook to export vars from AVD molecule scenarios
 # Must load inventory from file in source molecule scenario
 # Must give destination path as extra-var like "-e testdir=eos_designs_unit_tests"
 


### PR DESCRIPTION
## Change Summary

Update repo URL and name from ansible-avd to avd.

This will remain a draft until change the repo name from ansible-avd to avd.
CI should be run after the repo rename to ensure `Collection code testing / Validate mkdoc content` is successful

Note: I didn't update any of the Ansible changelog fragments backups or artifacts.
