### PR TITLE
Feat(eos_designs): Support routing protocol option on l3_edge p2p_links

### DIFF
--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -283,7 +283,6 @@ vlan 350
 | Ethernet4 | P2P_LINK_TO_DC1-SPINE4_Ethernet6 | routed | - | - | default | 1500 | False | - | - | - | - |
 | Ethernet9 | P2P_LINK_TO_DC1-BL1B_Ethernet9 | routed | - | - | default | 1500 | False | - | - | - | - |
 | Ethernet10 | P2P_LINK_TO_DC1-BL1B_Ethernet10 | routed | - | - | default | 1500 | False | - | - | - | - |
-| Ethernet11 | P2P_LINK_TO_outside-r1_other1 | routed | - | - | default | 1500 | False | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -337,7 +336,6 @@ interface Ethernet11
    mtu 1500
    no switchport
    ip address 10.23.23.1/30
-   ipv6 enable
 !
 interface Ethernet4000
    description My test

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1A.md
@@ -270,6 +270,7 @@ vlan 350
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
+| Ethernet11 | P2P_LINK_TO_outside-r1_other1 | routed | - | 10.23.23.1/30 | default | 1500 | False | - | - |
 | Ethernet4000 | My test | routed | - | 10.1.2.3/12 | default | 1500 | False | - | - |
 
 ##### IPv6
@@ -282,6 +283,7 @@ vlan 350
 | Ethernet4 | P2P_LINK_TO_DC1-SPINE4_Ethernet6 | routed | - | - | default | 1500 | False | - | - | - | - |
 | Ethernet9 | P2P_LINK_TO_DC1-BL1B_Ethernet9 | routed | - | - | default | 1500 | False | - | - | - | - |
 | Ethernet10 | P2P_LINK_TO_DC1-BL1B_Ethernet10 | routed | - | - | default | 1500 | False | - | - | - | - |
+| Ethernet11 | P2P_LINK_TO_outside-r1_other1 | routed | - | - | default | 1500 | False | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -327,6 +329,14 @@ interface Ethernet10
    no shutdown
    mtu 1500
    no switchport
+   ipv6 enable
+!
+interface Ethernet11
+   description P2P_LINK_TO_outside-r1_other1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.23.1/30
    ipv6 enable
 !
 interface Ethernet4000
@@ -597,6 +607,7 @@ router general
 
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive | TTL Max Hops |
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- | ------------ |
+| 10.23.23.2 | 64900 | default | - | Inherited from peer group UNDERLAY_PEERS | Inherited from peer group UNDERLAY_PEERS | - | - | - | - | - | - |
 | 192.168.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
 | 192.168.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
 | 192.168.255.3 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
@@ -673,6 +684,9 @@ router bgp 65104
    neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor interface Ethernet9 peer-group UNDERLAY_PEERS remote-as 65105
    neighbor interface Ethernet10 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 10.23.23.2 peer group UNDERLAY_PEERS
+   neighbor 10.23.23.2 remote-as 64900
+   neighbor 10.23.23.2 description outside-r1
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-BL1B.md
@@ -269,6 +269,7 @@ vlan 350
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
+| Ethernet11 | P2P_LINK_TO_outside-r1_other2 | routed | - | 10.23.23.5/30 | default | 1500 | False | - | - |
 | Ethernet4000 | My test | routed | - | 10.1.2.3/12 | default | 1500 | False | - | - |
 
 ##### IPv6
@@ -281,6 +282,7 @@ vlan 350
 | Ethernet4 | P2P_LINK_TO_DC1-SPINE4_Ethernet7 | routed | - | - | default | 1500 | False | - | - | - | - |
 | Ethernet9 | P2P_LINK_TO_DC1-BL1A_Ethernet9 | routed | - | - | default | 1500 | False | - | - | - | - |
 | Ethernet10 | P2P_LINK_TO_DC1-BL1A_Ethernet10 | routed | - | - | default | 1500 | False | - | - | - | - |
+| Ethernet11 | P2P_LINK_TO_outside-r1_other2 | routed | - | - | default | 1500 | False | - | - | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -326,6 +328,14 @@ interface Ethernet10
    no shutdown
    mtu 1500
    no switchport
+   ipv6 enable
+!
+interface Ethernet11
+   description P2P_LINK_TO_outside-r1_other2
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.23.5/30
    ipv6 enable
 !
 interface Ethernet4000
@@ -574,6 +584,7 @@ ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive | TTL Max Hops |
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- | ------------ |
+| 10.23.23.6 | 64900 | default | - | Inherited from peer group UNDERLAY_PEERS | Inherited from peer group UNDERLAY_PEERS | - | - | - | - | - | - |
 | 192.168.255.1 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
 | 192.168.255.2 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
 | 192.168.255.3 | 65001 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
