### PR TITLE
Feat(eos_cli_config_gen): Extend router_isis data-model

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -204,9 +204,9 @@ interface Vlan4094
 | SPF Interval | 250 |
 | SPF Interval Wait Time| 10 |
 | Graceful-restart Enabled | True |
-| Graceful-restart Restart-hold-time | 10 |
 | Graceful-restart t2 Level-1 | 10 |
 | Graceful-restart t2 Level-2 | 20 |
+| Graceful-restart Restart-hold-time | 10 |
 
 #### ISIS Route Redistribution
 
@@ -282,9 +282,9 @@ router isis EVPN_UNDERLAY
    advertise passive-only
    spf-interval 250 10
    graceful-restart
-   graceful-restart restart-hold-time 10
    graceful-restart t2 level-1 10
    graceful-restart t2 level-2 20
+   graceful-restart restart-hold-time 10
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -276,7 +276,7 @@ router isis EVPN_UNDERLAY
    graceful-restart
    graceful-restart restart-hold-time 10
    graceful-restart t2 level-1 10
-   graceful-restart t2 level-1 20
+   graceful-restart t2 level-2 20
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -272,6 +272,7 @@ router isis EVPN_UNDERLAY
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes
    advertise passive-only
+   spf-interval 250 10
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -273,6 +273,10 @@ router isis EVPN_UNDERLAY
    timers local-convergence-delay 15000 protected-prefixes
    advertise passive-only
    spf-interval 250 10
+   graceful-restart
+   graceful-restart restart-hold-time 10
+   graceful-restart t2 level-1 10
+   graceful-restart t2 level-1 20
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -201,6 +201,12 @@ interface Vlan4094
 | Local Convergence Delay (ms) | 15000 |
 | Advertise Passive-only | True |
 | SR MPLS Enabled | True |
+| SPF Interval | 250 |
+| SPF Interval Wait Time| 10 |
+| Graceful-restart Enabled | True |
+| Graceful-restart Restart-hold-time | 10 |
+| Graceful-restart t2 Level-1 | 10 |
+| Graceful-restart t2 Level-2 | 20 |
 
 #### ISIS Route Redistribution
 
@@ -235,6 +241,7 @@ interface Vlan4094
 | -------- | ----- |
 | IPv4 Address-family Enabled | True |
 | Maximum-paths | 4 |
+| BFD All-interfaces | True |
 | TI-LFA Mode | link-protection |
 | TI-LFA Level | level-2 |
 | TI-LFA SRLG Enabled | True |
@@ -252,6 +259,7 @@ interface Vlan4094
 | -------- | ----- |
 | IPv6 Address-family Enabled | True |
 | Maximum-paths | 4 |
+| BFD All-interfaces | True |
 | TI-LFA Mode | node-protection |
 | TI-LFA SRLG Enabled | True |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -281,11 +281,13 @@ router isis EVPN_UNDERLAY
    address-family ipv4 unicast
       maximum-paths 4
       tunnel source-protocol bgp ipv4 labeled-unicast rcf lu_2_sr_pfx()
+      bfd all-interfaces
       fast-reroute ti-lfa mode link-protection level-2
       fast-reroute ti-lfa srlg strict
    !
    address-family ipv6 unicast
       maximum-paths 4
+      bfd all-interfaces
       fast-reroute ti-lfa mode node-protection
       fast-reroute ti-lfa srlg
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
@@ -80,9 +80,9 @@ router isis EVPN_UNDERLAY
    advertise passive-only
    spf-interval 250 10
    graceful-restart
-   graceful-restart restart-hold-time 10
    graceful-restart t2 level-1 10
    graceful-restart t2 level-2 20
+   graceful-restart restart-hold-time 10
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
@@ -79,6 +79,10 @@ router isis EVPN_UNDERLAY
    timers local-convergence-delay 15000 protected-prefixes
    advertise passive-only
    spf-interval 250 10
+   graceful-restart
+   graceful-restart restart-hold-time 10
+   graceful-restart t2 level-1 10
+   graceful-restart t2 level-1 20
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
@@ -87,11 +87,13 @@ router isis EVPN_UNDERLAY
    address-family ipv4 unicast
       maximum-paths 4
       tunnel source-protocol bgp ipv4 labeled-unicast rcf lu_2_sr_pfx()
+      bfd all-interfaces
       fast-reroute ti-lfa mode link-protection level-2
       fast-reroute ti-lfa srlg strict
    !
    address-family ipv6 unicast
       maximum-paths 4
+      bfd all-interfaces
       fast-reroute ti-lfa mode node-protection
       fast-reroute ti-lfa srlg
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
@@ -82,7 +82,7 @@ router isis EVPN_UNDERLAY
    graceful-restart
    graceful-restart restart-hold-time 10
    graceful-restart t2 level-1 10
-   graceful-restart t2 level-1 20
+   graceful-restart t2 level-2 20
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
@@ -78,6 +78,7 @@ router isis EVPN_UNDERLAY
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes
    advertise passive-only
+   spf-interval 250 10
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
@@ -6,6 +6,9 @@ router_isis:
   is_type: level-2
   log_adjacency_changes: true
   mpls_ldp_sync_default: true
+  spf_interval:
+    interval: 250
+    wait_interval: 10
   timers:
     local_convergence:
       protected_prefixes: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
@@ -9,6 +9,12 @@ router_isis:
   spf_interval:
     interval: 250
     wait_interval: 10
+  graceful_restart:
+    enabled: true
+    restart_hold_time: 10
+    t2:
+      level_1_wait_time: 10
+      level_2_wait_time: 20
   timers:
     local_convergence:
       protected_prefixes: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
@@ -38,6 +38,7 @@ router_isis:
       route_map: RM-OSPF-NSSA_EXT-TO-ISIS
   address_family_ipv4:
     maximum_paths: 4
