### PR TITLE
Feat(eos_designs): Add support for virtual topologies constraints

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -107,8 +107,10 @@ router path-selection
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT
    !
    load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      loss-rate 42.0
    !
    load-balance policy LB-PROD-AVT-POLICY-VOICE
+      jitter 42
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -138,11 +138,13 @@ router path-selection
       path-group MPLS priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      loss-rate 42.0
       path-group LTE
       path-group MPLS
       path-group INET priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VOICE
+      jitter 42
       path-group MPLS
       path-group INET priority 2
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -136,11 +136,13 @@ router path-selection
       path-group MPLS priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      loss-rate 42.0
       path-group LTE
       path-group MPLS
       path-group INET priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VOICE
+      jitter 42
       path-group MPLS
       path-group INET priority 2
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -137,11 +137,13 @@ router path-selection
       path-group MPLS priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      loss-rate 42.0
       path-group LTE
       path-group MPLS
       path-group INET priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VOICE
+      jitter 42
       path-group MPLS
       path-group INET priority 2
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -146,11 +146,13 @@ router path-selection
       path-group MPLS priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      loss-rate 42.0
       path-group LTE
       path-group MPLS
       path-group INET priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VOICE
+      jitter 42
       path-group MPLS
       path-group INET priority 2
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
@@ -150,10 +150,12 @@ router path-selection
       path-group MPLS priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VIDEO
+      loss-rate 42.0
       path-group MPLS
       path-group INET priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VOICE
+      jitter 42
       path-group MPLS
       path-group INET priority 2
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -232,7 +232,9 @@ router_path_selection:
     path_groups:
     - name: Satellite
   - name: LB-PROD-AVT-POLICY-VOICE
+    jitter: 42
   - name: LB-PROD-AVT-POLICY-VIDEO
+    loss_rate: '42.0'
   - name: LB-PROD-AVT-POLICY-DEFAULT
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: LB-DEFAULT-AVT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -282,12 +282,14 @@ router_path_selection:
     - name: MPLS
     - name: INET
       priority: 2
+    jitter: 42
   - name: LB-PROD-AVT-POLICY-VIDEO
     path_groups:
     - name: MPLS
     - name: LTE
     - name: INET
       priority: 2
+    loss_rate: '42.0'
   - name: LB-PROD-AVT-POLICY-DEFAULT
     path_groups:
     - name: INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -266,12 +266,14 @@ router_path_selection:
     - name: MPLS
     - name: INET
       priority: 2
+    jitter: 42
   - name: LB-PROD-AVT-POLICY-VIDEO
     path_groups:
     - name: MPLS
     - name: LTE
     - name: INET
       priority: 2
+    loss_rate: '42.0'
   - name: LB-PROD-AVT-POLICY-DEFAULT
     path_groups:
     - name: INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -278,12 +278,14 @@ router_path_selection:
     - name: MPLS
     - name: INET
       priority: 2
+    jitter: 42
   - name: LB-PROD-AVT-POLICY-VIDEO
     path_groups:
     - name: MPLS
     - name: LTE
     - name: INET
       priority: 2
+    loss_rate: '42.0'
   - name: LB-PROD-AVT-POLICY-DEFAULT
     path_groups:
     - name: INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -295,12 +295,14 @@ router_path_selection:
     - name: MPLS
     - name: INET
       priority: 2
+    jitter: 42
   - name: LB-PROD-AVT-POLICY-VIDEO
     path_groups:
     - name: MPLS
     - name: LTE
     - name: INET
       priority: 2
+    loss_rate: '42.0'
   - name: LB-PROD-AVT-POLICY-DEFAULT
     path_groups:
     - name: INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
@@ -288,11 +288,13 @@ router_path_selection:
     - name: MPLS
     - name: INET
       priority: 2
+    jitter: 42
   - name: LB-PROD-AVT-POLICY-VIDEO
     path_groups:
     - name: MPLS
     - name: INET
       priority: 2
+    loss_rate: '42.0'
   - name: LB-PROD-AVT-POLICY-DEFAULT
     path_groups:
     - name: INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -225,6 +225,8 @@ wan_virtual_topologies:
               preference: preferred
             - names: [INET]
               preference: alternate
