### PR TITLE
Fix(eos_designs): Avoid in-place updates of network services impacting PyAVD

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils_filtered_tenants.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils_filtered_tenants.py
@@ -41,9 +41,13 @@ class UtilsFilteredTenantsMixin(object):
             tenants = convert_dicts(get(self._hostvars, network_services_key["name"]), "name")
             for tenant in tenants:
                 if tenant["name"] in filter_tenants or "all" in filter_tenants:
-                    tenant["l2vlans"] = self._filtered_l2vlans(tenant)
-                    tenant["vrfs"] = self._filtered_vrfs(tenant)
-                    filtered_tenants.append(tenant)
+                    filtered_tenants.append(
+                        {
+                            **tenant,
+                            "l2vlans": self._filtered_l2vlans(tenant),
+                            "vrfs": self._filtered_vrfs(tenant),
+                        }
+                    )
 
         no_vrf_default = all(vrf["name"] != "default" for tenant in filtered_tenants for vrf in tenant["vrfs"])
         if self.shared_utils.wan_role is not None and no_vrf_default:
@@ -89,14 +93,12 @@ class UtilsFilteredTenantsMixin(object):
 
         l2vlans: list[dict] = natural_sort(convert_dicts(tenant["l2vlans"], "id"), "id")
         l2vlans = [
-            l2vlan
+            # Copy and set tenant key on all l2vlans
+            {**l2vlan, "tenant": tenant["name"]}
             for l2vlan in l2vlans
             if self._is_accepted_vlan(l2vlan)
             and ("all" in self.shared_utils.filter_tags or set(l2vlan.get("tags", ["all"])).intersection(self.shared_utils.filter_tags))
         ]
-        # Set tenant key on all l2vlans
-        for l2vlan in l2vlans:
-            l2vlan.update({"tenant": tenant["name"]})
 
         return l2vlans
 
@@ -159,9 +161,10 @@ class UtilsFilteredTenantsMixin(object):
         always_include_vrfs_in_tenants = get(self.shared_utils.switch_data_combined, "filter.always_include_vrfs_in_tenants", default=[])
 
         vrfs: list[dict] = natural_sort(convert_dicts(tenant.get("vrfs", []), "name"), "name")
-        for vrf in vrfs:
-            # Storing tenant on VRF for use by child objects like SVIs
-            vrf["tenant"] = tenant["name"]
+        for original_vrf in vrfs:
+            # Copying original_vrf and setting "tenant" for use by child objects like SVIs
+            vrf = {**original_vrf, "tenant": tenant["name"]}
+
             bgp_peers = natural_sort(convert_dicts(vrf.get("bgp_peers"), "ip_address"), "ip_address")
             vrf["bgp_peers"] = [bgp_peer for bgp_peer in bgp_peers if self.shared_utils.hostname in bgp_peer.get("nodes", [])]
             vrf["static_routes"] = [
@@ -221,9 +224,6 @@ class UtilsFilteredTenantsMixin(object):
                             vrf["_evpn_l3_multicast_evpn_peg_transit"] = evpn_peg.get("transit")
                             break
 
-            if vrf["svis"] or vrf["l3_interfaces"] or "all" in always_include_vrfs_in_tenants or tenant["name"] in always_include_vrfs_in_tenants:
-                filtered_vrfs.append(vrf)
-
             vrf["additional_route_targets"] = [
                 rt
                 for rt in get(vrf, "additional_route_targets", default=[])
@@ -235,6 +235,9 @@ class UtilsFilteredTenantsMixin(object):
                 )
             ]
 
+            if vrf["svis"] or vrf["l3_interfaces"] or "all" in always_include_vrfs_in_tenants or tenant["name"] in always_include_vrfs_in_tenants:
+                filtered_vrfs.append(vrf)
+
         return filtered_vrfs
 
     @cached_property
@@ -245,11 +248,13 @@ class UtilsFilteredTenantsMixin(object):
         The key "nodes" is filtered to only contain one item with the relevant dict from "nodes" or {}
         """
         svi_profiles = convert_dicts(get(self._hostvars, "svi_profiles", default=[]), "profile")
-        for svi_profile in svi_profiles:
-            svi_profile["nodes"] = convert_dicts(svi_profile.get("nodes", []), "node")
-            svi_profile["nodes"] = [get_item(svi_profile["nodes"], "node", self.shared_utils.hostname, default={})]
-
-        return svi_profiles
+        return [
+            {
+                **svi_profile,
+                "nodes": [get_item(convert_dicts(svi_profile.get("nodes", []), "node"), "node", self.shared_utils.hostname, default={})],
+            }
+            for svi_profile in svi_profiles
+        ]
 
     def _get_merged_svi_config(self, svi: dict) -> list[dict]:
         """
@@ -268,10 +273,12 @@ class UtilsFilteredTenantsMixin(object):
         svi_profile = {"nodes": [{}]}
         svi_parent_profile = {"nodes": [{}]}
 
-        svi["nodes"] = convert_dicts(svi.get("nodes", []), "node")
-        svi["nodes"] = [get_item(svi["nodes"], "node", self.shared_utils.hostname, default={})]
+        filtered_svi = {
+            **svi,
+            "nodes": [get_item(convert_dicts(svi.get("nodes", []), "node"), "node", self.shared_utils.hostname, default={})],
+        }
 
-        if (svi_profile_name := svi.get("profile")) is not None:
+        if (svi_profile_name := filtered_svi.get("profile")) is not None:
             svi_profile = get_item(self._svi_profiles, "profile", svi_profile_name, default={})
 
         if (svi_parent_profile_name := svi_profile.get("parent_profile")) is not None:
@@ -283,30 +290,30 @@ class UtilsFilteredTenantsMixin(object):
         merged_svi = merge(
             svi_parent_profile,
             svi_profile,
-            svi,
+            filtered_svi,
             svi_parent_profile["nodes"][0],
             svi_profile["nodes"][0],
-            svi["nodes"][0],
+            filtered_svi["nodes"][0],
             list_merge="replace",
             destructive_merge=False,
         )
 
         # Override structured configs since we don't want to deep-merge those
         merged_svi["structured_config"] = default(
-            svi["nodes"][0].get("structured_config"),
+            filtered_svi["nodes"][0].get("structured_config"),
             svi_profile["nodes"][0].get("structured_config"),
             svi_parent_profile["nodes"][0].get("structured_config"),
-            svi.get("structured_config"),
+            filtered_svi.get("structured_config"),
             svi_profile.get("structured_config"),
             svi_parent_profile.get("structured_config"),
         )
 
         # Override bgp.structured configs since we don't want to deep-merge those
         merged_svi.setdefault("bgp", {})["structured_config"] = default(
-            get(svi["nodes"][0], "bgp.structured_config"),
+            get(filtered_svi["nodes"][0], "bgp.structured_config"),
             get(svi_profile["nodes"][0], "bgp.structured_config"),
             get(svi_parent_profile["nodes"][0], "bgp.structured_config"),
-            get(svi, "bgp.structured_config"),
+            get(filtered_svi, "bgp.structured_config"),
             get(svi_profile, "bgp.structured_config"),
             get(svi_parent_profile, "bgp.structured_config"),
         )


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Avoid in-place updates of network services impacting PyAVD.

When running PyAVD with multi-threading the parallel processes in-place updated the network services data, causing some threads to get incomplete data.

This change shallow copies the data structured to avoid affecting other devices.

I have not seen any performance impact in my tests, but I would expect a slight penalty.

Also tested by @emilarista who found the issue using PyAVD and Nornir.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
