### PR TITLE
Feat(eos_designs): Add the possibility to set CPU max allocation

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/invalid-wan-role-cv-pathfinder-role-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/invalid-wan-role-cv-pathfinder-role-1.yml
@@ -22,5 +22,8 @@ wan_edge:
       evpn_role: server
       id: 1
 
+# If this is not set, the other error message is not triggered
+data_plane_cpu_allocation_max: 1
+
 expected_error_message: >-
   'wan_role' must be 'client' when 'cv_pathfinder_role' is set to 'transit' or 'edge'

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-data-plane_cpu-allocation-max.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-data-plane_cpu-allocation-max.yml
@@ -7,5 +7,4 @@ wan_rr:
     - name: missing-data-plane_cpu-allocation-max
       id: 1
 
-expected_error_message: |
-  For AutoVPN RRs and Pathfinders, 'data_plane_cpu_allocation_max' must be set
+expected_error_message: "For AutoVPN RRs and Pathfinders, 'data_plane_cpu_allocation_max' must be set"

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-data-plane_cpu-allocation-max.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-data-plane_cpu-allocation-max.yml
@@ -1,0 +1,11 @@
+type: wan_rr
+bgp_as: 65000
+wan_rr:
+  defaults:
+    loopback_ipv4_pool: 10.42.0.0/24
+  nodes:
+    - name: missing-data-plane_cpu-allocation-max
+      id: 1
+
+expected_error_message: |
+  For AutoVPN RRs and Pathfinders, 'data_plane_cpu_allocation_max' must be set

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -102,6 +102,7 @@ all:
         source-interfaces-tacacs-missing-inband-mgmt-interface:
         source-interfaces-tacacs-missing-mgmt-ip:
         ul-filter-evpn-default-vrf-services:
+        missing-data-plane_cpu-allocation-max:
       children:
         duplicate-ip-address-router-bgp:
           hosts:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -58,6 +58,8 @@ router path-selection
 !
 spanning-tree mode none
 !
+platform sfe data-plane cpu allocation maximum 2
+!
 no enable password
 no aaa root
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -58,6 +58,8 @@ router path-selection
 !
 spanning-tree mode none
 !
+platform sfe data-plane cpu allocation maximum 2
+!
 no enable password
 no aaa root
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -156,6 +156,8 @@ router path-selection
 !
 spanning-tree mode none
 !
+platform sfe data-plane cpu allocation maximum 1
+!
 no enable password
 no aaa root
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -157,6 +157,8 @@ router path-selection
 !
 spanning-tree mode none
 !
+platform sfe data-plane cpu allocation maximum 3
+!
 no enable password
 no aaa root
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -166,6 +166,8 @@ router path-selection
 !
 spanning-tree mode none
 !
+platform sfe data-plane cpu allocation maximum 3
+!
 no enable password
 no aaa root
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -75,6 +75,9 @@ spanning_tree:
 vrfs:
 - name: MGMT
   ip_routing: false
+platform:
+  sfe:
+    data_plane_cpu_allocation_max: 2
 management_api_http:
   enable_vrfs:
   - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -75,6 +75,9 @@ spanning_tree:
 vrfs:
 - name: MGMT
   ip_routing: false
+platform:
+  sfe:
+    data_plane_cpu_allocation_max: 2
 management_api_http:
   enable_vrfs:
   - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -74,6 +74,9 @@ spanning_tree:
 vrfs:
 - name: MGMT
   ip_routing: false
+platform:
+  sfe:
+    data_plane_cpu_allocation_max: 1
 management_api_http:
   enable_vrfs:
   - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -100,6 +100,9 @@ spanning_tree:
 vrfs:
 - name: MGMT
   ip_routing: false
+platform:
+  sfe:
+    data_plane_cpu_allocation_max: 3
 management_api_http:
   enable_vrfs:
   - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -100,6 +100,9 @@ spanning_tree:
 vrfs:
 - name: MGMT
   ip_routing: false
+platform:
+  sfe:
+    data_plane_cpu_allocation_max: 3
 management_api_http:
   enable_vrfs:
   - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_RRS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_RRS.yml