+    bfd_all_interfaces: true
     fast_reroute_ti_lfa:
       mode: link-protection
       level: level-2
@@ -49,6 +50,7 @@ router_isis:
       rcf: lu_2_sr_pfx()
   address_family_ipv6:
     maximum_paths: 4
+    bfd_all_interfaces: true
     fast_reroute_ti_lfa:
       mode: node-protection
       srlg:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -59,6 +59,13 @@
     | [<samp>&nbsp;&nbsp;spf_interval</samp>](## "router_isis.spf_interval") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "router_isis.spf_interval.interval") | Integer |  |  | Min: 1<br>Max: 300 | Maximum interval between two SPFs in seconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;wait_interval</samp>](## "router_isis.spf_interval.wait_interval") | Integer |  |  | Min: 1<br>Max: 300000 | Initial wait interval for SPF in milliseconds |
+    | [<samp>&nbsp;&nbsp;graceful_restart</samp>](## "router_isis.graceful_restart") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.graceful_restart.enabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;restart_hold_time</samp>](## "router_isis.graceful_restart.restart_hold_time") | Integer |  |  | Min: 5<br>Max: 300 | Number of seconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;t2</samp>](## "router_isis.graceful_restart.t2") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;wait_time</samp>](## "router_isis.graceful_restart.t2.wait_time") | Integer |  |  | Min: 5<br>Max: 300 | LSP database sync wait time in seconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1_wait_time</samp>](## "router_isis.graceful_restart.t2.level_1_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Number of seconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2_wait_time</samp>](## "router_isis.graceful_restart.t2.level_2_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Number of seconds |
 
 === "YAML"
 
@@ -150,4 +157,19 @@
 
         # Initial wait interval for SPF in milliseconds
         wait_interval: <int; 1-300000>
+      graceful_restart:
+        enabled: <bool>
+
+        # Number of seconds
+        restart_hold_time: <int; 5-300>
+        t2:
+
+          # LSP database sync wait time in seconds
+          wait_time: <int; 5-300>
+
+          # Number of seconds
+          level_1_wait_time: <int; 5-300>
+
+          # Number of seconds
+          level_2_wait_time: <int; 5-300>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -32,6 +32,7 @@
     | [<samp>&nbsp;&nbsp;address_family_ipv4</samp>](## "router_isis.address_family_ipv4") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.address_family_ipv4.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv4.maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_all_interfaces</samp>](## "router_isis.address_family_ipv4.bfd_all_interfaces") | Boolean |  |  |  | Enable BFD on all interfaces |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- <code>link-protection</code><br>- <code>node-protection</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- <code>level-1</code><br>- <code>level-2</code> |  |
@@ -44,6 +45,7 @@
     | [<samp>&nbsp;&nbsp;address_family_ipv6</samp>](## "router_isis.address_family_ipv6") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.address_family_ipv6.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv6.maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_all_interfaces</samp>](## "router_isis.address_family_ipv6.bfd_all_interfaces") | Boolean |  |  |  | Enable BFD on all interfaces |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- <code>link-protection</code><br>- <code>node-protection</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- <code>level-1</code><br>- <code>level-2</code> | Optional, default is to protect all levels |
@@ -118,6 +120,9 @@
       address_family_ipv4:
         enabled: <bool>
         maximum_paths: <int; 1-128>
+
+        # Enable BFD on all interfaces
+        bfd_all_interfaces: <bool>
         fast_reroute_ti_lfa:
           mode: <str; "link-protection" | "node-protection">
           level: <str; "level-1" | "level-2">
@@ -134,6 +139,9 @@
       address_family_ipv6:
         enabled: <bool>
         maximum_paths: <int; 1-128>
+
+        # Enable BFD on all interfaces
+        bfd_all_interfaces: <bool>
         fast_reroute_ti_lfa:
           mode: <str; "link-protection" | "node-protection">
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -65,8 +65,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.graceful_restart.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;restart_hold_time</samp>](## "router_isis.graceful_restart.restart_hold_time") | Integer |  |  | Min: 5<br>Max: 300 | Number of seconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;t2</samp>](## "router_isis.graceful_restart.t2") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1_wait_time</samp>](## "router_isis.graceful_restart.t2.level_1_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-1 LSP database sync wait time in seconds. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2_wait_time</samp>](## "router_isis.graceful_restart.t2.level_2_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-2 LSP database sync wait time in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1_wait_time</samp>](## "router_isis.graceful_restart.t2.level_1_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-1 LSP database sync wait time in seconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2_wait_time</samp>](## "router_isis.graceful_restart.t2.level_2_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-2 LSP database sync wait time in seconds |
 
 === "YAML"
 
@@ -171,9 +171,9 @@
         restart_hold_time: <int; 5-300>
         t2:
 
-          # Level-1 LSP database sync wait time in seconds.
+          # Level-1 LSP database sync wait time in seconds
           level_1_wait_time: <int; 5-300>
 
-          # Level-2 LSP database sync wait time in seconds.
+          # Level-2 LSP database sync wait time in seconds
           level_2_wait_time: <int; 5-300>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -65,9 +65,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.graceful_restart.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;restart_hold_time</samp>](## "router_isis.graceful_restart.restart_hold_time") | Integer |  |  | Min: 5<br>Max: 300 | Number of seconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;t2</samp>](## "router_isis.graceful_restart.t2") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;wait_time</samp>](## "router_isis.graceful_restart.t2.wait_time") | Integer |  |  | Min: 5<br>Max: 300 | LSP database sync wait time in seconds |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1_wait_time</samp>](## "router_isis.graceful_restart.t2.level_1_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Number of seconds |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2_wait_time</samp>](## "router_isis.graceful_restart.t2.level_2_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Number of seconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1_wait_time</samp>](## "router_isis.graceful_restart.t2.level_1_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-1 LSP database sync wait time in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2_wait_time</samp>](## "router_isis.graceful_restart.t2.level_2_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-2 LSP database sync wait time in seconds. |
 
 === "YAML"
 
@@ -172,12 +171,9 @@
         restart_hold_time: <int; 5-300>
         t2:
 
-          # LSP database sync wait time in seconds
-          wait_time: <int; 5-300>
-
-          # Number of seconds
+          # Level-1 LSP database sync wait time in seconds.
           level_1_wait_time: <int; 5-300>
 
-          # Number of seconds
+          # Level-2 LSP database sync wait time in seconds.
           level_2_wait_time: <int; 5-300>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -32,7 +32,7 @@
     | [<samp>&nbsp;&nbsp;address_family_ipv4</samp>](## "router_isis.address_family_ipv4") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.address_family_ipv4.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv4.maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_all_interfaces</samp>](## "router_isis.address_family_ipv4.bfd_all_interfaces") | Boolean |  |  |  | Enable BFD on all interfaces |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_all_interfaces</samp>](## "router_isis.address_family_ipv4.bfd_all_interfaces") | Boolean |  |  |  | Enable BFD on all interfaces. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- <code>link-protection</code><br>- <code>node-protection</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv4.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- <code>level-1</code><br>- <code>level-2</code> |  |
@@ -45,10 +45,10 @@
     | [<samp>&nbsp;&nbsp;address_family_ipv6</samp>](## "router_isis.address_family_ipv6") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.address_family_ipv6.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;maximum_paths</samp>](## "router_isis.address_family_ipv6.maximum_paths") | Integer |  |  | Min: 1<br>Max: 128 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_all_interfaces</samp>](## "router_isis.address_family_ipv6.bfd_all_interfaces") | Boolean |  |  |  | Enable BFD on all interfaces |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_all_interfaces</samp>](## "router_isis.address_family_ipv6.bfd_all_interfaces") | Boolean |  |  |  | Enable BFD on all interfaces. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;fast_reroute_ti_lfa</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode") | String |  |  | Valid Values:<br>- <code>link-protection</code><br>- <code>node-protection</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- <code>level-1</code><br>- <code>level-2</code> | Optional, default is to protect all levels |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.level") | String |  |  | Valid Values:<br>- <code>level-1</code><br>- <code>level-2</code> | Optional, default is to protect all levels. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;srlg</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg") | Dictionary |  |  |  | Shared Risk Link Group |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg.enable") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;strict</samp>](## "router_isis.address_family_ipv6.fast_reroute_ti_lfa.srlg.strict") | Boolean |  |  |  |  |
@@ -59,14 +59,14 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].prefix") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;index</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].index") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;spf_interval</samp>](## "router_isis.spf_interval") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "router_isis.spf_interval.interval") | Integer |  |  | Min: 1<br>Max: 300 | Maximum interval between two SPFs in seconds |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;wait_interval</samp>](## "router_isis.spf_interval.wait_interval") | Integer |  |  | Min: 1<br>Max: 300000 | Initial wait interval for SPF in milliseconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "router_isis.spf_interval.interval") | Integer |  |  | Min: 1<br>Max: 300 | Maximum interval between two SPFs in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;wait_interval</samp>](## "router_isis.spf_interval.wait_interval") | Integer |  |  | Min: 1<br>Max: 300000 | Initial wait interval for SPF in milliseconds. |
     | [<samp>&nbsp;&nbsp;graceful_restart</samp>](## "router_isis.graceful_restart") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_isis.graceful_restart.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;restart_hold_time</samp>](## "router_isis.graceful_restart.restart_hold_time") | Integer |  |  | Min: 5<br>Max: 300 | Number of seconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;restart_hold_time</samp>](## "router_isis.graceful_restart.restart_hold_time") | Integer |  |  | Min: 5<br>Max: 300 | Number of seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;t2</samp>](## "router_isis.graceful_restart.t2") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1_wait_time</samp>](## "router_isis.graceful_restart.t2.level_1_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-1 LSP database sync wait time in seconds |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2_wait_time</samp>](## "router_isis.graceful_restart.t2.level_2_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-2 LSP database sync wait time in seconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1_wait_time</samp>](## "router_isis.graceful_restart.t2.level_1_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-1 LSP database sync wait time in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2_wait_time</samp>](## "router_isis.graceful_restart.t2.level_2_wait_time") | Integer |  |  | Min: 5<br>Max: 300 | Level-2 LSP database sync wait time in seconds. |
 
 === "YAML"
 
@@ -120,7 +120,7 @@
         enabled: <bool>
         maximum_paths: <int; 1-128>
 
-        # Enable BFD on all interfaces
+        # Enable BFD on all interfaces.
         bfd_all_interfaces: <bool>
         fast_reroute_ti_lfa:
           mode: <str; "link-protection" | "node-protection">
@@ -139,12 +139,12 @@
         enabled: <bool>
         maximum_paths: <int; 1-128>
 
-        # Enable BFD on all interfaces
+        # Enable BFD on all interfaces.
         bfd_all_interfaces: <bool>
         fast_reroute_ti_lfa:
           mode: <str; "link-protection" | "node-protection">
 
-          # Optional, default is to protect all levels
+          # Optional, default is to protect all levels.
           level: <str; "level-1" | "level-2">
 
           # Shared Risk Link Group
@@ -159,21 +159,21 @@
             index: <int>
       spf_interval:
 
-        # Maximum interval between two SPFs in seconds
+        # Maximum interval between two SPFs in seconds.
         interval: <int; 1-300>
 
-        # Initial wait interval for SPF in milliseconds
+        # Initial wait interval for SPF in milliseconds.
         wait_interval: <int; 1-300000>
       graceful_restart:
         enabled: <bool>
 
-        # Number of seconds
+        # Number of seconds.
         restart_hold_time: <int; 5-300>
         t2:
 
-          # Level-1 LSP database sync wait time in seconds
+          # Level-1 LSP database sync wait time in seconds.
           level_1_wait_time: <int; 5-300>
 
-          # Level-2 LSP database sync wait time in seconds
+          # Level-2 LSP database sync wait time in seconds.
           level_2_wait_time: <int; 5-300>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -56,6 +56,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix_segments</samp>](## "router_isis.segment_routing_mpls.prefix_segments") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].prefix") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;index</samp>](## "router_isis.segment_routing_mpls.prefix_segments.[].index") | Integer |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;spf_interval</samp>](## "router_isis.spf_interval") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "router_isis.spf_interval.interval") | Integer |  |  | Min: 1<br>Max: 300 | Maximum interval between two SPFs in seconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;wait_interval</samp>](## "router_isis.spf_interval.wait_interval") | Integer |  |  | Min: 1<br>Max: 300000 | Initial wait interval for SPF in milliseconds |
 
 === "YAML"
 
@@ -140,4 +143,11 @@
         prefix_segments:
           - prefix: <str>
             index: <int>
+      spf_interval:
+
+        # Maximum interval between two SPFs in seconds
+        interval: <int; 1-300>
+
+        # Initial wait interval for SPF in milliseconds
+        wait_interval: <int; 1-300000>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20494,6 +20494,11 @@
               "maximum": 128,
               "title": "Maximum Paths"
             },
+            "bfd_all_interfaces": {
+              "type": "boolean",
+              "description": "Enable BFD on all interfaces",
+              "title": "BFD All Interfaces"
+            },
             "fast_reroute_ti_lfa": {
               "type": "object",
               "properties": {
@@ -20577,6 +20582,11 @@
               "minimum": 1,
               "maximum": 128,
               "title": "Maximum Paths"
+            },
+            "bfd_all_interfaces": {
+              "type": "boolean",
+              "description": "Enable BFD on all interfaces",
+              "title": "BFD All Interfaces"
             },
             "fast_reroute_ti_lfa": {
               "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20669,6 +20669,30 @@
             "^_.+$": {}
           },
           "title": "Segment Routing MPLS"
+        },
+        "spf_interval": {
+          "type": "object",
+          "properties": {
+            "interval": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 300,
+              "description": "Maximum interval between two SPFs in seconds",
+              "title": "Interval"
+            },
+            "wait_interval": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 300000,
+              "description": "Initial wait interval for SPF in milliseconds",
+              "title": "Wait Interval"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "SPF Interval"
         }
       },
       "required": [

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20721,25 +20721,18 @@
             "t2": {
               "type": "object",
               "properties": {
-                "wait_time": {
-                  "type": "integer",
-                  "minimum": 5,
-                  "maximum": 300,
-                  "description": "LSP database sync wait time in seconds",
-                  "title": "Wait Time"
-                },
                 "level_1_wait_time": {
                   "type": "integer",
                   "minimum": 5,
                   "maximum": 300,
-                  "description": "Number of seconds",
+                  "description": "Level-1 LSP database sync wait time in seconds.",
                   "title": "Level 1 Wait Time"
                 },
                 "level_2_wait_time": {
                   "type": "integer",
                   "minimum": 5,
                   "maximum": 300,
-                  "description": "Number of seconds",
+                  "description": "Level-2 LSP database sync wait time in seconds.",
                   "title": "Level 2 Wait Time"
                 }
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20725,14 +20725,14 @@
                   "type": "integer",
                   "minimum": 5,
                   "maximum": 300,
-                  "description": "Level-1 LSP database sync wait time in seconds.",
+                  "description": "Level-1 LSP database sync wait time in seconds",
                   "title": "Level 1 Wait Time"
                 },
                 "level_2_wait_time": {
                   "type": "integer",
                   "minimum": 5,
                   "maximum": 300,
-                  "description": "Level-2 LSP database sync wait time in seconds.",
+                  "description": "Level-2 LSP database sync wait time in seconds",
                   "title": "Level 2 Wait Time"
                 }
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20496,7 +20496,7 @@
             },
             "bfd_all_interfaces": {
               "type": "boolean",
-              "description": "Enable BFD on all interfaces",
+              "description": "Enable BFD on all interfaces.",
               "title": "BFD All Interfaces"
             },
             "fast_reroute_ti_lfa": {
@@ -20585,7 +20585,7 @@
             },
             "bfd_all_interfaces": {
               "type": "boolean",
-              "description": "Enable BFD on all interfaces",
+              "description": "Enable BFD on all interfaces.",
               "title": "BFD All Interfaces"
             },
             "fast_reroute_ti_lfa": {
@@ -20605,7 +20605,7 @@
                     "level-1",
                     "level-2"
                   ],
-                  "description": "Optional, default is to protect all levels",
+                  "description": "Optional, default is to protect all levels.",
                   "title": "Level"
                 },
                 "srlg": {
@@ -20687,14 +20687,14 @@
               "type": "integer",
               "minimum": 1,
               "maximum": 300,
-              "description": "Maximum interval between two SPFs in seconds",
+              "description": "Maximum interval between two SPFs in seconds.",
               "title": "Interval"
             },
             "wait_interval": {
               "type": "integer",
               "minimum": 1,
               "maximum": 300000,
-              "description": "Initial wait interval for SPF in milliseconds",
+              "description": "Initial wait interval for SPF in milliseconds.",
               "title": "Wait Interval"
             }
           },
@@ -20715,7 +20715,7 @@
               "type": "integer",
               "minimum": 5,
               "maximum": 300,
-              "description": "Number of seconds",
+              "description": "Number of seconds.",
               "title": "Restart Hold Time"
             },
             "t2": {
@@ -20725,14 +20725,14 @@
                   "type": "integer",
                   "minimum": 5,
                   "maximum": 300,
-                  "description": "Level-1 LSP database sync wait time in seconds",
+                  "description": "Level-1 LSP database sync wait time in seconds.",
                   "title": "Level 1 Wait Time"
                 },
                 "level_2_wait_time": {
                   "type": "integer",
                   "minimum": 5,
                   "maximum": 300,
-                  "description": "Level-2 LSP database sync wait time in seconds",
+                  "description": "Level-2 LSP database sync wait time in seconds.",
                   "title": "Level 2 Wait Time"
                 }
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20693,6 +20693,58 @@
             "^_.+$": {}
           },
           "title": "SPF Interval"