+          constraints:
+            jitter: 42
           id: 2
         - application_profile: VIDEO
           path_groups:
@@ -232,6 +234,8 @@ wan_virtual_topologies:
               preference: preferred
             - names: [INET]
               preference: alternate
+          constraints:
+            loss_rate: 42.0
           id: 4
     - name: DEFAULT-AVT-POLICY
       default_virtual_topology:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
@@ -44,7 +44,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lowest_hop_count</samp>](## "router_path_selection.load_balance_policies.[].lowest_hop_count") | Boolean |  |  |  | Prefer paths with lowest hop-count. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "router_path_selection.load_balance_policies.[].jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "router_path_selection.load_balance_policies.[].latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "router_path_selection.load_balance_policies.[].loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "router_path_selection.load_balance_policies.[].loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "router_path_selection.load_balance_policies.[].path_groups") | List, items: Dictionary |  |  |  | List of path-groups to use for this load balance policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_path_selection.load_balance_policies.[].path_groups.[].name") | String | Required, Unique |  |  | Path-group name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "router_path_selection.load_balance_policies.[].path_groups.[].priority") | Integer |  |  | Min: 1<br>Max: 65535 | Priority for this path-group.<br>The EOS default value is 1. |
@@ -151,7 +151,7 @@
           latency: <int; 0-10000>
 
           # Loss Rate requirement in percentage for this load balance policy.
-          # Value between 0.00 and 100.00 %
+          # Value between 0.00 and 100.00.
           loss_rate: <str>
 
           # List of path-groups to use for this load balance policy.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -22048,7 +22048,7 @@
               },
               "loss_rate": {
                 "type": "string",
-                "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00 %",
+                "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00.",
                 "pattern": "^\\d+(\\.\\d{1,2})?$",
                 "title": "Loss Rate"
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -12759,7 +12759,7 @@ keys:
               description: 'Loss Rate requirement in percentage for this load balance
                 policy.
 
-                Value between 0.00 and 100.00 %'
+                Value between 0.00 and 100.00.'
               convert_types:
               - int
               - float

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_path_selection.schema.yml
@@ -167,7 +167,7 @@ keys:
               type: str
               description: |-
                 Loss Rate requirement in percentage for this load balance policy.
-                Value between 0.00 and 100.00 %
+                Value between 0.00 and 100.00.
               convert_types:
                 - int
                 - float

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
@@ -15,6 +15,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.name") | String |  |  |  | Optional name, if not set `CONTROL-PLANE-PROFILE` is used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.traffic_class") | Integer |  |  | Min: 0<br>Max: 7 | Set traffic-class for matched traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.dscp") | Integer |  |  | Min: 0<br>Max: 63 | Set DSCP for matched traffic. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;constraints</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.constraints") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.constraints.jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.constraints.latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.constraints.loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
@@ -27,6 +31,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].id") | Integer | Required |  | Min: 2<br>Max: 253 | ID of the AVT in each VRFs. ID must be unique across all virtual topologies in a policy.<br>ID 1 is reserved for the default_virtual_toplogy.<br>ID 254 is reserved for the control_plane_virtual_topology. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].traffic_class") | Integer |  |  | Min: 0<br>Max: 7 | Set traffic-class for matched traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].dscp") | Integer |  |  | Min: 0<br>Max: 63 | Set DSCP for matched traffic. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constraints</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].constraints") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].constraints.jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].constraints.latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].constraints.loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names.[]") | String |  |  |  |  |
@@ -36,6 +44,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;drop_unmatched</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.drop_unmatched") | Boolean |  | `False` |  | When set, no `catch-all` match is configured for the policy and unmatched traffic is dropped. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.traffic_class") | Integer |  |  | Min: 0<br>Max: 7 | Set traffic-class for matched traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.dscp") | Integer |  |  | Min: 0<br>Max: 63 | Set DSCP for matched traffic. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constraints</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.constraints") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.constraints.jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.constraints.latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.constraints.loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
@@ -76,6 +88,17 @@
 
         # Set DSCP for matched traffic.
         dscp: <int; 0-63>