@@ -1,0 +1,2 @@
+---
+data_plane_cpu_allocation_max: 2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDERS.yml
@@ -1,0 +1,2 @@
+---
+data_plane_cpu_allocation_max: 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_MULTI_RR_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_MULTI_RR_TESTS.yml
@@ -1,6 +1,9 @@
 ---
 # Inherit most of the variables from CV_PATHFINDERS_TESTS
 
+# overwriting data_plane_cpu_allocation_max from CV_PATHINDERS
+data_plane_cpu_allocation_max: 3
+
 wan_route_servers:
   # Not testing the overloading
   - hostname: cv-pathfinder-pathfinder1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -285,21 +285,27 @@ all:
         WAN_TESTS:
           children:
             AUTOVPN_TESTS:
+              children:
+                AUTOVPN_RRS:
+                  hosts:
+                    autovpn-rr1:
+                    autovpn-rr2:
               hosts:
                 autovpn-edge:
-                autovpn-rr1:
-                autovpn-rr2:
             CV_PATHFINDER_TESTS:
               hosts:
                 cv-pathfinder-edge:
                 cv-pathfinder-edge-no-common-path-group:
                 cv-pathfinder-transit:
-                cv-pathfinder-pathfinder:
               children:
-                CV_PATHFINDER_MULTI_RR_TESTS:
+                CV_PATHFINDERS:
                   hosts:
-                    cv-pathfinder-pathfinder1:
-                    cv-pathfinder-pathfinder2:
+                    cv-pathfinder-pathfinder:
+                  children:
+                    CV_PATHFINDER_MULTI_RR_TESTS:
+                      hosts:
+                        cv-pathfinder-pathfinder1:
+                        cv-pathfinder-pathfinder2:
         AVD_LAB:
           children:
             DC1_FABRIC:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/system-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/system-settings.md
