### PR TITLE
Feat(eos_designs): Make maximum-path 16 default for WAN routers

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -140,7 +140,7 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.30.1
-   maximum-paths 4 ecmp 4
+   maximum-paths 16
    update wait-install
    no bgp default ipv4-unicast
    neighbor WAN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -124,7 +124,7 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.31.1
-   maximum-paths 4 ecmp 4
+   maximum-paths 16
    update wait-install
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.31.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -125,7 +125,7 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.31.2
-   maximum-paths 4 ecmp 4
+   maximum-paths 16
    update wait-install
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.31.2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -236,7 +236,7 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.42.6
-   maximum-paths 4 ecmp 4
+   maximum-paths 16
    update wait-install
    no bgp default ipv4-unicast
    neighbor WAN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -284,7 +284,7 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.42.1
-   maximum-paths 4 ecmp 4
+   maximum-paths 16
    update wait-install
    no bgp default ipv4-unicast
    neighbor WAN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -280,7 +280,7 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.44.1
-   maximum-paths 4 ecmp 4
+   maximum-paths 16
    update wait-install
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.44.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -267,7 +267,7 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.44.2
-   maximum-paths 4 ecmp 4
+   maximum-paths 16
    update wait-install
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.44.2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -282,7 +282,7 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.44.3
-   maximum-paths 4 ecmp 4
+   maximum-paths 16
    update wait-install
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.44.3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
@@ -301,7 +301,7 @@ router bfd
 !
 router bgp 65000
    router-id 192.168.43.1
-   maximum-paths 4 ecmp 4
+   maximum-paths 16
    update wait-install
    no bgp default ipv4-unicast
    neighbor WAN-OVERLAY-PEERS peer group

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -7,8 +7,7 @@ router_bgp:
     default:
       ipv4_unicast: false
   maximum_paths:
-    paths: 4
-    ecmp: 4
+    paths: 16
   updates:
     wait_install: true
   peer_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -7,8 +7,7 @@ router_bgp:
     default:
       ipv4_unicast: false
   maximum_paths:
-    paths: 4
-    ecmp: 4
+    paths: 16
   updates:
     wait_install: true
   bgp_cluster_id: 192.168.31.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -7,8 +7,7 @@ router_bgp:
     default:
       ipv4_unicast: false
   maximum_paths:
-    paths: 4
-    ecmp: 4
+    paths: 16
   updates:
     wait_install: true
   bgp_cluster_id: 192.168.31.2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -7,8 +7,7 @@ router_bgp:
     default:
       ipv4_unicast: false
   maximum_paths:
-    paths: 4
-    ecmp: 4
+    paths: 16
   updates:
     wait_install: true
   peer_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -7,8 +7,7 @@ router_bgp:
     default:
       ipv4_unicast: false
   maximum_paths:
-    paths: 4
-    ecmp: 4
+    paths: 16
   updates:
     wait_install: true
   peer_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -7,8 +7,7 @@ router_bgp:
     default:
       ipv4_unicast: false
   maximum_paths:
-    paths: 4
-    ecmp: 4
+    paths: 16
   updates:
     wait_install: true
   bgp_cluster_id: 192.168.44.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -7,8 +7,7 @@ router_bgp:
     default:
       ipv4_unicast: false
   maximum_paths:
-    paths: 4
-    ecmp: 4
+    paths: 16
   updates:
     wait_install: true
   bgp_cluster_id: 192.168.44.2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -7,8 +7,7 @@ router_bgp:
     default:
       ipv4_unicast: false
   maximum_paths:
-    paths: 4
-    ecmp: 4
+    paths: 16
   updates:
     wait_install: true
   bgp_cluster_id: 192.168.44.3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
@@ -7,8 +7,7 @@ router_bgp:
     default:
       ipv4_unicast: false
   maximum_paths:
-    paths: 4
-    ecmp: 4
+    paths: 16
   updates:
     wait_install: true
   peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