+        constraints:
+
+          # Jitter requirement for this load balance policy in milliseconds.
+          jitter: <int; 0-10000>
+
+          # One way delay requirement for this load balance policy in milliseconds.
+          latency: <int; 0-10000>
+
+          # Loss Rate requirement in percentage for this load balance policy.
+          # Value between 0.00 and 100.00 %
+          loss_rate: <str>
         path_groups: # >=1 items
 
             # List of path-group names.
@@ -136,6 +159,17 @@
 
               # Set DSCP for matched traffic.
               dscp: <int; 0-63>
+              constraints:
+
+                # Jitter requirement for this load balance policy in milliseconds.
+                jitter: <int; 0-10000>
+
+                # One way delay requirement for this load balance policy in milliseconds.
+                latency: <int; 0-10000>
+
+                # Loss Rate requirement in percentage for this load balance policy.
+                # Value between 0.00 and 100.00 %
+                loss_rate: <str>
               path_groups: # >=1 items
 
                   # List of path-group names.
@@ -164,6 +198,17 @@
 
             # Set DSCP for matched traffic.
             dscp: <int; 0-63>
+            constraints:
+
+              # Jitter requirement for this load balance policy in milliseconds.
+              jitter: <int; 0-10000>
+
+              # One way delay requirement for this load balance policy in milliseconds.
+              latency: <int; 0-10000>
+
+              # Loss Rate requirement in percentage for this load balance policy.
+              # Value between 0.00 and 100.00 %
+              loss_rate: <str>
             path_groups: # >=1 items
 
                 # List of path-group names.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
@@ -18,7 +18,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;constraints</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.constraints") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.constraints.jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.constraints.latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.constraints.loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.constraints.loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
@@ -34,7 +34,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constraints</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].constraints") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].constraints.jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].constraints.latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].constraints.loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].constraints.loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names.[]") | String |  |  |  |  |
@@ -47,7 +47,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;constraints</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.constraints") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;jitter</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.constraints.jitter") | Integer |  |  | Min: 0<br>Max: 10000 | Jitter requirement for this load balance policy in milliseconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;latency</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.constraints.latency") | Integer |  |  | Min: 0<br>Max: 10000 | One way delay requirement for this load balance policy in milliseconds. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.constraints.loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00 % |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;loss_rate</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.constraints.loss_rate") | String |  |  | Pattern: ^\d+(\.\d{1,2})?$ | Loss Rate requirement in percentage for this load balance policy.<br>Value between 0.00 and 100.00. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
@@ -97,7 +97,7 @@
           latency: <int; 0-10000>
 
           # Loss Rate requirement in percentage for this load balance policy.
-          # Value between 0.00 and 100.00 %
+          # Value between 0.00 and 100.00.
           loss_rate: <str>
         path_groups: # >=1 items
 
@@ -168,7 +168,7 @@
                 latency: <int; 0-10000>
 
                 # Loss Rate requirement in percentage for this load balance policy.
-                # Value between 0.00 and 100.00 %
+                # Value between 0.00 and 100.00.
                 loss_rate: <str>
               path_groups: # >=1 items
 
@@ -207,7 +207,7 @@
               latency: <int; 0-10000>
 
               # Loss Rate requirement in percentage for this load balance policy.
-              # Value between 0.00 and 100.00 %
+              # Value between 0.00 and 100.00.
               loss_rate: <str>
             path_groups: # >=1 items
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
@@ -156,7 +156,7 @@ class RouterBgpMixin(UtilsMixin):
                     else:
                         target["route_targets"].append(vrf_rt)
 
-                for rt in get(vrf, "additional_route_targets", default=[]):
+                for rt in vrf["additional_route_targets"]:
                     if (target := get_item(route_targets[rt["type"]], "address_family", rt["address_family"])) is None:
                         route_targets[rt["type"]].append({"address_family": rt["address_family"], "route_targets": [rt["route_target"]]})
                     else:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
@@ -156,7 +156,7 @@ class RouterBgpMixin(UtilsMixin):
                     else:
                         target["route_targets"].append(vrf_rt)
 
