### PR TITLE
CI: Fix actions for containers

### DIFF
--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -13,7 +13,7 @@ on:
     branches:
       - devel
   release:
-    types: [published, prereleased]
+    types: [published]
 
 jobs:
   build_universal_container:

--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -9,6 +9,7 @@ on:
       - containers/universal/**
       - .github/workflows/container_build_template.yml
       - .github/workflows/container_build_universal.yml
+      - ansible_collections/arista/avd/**
   workflow_dispatch:
     branches:
       - devel


### PR DESCRIPTION
## Change Summary

- remove `pre-release` trigger as according to the latest testing it is part of `published` and earlier pre-release build failed due to unrelated reason. This will prevent triggering redundant container build
- start building universal container on pushes to `ansible_collections/arista/avd/**` to keep image with `avd-devel` tag in sync with devel branch

## Component(s) name

CI
