### PR TITLE
Refactor(eos_designs): Better error message for missing WAN policy

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -30,12 +30,12 @@ The intention is to support both a single [AutoVPN design](https://www.arista.co
 4. The default VRF is being configured by default on all WAN devices with a `vni_id` of 1. To override this, it is necessary to configure the `default` VRF in a tenant in `network_services`.
 5. When configuring HA on a site, the path-group ID `65535` is reserved for the path-group called `LAN_HA`.
 6. The policies definition works as follow:
-     - The policies are defined under `wan_virtual_topologies.policies`. For AutoVPN mode, the policies are configured under `router path-selection`, for CV Pathfinder, they are configured under `router adaptive-virtual-topology`.
-     - A policy is composed of a list of `application_virtual_topologies` and one `default_virtual_topology`.
-     - The `application_virtual_topologies` entries and the `default_virtual_topology` key are used to create the policy match statement, the AVT profile (when `wan_mode` is CV Pathfinder) and the load balancing policy.
-     - The `default_virtual_topology` is used as the default match in the policy.  To prevent configuring it, the `drop_unmatched` boolean must be set to `true` otherwise, at least one `path-group` must be configured or AVD will raise an error.
-     - Policies are assigned to VRFs using the list `wan_virtual_topologies.vrfs`. A policy can be reused in multiple VRFs.
-     - AVD requires that a policy is assigned for the `default` VRF policy. An extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `CONTROL-PLANE-APPLICATION-PROFILE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
+  - The policies are defined under `wan_virtual_topologies.policies`. For AutoVPN mode, the policies are configured under `router path-selection`, for CV Pathfinder, they are configured under `router adaptive-virtual-topology`.
+  - A policy is composed of a list of `application_virtual_topologies` and one `default_virtual_topology`.
+  - The `application_virtual_topologies` entries and the `default_virtual_topology` key are used to create the policy match statement, the AVT profile (when `wan_mode` is CV Pathfinder) and the load balancing policy.
+  - The `default_virtual_topology` is used as the default match in the policy.  To prevent configuring it, the `drop_unmatched` boolean must be set to `true` otherwise, at least one `path-group` must be configured or AVD will raise an error.
+  - Policies are assigned to VRFs using the list `wan_virtual_topologies.vrfs`. A policy can be reused in multiple VRFs.
+  - AVD requires that a policy is assigned for the `default` VRF policy. An extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `CONTROL-PLANE-APPLICATION-PROFILE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
 
 ## Known limitations
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -30,6 +30,7 @@ The intention is to support both a single [AutoVPN design](https://www.arista.co
 4. The default VRF is being configured by default on all WAN devices with a `vni_id` of 1. To override this, it is necessary to configure the `default` VRF in a tenant in `network_services`.
 5. When configuring HA on a site, the path-group ID `65535` is reserved for the path-group called `LAN_HA`.
 6. The policies definition works as follow:
+
   - The policies are defined under `wan_virtual_topologies.policies`. For AutoVPN mode, the policies are configured under `router path-selection`, for CV Pathfinder, they are configured under `router adaptive-virtual-topology`.
   - A policy is composed of a list of `application_virtual_topologies` and one `default_virtual_topology`.
   - The `application_virtual_topologies` entries and the `default_virtual_topology` key are used to create the policy match statement, the AVT profile (when `wan_mode` is CV Pathfinder) and the load balancing policy.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -24,19 +24,19 @@ The intention is to support both a single [AutoVPN design](https://www.arista.co
 
 ### Design points
 
-1. The intent is to be able to support having the different WAN participating devices in different inventories.
-2. Only iBGP is supported as an overlay_routing_protocol.
-3. On the AutoVPN Route Reflectors and Pathfinders, a listen range statement is used for BGP to allow for point number 1.
-4. The default VRF is being configured by default on all WAN devices with a `vni_id` of 1. To override this, it is necessary to configure the `default` VRF in a tenant in `network_services`.
-5. When configuring HA on a site, the path-group ID `65535` is reserved for the path-group called `LAN_HA`.
-6. The policies definition works as follow:
+- The intent is to be able to support having the different WAN participating devices in different inventories.
+- Only iBGP is supported as an overlay_routing_protocol.
+- On the AutoVPN Route Reflectors and Pathfinders, a listen range statement is used for BGP to allow for point number 1.
+- The default VRF is being configured by default on all WAN devices with a `vni_id` of 1. To override this, it is necessary to configure the `default` VRF in a tenant in `network_services`.
+- When configuring HA on a site, the path-group ID `65535` is reserved for the path-group called `LAN_HA`.
+- The policies definition works as follow:
 
-    - The policies are defined under `wan_virtual_topologies.policies`. For AutoVPN mode, the policies are configured under `router path-selection`, for CV Pathfinder, they are configured under `router adaptive-virtual-topology`.
-    - A policy is composed of a list of `application_virtual_topologies` and one `default_virtual_topology`.
-    - The `application_virtual_topologies` entries and the `default_virtual_topology` key are used to create the policy match statement, the AVT profile (when `wan_mode` is CV Pathfinder) and the load balancing policy.
-    - The `default_virtual_topology` is used as the default match in the policy.  To prevent configuring it, the `drop_unmatched` boolean must be set to `true` otherwise, at least one `path-group` must be configured or AVD will raise an error.
-    - Policies are assigned to VRFs using the list `wan_virtual_topologies.vrfs`. A policy can be reused in multiple VRFs.
-    - AVD requires that a policy is assigned for the `default` VRF policy. An extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `CONTROL-PLANE-APPLICATION-PROFILE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
+  - The policies are defined under `wan_virtual_topologies.policies`. For AutoVPN mode, the policies are configured under `router path-selection`, for CV Pathfinder, they are configured under `router adaptive-virtual-topology`.
+  - A policy is composed of a list of `application_virtual_topologies` and one `default_virtual_topology`.
+  - The `application_virtual_topologies` entries and the `default_virtual_topology` key are used to create the policy match statement, the AVT profile (when `wan_mode` is CV Pathfinder) and the load balancing policy.
+  - The `default_virtual_topology` is used as the default match in the policy.  To prevent configuring it, the `drop_unmatched` boolean must be set to `true` otherwise, at least one `path-group` must be configured or AVD will raise an error.
+  - Policies are assigned to VRFs using the list `wan_virtual_topologies.vrfs`. A policy can be reused in multiple VRFs.
+  - AVD requires that a policy is assigned for the `default` VRF policy. An extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `CONTROL-PLANE-APPLICATION-PROFILE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
 
 ## Known limitations
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -31,12 +31,12 @@ The intention is to support both a single [AutoVPN design](https://www.arista.co
 5. When configuring HA on a site, the path-group ID `65535` is reserved for the path-group called `LAN_HA`.
 6. The policies definition works as follow:
 
-  - The policies are defined under `wan_virtual_topologies.policies`. For AutoVPN mode, the policies are configured under `router path-selection`, for CV Pathfinder, they are configured under `router adaptive-virtual-topology`.
-  - A policy is composed of a list of `application_virtual_topologies` and one `default_virtual_topology`.
-  - The `application_virtual_topologies` entries and the `default_virtual_topology` key are used to create the policy match statement, the AVT profile (when `wan_mode` is CV Pathfinder) and the load balancing policy.
-  - The `default_virtual_topology` is used as the default match in the policy.  To prevent configuring it, the `drop_unmatched` boolean must be set to `true` otherwise, at least one `path-group` must be configured or AVD will raise an error.
-  - Policies are assigned to VRFs using the list `wan_virtual_topologies.vrfs`. A policy can be reused in multiple VRFs.
-  - AVD requires that a policy is assigned for the `default` VRF policy. An extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `CONTROL-PLANE-APPLICATION-PROFILE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
+    - The policies are defined under `wan_virtual_topologies.policies`. For AutoVPN mode, the policies are configured under `router path-selection`, for CV Pathfinder, they are configured under `router adaptive-virtual-topology`.
+    - A policy is composed of a list of `application_virtual_topologies` and one `default_virtual_topology`.
+    - The `application_virtual_topologies` entries and the `default_virtual_topology` key are used to create the policy match statement, the AVT profile (when `wan_mode` is CV Pathfinder) and the load balancing policy.
+    - The `default_virtual_topology` is used as the default match in the policy.  To prevent configuring it, the `drop_unmatched` boolean must be set to `true` otherwise, at least one `path-group` must be configured or AVD will raise an error.
+    - Policies are assigned to VRFs using the list `wan_virtual_topologies.vrfs`. A policy can be reused in multiple VRFs.
+    - AVD requires that a policy is assigned for the `default` VRF policy. An extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `CONTROL-PLANE-APPLICATION-PROFILE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
 
 ## Known limitations
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -390,7 +390,20 @@ class UtilsMixin(UtilsFilteredTenantsMixin):
         """
         policies = get(self._hostvars, "wan_virtual_topologies.policies", default=[])
         # Need to handle VRF default differently
-        filtered_policies = [get_item(policies, "name", wan_vrf[self._wan_policy_key]) for wan_vrf in self._filtered_wan_vrfs if wan_vrf["name"] != "default"]
+        filtered_policies = [
+            get_item(
+                policies,
+                "name",
+                wan_vrf[self._wan_policy_key],
+                required=True,
+                custom_error_msg=(
+                    f"The policy {wan_vrf[self._wan_policy_key]} applied to vrf {wan_vrf['name']} under `wan_virtual_topologies.vrfs` is not "
+                    "defined under `wan_virtual_topologies.policies`."
+                ),
+            )
+            for wan_vrf in self._filtered_wan_vrfs
+            if wan_vrf["name"] != "default"
+        ]
         filtered_policies.append(self._default_vrf_policy)
         return filtered_policies
 


### PR DESCRIPTION
## Change Summary

When using the following snippet

```
wan_virtual_topologies:
  vrfs:
    - name: PROD
      policy: DOES-NOT-EXIST
```

The error message on the Pathfinder devices was very cryptic as it was trying to look up a policy name in a non existing dict
This is now returning a better error message

## Related Issue(s)

Reported by field

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Better error message

## How to test

Tested manually - a new negative test could be added but not done here

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
