### PR TITLE
Feat(eos_designs): Add router traffic-engineering for CV Pathfinder

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -267,6 +267,8 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
 !
+router traffic-engineering
+!
 management api http-commands
    protocol https
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -315,6 +315,8 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
 !
+router traffic-engineering
+!
 management api http-commands
    protocol https
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -315,6 +315,8 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
 !
+router traffic-engineering
+!
 management api http-commands
    protocol https
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -317,6 +317,8 @@ router bgp 65000
       neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
 !
+router traffic-engineering
+!
 management api http-commands
    protocol https
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -332,6 +332,8 @@ router bgp 65000
       neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
 !
+router traffic-engineering
+!
 management api http-commands
    protocol https
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
@@ -332,6 +332,8 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
 !
+router traffic-engineering
+!
 management api http-commands
    protocol https
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -238,6 +238,8 @@ router_path_selection:
   - name: LB-PROD-AVT-POLICY-DEFAULT
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+router_traffic_engineering:
+  enabled: true
 application_traffic_recognition:
   application_profiles:
   - name: VOICE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -304,6 +304,8 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 42
+router_traffic_engineering:
+  enabled: true
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -299,6 +299,8 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
+router_traffic_engineering:
+  enabled: true
 stun:
   server:
     local_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -311,6 +311,8 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
+router_traffic_engineering:
+  enabled: true
 stun:
   server:
     local_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -328,6 +328,8 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
+router_traffic_engineering:
+  enabled: true
 stun:
   server:
     local_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
@@ -319,6 +319,8 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
+router_traffic_engineering:
+  enabled: true
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/avdstructuredconfig.py
@@ -13,6 +13,7 @@ from .router_adaptive_virtual_topology import RouterAdaptiveVirtualTopologyMixin
 from .router_bfd import RouterBfdMixin
 from .router_bgp import RouterBgpMixin
 from .router_path_selection import RouterPathSelectionMixin
+from .router_traffic_engineering import RouterTrafficEngineering
 from .stun import StunMixin
 
 
@@ -28,6 +29,7 @@ class AvdStructuredConfigOverlay(
     RouterBgpMixin,
     RouteMapsMixin,
     RouterPathSelectionMixin,
+    RouterTrafficEngineering,
     StunMixin,
 ):
     """

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_traffic_engineering.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_traffic_engineering.py
@@ -1,0 +1,29 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from functools import cached_property
+
+from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_empties_from_dict
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, get_item
+
+from .utils import UtilsMixin
+
+
+class RouterTrafficEngineering(UtilsMixin):
+    """
+    Mixin Class used to generate structured config for one key.
+    Class should only be used as Mixin to a AvdStructuredConfig class
+    """
+
+    @cached_property
+    def router_traffic_engineering(self) -> dict | None:
+        """
+        Return structured config for router traffic-engineering
+        """
+
+        if not self.shared_utils.cv_pathfinder_role:
+            return None
+
+        return {"enabled": True}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_traffic_engineering.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_traffic_engineering.py
@@ -5,9 +5,6 @@ from __future__ import annotations
 
 from functools import cached_property
 
-from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_empties_from_dict
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, get_item
-
 from .utils import UtilsMixin
 
 


### PR DESCRIPTION
## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Configure `router traffic-engineering` block for all CV Pathfinder routers

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