@@ -650,6 +661,9 @@ router bgp 65105
    neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor interface Ethernet9 peer-group UNDERLAY_PEERS remote-as 65104
    neighbor interface Ethernet10 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor 10.23.23.6 peer group UNDERLAY_PEERS
+   neighbor 10.23.23.6 remote-as 64900
+   neighbor 10.23.23.6 description outside-r1
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/fabric/DC1_FABRIC-topology.csv
@@ -5,6 +5,7 @@ l3leaf,DC1-BL1A,Ethernet3,spine,DC1-SPINE3,Ethernet6,True
 l3leaf,DC1-BL1A,Ethernet4,spine,DC1-SPINE4,Ethernet6,True
 l3leaf,DC1-BL1A,Ethernet9,l3leaf,DC1-BL1B,Ethernet9,True
 l3leaf,DC1-BL1A,Ethernet10,l3leaf,DC1-BL1B,Ethernet10,True
+l3leaf,DC1-BL1A,Ethernet11,other,outside-r1,other1,True
 l3leaf,DC1-BL1A,Ethernet4000,my_precious,MY-own-peer,Ethernet123,True
 l3leaf,DC1-BL1B,Ethernet1,spine,DC1-SPINE1,Ethernet7,True
 l3leaf,DC1-BL1B,Ethernet2,spine,DC1-SPINE2,Ethernet7,True
@@ -12,6 +13,7 @@ l3leaf,DC1-BL1B,Ethernet3,spine,DC1-SPINE3,Ethernet7,True
 l3leaf,DC1-BL1B,Ethernet4,spine,DC1-SPINE4,Ethernet7,True
 l3leaf,DC1-BL1B,Ethernet9,l3leaf,DC1-BL1A,Ethernet9,True
 l3leaf,DC1-BL1B,Ethernet10,l3leaf,DC1-BL1A,Ethernet10,True
+l3leaf,DC1-BL1B,Ethernet11,other,outside-r1,other2,True
 l3leaf,DC1-BL1B,Ethernet4000,my_precious,MY-own-peer,Ethernet123,True
 l2leaf,DC1-L2LEAF1A,Ethernet1,l3leaf,DC1-LEAF2A,Ethernet7,True
 l2leaf,DC1-L2LEAF1A,Ethernet2,l3leaf,DC1-LEAF2B,Ethernet7,True

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -87,6 +87,14 @@ interface Ethernet10
    no switchport
    ipv6 enable
 !
+interface Ethernet11
+   description P2P_LINK_TO_outside-r1_other1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.23.1/30
+   ipv6 enable
+!
 interface Ethernet4000
    description My test
    no shutdown
@@ -194,6 +202,9 @@ router bgp 65104
    neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor interface Ethernet9 peer-group UNDERLAY_PEERS remote-as 65105
    neighbor interface Ethernet10 peer-group UNDERLAY_PEERS remote-as 65105
+   neighbor 10.23.23.2 peer group UNDERLAY_PEERS
+   neighbor 10.23.23.2 remote-as 64900
+   neighbor 10.23.23.2 description outside-r1
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -93,7 +93,6 @@ interface Ethernet11
    mtu 1500
    no switchport
    ip address 10.23.23.1/30
-   ipv6 enable
 !
 interface Ethernet4000
    description My test

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -87,6 +87,14 @@ interface Ethernet10
    no switchport
    ipv6 enable
 !
+interface Ethernet11
+   description P2P_LINK_TO_outside-r1_other2
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.23.5/30
+   ipv6 enable
+!
 interface Ethernet4000
    description My test
    no shutdown
@@ -194,6 +202,9 @@ router bgp 65105
    neighbor interface Ethernet4 peer-group UNDERLAY_PEERS remote-as 65001
    neighbor interface Ethernet9 peer-group UNDERLAY_PEERS remote-as 65104
    neighbor interface Ethernet10 peer-group UNDERLAY_PEERS remote-as 65104
+   neighbor 10.23.23.6 peer group UNDERLAY_PEERS
+   neighbor 10.23.23.6 remote-as 64900
+   neighbor 10.23.23.6 description outside-r1
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -100,6 +100,11 @@ router_bgp:
     peer: DC1-SPINE4
     description: DC1-SPINE4
     remote_as: '65001'
+  - ip_address: 10.23.23.2
+    remote_as: '64900'
+    peer: outside-r1
+    description: outside-r1
+    peer_group: UNDERLAY_PEERS
   vrfs:
   - name: Tenant_A_WAN_Zone
     router_id: 192.168.255.10
