### PR TITLE
Refactor(eos_designs): Render all configured path-groups on the Pathfinders

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -20,6 +20,11 @@ router path-selection
          name autovpn-rr2
          ipv4 address 10.8.8.8
    !
+   path-group LTE id 102
+      ipsec profile AUTOVPN
+   !
+   path-group MPLS id 100
+   !
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -20,6 +20,11 @@ router path-selection
          name autovpn-rr1
          ipv4 address 10.7.7.7
    !
+   path-group LTE id 102
+      ipsec profile AUTOVPN
+   !
+   path-group MPLS id 100
+   !
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -107,6 +107,9 @@ router adaptive-virtual-topology
 router path-selection
    peer dynamic source stun
    !
+   path-group Equinix id 103
+      ipsec profile CP-PROFILE
+   !
    path-group INET id 101
       ipsec profile CP-PROFILE
       !
@@ -114,9 +117,15 @@ router path-selection
       !
       local interface Ethernet3
    !
+   path-group LTE id 102
+      ipsec profile CP-PROFILE
+   !
    path-group MPLS id 100
       !
       local interface Ethernet2
+   !
+   path-group Satellite id 104
+      ipsec profile CP-PROFILE
    !
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -107,6 +107,9 @@ router adaptive-virtual-topology
 router path-selection
    peer dynamic source stun
    !
+   path-group Equinix id 103
+      ipsec profile CP-PROFILE
+   !
    path-group INET id 101
       ipsec profile CP-PROFILE
       !
@@ -119,6 +122,14 @@ router path-selection
       peer static router-ip 192.168.44.3
          name cv-pathfinder-pathfinder2
          ipv4 address 10.9.9.9
+   !
+   path-group LTE id 102
+      ipsec profile CP-PROFILE
+   !
+   path-group MPLS id 100
+   !
+   path-group Satellite id 104
+      ipsec profile CP-PROFILE
    !
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -107,6 +107,9 @@ router adaptive-virtual-topology
 router path-selection
    peer dynamic source stun
    !
+   path-group Equinix id 103
+      ipsec profile CP-PROFILE
+   !
    path-group INET id 101
       ipsec profile CP-PROFILE
       !
@@ -120,6 +123,9 @@ router path-selection
          name cv-pathfinder-pathfinder1
          ipv4 address 10.8.8.8
    !
+   path-group LTE id 102
+      ipsec profile CP-PROFILE
+   !
    path-group MPLS id 100
       !
       local interface Ethernet2
@@ -127,6 +133,9 @@ router path-selection
       peer static router-ip 6.6.6.6
          name cv-pathfinder-pathfinder3
          ipv4 address 172.17.17.17
+   !
+   path-group Satellite id 104
+      ipsec profile CP-PROFILE
    !
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -115,6 +115,8 @@ router_bfd:
     multiplier: 3
 router_path_selection:
   path_groups:
+  - name: MPLS
+    id: 100
   - name: INET
     id: 101
     local_interfaces:
@@ -124,6 +126,9 @@ router_path_selection:
       name: autovpn-rr2
       ipv4_addresses:
       - 10.8.8.8
+    ipsec_profile: AUTOVPN
+  - name: LTE
+    id: 102
     ipsec_profile: AUTOVPN
   peer_dynamic_source: stun
   load_balance_policies:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -117,6 +117,8 @@ router_bfd:
     multiplier: 3
 router_path_selection:
   path_groups:
+  - name: MPLS
+    id: 100
   - name: INET
     id: 101
     local_interfaces:
@@ -126,6 +128,9 @@ router_path_selection:
       name: autovpn-rr1
       ipv4_addresses:
       - 10.7.7.7
+    ipsec_profile: AUTOVPN
+  - name: LTE
+    id: 102
     ipsec_profile: AUTOVPN
   peer_dynamic_source: stun
   load_balance_policies:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -245,16 +245,25 @@ router_bfd:
     multiplier: 3
 router_path_selection:
   path_groups:
