### PR TITLE
Feat: Additional fixes for Github Codespaces support

### DIFF
--- a/containers/base/.devcontainer/Dockerfile
+++ b/containers/base/.devcontainer/Dockerfile
@@ -13,6 +13,11 @@ RUN apt-get update \
     && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
     && apt-get clean
 
+# set ANSIBLE_CONFIG to ansible.cfg in local directory
+# this is required to address Ansible ignoring config in a world writable directory
+# on Codespaces, Gitlab Runner, etc.
+ENV ANSIBLE_CONFIG="ansible.cfg"
+
 # Add entrypoint script.
 COPY ./entrypoint.sh /bin/entrypoint.sh
 RUN chmod +x /bin/entrypoint.sh

--- a/containers/dev/.devcontainer/devcontainer.json
+++ b/containers/dev/.devcontainer/devcontainer.json
@@ -23,8 +23,6 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                // Git essentials.
-                "github.vscode-pull-request-github",
                 // Python.
                 "ms-python.python",
                 "ms-python.vscode-pylance",

--- a/containers/dev/.devcontainer/entrypoint.sh
+++ b/containers/dev/.devcontainer/entrypoint.sh
@@ -25,9 +25,11 @@ fi
 if ! [ -z "${ANSIBLE_CORE_VERSION}" ]; then
   pip3 install "${ANSIBLE_CORE_VERSION}"
   if ! [ -z "${AVD_INSTALL_PATH}" ]; then
-    ansible-galaxy collection install ${AVD_INSTALL_PATH}
+    ansible-galaxy collection install --force ${AVD_INSTALL_PATH}
+  else
+    # if collection was mounted and not installed - add requirements
+    ansible-galaxy collection install -r ${AVD_COLLECTION_PATH}/collections.yml
   fi
-  ansible-galaxy collection install -r ${AVD_COLLECTION_PATH}/collections.yml
   pip3 install -r ${AVD_COLLECTION_PATH}/requirements.txt -r ${AVD_COLLECTION_PATH}/requirements-dev.txt
 fi
 

--- a/containers/universal/.devcontainer/devcontainer.json
+++ b/containers/universal/.devcontainer/devcontainer.json
@@ -25,8 +25,6 @@
     "customizations": {
         "vscode": {
             "extensions": [
-                // Git essentials.
-                "github.vscode-pull-request-github",
                 // Python.
                 "ms-python.python",
                 "ms-python.vscode-pylance",


### PR DESCRIPTION
## Change Summary

Add additional fixes to make AVD dev image compatible with Github Codespaces

## Component(s) name

containers

## Proposed changes

- add `ANSIBLE_CONFIG="ansible.cfg"` to base container. Dev and universal image build must be triggered to reflect this change.
- Install AVD with `--force` to avoid empty mount breaking installation process
- Only install collection requirements when AVD is mounted to default Ansible path. When `ansible-galaxy collection install` is in use - requirements will be installed anyway.

## How to test

Build dev container locally as described in #3476, but this time also test with mount to AVD collection path that is pointing to an empty/non-existing location.