@@ -335,6 +340,16 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
+  ipv6_enable: true
+- name: Ethernet11
+  peer: outside-r1
+  peer_interface: other1
+  peer_type: other
+  description: P2P_LINK_TO_outside-r1_other1
+  type: routed
+  shutdown: false
+  mtu: 1500
+  ip_address: 10.23.23.1/30
   ipv6_enable: true
 - name: Ethernet4000
   description: My test

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -350,7 +350,6 @@ ethernet_interfaces:
   shutdown: false
   mtu: 1500
   ip_address: 10.23.23.1/30
-  ipv6_enable: true
 - name: Ethernet4000
   description: My test
   ip_address: 10.1.2.3/12

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -100,6 +100,11 @@ router_bgp:
     peer: DC1-SPINE4
     description: DC1-SPINE4
     remote_as: '65001'
+  - ip_address: 10.23.23.6
+    remote_as: '64900'
+    peer: outside-r1
+    description: outside-r1
+    peer_group: UNDERLAY_PEERS
   vrfs:
   - name: Tenant_A_WAN_Zone
     router_id: 192.168.255.11
@@ -335,6 +340,16 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
+  ipv6_enable: true
+- name: Ethernet11
+  peer: outside-r1
+  peer_interface: other2
+  peer_type: other
+  description: P2P_LINK_TO_outside-r1_other2
+  type: routed
+  shutdown: false
+  mtu: 1500
+  ip_address: 10.23.23.5/30
   ipv6_enable: true
 - name: Ethernet4000
   description: My test

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -252,3 +252,20 @@ core_interfaces:
       nodes: [ DC1-BL1A, DC1-BL1B ]
       interfaces: [ Ethernet10, Ethernet10 ]
       as: [ "65104", "65105" ]
+
+l3_edge:
+  p2p_links_profiles:
+    - name: IPV4-UNDERLAY-EXTERNAL
+      ipv6_enable: False
+      routing_protocol: ebgp
+  p2p_links:
+    - nodes: [ DC1-BL1A, outside-r1]
+      interfaces: [ Ethernet11, other1]
+      as: [ "65104", "64900" ]
+      subnet: 10.23.23.0/30
+      profile: IPV4-UNDERLAY-EXTERNAL
+    - nodes: [ DC1-BL1B, outside-r1]
+      interfaces: [ Ethernet11, other2]
+      as: [ "65105", "64900" ]
+      subnet: 10.23.23.4/30
+      profile: IPV4-UNDERLAY-EXTERNAL

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/inventory/group_vars/DC1_FABRIC.yml
@@ -256,7 +256,6 @@ core_interfaces:
 l3_edge:
   p2p_links_profiles:
     - name: IPV4-UNDERLAY-EXTERNAL
-      ipv6_enable: False
       routing_protocol: ebgp
   p2p_links:
     - nodes: [ DC1-BL1A, outside-r1]
@@ -269,3 +268,4 @@ l3_edge:
       as: [ "65105", "64900" ]
       subnet: 10.23.23.4/30
       profile: IPV4-UNDERLAY-EXTERNAL