+        },
+        "graceful_restart": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "title": "Enabled"
+            },
+            "restart_hold_time": {
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 300,
+              "description": "Number of seconds",
+              "title": "Restart Hold Time"
+            },
+            "t2": {
+              "type": "object",
+              "properties": {
+                "wait_time": {
+                  "type": "integer",
+                  "minimum": 5,
+                  "maximum": 300,
+                  "description": "LSP database sync wait time in seconds",
+                  "title": "Wait Time"
+                },
+                "level_1_wait_time": {
+                  "type": "integer",
+                  "minimum": 5,
+                  "maximum": 300,
+                  "description": "Number of seconds",
+                  "title": "Level 1 Wait Time"
+                },
+                "level_2_wait_time": {
+                  "type": "integer",
+                  "minimum": 5,
+                  "maximum": 300,
+                  "description": "Number of seconds",
+                  "title": "Level 2 Wait Time"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "T2"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Graceful Restart"
         }
       },
       "required": [

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11897,6 +11897,9 @@ keys:
             - str
             min: 1
             max: 128
+          bfd_all_interfaces:
+            type: bool
+            description: Enable BFD on all interfaces
           fast_reroute_ti_lfa:
             type: dict
             keys:
@@ -11937,6 +11940,9 @@ keys:
             - str
             min: 1
             max: 128
+          bfd_all_interfaces:
+            type: bool
+            description: Enable BFD on all interfaces
           fast_reroute_ti_lfa:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11899,7 +11899,7 @@ keys:
             max: 128
           bfd_all_interfaces:
             type: bool
-            description: Enable BFD on all interfaces
+            description: Enable BFD on all interfaces.
           fast_reroute_ti_lfa:
             type: dict
             keys:
@@ -11942,7 +11942,7 @@ keys:
             max: 128
           bfd_all_interfaces:
             type: bool
-            description: Enable BFD on all interfaces
+            description: Enable BFD on all interfaces.
           fast_reroute_ti_lfa:
             type: dict
             keys:
@@ -11956,7 +11956,7 @@ keys:
                 valid_values:
                 - level-1
                 - level-2
-                description: Optional, default is to protect all levels
+                description: Optional, default is to protect all levels.
               srlg:
                 type: dict
                 description: Shared Risk Link Group
@@ -11994,14 +11994,14 @@ keys:
             - str
             min: 1
             max: 300
-            description: Maximum interval between two SPFs in seconds
+            description: Maximum interval between two SPFs in seconds.
           wait_interval:
             type: int
             convert_types:
             - str
             min: 1
             max: 300000
-            description: Initial wait interval for SPF in milliseconds
+            description: Initial wait interval for SPF in milliseconds.
       graceful_restart:
         type: dict
         keys:
@@ -12013,7 +12013,7 @@ keys:
             - str
             min: 5
             max: 300
-            description: Number of seconds
+            description: Number of seconds.
           t2:
             type: dict
             keys:
@@ -12023,14 +12023,14 @@ keys:
                 - str
                 min: 5
                 max: 300
-                description: Level-1 LSP database sync wait time in seconds
+                description: Level-1 LSP database sync wait time in seconds.
               level_2_wait_time:
                 type: int
                 convert_types:
                 - str
                 min: 5
                 max: 300
-                description: Level-2 LSP database sync wait time in seconds
+                description: Level-2 LSP database sync wait time in seconds.
   router_l2_vpn:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11979,6 +11979,23 @@ keys:
                   type: int
                   convert_types:
                   - str
+      spf_interval:
+        type: dict
+        keys:
+          interval:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 300
+            description: Maximum interval between two SPFs in seconds
+          wait_interval:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 300000
+            description: Initial wait interval for SPF in milliseconds
   router_l2_vpn:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11996,6 +11996,42 @@ keys:
             min: 1
             max: 300000
             description: Initial wait interval for SPF in milliseconds
+      graceful_restart:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          restart_hold_time:
+            type: int
+            convert_types:
+            - str
+            min: 5
+            max: 300
+            description: Number of seconds
+          t2:
+            type: dict
+            keys:
+              wait_time:
+                type: int
+                convert_types:
+                - str
+                min: 5
+                max: 300
+                description: LSP database sync wait time in seconds
+              level_1_wait_time:
+                type: int
+                convert_types:
+                - str
+                min: 5
+                max: 300
+                description: Number of seconds
+              level_2_wait_time:
+                type: int
+                convert_types:
+                - str
+                min: 5
+                max: 300
+                description: Number of seconds
   router_l2_vpn:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -12017,27 +12017,20 @@ keys:
           t2:
             type: dict
             keys:
-              wait_time:
-                type: int
-                convert_types:
-                - str
-                min: 5
-                max: 300
-                description: LSP database sync wait time in seconds
               level_1_wait_time:
                 type: int
                 convert_types:
                 - str
                 min: 5
                 max: 300
-                description: Number of seconds
+                description: Level-1 LSP database sync wait time in seconds.
               level_2_wait_time:
                 type: int
                 convert_types:
                 - str
                 min: 5
                 max: 300
-                description: Number of seconds
+                description: Level-2 LSP database sync wait time in seconds.
   router_l2_vpn:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -12023,14 +12023,14 @@ keys:
                 - str
                 min: 5
                 max: 300
-                description: Level-1 LSP database sync wait time in seconds.
+                description: Level-1 LSP database sync wait time in seconds
               level_2_wait_time:
                 type: int
                 convert_types:
                 - str
                 min: 5
                 max: 300
-                description: Level-2 LSP database sync wait time in seconds.
+                description: Level-2 LSP database sync wait time in seconds
   router_l2_vpn:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -194,3 +194,20 @@ keys:
                   type: int
                   convert_types:
                     - str
+      spf_interval:
+        type: dict
+        keys:
+          interval:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 300
+            description: Maximum interval between two SPFs in seconds
+          wait_interval:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 300000
+            description: Initial wait interval for SPF in milliseconds

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -112,6 +112,9 @@ keys:
               - "str"
             min: 1
             max: 128
+          bfd_all_interfaces:
+            type: bool
+            description: Enable BFD on all interfaces
           fast_reroute_ti_lfa:
             type: dict
             keys:
@@ -152,6 +155,9 @@ keys:
               - "str"
             min: 1
             max: 128
+          bfd_all_interfaces:
+            type: bool
+            description: Enable BFD on all interfaces
           fast_reroute_ti_lfa:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -238,11 +238,11 @@ keys:
                   - str
                 min: 5
                 max: 300
-                description: Level-1 LSP database sync wait time in seconds.
+                description: Level-1 LSP database sync wait time in seconds
               level_2_wait_time:
                 type: int
                 convert_types:
                   - str
                 min: 5
                 max: 300
-                description: Level-2 LSP database sync wait time in seconds.
+                description: Level-2 LSP database sync wait time in seconds

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -211,3 +211,39 @@ keys:
             min: 1
             max: 300000
             description: Initial wait interval for SPF in milliseconds
+      graceful_restart:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+          restart_hold_time:
+            type: int
+            convert_types:
+              - str
+            min: 5
+            max: 300
+            description: Number of seconds
+          t2:
+            type: dict
+            keys:
+              wait_time:
+                type: int
+                convert_types:
+                  - str
+                min: 5
+                max: 300
+                description: LSP database sync wait time in seconds
+              level_1_wait_time:
+                type: int
+                convert_types:
+                  - str
+                min: 5
+                max: 300
+                description: Number of seconds
+              level_2_wait_time:
+                type: int
+                convert_types:
+                  - str
+                min: 5
+                max: 300
+                description: Number of seconds

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -245,11 +245,11 @@ keys:
                   - str
                 min: 5
                 max: 300
-                description: Number of seconds
+                description: Level-1 LSP database sync wait time in seconds.
               level_2_wait_time:
                 type: int
                 convert_types:
                   - str
                 min: 5
                 max: 300
-                description: Number of seconds
+                description: Level-2 LSP database sync wait time in seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -232,13 +232,6 @@ keys:
           t2:
             type: dict
             keys:
-              wait_time:
-                type: int
-                convert_types:
-                  - str
-                min: 5
-                max: 300
-                description: LSP database sync wait time in seconds
               level_1_wait_time:
                 type: int
                 convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_isis.schema.yml
@@ -114,7 +114,7 @@ keys:
             max: 128
           bfd_all_interfaces:
             type: bool
-            description: Enable BFD on all interfaces
+            description: Enable BFD on all interfaces.
           fast_reroute_ti_lfa:
             type: dict
             keys:
@@ -157,7 +157,7 @@ keys:
             max: 128
           bfd_all_interfaces:
             type: bool
-            description: Enable BFD on all interfaces
+            description: Enable BFD on all interfaces.
           fast_reroute_ti_lfa:
             type: dict
             keys:
@@ -171,7 +171,7 @@ keys:
                 valid_values:
                   - "level-1"
                   - "level-2"
-                description: Optional, default is to protect all levels
+                description: Optional, default is to protect all levels.
               srlg:
                 type: dict
                 description: Shared Risk Link Group
@@ -209,14 +209,14 @@ keys:
               - str
             min: 1
             max: 300
-            description: Maximum interval between two SPFs in seconds
+            description: Maximum interval between two SPFs in seconds.
           wait_interval:
             type: int
             convert_types:
               - str
             min: 1
             max: 300000
-            description: Initial wait interval for SPF in milliseconds
+            description: Initial wait interval for SPF in milliseconds.
       graceful_restart:
         type: dict
         keys:
@@ -228,7 +228,7 @@ keys:
               - str
             min: 5
             max: 300
-            description: Number of seconds
+            description: Number of seconds.
           t2:
             type: dict
             keys:
@@ -238,11 +238,11 @@ keys:
                   - str
                 min: 5
                 max: 300
-                description: Level-1 LSP database sync wait time in seconds
+                description: Level-1 LSP database sync wait time in seconds.
               level_2_wait_time:
                 type: int
                 convert_types:
                   - str
                 min: 5
                 max: 300
-                description: Level-2 LSP database sync wait time in seconds
+                description: Level-2 LSP database sync wait time in seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -52,14 +52,14 @@
 {%         if router_isis.graceful_restart.enabled is arista.avd.defined(true) %}
 | Graceful-restart Enabled | {{ router_isis.graceful_restart.enabled }} |
 {%         endif %}
-{%         if router_isis.graceful_restart.restart_hold_time is arista.avd.defined %}
-| Graceful-restart Restart-hold-time | {{ router_isis.graceful_restart.restart_hold_time }} |
-{%         endif %}
 {%         if router_isis.graceful_restart.t2.level_1_wait_time is arista.avd.defined %}
 | Graceful-restart t2 Level-1 | {{ router_isis.graceful_restart.t2.level_1_wait_time }} |
 {%         endif %}
 {%         if router_isis.graceful_restart.t2.level_2_wait_time is arista.avd.defined %}
 | Graceful-restart t2 Level-2 | {{ router_isis.graceful_restart.t2.level_2_wait_time }} |
+{%         endif %}
+{%         if router_isis.graceful_restart.restart_hold_time is arista.avd.defined %}
+| Graceful-restart Restart-hold-time | {{ router_isis.graceful_restart.restart_hold_time }} |
 {%         endif %}
 {%     endif %}
 {%     if router_isis.redistribute_routes is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-isis.j2
@@ -42,6 +42,26 @@
 {%     if router_isis.segment_routing_mpls.enabled is arista.avd.defined %}
 | SR MPLS Enabled | {{ router_isis.segment_routing_mpls.enabled }} |
 {%     endif %}
+{%     if router_isis.spf_interval.interval is arista.avd.defined %}
+| SPF Interval | {{ router_isis.spf_interval.interval }} |
+{%         if router_isis.spf_interval.wait_interval is arista.avd.defined %}
+| SPF Interval Wait Time| {{ router_isis.spf_interval.wait_interval }} |
+{%         endif %}
+{%     endif %}
+{%     if router_isis.graceful_restart is arista.avd.defined %}
+{%         if router_isis.graceful_restart.enabled is arista.avd.defined(true) %}
+| Graceful-restart Enabled | {{ router_isis.graceful_restart.enabled }} |
+{%         endif %}
+{%         if router_isis.graceful_restart.restart_hold_time is arista.avd.defined %}
+| Graceful-restart Restart-hold-time | {{ router_isis.graceful_restart.restart_hold_time }} |
+{%         endif %}
+{%         if router_isis.graceful_restart.t2.level_1_wait_time is arista.avd.defined %}
+| Graceful-restart t2 Level-1 | {{ router_isis.graceful_restart.t2.level_1_wait_time }} |
+{%         endif %}
+{%         if router_isis.graceful_restart.t2.level_2_wait_time is arista.avd.defined %}
+| Graceful-restart t2 Level-2 | {{ router_isis.graceful_restart.t2.level_2_wait_time }} |
+{%         endif %}
+{%     endif %}
 {%     if router_isis.redistribute_routes is arista.avd.defined %}
 
 #### ISIS Route Redistribution
@@ -161,6 +181,9 @@
 {%         if router_isis.address_family_ipv4.maximum_paths is arista.avd.defined %}
 | Maximum-paths | {{ router_isis.address_family_ipv4.maximum_paths }} |
 {%         endif %}
+{%         if router_isis.address_family_ipv4.bfd_all_interfaces is arista.avd.defined %}
+| BFD All-interfaces | {{ router_isis.address_family_ipv4.bfd_all_interfaces }} |
+{%         endif %}
 {%         if router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode is arista.avd.defined %}
 | TI-LFA Mode | {{ router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode }} |
 {%             if router_isis.address_family_ipv4.fast_reroute_ti_lfa.level is arista.avd.defined %}
@@ -192,6 +215,9 @@
 | IPv6 Address-family Enabled | True |
 {%         if router_isis.address_family_ipv6.maximum_paths is arista.avd.defined %}
 | Maximum-paths | {{ router_isis.address_family_ipv6.maximum_paths }} |
+{%         endif %}
+{%         if router_isis.address_family_ipv6.bfd_all_interfaces is arista.avd.defined %}
+| BFD All-interfaces | {{ router_isis.address_family_ipv6.bfd_all_interfaces }} |
 {%         endif %}
 {%         if router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode is arista.avd.defined %}
 | TI-LFA Mode | {{ router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -113,6 +113,9 @@ router isis {{ router_isis.instance }}
 {%             endif %}
       {{ lu_cli }}
 {%         endif %}
+{%         if router_isis.address_family_ipv4.bfd_all_interfaces is arista.avd.defined(true) %}
+      bfd all-interfaces
+{%         endif %}
 {%         if router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode is arista.avd.defined %}
 {%             set ti_lfa_cli = "fast-reroute ti-lfa mode " ~ router_isis.address_family_ipv4.fast_reroute_ti_lfa.mode %}
 {%             if router_isis.address_family_ipv4.fast_reroute_ti_lfa.level is arista.avd.defined %}
@@ -133,6 +136,9 @@ router isis {{ router_isis.instance }}
    address-family ipv6 unicast
 {%         if router_isis.address_family_ipv6.maximum_paths is arista.avd.defined %}
       maximum-paths {{ router_isis.address_family_ipv6.maximum_paths }}
+{%         endif %}
+{%         if router_isis.address_family_ipv4.bfd_all_interfaces is arista.avd.defined(true) %}
+      bfd all-interfaces
 {%         endif %}
 {%         if router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode is arista.avd.defined %}
 {%             set ti_lfa_cli = "fast-reroute ti-lfa mode " ~ router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -77,16 +77,11 @@ router isis {{ router_isis.instance }}
 {%         if router_isis.graceful_restart.restart_hold_time is arista.avd.defined %}
    graceful-restart restart-hold-time {{ router_isis.graceful_restart.restart_hold_time }}
 {%         endif %}
-{%         if router_isis.graceful_restart.t2.wait_time is arista.avd.defined %}
-   graceful-restart t2 level-1 {{ router_isis.graceful_restart.t2.wait_time }}
-   graceful-restart t2 level-2 {{ router_isis.graceful_restart.t2.wait_time }}
-{%         else %}
-{%             if router_isis.graceful_restart.t2.level_1_wait_time is arista.avd.defined %}
+{%         if router_isis.graceful_restart.t2.level_1_wait_time is arista.avd.defined %}
    graceful-restart t2 level-1 {{ router_isis.graceful_restart.t2.level_1_wait_time }}
-{%             endif %}
-{%             if router_isis.graceful_restart.t2.level_2_wait_time is arista.avd.defined %}
+{%         endif %}
+{%         if router_isis.graceful_restart.t2.level_2_wait_time is arista.avd.defined %}
    graceful-restart t2 level-2 {{ router_isis.graceful_restart.t2.level_2_wait_time }}
-{%             endif %}
 {%         endif %}
 {%     endif %}
    !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -63,6 +63,13 @@ router isis {{ router_isis.instance }}
 {%     if router_isis.advertise.passive_only is arista.avd.defined(true) %}
    advertise passive-only
 {%     endif %}
+{%     if router_isis.spf_interval.interval is arista.avd.defined %}
+{%         if router_isis.spf_interval.wait_interval is arista.avd.defined %}
+   spf-interval {{ router_isis.spf_interval.interval }} {{ router_isis.spf_interval.wait_interval }}
+{%         else %}
+   spf-interval {{ router_isis.spf_interval.interval }}
+{%         endif %}
+{%     endif %}
    !
 {%     if router_isis.address_family is arista.avd.defined %}
 {%         for address_family in router_isis.address_family %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -74,14 +74,14 @@ router isis {{ router_isis.instance }}
 {%         if router_isis.graceful_restart.enabled is arista.avd.defined(true) %}
    graceful-restart
 {%         endif %}
-{%         if router_isis.graceful_restart.restart_hold_time is arista.avd.defined %}
-   graceful-restart restart-hold-time {{ router_isis.graceful_restart.restart_hold_time }}
-{%         endif %}
 {%         if router_isis.graceful_restart.t2.level_1_wait_time is arista.avd.defined %}
    graceful-restart t2 level-1 {{ router_isis.graceful_restart.t2.level_1_wait_time }}
 {%         endif %}
 {%         if router_isis.graceful_restart.t2.level_2_wait_time is arista.avd.defined %}
    graceful-restart t2 level-2 {{ router_isis.graceful_restart.t2.level_2_wait_time }}
+{%         endif %}
+{%         if router_isis.graceful_restart.restart_hold_time is arista.avd.defined %}
+   graceful-restart restart-hold-time {{ router_isis.graceful_restart.restart_hold_time }}
 {%         endif %}
 {%     endif %}
    !

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -70,6 +70,25 @@ router isis {{ router_isis.instance }}
    spf-interval {{ router_isis.spf_interval.interval }}
 {%         endif %}
 {%     endif %}
+{%     if router_isis.graceful_restart is arista.avd.defined %}
+{%         if router_isis.graceful_restart.enabled is arista.avd.defined(true) %}
+   graceful-restart
+{%         endif %}
+{%         if router_isis.graceful_restart.restart_hold_time is arista.avd.defined %}
+   graceful-restart restart-hold-time {{ router_isis.graceful_restart.restart_hold_time }}
+{%         endif %}
+{%         if router_isis.graceful_restart.t2.wait_time is arista.avd.defined %}
+   graceful-restart t2 level-1 {{ router_isis.graceful_restart.t2.wait_time }}
+   graceful-restart t2 level-2 {{ router_isis.graceful_restart.t2.wait_time }}
+{%         else %}
+{%             if router_isis.graceful_restart.t2.level_1_wait_time is arista.avd.defined %}
+   graceful-restart t2 level-1 {{ router_isis.graceful_restart.t2.level_1_wait_time }}
+{%             endif %}
+{%             if router_isis.graceful_restart.t2.level_2_wait_time is arista.avd.defined %}
+   graceful-restart t2 level-1 {{ router_isis.graceful_restart.t2.level_2_wait_time }}
+{%             endif %}
+{%         endif %}
+{%     endif %}
    !
 {%     if router_isis.address_family is arista.avd.defined %}
 {%         for address_family in router_isis.address_family %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-isis.j2
@@ -85,7 +85,7 @@ router isis {{ router_isis.instance }}
    graceful-restart t2 level-1 {{ router_isis.graceful_restart.t2.level_1_wait_time }}
 {%             endif %}
 {%             if router_isis.graceful_restart.t2.level_2_wait_time is arista.avd.defined %}
-   graceful-restart t2 level-1 {{ router_isis.graceful_restart.t2.level_2_wait_time }}
+   graceful-restart t2 level-2 {{ router_isis.graceful_restart.t2.level_2_wait_time }}
 {%             endif %}
 {%         endif %}
 {%     endif %}
@@ -137,7 +137,7 @@ router isis {{ router_isis.instance }}
 {%         if router_isis.address_family_ipv6.maximum_paths is arista.avd.defined %}
       maximum-paths {{ router_isis.address_family_ipv6.maximum_paths }}
 {%         endif %}
-{%         if router_isis.address_family_ipv4.bfd_all_interfaces is arista.avd.defined(true) %}
+{%         if router_isis.address_family_ipv6.bfd_all_interfaces is arista.avd.defined(true) %}
       bfd all-interfaces
 {%         endif %}
 {%         if router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Add support in the router_isis data model for:

spf-interval <values>
graceful-restart
bfd all-interfaces under address-family

## Related Issue(s)

Fixes #3390 

## Component(s) name

`arista.avd.eos_cli_config_gen`


## Checklist

### User Checklist

- [x] Verify command ordering in EOS CLI

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