@@ -13,11 +13,11 @@
     | [<samp>&nbsp;&nbsp;external_routes</samp>](## "bgp_distance.external_routes") | Integer | Required |  | Min: 1<br>Max: 255 |  |
     | [<samp>&nbsp;&nbsp;internal_routes</samp>](## "bgp_distance.internal_routes") | Integer | Required |  | Min: 1<br>Max: 255 |  |
     | [<samp>&nbsp;&nbsp;local_routes</samp>](## "bgp_distance.local_routes") | Integer | Required |  | Min: 1<br>Max: 255 |  |
-    | [<samp>bgp_ecmp</samp>](## "bgp_ecmp") | Integer |  | `4` |  | Maximum ECMP for BGP multi-path. |
+    | [<samp>bgp_ecmp</samp>](## "bgp_ecmp") | Integer |  |  |  | Maximum ECMP for BGP multi-path.<br>The default value is 4 except for WAN Routers where the default value is unset (falls back to EOS default). |
     | [<samp>bgp_graceful_restart</samp>](## "bgp_graceful_restart") | Dictionary |  |  |  | BGP graceful-restart allows a BGP speaker with separate control plane and data plane processing to continue forwarding traffic during a BGP restart.<br>Its neighbors (receiving speakers) may retain routing information from the restarting speaker while a BGP session with it is being re-established, reducing route flapping.<br> |
     | [<samp>&nbsp;&nbsp;enabled</samp>](## "bgp_graceful_restart.enabled") | Boolean | Required | `False` |  | Enable or disable graceful-restart for all BGP peers. |
     | [<samp>&nbsp;&nbsp;restart_time</samp>](## "bgp_graceful_restart.restart_time") | Integer |  | `300` | Min: 1<br>Max: 3600 | Restart time in seconds. |
-    | [<samp>bgp_maximum_paths</samp>](## "bgp_maximum_paths") | Integer |  | `4` | Min: 1<br>Max: 512 | Maximum Paths for BGP multi-path. |
+    | [<samp>bgp_maximum_paths</samp>](## "bgp_maximum_paths") | Integer |  |  | Min: 1<br>Max: 512 | Maximum Paths for BGP multi-path.<br>The default value is 4 except for WAN Routers where the default value is 16. |
     | [<samp>bgp_peer_groups</samp>](## "bgp_peer_groups") | Dictionary |  |  |  | Leverage an Arista EOS switch to generate the encrypted password using the correct peer group name.<br>Note that the name of the peer groups use '-' instead of '_' in EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;ipv4_underlay_peers</samp>](## "bgp_peer_groups.ipv4_underlay_peers") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.ipv4_underlay_peers.name") | String |  | `IPv4-UNDERLAY-PEERS` |  | Name of peer group. |
@@ -75,7 +75,8 @@
       local_routes: <int; 1-255; required>
 
     # Maximum ECMP for BGP multi-path.
-    bgp_ecmp: <int; default=4>
+    # The default value is 4 except for WAN Routers where the default value is unset (falls back to EOS default).
+    bgp_ecmp: <int>
 
     # BGP graceful-restart allows a BGP speaker with separate control plane and data plane processing to continue forwarding traffic during a BGP restart.
     # Its neighbors (receiving speakers) may retain routing information from the restarting speaker while a BGP session with it is being re-established, reducing route flapping.
@@ -88,7 +89,8 @@
       restart_time: <int; 1-3600; default=300>
 
     # Maximum Paths for BGP multi-path.
-    bgp_maximum_paths: <int; 1-512; default=4>
+    # The default value is 4 except for WAN Routers where the default value is 16.
+    bgp_maximum_paths: <int; 1-512>
 
     # Leverage an Arista EOS switch to generate the encrypted password using the correct peer group name.
     # Note that the name of the peer groups use '-' instead of '_' in EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -59,6 +59,9 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
         )
         platform_bgp_update_wait_install = get(self.shared_utils.platform_settings, "feature_support.bgp_update_wait_install", default=True) is True
 
+        default_maximum_paths = 16 if self.shared_utils.wan_role is not None else 4
+        default_ecmp = None if self.shared_utils.wan_role is not None else 4
+
         router_bgp = {
             "as": self.shared_utils.bgp_as,
             "router_id": self.shared_utils.router_id,
@@ -70,8 +73,8 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
                 },
             },
             "maximum_paths": {
-                "paths": get(self._hostvars, "bgp_maximum_paths", default=4),
-                "ecmp": get(self._hostvars, "bgp_ecmp", default=4),
+                "paths": get(self._hostvars, "bgp_maximum_paths", default=default_maximum_paths),
+                "ecmp": get(self._hostvars, "bgp_ecmp", default=default_ecmp),
             },
         }
         if get(self._hostvars, "bgp_update_wait_for_convergence", default=False) is True and platform_bgp_update_wait_for_convergence:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -59,8 +59,13 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
         )
         platform_bgp_update_wait_install = get(self.shared_utils.platform_settings, "feature_support.bgp_update_wait_install", default=True) is True
 
-        default_maximum_paths = 16 if self.shared_utils.wan_role is not None else 4
-        default_ecmp = None if self.shared_utils.wan_role is not None else 4
+        if self.shared_utils.wan_role is not None:
+            # Special defaults for WAN routers
+            default_maximum_paths = 16
+            default_ecmp = None
+        else:
+            default_maximum_paths = 4
+            default_ecmp = 4
 
         router_bgp = {
             "as": self.shared_utils.bgp_as,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -444,9 +444,8 @@
       "title": "BGP Distance"
     },
     "bgp_ecmp": {
-      "description": "Maximum ECMP for BGP multi-path.",
+      "description": "Maximum ECMP for BGP multi-path.\nThe default value is 4 except for WAN Routers where the default value is unset (falls back to EOS default).",
       "type": "integer",
-      "default": 4,
       "title": "BGP ECMP"
     },
     "bgp_graceful_restart": {
@@ -478,9 +477,8 @@
       "title": "BGP Graceful Restart"
     },
     "bgp_maximum_paths": {
-      "description": "Maximum Paths for BGP multi-path.",
+      "description": "Maximum Paths for BGP multi-path.\nThe default value is 4 except for WAN Routers where the default value is 16.",
       "type": "integer",
-      "default": 4,
       "minimum": 1,
       "maximum": 512,
       "title": "BGP Maximum Paths"

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -128,11 +128,13 @@ keys:
   bgp_ecmp:
     documentation_options:
       table: bgp-settings
-    description: Maximum ECMP for BGP multi-path.
+    description: 'Maximum ECMP for BGP multi-path.
+
+      The default value is 4 except for WAN Routers where the default value is unset
+      (falls back to EOS default).'
     type: int
     convert_types:
     - str
-    default: 4
   bgp_graceful_restart:
     documentation_options:
       table: bgp-settings
@@ -163,11 +165,12 @@ keys:
   bgp_maximum_paths:
     documentation_options:
       table: bgp-settings
-    description: Maximum Paths for BGP multi-path.
+    description: 'Maximum Paths for BGP multi-path.
+
+      The default value is 4 except for WAN Routers where the default value is 16.'
     type: int
     convert_types:
     - str
-    default: 4
     min: 1
     max: 512
   bgp_mesh_pes:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_ecmp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_ecmp.schema.yml
@@ -9,8 +9,9 @@ keys:
   bgp_ecmp:
     documentation_options:
       table: bgp-settings
-    description: Maximum ECMP for BGP multi-path.
+    description: |-
+      Maximum ECMP for BGP multi-path.
+      The default value is 4 except for WAN Routers where the default value is unset (falls back to EOS default).
     type: int
     convert_types:
       - str
-    default: 4

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_maximum_paths.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_maximum_paths.schema.yml
@@ -9,10 +9,11 @@ keys:
   bgp_maximum_paths:
     documentation_options:
       table: bgp-settings
-    description: Maximum Paths for BGP multi-path.
+    description: |-
+      Maximum Paths for BGP multi-path.
+      The default value is 4 except for WAN Routers where the default value is 16.
     type: int
     convert_types:
       - str
-    default: 4
     min: 1
     max: 512


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Make maximum-path 16 default for WAN routers

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Add different defaults for `bgp_maximum_paths` and `bgp_ecmp` depending on `wan_role`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing WAN molecule got updated.
No changes to other molecule.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