+      ipv6_enable: True

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/core-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/core-interfaces.md
@@ -51,6 +51,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "core_interfaces.p2p_links_profiles.[].port_channel.nodes_child_interfaces.[].interfaces") | List, items: String |  |  |  | List of node interfaces. Ex.- [ 'node1 interface1', 'node1 interface2' ]. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "core_interfaces.p2p_links_profiles.[].port_channel.nodes_child_interfaces.[].interfaces.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "core_interfaces.p2p_links_profiles.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the point-to-point interface in the final EOS configuration. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;routing_protocol</samp>](## "core_interfaces.p2p_links_profiles.[].routing_protocol") | String |  |  | Valid Values:<br>- <code>ebgp</code> | Enables deviation of the routing protocol used on this link from the fabric underlay default.<br>- ebgp: Enforce plain IPv4 BGP peering |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "core_interfaces.p2p_links_profiles.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
     | [<samp>&nbsp;&nbsp;p2p_links</samp>](## "core_interfaces.p2p_links") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;nodes</samp>](## "core_interfaces.p2p_links.[].nodes") | List, items: String | Required |  |  | Nodes where this link should be configured. |
@@ -91,6 +92,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "core_interfaces.p2p_links.[].port_channel.nodes_child_interfaces.[].interfaces") | List, items: String |  |  |  | List of node interfaces. Ex.- [ 'node1 interface1', 'node1 interface2' ]. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "core_interfaces.p2p_links.[].port_channel.nodes_child_interfaces.[].interfaces.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "core_interfaces.p2p_links.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the point-to-point interface in the final EOS configuration. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;routing_protocol</samp>](## "core_interfaces.p2p_links.[].routing_protocol") | String |  |  | Valid Values:<br>- <code>ebgp</code> | Enables deviation of the routing protocol used on this link from the fabric underlay default.<br>- ebgp: Enforce plain IPv4 BGP peering |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "core_interfaces.p2p_links.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
 
 === "YAML"
@@ -209,6 +211,10 @@
           # EOS CLI rendered directly on the point-to-point interface in the final EOS configuration.
           raw_eos_cli: <str>
 
+          # Enables deviation of the routing protocol used on this link from the fabric underlay default.
+          # - ebgp: Enforce plain IPv4 BGP peering
+          routing_protocol: <str; "ebgp">
+
           # Custom structured config for interfaces
           # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
           structured_config: <dict>
@@ -313,6 +319,10 @@
 
           # EOS CLI rendered directly on the point-to-point interface in the final EOS configuration.
           raw_eos_cli: <str>
+
+          # Enables deviation of the routing protocol used on this link from the fabric underlay default.
+          # - ebgp: Enforce plain IPv4 BGP peering
+          routing_protocol: <str; "ebgp">
 
           # Custom structured config for interfaces
           # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/l3-edge.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/l3-edge.md
@@ -51,6 +51,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "l3_edge.p2p_links_profiles.[].port_channel.nodes_child_interfaces.[].interfaces") | List, items: String |  |  |  | List of node interfaces. Ex.- [ 'node1 interface1', 'node1 interface2' ]. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "l3_edge.p2p_links_profiles.[].port_channel.nodes_child_interfaces.[].interfaces.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "l3_edge.p2p_links_profiles.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the point-to-point interface in the final EOS configuration. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;routing_protocol</samp>](## "l3_edge.p2p_links_profiles.[].routing_protocol") | String |  |  | Valid Values:<br>- <code>ebgp</code> | Enables deviation of the routing protocol used on this link from the fabric underlay default.<br>- ebgp: Enforce plain IPv4 BGP peering |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "l3_edge.p2p_links_profiles.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
     | [<samp>&nbsp;&nbsp;p2p_links</samp>](## "l3_edge.p2p_links") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;nodes</samp>](## "l3_edge.p2p_links.[].nodes") | List, items: String | Required |  |  | Nodes where this link should be configured. |
@@ -91,6 +92,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "l3_edge.p2p_links.[].port_channel.nodes_child_interfaces.[].interfaces") | List, items: String |  |  |  | List of node interfaces. Ex.- [ 'node1 interface1', 'node1 interface2' ]. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "l3_edge.p2p_links.[].port_channel.nodes_child_interfaces.[].interfaces.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "l3_edge.p2p_links.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the point-to-point interface in the final EOS configuration. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;routing_protocol</samp>](## "l3_edge.p2p_links.[].routing_protocol") | String |  |  | Valid Values:<br>- <code>ebgp</code> | Enables deviation of the routing protocol used on this link from the fabric underlay default.<br>- ebgp: Enforce plain IPv4 BGP peering |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "l3_edge.p2p_links.[].structured_config") | Dictionary |  |  |  | Custom structured config for interfaces<br>Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces. |
 
 === "YAML"
@@ -209,6 +211,10 @@
           # EOS CLI rendered directly on the point-to-point interface in the final EOS configuration.
           raw_eos_cli: <str>
 
+          # Enables deviation of the routing protocol used on this link from the fabric underlay default.
+          # - ebgp: Enforce plain IPv4 BGP peering
+          routing_protocol: <str; "ebgp">
+
           # Custom structured config for interfaces
           # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
           structured_config: <dict>
@@ -313,6 +319,10 @@
 
           # EOS CLI rendered directly on the point-to-point interface in the final EOS configuration.
           raw_eos_cli: <str>
+
+          # Enables deviation of the routing protocol used on this link from the fabric underlay default.
+          # - ebgp: Enforce plain IPv4 BGP peering
+          routing_protocol: <str; "ebgp">
 
           # Custom structured config for interfaces
           # Note! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
@@ -42,7 +42,7 @@ class RouterBgpMixin(UtilsMixin):
             }
 
             # RFC5549
-            if self.shared_utils.underlay_rfc5549:
+            if self.shared_utils.underlay_rfc5549 and p2p_link.get("routing_protocol") != "ebgp":
                 neighbor_interfaces.append({"name": p2p_link["data"]["interface"], **neighbor})
                 continue
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
@@ -229,7 +229,7 @@ class UtilsMixin:
             interface_cfg["ip_address"] = ip[index]
 
         if p2p_link.get("include_in_underlay_protocol", True) is True:
