### PR TITLE
Feat(eos_designs): WAN Preview - Generate cv_pathfinder metadata for AVTs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -475,3 +475,94 @@ metadata:
           id: 511
         - name: Site512
           id: 512
+    vrfs:
+    - name: default
+      vni: 1
+      avts:
+      - id: 254
+        name: CONTROL-PLANE-PROFILE
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: preferred
+      - id: 3
+        name: DEFAULT-AVT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: preferred
+      - id: 1
+        name: DEFAULT-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: Equinix
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+    - name: PROD
+      vni: 42
+      avts:
+      - constraints:
+          jitter: 42
+        id: 2
+        name: PROD-AVT-POLICY-VOICE
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: alternate
+      - id: 4
+        name: PROD-AVT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: LTE
+          preference: preferred
+        - name: INET
+          preference: alternate
+      - id: 1
+        name: PROD-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+    - name: IT
+      vni: 100
+      avts:
+      - id: 3
+        name: DEFAULT-AVT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: preferred
+      - id: 1
+        name: DEFAULT-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: Equinix
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+    - name: TRANSIT
+      vni: 66
+      avts:
+      - id: 42
+        name: TRANSIT-AVT-POLICY-VOICE
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: alternate
+      - id: 1
+        name: TRANSIT-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: alternate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -463,3 +463,92 @@ metadata:
           id: 511
         - name: Site512
           id: 512
+    vrfs:
+    - name: default
+      vni: 1
+      avts:
+      - id: 254
+        name: CONTROL-PLANE-PROFILE
+        pathgroups:
+        - name: INET
+          preference: preferred
+      - id: 3
+        name: DEFAULT-AVT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: preferred
+      - id: 1
+        name: DEFAULT-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: Equinix
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+    - name: PROD
+      vni: 42
+      avts:
+      - constraints:
+          jitter: 42
+        id: 2
+        name: PROD-AVT-POLICY-VOICE
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: alternate
+      - id: 4
+        name: PROD-AVT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: LTE
+          preference: preferred
+        - name: INET
+          preference: alternate
+      - id: 1
+        name: PROD-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+    - name: IT
+      vni: 100
+      avts:
+      - id: 3
+        name: DEFAULT-AVT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: preferred
+      - id: 1
+        name: DEFAULT-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: Equinix
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+    - name: TRANSIT
+      vni: 66
+      avts:
+      - id: 42
+        name: TRANSIT-AVT-POLICY-VOICE
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: alternate
+      - id: 1
+        name: TRANSIT-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: alternate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -491,3 +491,94 @@ metadata:
           id: 511
         - name: Site512
           id: 512
+    vrfs:
+    - name: default
+      vni: 1
+      avts:
+      - id: 254
+        name: CONTROL-PLANE-PROFILE
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: preferred
+      - id: 3
+        name: DEFAULT-AVT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: preferred
+      - id: 1
+        name: DEFAULT-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: Equinix
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+    - name: PROD
+      vni: 42
+      avts:
+      - constraints:
+          jitter: 42
+        id: 2
+        name: PROD-AVT-POLICY-VOICE
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: alternate
+      - id: 4
+        name: PROD-AVT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: LTE
+          preference: preferred
+        - name: INET
+          preference: alternate
+      - id: 1
+        name: PROD-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+    - name: IT
+      vni: 100
+      avts:
+      - id: 3
+        name: DEFAULT-AVT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: preferred
+      - id: 1
+        name: DEFAULT-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: Equinix
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+    - name: TRANSIT
+      vni: 66
+      avts:
+      - id: 42
+        name: TRANSIT-AVT-POLICY-VOICE
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: alternate
+      - id: 1
+        name: TRANSIT-AVT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: alternate

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
@@ -352,13 +352,21 @@ class FilteredTenantsMixin:
             return []
         return [int(id) for id in range_expand(endpoint_vlans)]
 
-    def get_vrf_id(self: SharedUtils, vrf, required: bool = True) -> int | None:
+    @staticmethod
+    def get_vrf_id(vrf, required: bool = True) -> int | None:
         vrf_id = default(vrf.get("vrf_id"), vrf.get("vrf_vni"))
         if vrf_id is None:
             if required:
                 raise AristaAvdMissingVariableError(f"'vrf_id' or 'vrf_vni' for VRF '{vrf['name']} must be set.")
             return None
         return int(vrf_id)
+
+    @staticmethod
+    def get_vrf_vni(vrf: dict) -> int:
+        vrf_vni = default(vrf.get("vrf_vni"), vrf.get("vrf_id"))
+        if vrf_vni is None:
+            raise AristaAvdMissingVariableError(f"'vrf_vni' or 'vrf_id' for VRF '{vrf['name']} must be set.")
+        return int(vrf_vni)
 
     @cached_property
     def vrfs(self: SharedUtils) -> list:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
@@ -3,9 +3,12 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING
 
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
+from ansible_collections.arista.avd.plugins.filter.convert_dicts import convert_dicts
+from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, get_item
 
 if TYPE_CHECKING:
     from .avdstructuredconfig import AvdStructuredConfigMetadata
@@ -114,9 +117,6 @@ class CvPathfinderMixin:
             for region in regions
         ]
 
