### PR TITLE
Refactor: Better Control plane AVT for WAN route servers

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -102,7 +102,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
    !
    application-profile CONTROL-PLANE-APPLICATION-PROFILE
       application CONTROL-PLANE-APPLICATION
@@ -113,8 +113,8 @@ application traffic recognition
    !
    application-profile VOICE
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
-      192.168.30.0/24 192.168.31.2/32
+   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+      192.168.31.1/32
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -101,7 +101,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
    !
    application-profile CONTROL-PLANE-APPLICATION-PROFILE
       application CONTROL-PLANE-APPLICATION
@@ -112,8 +112,8 @@ application traffic recognition
    !
    application-profile VOICE
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
-      192.168.30.0/24 192.168.31.1/32
+   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+      192.168.31.2/32
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -230,7 +230,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -255,8 +255,8 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
-      192.168.42.0/24 192.168.43.0/24
+   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+      192.168.44.1/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -219,7 +219,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -244,8 +244,8 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
-      192.168.42.0/24 192.168.43.0/24 192.168.44.3/32 6.6.6.6/32
+   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+      192.168.44.2/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -234,7 +234,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -259,8 +259,8 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
-      192.168.42.0/24 192.168.43.0/24 192.168.44.2/32 6.6.6.6/32
+   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+      192.168.44.3/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -183,13 +183,12 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: CONTROL-PLANE-APP-SRC-PREFIXES
       prefix_values:
-      - 192.168.31.2/32
-      - 192.168.30.0/24
+      - 192.168.31.1/32
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -185,13 +185,12 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: CONTROL-PLANE-APP-SRC-PREFIXES
       prefix_values:
-      - 192.168.31.1/32
-      - 192.168.30.0/24
+      - 192.168.31.2/32
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -337,7 +337,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -354,10 +354,9 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: CONTROL-PLANE-APP-SRC-PREFIXES
       prefix_values:
-      - 192.168.42.0/24
-      - 192.168.43.0/24
+      - 192.168.44.1/32
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -347,7 +347,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -364,12 +364,9 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: CONTROL-PLANE-APP-SRC-PREFIXES
       prefix_values:
-      - 192.168.44.3/32
-      - 6.6.6.6/32
-      - 192.168.42.0/24
-      - 192.168.43.0/24
+      - 192.168.44.2/32
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -365,7 +365,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -382,12 +382,9 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: CONTROL-PLANE-APP-SRC-PREFIXES
       prefix_values:
-      - 192.168.44.2/32
-      - 6.6.6.6/32
-      - 192.168.42.0/24
-      - 192.168.43.0/24
+      - 192.168.44.3/32
 dps_interfaces:
 - name: Dps1
   description: DPS Interface


### PR DESCRIPTION
## Change Summary

Rather than matching on destination. match on source prefix

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Change Application profile for Control Plane traffic to match on the source IP of the pathfinder/RR when configuring it on the pathfinder/RR

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