@@ -7,6 +7,7 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>data_plane_cpu_allocation_max</samp>](## "data_plane_cpu_allocation_max") | Integer |  |  | Min: 1<br>Max: 128 | Set the maximum number of CPU used for the data plane.<br>This setting is useful on virtual Route Reflectors and Pathfinders node. |
     | [<samp>default_igmp_snooping_enabled</samp>](## "default_igmp_snooping_enabled") | Boolean |  | `True` |  | When set to false, disables IGMP snooping at fabric level and overrides per vlan settings.<br> |
     | [<samp>hardware_counters</samp>](## "hardware_counters") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;features</samp>](## "hardware_counters.features") | List, items: Dictionary |  |  |  | This data model allows to configure the list of hardware counters feature<br>available on Arista platforms.<br><br>The `name` key accepts a list of valid_values which MUST be updated to support<br>new feature as they are released in EOS.<br><br>The available values of the different keys like 'direction' or 'address_type'<br>are feature and hardware dependent and this model DOES NOT validate that the<br>combinations are valid. It is the responsability of the user of this data model<br>to make sure that the rendered CLI is accepted by the targeted device.<br><br>Examples:<br><br>  * Use:<br>    ```yaml<br>    hardware_counters:<br>      features:<br>        - name: ip<br>          direction: out<br>          layer3: true<br>          units_packets: true<br>    ```<br><br>    to render:<br>    ```eos<br>    hardware counter feature ip out layer3 units packets<br>    ```<br>  * Use:<br>    ```yaml<br>    hardware_counters:<br>      features:<br>        - name: route<br>          address_type: ipv4<br>          vrf: test<br>          prefix: 192.168.0.0/24<br>    ```<br><br>    to render:<br>    ```eos<br>    hardware counter feature route ipv4 vrf test 192.168.0.0/24<br>    ```<br> |
@@ -44,6 +45,10 @@
 === "YAML"
 
     ```yaml
+    # Set the maximum number of CPU used for the data plane.
+    # This setting is useful on virtual Route Reflectors and Pathfinders node.
+    data_plane_cpu_allocation_max: <int; 1-128>
+
     # When set to false, disables IGMP snooping at fabric level and overrides per vlan settings.
     default_igmp_snooping_enabled: <bool; default=True>
     hardware_counters:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -509,8 +509,10 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
     @cached_property
     def platform(self) -> dict | None:
         """
-        platform set based on platform_settings.lag_hardware_only,
-        platform_settings.trident_forwarding_table_partition and switch.evpn_multicast facts
+        platform set based on:
+        * platform_settings.lag_hardware_only,
+        * platform_settings.trident_forwarding_table_partition and switch.evpn_multicast facts
+        * data_plane_cpu_allocation_max
         """
         platform = {}
         if (lag_hardware_only := get(self.shared_utils.platform_settings, "lag_hardware_only")) is not None:
@@ -519,6 +521,13 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
         trident_forwarding_table_partition = get(self.shared_utils.platform_settings, "trident_forwarding_table_partition")
         if trident_forwarding_table_partition is not None and get(self._hostvars, "switch.evpn_multicast") is True:
             platform["trident"] = {"forwarding_table_partition": trident_forwarding_table_partition}
+
+        if (cpu_max_allocation := get(self._hostvars, "data_plane_cpu_allocation_max")) is not None:
+            platform["sfe"] = {"data_plane_cpu_allocation_max": cpu_max_allocation}
+        elif self.shared_utils.wan_role == "server":
+            # For AutoVPN Route Reflectors and Pathfinders, running on CloudEOS, setting
+            # this value is required for the solution to work.
+            raise AristaAvdMissingVariableError("For AutoVPN RRs and Pathfinders, 'data_plane_cpu_allocation_max' must be set")
 
         if platform:
             return platform

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4094,6 +4094,13 @@
       "description": "cvp_token_file is the path to the token file on the switch.\nIf not set the default locations for on-premise or CVaaS will be used.\nSee cvp_ingestauth_key for details.",
       "title": "CVP Token File"
     },
+    "data_plane_cpu_allocation_max": {
+      "type": "integer",
+      "description": "Set the maximum number of CPU used for the data plane.\nThis setting is useful on virtual Route Reflectors and Pathfinders node.",
+      "minimum": 1,
+      "maximum": 128,
+      "title": "Data Plane CPU Allocation Max"
+    },
     "dc_name": {
       "description": "POD Name is used in:\n- Fabric Documentation (Optional, falls back to fabric_name)\n- SNMP Location: `snmp_settings.location` (Optional)\n- HER Overlay DC scoped flood lists: `overlay_her_flood_list_scope: dc` (Required)\n",
       "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -656,6 +656,14 @@ keys:
       If not set the default locations for on-premise or CVaaS will be used.
 
       See cvp_ingestauth_key for details.'
+  data_plane_cpu_allocation_max:
+    documentation_options:
+      table: system-settings
+    type: int
+    $ref: eos_cli_config_gen#/keys/platform/keys/sfe/keys/data_plane_cpu_allocation_max
+    description: 'Set the maximum number of CPU used for the data plane.
+
+      This setting is useful on virtual Route Reflectors and Pathfinders node.'
   dc_name:
     documentation_options:
       table: fabric-topology

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/data_plane_cpu_allocation_max.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/data_plane_cpu_allocation_max.schema.yml
@@ -1,0 +1,16 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  data_plane_cpu_allocation_max:
+    documentation_options:
+      table: system-settings
+    type: int
+    $ref: "eos_cli_config_gen#/keys/platform/keys/sfe/keys/data_plane_cpu_allocation_max"
+    description: |-
+      Set the maximum number of CPU used for the data plane.
+      This setting is useful on virtual Route Reflectors and Pathfinders node.


### PR DESCRIPTION
## Change Summary

For AutoVPN RRs and Pathfinders, it is recommended to limit the number of CPUs allocated to Data Plane. This PR allows to set it for every device and enforce it for WAN Routes Reflectors (this may need to be relaxed).

Setting this as default at the platform level would requires to maintain a list of Cloud platforms which would be quite cumbersome.

## Component(s) name

`arista.avd.eos_designs`

## How to test

molecule tests added

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