-    def _metadata_vrfs(self: AvdStructuredConfigMetadata) -> list:
-        return []  # TODO
-
     def _metadata_pathfinder_vtep_ips(self: AvdStructuredConfigMetadata) -> list:
         return [
             {
@@ -124,3 +124,69 @@ class CvPathfinderMixin:
             }
             for wan_route_server in self.shared_utils.filtered_wan_route_servers.values()
         ]
+
+    def _metadata_vrfs(self: AvdStructuredConfigMetadata) -> list:
+        """
+        Extracting metadata for VRFs by parsing the generated structured config
+        and flatten it a bit (like hiding load-balance policies)
+        """
+        if (avt_vrfs := get(self._hostvars, "router_adaptive_virtual_topology.vrfs")) is None:
+            return []
+
+        if (load_balance_policies := get(self._hostvars, "router_path_selection.load_balance_policies")) is None:
+            return []
+
+        return [
+            {
+                "name": vrf["name"],
+                "vni": self._get_vni_for_vrf_name(vrf["name"]),
+                "avts": [
+                    {
+                        "constraints": {
+                            "jitter": lb_policy.get("jitter"),
+                            "latency": lb_policy.get("latency"),
+                            "lossrate": float(lb_policy["lossrate"]) if "lossrate" in lb_policy else None,
+                        },
+                        "description": "",  # TODO: Not sure we have this field anywhere
+                        "id": profile["id"],
+                        "name": profile["name"],
+                        "pathgroups": [
+                            {
+                                "name": pathgroup["name"],
+                                "preference": "alternate" if pathgroup.get("priority", 1) > 1 else "preferred",
+                            }
+                            for pathgroup in lb_policy["path_groups"]
+                        ],
+                    }
+                    for profile in vrf["profiles"]
+                    for lb_policy in [get_item(load_balance_policies, "name", f"LB-{profile['name']}", required=True)]
+                ],
+            }
+            for vrf in avt_vrfs
+        ]
+
+    @cached_property
+    def _all_vrfs_from_all_tenants(self: AvdStructuredConfigMetadata) -> list[dict]:
+        """
+        Unfiltered list of VRFs found under tenants.
+        Used to find VNI for each VRF used in cv_pathfinder.
+
+        We cannot use filtered_tenants since pathfinders do not necessarily have all VRFs defined in the policies.
+
+        Potential issue with this is if some VRFs are defined multiple times with different information.
+        """
+        all_vrfs = [
+            vrf
+            for network_services_key in self.shared_utils.network_services_keys
+            for tenant in convert_dicts(get(self._hostvars, network_services_key["name"]), "name")
+            for vrf in tenant["vrfs"]
+        ]
+        # Add the default WAN VRF at the end. Will only be reached if default VRF was not defined in inputs
+        all_vrfs.append({"name": "default", "vrf_id": 1})
+        return all_vrfs
+
+    def _get_vni_for_vrf_name(self: AvdStructuredConfigMetadata, vrf_name: str):
+        if (vrf := get_item(self._all_vrfs_from_all_tenants, "name", vrf_name)) is None:
+            raise AristaAvdError(f"Unable to find VNI for VRF {vrf_name} during generation of cv_pathfinder metadata.")
+
+        return self.shared_utils.get_vrf_vni(vrf)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_bgp.py
@@ -511,7 +511,7 @@ class RouterBgpMixin(UtilsMixin):
             name=vrf["name"],
             vlans=vrf["svis"],
             rd=self.get_vlan_aware_bundle_rd(id=self.shared_utils.get_vrf_id(vrf), tenant=tenant, is_vrf=True),
-            rt=self.get_vlan_aware_bundle_rt(id=self.shared_utils.get_vrf_id(vrf), vni=self.get_vrf_vni(vrf), tenant=tenant, is_vrf=True),
+            rt=self.get_vlan_aware_bundle_rt(id=self.shared_utils.get_vrf_id(vrf), vni=self.shared_utils.get_vrf_vni(vrf), tenant=tenant, is_vrf=True),
             evpn_l2_multi_domain=default(vrf.get("evpn_l2_multi_domain"), tenant.get("evpn_l2_multi_domain", True)) is True,
             tenant=tenant,
         )
@@ -650,12 +650,6 @@ class RouterBgpMixin(UtilsMixin):
 
         return None
 
-    def get_vrf_vni(self, vrf) -> int:
-        vrf_vni = default(vrf.get("vrf_vni"), vrf.get("vrf_id"))
-        if vrf_vni is None:
-            raise AristaAvdMissingVariableError(f"'vrf_vni' or 'vrf_id' for VRF '{vrf['name']} must be set.")
-        return int(vrf_vni)
-
     def get_vrf_rd(self, vrf) -> str:
         """
         Return a string with the route-destinguisher for one VRF
@@ -682,7 +676,7 @@ class RouterBgpMixin(UtilsMixin):
         if self._vrf_rt_admin_subfield is not None:
             admin_subfield = self._vrf_rt_admin_subfield
         elif self.shared_utils.overlay_rt_type["vrf_admin_subfield"] == "vrf_vni":
-            admin_subfield = self.get_vrf_vni(vrf)
+            admin_subfield = self.shared_utils.get_vrf_vni(vrf)
         else:
             # Both for 'id' and 'vrf_id' options.
             admin_subfield = self.shared_utils.get_vrf_id(vrf)


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
WAN Preview - Generate cv_pathfinder metadata for AVTs

Adding the metadata for vrfs/avts/lb-policies.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing molecule test got updated and verified that the generated data is correct.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