+  - name: MPLS
+    id: 100
+    local_interfaces:
+    - name: Ethernet2
   - name: INET
     id: 101
     local_interfaces:
     - name: Ethernet1
     - name: Ethernet3
     ipsec_profile: CP-PROFILE
-  - name: MPLS
-    id: 100
-    local_interfaces:
-    - name: Ethernet2
+  - name: LTE
+    id: 102
+    ipsec_profile: CP-PROFILE
+  - name: Equinix
+    id: 103
+    ipsec_profile: CP-PROFILE
+  - name: Satellite
+    id: 104
+    ipsec_profile: CP-PROFILE
   peer_dynamic_source: stun
   load_balance_policies:
   - name: LB-CONTROL-PLANE-PROFILE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -254,6 +254,8 @@ router_bfd:
     multiplier: 3
 router_path_selection:
   path_groups:
+  - name: MPLS
+    id: 100
   - name: INET
     id: 101
     local_interfaces:
@@ -267,6 +269,15 @@ router_path_selection:
       name: cv-pathfinder-pathfinder3
       ipv4_addresses:
       - 10.50.50.50
+    ipsec_profile: CP-PROFILE
+  - name: LTE
+    id: 102
+    ipsec_profile: CP-PROFILE
+  - name: Equinix
+    id: 103
+    ipsec_profile: CP-PROFILE
+  - name: Satellite
+    id: 104
     ipsec_profile: CP-PROFILE
   peer_dynamic_source: stun
   load_balance_policies:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -261,6 +261,15 @@ router_bfd:
     multiplier: 3
 router_path_selection:
   path_groups:
+  - name: MPLS
+    id: 100
+    local_interfaces:
+    - name: Ethernet2
+    static_peers:
+    - router_ip: 6.6.6.6
+      name: cv-pathfinder-pathfinder3
+      ipv4_addresses:
+      - 172.17.17.17
   - name: INET
     id: 101
     local_interfaces:
@@ -275,15 +284,15 @@ router_path_selection:
       ipv4_addresses:
       - 10.50.50.50
     ipsec_profile: CP-PROFILE
-  - name: MPLS
-    id: 100
-    local_interfaces:
-    - name: Ethernet2
-    static_peers:
-    - router_ip: 6.6.6.6
-      name: cv-pathfinder-pathfinder3
-      ipv4_addresses:
-      - 172.17.17.17
+  - name: LTE
+    id: 102
+    ipsec_profile: CP-PROFILE
+  - name: Equinix
+    id: 103
+    ipsec_profile: CP-PROFILE
+  - name: Satellite
+    id: 104
+    ipsec_profile: CP-PROFILE
   peer_dynamic_source: stun
   load_balance_policies:
   - name: LB-CONTROL-PLANE-PROFILE

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_path_selection.py
@@ -46,7 +46,13 @@ class RouterPathSelectionMixin(UtilsMixin):
         # TODO - need to have default value in one place only -> maybe facts / shared_utils ?
         ipsec_profile_name = get(self._hostvars, "wan_ipsec_profiles.control_plane.profile_name", default="CP-PROFILE")
 
-        for path_group in self.shared_utils.wan_local_path_groups:
+        if self.shared_utils.wan_role == "server":
+            # Configure all path-groups on Pathfinders and AutoVPN RRs
+            path_groups_to_configure = self.shared_utils.wan_path_groups
+        else:
+            path_groups_to_configure = self.shared_utils.wan_local_path_groups
+
+        for path_group in path_groups_to_configure:
             pg_name = path_group.get("name")
 
             path_group_data = {


### PR DESCRIPTION
## Change Summary

Even without local interfaces, Pathfinders require to have all path-groups configured with their IDs. This was missing

## Component(s) name

`arista.avd.eos_designs`


## How to test

molecule update

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