-                for rt in vrf["additional_route_targets"]:
+                for rt in get(vrf, "additional_route_targets", default=[]):
                     if (target := get_item(route_targets[rt["type"]], "address_family", rt["address_family"])) is None:
                         route_targets[rt["type"]].append({"address_family": rt["address_family"], "route_targets": [rt["route_target"]]})
                     else:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -244,10 +244,7 @@ class UtilsMixin(UtilsFilteredTenantsMixin):
         * implement also the jitter / ...
         """
         wan_local_path_group_names = [path_group["name"] for path_group in self.shared_utils.wan_local_path_groups]
-        wan_load_balance_policy = {"name": name, "path_groups": []}
-
-        # Handle constraints
-        wan_load_balance_policy |= get(input_dict, "constraints", default={})
+        wan_load_balance_policy = {"name": name, "path_groups": [], **get(input_dict, "constraints", default={})}
 
         # An entry is composed of a list of path-groups in `names` and a `priority`
         policy_entries = get(input_dict, "path_groups", [])

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -246,6 +246,9 @@ class UtilsMixin(UtilsFilteredTenantsMixin):
         wan_local_path_group_names = [path_group["name"] for path_group in self.shared_utils.wan_local_path_groups]
         wan_load_balance_policy = {"name": name, "path_groups": []}
 
+        # Handle constraints
+        wan_load_balance_policy |= get(input_dict, "constraints", default={})
+
         # An entry is composed of a list of path-groups in `names` and a `priority`
         policy_entries = get(input_dict, "path_groups", [])
         if not policy_entries and default_all:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils_filtered_tenants.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils_filtered_tenants.py
@@ -60,6 +60,7 @@ class UtilsFilteredTenantsMixin(object):
                             "ipv6_static_routes": [],
                             "static_routes": [],
                             "loopbacks": [],
+                            "additional_route_targets": [],
                         }
                     ],
                     "l2vlans": [],

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24137,7 +24137,7 @@
                 },
                 "loss_rate": {
                   "type": "string",
-                  "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00 %",
+                  "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00.",
                   "pattern": "^\\d+(\\.\\d{1,2})?$",
                   "title": "Loss Rate"
                 }
@@ -24254,7 +24254,7 @@
                         },
                         "loss_rate": {
                           "type": "string",
-                          "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00 %",
+                          "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00.",
                           "pattern": "^\\d+(\\.\\d{1,2})?$",
                           "title": "Loss Rate"
                         }
@@ -24357,7 +24357,7 @@
                       },
                       "loss_rate": {
                         "type": "string",
-                        "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00 %",
+                        "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00.",
                         "pattern": "^\\d+(\\.\\d{1,2})?$",
                         "title": "Loss Rate"
                       }

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24118,6 +24118,36 @@
               "description": "Set DSCP for matched traffic.",
               "title": "DSCP"
             },
+            "constraints": {
+              "type": "object",
+              "properties": {
+                "jitter": {
+                  "type": "integer",
+                  "description": "Jitter requirement for this load balance policy in milliseconds.",
+                  "minimum": 0,
+                  "maximum": 10000,
+                  "title": "Jitter"
+                },
+                "latency": {
+                  "type": "integer",
+                  "description": "One way delay requirement for this load balance policy in milliseconds.",
+                  "minimum": 0,
+                  "maximum": 10000,
+                  "title": "Latency"
+                },
+                "loss_rate": {
+                  "type": "string",
+                  "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00 %",
+                  "pattern": "^\\d+(\\.\\d{1,2})?$",
+                  "title": "Loss Rate"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Constraints"
+            },
             "path_groups": {
               "type": "array",
               "minItems": 1,
@@ -24205,6 +24235,36 @@
                       "description": "Set DSCP for matched traffic.",
                       "title": "DSCP"
                     },
+                    "constraints": {
+                      "type": "object",
+                      "properties": {
+                        "jitter": {
+                          "type": "integer",
+                          "description": "Jitter requirement for this load balance policy in milliseconds.",
+                          "minimum": 0,
+                          "maximum": 10000,
+                          "title": "Jitter"
+                        },
+                        "latency": {
+                          "type": "integer",
+                          "description": "One way delay requirement for this load balance policy in milliseconds.",
+                          "minimum": 0,
+                          "maximum": 10000,
+                          "title": "Latency"
+                        },
+                        "loss_rate": {
+                          "type": "string",
+                          "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00 %",
+                          "pattern": "^\\d+(\\.\\d{1,2})?$",
+                          "title": "Loss Rate"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Constraints"
+                    },
                     "path_groups": {
                       "type": "array",
                       "minItems": 1,
@@ -24277,6 +24337,36 @@
                     "maximum": 63,
                     "description": "Set DSCP for matched traffic.",
                     "title": "DSCP"
+                  },
+                  "constraints": {
+                    "type": "object",
+                    "properties": {
+                      "jitter": {
+                        "type": "integer",
+                        "description": "Jitter requirement for this load balance policy in milliseconds.",
+                        "minimum": 0,
+                        "maximum": 10000,
+                        "title": "Jitter"
+                      },
+                      "latency": {
+                        "type": "integer",
+                        "description": "One way delay requirement for this load balance policy in milliseconds.",
+                        "minimum": 0,
+                        "maximum": 10000,
+                        "title": "Latency"
+                      },
+                      "loss_rate": {
+                        "type": "string",
+                        "description": "Loss Rate requirement in percentage for this load balance policy.\nValue between 0.00 and 100.00 %",
+                        "pattern": "^\\d+(\\.\\d{1,2})?$",
+                        "title": "Loss Rate"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Constraints"
                   },
                   "path_groups": {
                     "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -8018,6 +8018,18 @@ $defs:
       dscp:
         type: int
         $ref: eos_cli_config_gen#keys/router_adaptive_virtual_topology/keys/policies/items/keys/matches/items/keys/dscp
+      constraints:
+        type: dict
+        keys:
+          jitter:
+            type: int
+            $ref: eos_cli_config_gen#keys/router_path_selection/keys/load_balance_policies/items/keys/jitter
+          latency:
+            type: int
+            $ref: eos_cli_config_gen#keys/router_path_selection/keys/load_balance_policies/items/keys/latency
+          loss_rate:
+            type: str
+            $ref: eos_cli_config_gen#keys/router_path_selection/keys/load_balance_policies/items/keys/loss_rate
       path_groups:
         type: list
         min_length: 1

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_virtual_topology.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_virtual_topology.schema.yml
@@ -18,6 +18,18 @@ $defs:
       dscp:
         type: int
         $ref: "eos_cli_config_gen#keys/router_adaptive_virtual_topology/keys/policies/items/keys/matches/items/keys/dscp"
+      constraints:
+        type: dict
+        keys:
+          jitter:
+            type: int
+            $ref: "eos_cli_config_gen#keys/router_path_selection/keys/load_balance_policies/items/keys/jitter"
+          latency:
+            type: int
+            $ref: "eos_cli_config_gen#keys/router_path_selection/keys/load_balance_policies/items/keys/latency"
+          loss_rate:
+            type: str
+            $ref: "eos_cli_config_gen#keys/router_path_selection/keys/load_balance_policies/items/keys/loss_rate"
       path_groups:
         type: list
         min_length: 1


### PR DESCRIPTION
## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Add

```
      wan_virtual_topologies:
        control_plane_virtual_topology:
          constraints:
            # Jitter requirement for this load balance policy in milliseconds.
            jitter: <int; 0-10000>
            # One way delay requirement for this load balance policy in milliseconds.
            latency: <int; 0-10000>
            # Loss Rate requirement in percentage for this load balance policy.
            # Value between 0.00 and 100.00 %
            loss_rate: <str>
        policies:
          application_virtual_topologies:
                constraints:
                  # Jitter requirement for this load balance policy in milliseconds.
                  jitter: <int; 0-10000>
                  # One way delay requirement for this load balance policy in milliseconds.
                  latency: <int; 0-10000>
                  # Loss Rate requirement in percentage for this load balance policy.
                  # Value between 0.00 and 100.00 %
                  loss_rate: <str>
           default_virtual_topology:
                constraints:
                  # Jitter requirement for this load balance policy in milliseconds.
                  jitter: <int; 0-10000>
                  # One way delay requirement for this load balance policy in milliseconds.
                  latency: <int; 0-10000>
                  # Loss Rate requirement in percentage for this load balance policy.
                  # Value between 0.00 and 100.00 %
                  loss_rate: <str>
```

## How to test
molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