-            if self.shared_utils.underlay_rfc5549 or p2p_link.get("ipv6_enable") is True:
+            if (self.shared_utils.underlay_rfc5549 and p2p_link.get("routing_protocol") != "ebgp") or p2p_link.get("ipv6_enable") is True:
                 interface_cfg["ipv6_enable"] = True
 
             if self.shared_utils.underlay_ospf:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -3637,6 +3637,14 @@
                 "description": "EOS CLI rendered directly on the point-to-point interface in the final EOS configuration.",
                 "title": "Raw EOS CLI"
               },
+              "routing_protocol": {
+                "type": "string",
+                "enum": [
+                  "ebgp"
+                ],
+                "description": "Enables deviation of the routing protocol used on this link from the fabric underlay default.\n- ebgp: Enforce plain IPv4 BGP peering",
+                "title": "Routing Protocol"
+              },
               "structured_config": {
                 "type": "object",
                 "description": "Custom structured config for interfaces\nNote! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.",
@@ -3871,6 +3879,14 @@
                 "type": "string",
                 "description": "EOS CLI rendered directly on the point-to-point interface in the final EOS configuration.",
                 "title": "Raw EOS CLI"
+              },
+              "routing_protocol": {
+                "type": "string",
+                "enum": [
+                  "ebgp"
+                ],
+                "description": "Enables deviation of the routing protocol used on this link from the fabric underlay default.\n- ebgp: Enforce plain IPv4 BGP peering",
+                "title": "Routing Protocol"
               },
               "structured_config": {
                 "type": "object",
@@ -5158,6 +5174,14 @@
                 "description": "EOS CLI rendered directly on the point-to-point interface in the final EOS configuration.",
                 "title": "Raw EOS CLI"
               },
+              "routing_protocol": {
+                "type": "string",
+                "enum": [
+                  "ebgp"
+                ],
+                "description": "Enables deviation of the routing protocol used on this link from the fabric underlay default.\n- ebgp: Enforce plain IPv4 BGP peering",
+                "title": "Routing Protocol"
+              },
               "structured_config": {
                 "type": "object",
                 "description": "Custom structured config for interfaces\nNote! The content of this dictionary is _not_ validated by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.",
@@ -5392,6 +5416,14 @@
                 "type": "string",
                 "description": "EOS CLI rendered directly on the point-to-point interface in the final EOS configuration.",
                 "title": "Raw EOS CLI"
+              },
+              "routing_protocol": {
+                "type": "string",
+                "enum": [
+                  "ebgp"
+                ],
+                "description": "Enables deviation of the routing protocol used on this link from the fabric underlay default.\n- ebgp: Enforce plain IPv4 BGP peering",
+                "title": "Routing Protocol"
               },
               "structured_config": {
                 "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -7769,6 +7769,14 @@ $defs:
           type: str
           description: EOS CLI rendered directly on the point-to-point interface in
             the final EOS configuration.
+        routing_protocol:
+          type: str
+          valid_values:
+          - ebgp
+          description: 'Enables deviation of the routing protocol used on this link
+            from the fabric underlay default.
+
+            - ebgp: Enforce plain IPv4 BGP peering'
         structured_config:
           type: dict
           documentation_options:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_p2p_links.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_p2p_links.schema.yml
@@ -152,6 +152,13 @@ $defs:
         raw_eos_cli:
           type: str
           description: EOS CLI rendered directly on the point-to-point interface in the final EOS configuration.
+        routing_protocol:
+          type: str
+          valid_values:
+            - ebgp
+          description: |-
+            Enables deviation of the routing protocol used on this link from the fabric underlay default.
+            - ebgp: Enforce plain IPv4 BGP peering
         structured_config:
           type: dict
           documentation_options:


### PR DESCRIPTION
## Change Summary

Implement an additional key in
- `l3_edge.p2p_links_profiles[].routing_protocol`
- `l3_edge.p2p_links[].routing_protocol`
- `core_interfaces.p2p_links_profiles[].routing_protocol` and
- `core_interfaces.p2p_links[].routing_protocol`

to overwrite underlay routing protocol used on the link. Currently only `ebgp` is implemented which enforces classic IPv4 BGP Peering in a RFC5549 enabled fabric.

## Related Issue(s)

Fixes #3493

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
- Added the new keys to the role schema
- Changed the structured config generation in corresponding underlay python module

## How to test
- Added a test case to molecule scenario `evpn_underlay_rfc5549_overlay_ebgp`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/ansible-avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
