### PR TITLE
Feat(eos_cli_config_gen): Support disabling hardware encryption for ip security

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -41,6 +41,8 @@ interface Management1
 
 ## IP Security
 
+- Hardware encryption is disabled
+
 ### IKE policies
 
 | Policy name | IKE lifetime | Encryption | DH group | Local ID |
@@ -112,4 +114,5 @@ ip security
    !
    key controller
       profile Profile-1
+   hardware encryption disabled
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -46,6 +46,7 @@ ip security
    !
    key controller
       profile Profile-1
+   hardware encryption disabled
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -41,3 +41,4 @@ ip_security:
       mode: tunnel
   key_controller:
     profile: Profile-1
+  hardware_encryption_disabled: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -33,6 +33,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ip_security.profiles.[].mode") | String |  |  | Valid Values:<br>- <code>transport</code><br>- <code>tunnel</code> | Ipsec mode type. |
     | [<samp>&nbsp;&nbsp;key_controller</samp>](## "ip_security.key_controller") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ip_security.key_controller.profile") | String |  |  |  | IPsec profile name to use. |
+    | [<samp>&nbsp;&nbsp;hardware_encryption_disabled</samp>](## "ip_security.hardware_encryption_disabled") | Boolean |  | `False` |  | Disable hardware encryption.<br>A SFE restart is needed for this change to take effect. |
 
 === "YAML"
 
@@ -108,4 +109,8 @@
 
         # IPsec profile name to use.
         profile: <str>
+
+      # Disable hardware encryption.
+      # A SFE restart is needed for this change to take effect.
+      hardware_encryption_disabled: <bool; default=False>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -33,7 +33,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ip_security.profiles.[].mode") | String |  |  | Valid Values:<br>- <code>transport</code><br>- <code>tunnel</code> | Ipsec mode type. |
     | [<samp>&nbsp;&nbsp;key_controller</samp>](## "ip_security.key_controller") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ip_security.key_controller.profile") | String |  |  |  | IPsec profile name to use. |
-    | [<samp>&nbsp;&nbsp;hardware_encryption_disabled</samp>](## "ip_security.hardware_encryption_disabled") | Boolean |  | `False` |  | Disable hardware encryption.<br>A SFE restart is needed for this change to take effect. |
+    | [<samp>&nbsp;&nbsp;hardware_encryption_disabled</samp>](## "ip_security.hardware_encryption_disabled") | Boolean |  | `False` |  | Disable hardware encryption.<br>An SFE restart is needed for this change to take effect. |
 
 === "YAML"
 
@@ -111,6 +111,6 @@
         profile: <str>
 
       # Disable hardware encryption.
-      # A SFE restart is needed for this change to take effect.
+      # An SFE restart is needed for this change to take effect.
       hardware_encryption_disabled: <bool; default=False>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7413,6 +7413,12 @@
             "^_.+$": {}
           },
           "title": "Key Controller"
+        },
+        "hardware_encryption_disabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Disable hardware encryption.\nA SFE restart is needed for this change to take effect.",
+          "title": "Hardware Encryption Disabled"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7417,7 +7417,7 @@
         "hardware_encryption_disabled": {
           "type": "boolean",
           "default": false,
-          "description": "Disable hardware encryption.\nA SFE restart is needed for this change to take effect.",
+          "description": "Disable hardware encryption.\nAn SFE restart is needed for this change to take effect.",
           "title": "Hardware Encryption Disabled"
         }
       },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4388,6 +4388,12 @@ keys:
           profile:
             type: str
             description: IPsec profile name to use.
+      hardware_encryption_disabled:
+        type: bool
+        default: false
+        description: 'Disable hardware encryption.
+
+          A SFE restart is needed for this change to take effect.'
   ip_ssh_client_source_interfaces:
     type: list
     items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4393,7 +4393,7 @@ keys:
         default: false
         description: 'Disable hardware encryption.
 
-          A SFE restart is needed for this change to take effect.'
+          An SFE restart is needed for this change to take effect.'
   ip_ssh_client_source_interfaces:
     type: list
     items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
@@ -155,4 +155,4 @@ keys:
         default: False
         description: |-
           Disable hardware encryption.
-          A SFE restart is needed for this change to take effect.
+          An SFE restart is needed for this change to take effect.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
@@ -150,3 +150,9 @@ keys:
           profile:
             type: str
             description: IPsec profile name to use.
+      hardware_encryption_disabled:
+        type: bool
+        default: False
+        description: |-
+          Disable hardware encryption.
+          A SFE restart is needed for this change to take effect.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
@@ -7,6 +7,10 @@
 {% if ip_security is arista.avd.defined %}
 
 ## IP Security
+{%     if ip_security.hardware_encryption_disabled is arista.avd.defined(true) %}
+
+- Hardware encryption is disabled
+{%     endif %}
 {%     if ip_security.ike_policies is arista.avd.defined %}
 
 ### IKE policies

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
@@ -73,4 +73,7 @@ ip security
       profile {{ ip_security.key_controller.profile }}
 {%         endif %}
 {%     endif %}
+{%     if ip_security.hardware_encryption_disabled is arista.avd.defined(true) %}
+   hardware encryption disabled
+{%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Support disabling hardware encryption for ip security

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add a key
```
ip_security:
  hardware_encryption_disabled: <bool>
```

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
