### PR TITLE
Feat(eos_cli_config_gen): add router IGMP host proxy configuration support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
@@ -47,7 +47,6 @@ interface Management1
 | default | --- | all |
 | BLUE | --- | iif |
 
-
 #### Router IGMP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
@@ -41,11 +41,11 @@ interface Management1
 
 #### Router IGMP Summary
 
-| Settings | Value | VRF |
-| -------- | ----- | --- |
-| SSM Aware | True | N/A |
-| Host Proxy | iif | BLUE |
-| Host Proxy | all | default |
+| VRF | SSM Aware | Host Proxy |
+| --- | --------- | ---------- |
+| --- | Enabled | --- |
+| BLUE | --- | iif |
+| default | --- | all |
 
 #### Router IGMP Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
@@ -41,14 +41,20 @@ interface Management1
 
 #### Router IGMP Summary
 
-| Settings | Value |
-| -------- | ----- |
-| SSM Aware | True |
+| Settings | Value | VRF |
+| -------- | ----- | --- |
+| SSM Aware | True | N/A |
+| Host Proxy | iif | BLUE |
+| Host Proxy | all | default |
 
 #### Router IGMP Device Configuration
 
 ```eos
 !
 router igmp
+   host-proxy match mroute all
    ssm aware
+   !
+   vrf BLUE
+     host-proxy match mroute iif
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
@@ -44,8 +44,9 @@ interface Management1
 | VRF | SSM Aware | Host Proxy |
 | --- | --------- | ---------- |
 | --- | Enabled | --- |
-| BLUE | --- | iif |
 | default | --- | all |
+| BLUE | --- | iif |
+
 
 #### Router IGMP Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
@@ -46,6 +46,7 @@ interface Management1
 | SSM Aware | True | N/A |
 | Host Proxy | iif | BLUE |
 | Host Proxy | all | default |
+
 #### Router IGMP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
@@ -43,9 +43,9 @@ interface Management1
 
 | VRF | SSM Aware | Host Proxy |
 | --- | --------- | ---------- |
-| --- | Enabled | --- |
-| default | --- | all |
-| BLUE | --- | iif |
+| - | Enabled | - |
+| default | - | all |
+| BLUE | - | iif |
 
 #### Router IGMP Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-igmp.md
@@ -46,7 +46,6 @@ interface Management1
 | SSM Aware | True | N/A |
 | Host Proxy | iif | BLUE |
 | Host Proxy | all | default |
-
 #### Router IGMP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-igmp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-igmp.cfg
@@ -13,6 +13,10 @@ interface Management1
    ip address 10.73.255.122/24
 !
 router igmp
+   host-proxy match mroute all
    ssm aware
+   !
+   vrf BLUE
+     host-proxy match mroute iif
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-igmp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-igmp.yml
@@ -1,7 +1,7 @@
 router_igmp:
   ssm_aware: true
   host_proxy:
-    vrf:
+    vrfs:
       - name: default
         match_mroute: all
       - name: BLUE

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-igmp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-igmp.yml
@@ -1,8 +1,6 @@
 router_igmp:
+  host_proxy_match_mroute: all
   ssm_aware: true
-  host_proxy:
-    vrfs:
-      - name: default
-        match_mroute: all
-      - name: BLUE
-        match_mroute: iif
+  vrfs:
+    - name: BLUE
+      host_proxy_match_mroute: iif

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-igmp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-igmp.yml
@@ -1,2 +1,8 @@
 router_igmp:
   ssm_aware: true
+  host_proxy:
+    vrf:
+      - name: default
+        match_mroute: all
+      - name: BLUE
+        match_mroute: iif

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
@@ -9,10 +9,26 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>router_igmp</samp>](## "router_igmp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;ssm_aware</samp>](## "router_igmp.ssm_aware") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;host_proxy</samp>](## "router_igmp.host_proxy") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "router_igmp.host_proxy.vrf") | List, items: Dictionary |  |  |  | Configure IGMP in a VRF |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_igmp.host_proxy.vrf.[].name") | String | Required, Unique |  |  | VRF name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;match_mroute</samp>](## "router_igmp.host_proxy.vrf.[].match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
 
 === "YAML"
 
     ```yaml
     router_igmp:
       ssm_aware: <bool>
+      host_proxy:
+
+        # Configure IGMP in a VRF
+        vrf:
+
+            # VRF name
+          - name: <str; required; unique>
+
+            # Specify conditions for sending IGMP joins for host-proxy
+            # 'iif' will enable igmp host-proxy to work in iif aware
+            # 'all' will enable igmp host-proxy to work in iif unaware mode
+            match_mroute: <str; "all" | "iif">
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
@@ -10,7 +10,7 @@
     | [<samp>router_igmp</samp>](## "router_igmp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;host_proxy_match_mroute</samp>](## "router_igmp.host_proxy_match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
     | [<samp>&nbsp;&nbsp;ssm_aware</samp>](## "router_igmp.ssm_aware") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_igmp.vrfs") | List, items: Dictionary |  |  |  | Configure IGMP in a VRF |
+    | [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_igmp.vrfs") | List, items: Dictionary |  |  |  | Configure IGMP in a VRF<br>default vrf is not supported in EOS, please see keys directly under 'router_igmp'<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_igmp.vrfs.[].name") | String | Required, Unique |  |  | VRF name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_proxy_match_mroute</samp>](## "router_igmp.vrfs.[].host_proxy_match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
 
@@ -26,6 +26,7 @@
       ssm_aware: <bool>
 
       # Configure IGMP in a VRF
+      # default vrf is not supported in EOS, please see keys directly under 'router_igmp'
       vrfs:
 
           # VRF name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
@@ -8,11 +8,11 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>router_igmp</samp>](## "router_igmp") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;host_proxy_match_mroute</samp>](## "router_igmp.host_proxy_match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
+    | [<samp>&nbsp;&nbsp;host_proxy_match_mroute</samp>](## "router_igmp.host_proxy_match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode (EOS default)<br> |
     | [<samp>&nbsp;&nbsp;ssm_aware</samp>](## "router_igmp.ssm_aware") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_igmp.vrfs") | List, items: Dictionary |  |  |  | Configure IGMP in a VRF<br>default vrf is not supported in EOS, please see keys directly under 'router_igmp'<br> |
+    | [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_igmp.vrfs") | List, items: Dictionary |  |  |  | Configure IGMP in a VRF.<br>VRF 'default' is not supported in EOS, please see keys directly under 'router_igmp'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_igmp.vrfs.[].name") | String | Required, Unique |  |  | VRF name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_proxy_match_mroute</samp>](## "router_igmp.vrfs.[].host_proxy_match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_proxy_match_mroute</samp>](## "router_igmp.vrfs.[].host_proxy_match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode (EOS default)<br> |
 
 === "YAML"
 
@@ -21,12 +21,12 @@
 
       # Specify conditions for sending IGMP joins for host-proxy
       # 'iif' will enable igmp host-proxy to work in iif aware
-      # 'all' will enable igmp host-proxy to work in iif unaware mode
+      # 'all' will enable igmp host-proxy to work in iif unaware mode (EOS default)
       host_proxy_match_mroute: <str; "all" | "iif">
       ssm_aware: <bool>
 
-      # Configure IGMP in a VRF
-      # default vrf is not supported in EOS, please see keys directly under 'router_igmp'
+      # Configure IGMP in a VRF.
+      # VRF 'default' is not supported in EOS, please see keys directly under 'router_igmp'.
       vrfs:
 
           # VRF name
@@ -34,6 +34,6 @@
 
           # Specify conditions for sending IGMP joins for host-proxy
           # 'iif' will enable igmp host-proxy to work in iif aware
-          # 'all' will enable igmp host-proxy to work in iif unaware mode
+          # 'all' will enable igmp host-proxy to work in iif unaware mode (EOS default)
           host_proxy_match_mroute: <str; "all" | "iif">
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
@@ -10,9 +10,9 @@
     | [<samp>router_igmp</samp>](## "router_igmp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;ssm_aware</samp>](## "router_igmp.ssm_aware") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;host_proxy</samp>](## "router_igmp.host_proxy") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "router_igmp.host_proxy.vrf") | List, items: Dictionary |  |  |  | Configure IGMP in a VRF |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_igmp.host_proxy.vrf.[].name") | String | Required, Unique |  |  | VRF name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;match_mroute</samp>](## "router_igmp.host_proxy.vrf.[].match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "router_igmp.host_proxy.vrfs") | List, items: Dictionary |  |  |  | Configure IGMP in a VRF |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_igmp.host_proxy.vrfs.[].name") | String | Required, Unique |  |  | VRF name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;match_mroute</samp>](## "router_igmp.host_proxy.vrfs.[].match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
 
 === "YAML"
 
@@ -22,7 +22,7 @@
       host_proxy:
 
         # Configure IGMP in a VRF
-        vrf:
+        vrfs:
 
             # VRF name
           - name: <str; required; unique>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-igmp.md
@@ -8,27 +8,31 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>router_igmp</samp>](## "router_igmp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;host_proxy_match_mroute</samp>](## "router_igmp.host_proxy_match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
     | [<samp>&nbsp;&nbsp;ssm_aware</samp>](## "router_igmp.ssm_aware") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;host_proxy</samp>](## "router_igmp.host_proxy") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "router_igmp.host_proxy.vrfs") | List, items: Dictionary |  |  |  | Configure IGMP in a VRF |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_igmp.host_proxy.vrfs.[].name") | String | Required, Unique |  |  | VRF name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;match_mroute</samp>](## "router_igmp.host_proxy.vrfs.[].match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
+    | [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_igmp.vrfs") | List, items: Dictionary |  |  |  | Configure IGMP in a VRF |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_igmp.vrfs.[].name") | String | Required, Unique |  |  | VRF name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;host_proxy_match_mroute</samp>](## "router_igmp.vrfs.[].host_proxy_match_mroute") | String |  |  | Valid Values:<br>- <code>all</code><br>- <code>iif</code> | Specify conditions for sending IGMP joins for host-proxy<br>'iif' will enable igmp host-proxy to work in iif aware<br>'all' will enable igmp host-proxy to work in iif unaware mode<br> |
 
 === "YAML"
 
     ```yaml
     router_igmp:
+
+      # Specify conditions for sending IGMP joins for host-proxy
+      # 'iif' will enable igmp host-proxy to work in iif aware
+      # 'all' will enable igmp host-proxy to work in iif unaware mode
+      host_proxy_match_mroute: <str; "all" | "iif">
       ssm_aware: <bool>
-      host_proxy:
 
-        # Configure IGMP in a VRF
-        vrfs:
+      # Configure IGMP in a VRF
+      vrfs:
 
-            # VRF name
-          - name: <str; required; unique>
+          # VRF name
+        - name: <str; required; unique>
 
-            # Specify conditions for sending IGMP joins for host-proxy
-            # 'iif' will enable igmp host-proxy to work in iif aware
-            # 'all' will enable igmp host-proxy to work in iif unaware mode
-            match_mroute: <str; "all" | "iif">
+          # Specify conditions for sending IGMP joins for host-proxy
+          # 'iif' will enable igmp host-proxy to work in iif aware
+          # 'all' will enable igmp host-proxy to work in iif unaware mode
+          host_proxy_match_mroute: <str; "all" | "iif">
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20345,50 +20345,49 @@
       "type": "object",
       "title": "Router IGMP Configuration",
       "properties": {
+        "host_proxy_match_mroute": {
+          "type": "string",
+          "description": "Specify conditions for sending IGMP joins for host-proxy\n'iif' will enable igmp host-proxy to work in iif aware\n'all' will enable igmp host-proxy to work in iif unaware mode\n",
+          "enum": [
+            "all",
+            "iif"
+          ],
+          "title": "Host Proxy Match Mroute"
+        },
         "ssm_aware": {
           "type": "boolean",
           "title": "Ssm Aware"
         },
-        "host_proxy": {
-          "type": "object",
-          "properties": {
-            "vrfs": {
-              "type": "array",
-              "description": "Configure IGMP in a VRF",
-              "items": {
-                "type": "object",
-                "properties": {
-                  "name": {
-                    "type": "string",
-                    "description": "VRF name",
-                    "title": "Name"
-                  },
-                  "match_mroute": {
-                    "type": "string",
-                    "description": "Specify conditions for sending IGMP joins for host-proxy\n'iif' will enable igmp host-proxy to work in iif aware\n'all' will enable igmp host-proxy to work in iif unaware mode\n",
-                    "enum": [
-                      "all",
-                      "iif"
-                    ],
-                    "title": "Match Mroute"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "required": [
-                  "name"
-                ]
+        "vrfs": {
+          "type": "array",
+          "description": "Configure IGMP in a VRF",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string",
+                "description": "VRF name",
+                "title": "Name"
               },
-              "title": "VRFs"
-            }
+              "host_proxy_match_mroute": {
+                "type": "string",
+                "description": "Specify conditions for sending IGMP joins for host-proxy\n'iif' will enable igmp host-proxy to work in iif aware\n'all' will enable igmp host-proxy to work in iif unaware mode\n",
+                "enum": [
+                  "all",
+                  "iif"
+                ],
+                "title": "Host Proxy Match Mroute"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "required": [
+              "name"
+            ]
           },
-          "additionalProperties": false,
-          "patternProperties": {
-            "^_.+$": {}
-          },
-          "title": "Host Proxy"
+          "title": "VRFs"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20347,7 +20347,7 @@
       "properties": {
         "host_proxy_match_mroute": {
           "type": "string",
-          "description": "Specify conditions for sending IGMP joins for host-proxy\n'iif' will enable igmp host-proxy to work in iif aware\n'all' will enable igmp host-proxy to work in iif unaware mode\n",
+          "description": "Specify conditions for sending IGMP joins for host-proxy\n'iif' will enable igmp host-proxy to work in iif aware\n'all' will enable igmp host-proxy to work in iif unaware mode (EOS default)\n",
           "enum": [
             "all",
             "iif"
@@ -20360,7 +20360,7 @@
         },
         "vrfs": {
           "type": "array",
-          "description": "Configure IGMP in a VRF\ndefault vrf is not supported in EOS, please see keys directly under 'router_igmp'\n",
+          "description": "Configure IGMP in a VRF.\nVRF 'default' is not supported in EOS, please see keys directly under 'router_igmp'.",
           "items": {
             "type": "object",
             "properties": {
@@ -20371,7 +20371,7 @@
               },
               "host_proxy_match_mroute": {
                 "type": "string",
-                "description": "Specify conditions for sending IGMP joins for host-proxy\n'iif' will enable igmp host-proxy to work in iif aware\n'all' will enable igmp host-proxy to work in iif unaware mode\n",
+                "description": "Specify conditions for sending IGMP joins for host-proxy\n'iif' will enable igmp host-proxy to work in iif aware\n'all' will enable igmp host-proxy to work in iif unaware mode (EOS default)\n",
                 "enum": [
                   "all",
                   "iif"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20360,7 +20360,7 @@
         },
         "vrfs": {
           "type": "array",
-          "description": "Configure IGMP in a VRF",
+          "description": "Configure IGMP in a VRF\ndefault vrf is not supported in EOS, please see keys directly under 'router_igmp'\n",
           "items": {
             "type": "object",
             "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20348,6 +20348,47 @@
         "ssm_aware": {
           "type": "boolean",
           "title": "Ssm Aware"
+        },
+        "host_proxy": {
+          "type": "object",
+          "properties": {
+            "vrfs": {
+              "type": "array",
+              "description": "Configure IGMP in a VRF",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "VRF name",
+                    "title": "Name"
+                  },
+                  "match_mroute": {
+                    "type": "string",
+                    "description": "Specify conditions for sending IGMP joins for host-proxy\n'iif' will enable igmp host-proxy to work in iif aware\n'all' will enable igmp host-proxy to work in iif unaware mode\n",
+                    "enum": [
+                      "all",
+                      "iif"
+                    ],
+                    "title": "Match Mroute"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "title": "VRFs"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Host Proxy"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11865,7 +11865,11 @@ keys:
         type: bool
       vrfs:
         type: list
-        description: Configure IGMP in a VRF
+        description: 'Configure IGMP in a VRF
+
+          default vrf is not supported in EOS, please see keys directly under ''router_igmp''
+
+          '
         primary_key: name
         convert_types:
         - dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11855,7 +11855,7 @@ keys:
 
           ''iif'' will enable igmp host-proxy to work in iif aware
 
-          ''all'' will enable igmp host-proxy to work in iif unaware mode
+          ''all'' will enable igmp host-proxy to work in iif unaware mode (EOS default)
 
           '
         valid_values:
@@ -11865,11 +11865,10 @@ keys:
         type: bool
       vrfs:
         type: list
-        description: 'Configure IGMP in a VRF
+        description: 'Configure IGMP in a VRF.
 
-          default vrf is not supported in EOS, please see keys directly under ''router_igmp''
-
-          '
+          VRF ''default'' is not supported in EOS, please see keys directly under
+          ''router_igmp''.'
         primary_key: name
         convert_types:
         - dict
@@ -11885,7 +11884,8 @@ keys:
 
                 ''iif'' will enable igmp host-proxy to work in iif aware
 
-                ''all'' will enable igmp host-proxy to work in iif unaware mode
+                ''all'' will enable igmp host-proxy to work in iif unaware mode (EOS
+                default)
 
                 '
               valid_values:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11849,26 +11849,35 @@ keys:
     type: dict
     display_name: Router IGMP Configuration
     keys:
+      host_proxy_match_mroute:
+        type: str
+        description: 'Specify conditions for sending IGMP joins for host-proxy
+
+          ''iif'' will enable igmp host-proxy to work in iif aware
+
+          ''all'' will enable igmp host-proxy to work in iif unaware mode
+
+          '
+        valid_values:
+        - all
+        - iif
       ssm_aware:
         type: bool
-      host_proxy:
-        type: dict
-        keys:
-          vrfs:
-            type: list
-            description: Configure IGMP in a VRF
-            primary_key: name
-            convert_types:
-            - dict
-            items:
-              type: dict
-              keys:
-                name:
-                  type: str
-                  description: VRF name
-                match_mroute:
-                  type: str
-                  description: 'Specify conditions for sending IGMP joins for host-proxy
+      vrfs:
+        type: list
+        description: Configure IGMP in a VRF
+        primary_key: name
+        convert_types:
+        - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: VRF name
+            host_proxy_match_mroute:
+              type: str
+              description: 'Specify conditions for sending IGMP joins for host-proxy
 
                     ''iif'' will enable igmp host-proxy to work in iif aware
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11851,6 +11851,33 @@ keys:
     keys:
       ssm_aware:
         type: bool
+      host_proxy:
+        type: dict
+        keys:
+          vrfs:
+            type: list
+            description: Configure IGMP in a VRF
+            primary_key: name
+            convert_types:
+            - dict
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: VRF name
+                match_mroute:
+                  type: str
+                  description: 'Specify conditions for sending IGMP joins for host-proxy
+
+                    ''iif'' will enable igmp host-proxy to work in iif aware
+
+                    ''all'' will enable igmp host-proxy to work in iif unaware mode
+
+                    '
+                  valid_values:
+                  - all
+                  - iif
   router_isis:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11879,14 +11879,14 @@ keys:
               type: str
               description: 'Specify conditions for sending IGMP joins for host-proxy
 
-                    ''iif'' will enable igmp host-proxy to work in iif aware
+                ''iif'' will enable igmp host-proxy to work in iif aware
 
-                    ''all'' will enable igmp host-proxy to work in iif unaware mode
+                ''all'' will enable igmp host-proxy to work in iif unaware mode
 
-                    '
-                  valid_values:
-                  - all
-                  - iif
+                '
+              valid_values:
+              - all
+              - iif
   router_isis:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
@@ -10,29 +10,35 @@ keys:
     type: dict
     display_name: Router IGMP Configuration
     keys:
+      host_proxy_match_mroute:
+        type: str
+        description: |
+          Specify conditions for sending IGMP joins for host-proxy
+          'iif' will enable igmp host-proxy to work in iif aware
+          'all' will enable igmp host-proxy to work in iif unaware mode
+        valid_values:
+          - all
+          - iif
       ssm_aware:
         type: bool
-      host_proxy:
-        type: dict
-        keys:
-          vrfs:
-            type: list
-            description: Configure IGMP in a VRF
-            primary_key: name
-            convert_types:
-              - dict
-            items:
-              type: dict
-              keys:
-                name:
-                  type: str
-                  description: VRF name
-                match_mroute:
-                  type: str
-                  description: |
-                    Specify conditions for sending IGMP joins for host-proxy
-                    'iif' will enable igmp host-proxy to work in iif aware
-                    'all' will enable igmp host-proxy to work in iif unaware mode
-                  valid_values:
-                    - all
-                    - iif
+      vrfs:
+        type: list
+        description: Configure IGMP in a VRF
+        primary_key: name
+        convert_types:
+          - dict
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: VRF name
+            host_proxy_match_mroute:
+              type: str
+              description: |
+                Specify conditions for sending IGMP joins for host-proxy
+                'iif' will enable igmp host-proxy to work in iif aware
+                'all' will enable igmp host-proxy to work in iif unaware mode
+              valid_values:
+                - all
+                - iif

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
@@ -23,9 +23,9 @@ keys:
         type: bool
       vrfs:
         type: list
-        description: |
-          Configure IGMP in a VRF
-          default vrf is not supported in EOS, please see keys directly under 'router_igmp'
+        description: |-
+          Configure IGMP in a VRF.
+          VRF 'default' is not supported in EOS, please see keys directly under 'router_igmp'.
         primary_key: name
         convert_types:
           - dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
@@ -15,7 +15,7 @@ keys:
         description: |
           Specify conditions for sending IGMP joins for host-proxy
           'iif' will enable igmp host-proxy to work in iif aware
-          'all' will enable igmp host-proxy to work in iif unaware mode
+          'all' will enable igmp host-proxy to work in iif unaware mode (EOS default)
         valid_values:
           - all
           - iif

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
@@ -23,7 +23,9 @@ keys:
         type: bool
       vrfs:
         type: list
-        description: Configure IGMP in a VRF
+        description: |
+          Configure IGMP in a VRF
+          default vrf is not supported in EOS, please see keys directly under 'router_igmp'
         primary_key: name
         convert_types:
           - dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
@@ -12,3 +12,27 @@ keys:
     keys:
       ssm_aware:
         type: bool
+      host_proxy:
+        type: dict
+        keys:
+          vrf:
+            type: list
+            description: Configure IGMP in a VRF
+            primary_key: name
+            convert_types:
+              - dict
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: VRF name
+                match_mroute:
+                  type: str
+                  description: |
+                    Specify conditions for sending IGMP joins for host-proxy
+                    'iif' will enable igmp host-proxy to work in iif aware
+                    'all' will enable igmp host-proxy to work in iif unaware mode
+                  valid_values:
+                    - all
+                    - iif

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
@@ -40,7 +40,7 @@ keys:
               description: |
                 Specify conditions for sending IGMP joins for host-proxy
                 'iif' will enable igmp host-proxy to work in iif aware
-                'all' will enable igmp host-proxy to work in iif unaware mode
+                'all' will enable igmp host-proxy to work in iif unaware mode (EOS default)
               valid_values:
                 - all
                 - iif

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_igmp.schema.yml
@@ -15,7 +15,7 @@ keys:
       host_proxy:
         type: dict
         keys:
-          vrf:
+          vrfs:
             type: list
             description: Configure IGMP in a VRF
             primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -10,12 +10,16 @@
 
 #### Router IGMP Summary
 
-| Settings | Value |
-| -------- | ----- |
+| Settings | Value | VRF |
+| -------- | ----- | --- |
 {%     if router_igmp.ssm_aware is arista.avd.defined %}
-| SSM Aware | {{ router_igmp.ssm_aware }} |
+| SSM Aware | {{ router_igmp.ssm_aware }} | N/A |
 {%     endif %}
-
+{%     if router_igmp.host_proxy is arista.avd.defined %}
+{%         for vrf in router_igmp.host_proxy.vrf | arista.avd.natural_sort('name') %}
+| Host Proxy | {{ vrf.match_mroute }} | {{ vrf.name }} |
+{%         endfor %}
+{%     endif %}
 #### Router IGMP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -16,7 +16,7 @@
 | --- | Enabled | --- |
 {%     endif %}
 {%     if router_igmp.host_proxy_match_mroute is arista.avd.defined %}
-| default | --- | {{ router_igmp.host_proxy_match_mroute }} |
+| default | - | {{ router_igmp.host_proxy_match_mroute }} |
 {%     endif %}
 {%     if router_igmp.vrfs is arista.avd.defined %}
 {%         for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -13,7 +13,7 @@
 | VRF | SSM Aware | Host Proxy |
 | --- | --------- | ---------- |
 {%     if router_igmp.ssm_aware is arista.avd.defined %}
-| --- | Enabled | --- |
+| - | Enabled | - |
 {%     endif %}
 {%     if router_igmp.host_proxy_match_mroute is arista.avd.defined %}
 | default | - | {{ router_igmp.host_proxy_match_mroute }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -26,7 +26,6 @@
 {%         endfor %}
 {%     endif %}
 
-
 #### Router IGMP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -15,16 +15,10 @@
 {%     if router_igmp.ssm_aware is arista.avd.defined %}
 | - | Enabled | - |
 {%     endif %}
-{%     if router_igmp.host_proxy_match_mroute is arista.avd.defined %}
 | default | - | {{ router_igmp.host_proxy_match_mroute }} |
-{%     endif %}
-{%     if router_igmp.vrfs is arista.avd.defined %}
-{%         for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}
-{%             if vrf.host_proxy_match_mroute is arista.avd.defined %}
+{%     for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}
 | {{ vrf.name }} | - | {{ vrf.host_proxy_match_mroute }} |
-{%             endif %}
-{%         endfor %}
-{%     endif %}
+{%     endfor %}
 
 #### Router IGMP Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -20,6 +20,7 @@
 | Host Proxy | {{ vrf.match_mroute }} | {{ vrf.name }} |
 {%         endfor %}
 {%     endif %}
+
 #### Router IGMP Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -15,9 +15,13 @@
 {%     if router_igmp.ssm_aware is arista.avd.defined %}
 | - | Enabled | - |
 {%     endif %}
+{%     if router_igmp.host_proxy_match_mroute is arista.avd.defined %}
 | default | - | {{ router_igmp.host_proxy_match_mroute }} |
+{%     endif %}
 {%     for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}
+{%         if vrf.host_proxy_match_mroute is arista.avd.defined %}
 | {{ vrf.name }} | - | {{ vrf.host_proxy_match_mroute }} |
+{%         endif %}
 {%     endfor %}
 
 #### Router IGMP Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -16,7 +16,7 @@
 | SSM Aware | {{ router_igmp.ssm_aware }} | N/A |
 {%     endif %}
 {%     if router_igmp.host_proxy is arista.avd.defined %}
-{%         for vrf in router_igmp.host_proxy.vrf | arista.avd.natural_sort('name') %}
+{%         for vrf in router_igmp.host_proxy.vrfs | arista.avd.natural_sort('name') %}
 | Host Proxy | {{ vrf.match_mroute }} | {{ vrf.name }} |
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -21,7 +21,7 @@
 {%     if router_igmp.vrfs is arista.avd.defined %}
 {%         for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}
 {%             if vrf.host_proxy_match_mroute is arista.avd.defined %}
-| {{ vrf.name }} | --- | {{ vrf.host_proxy_match_mroute }} |
+| {{ vrf.name }} | - | {{ vrf.host_proxy_match_mroute }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -10,14 +10,14 @@
 
 #### Router IGMP Summary
 
-| Settings | Value | VRF |
-| -------- | ----- | --- |
+| VRF | SSM Aware | Host Proxy |
+| --- | --------- | ---------- |
 {%     if router_igmp.ssm_aware is arista.avd.defined %}
-| SSM Aware | {{ router_igmp.ssm_aware }} | N/A |
+| --- | Enabled | --- |
 {%     endif %}
 {%     if router_igmp.host_proxy is arista.avd.defined %}
 {%         for vrf in router_igmp.host_proxy.vrfs | arista.avd.natural_sort('name') %}
-| Host Proxy | {{ vrf.match_mroute }} | {{ vrf.name }} |
+| {{ vrf.name }} | --- | {{ vrf.match_mroute }} |
 {%         endfor %}
 {%     endif %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/router-igmp.j2
@@ -15,11 +15,17 @@
 {%     if router_igmp.ssm_aware is arista.avd.defined %}
 | --- | Enabled | --- |
 {%     endif %}
-{%     if router_igmp.host_proxy is arista.avd.defined %}
-{%         for vrf in router_igmp.host_proxy.vrfs | arista.avd.natural_sort('name') %}
-| {{ vrf.name }} | --- | {{ vrf.match_mroute }} |
+{%     if router_igmp.host_proxy_match_mroute is arista.avd.defined %}
+| default | --- | {{ router_igmp.host_proxy_match_mroute }} |
+{%     endif %}
+{%     if router_igmp.vrfs is arista.avd.defined %}
+{%         for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}
+{%             if vrf.host_proxy_match_mroute is arista.avd.defined %}
+| {{ vrf.name }} | --- | {{ vrf.host_proxy_match_mroute }} |
+{%             endif %}
 {%         endfor %}
 {%     endif %}
+
 
 #### Router IGMP Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
@@ -7,7 +7,23 @@
 {% if router_igmp is arista.avd.defined %}
 !
 router igmp
+{%     if router_igmp.host_proxy is arista.avd.defined %}
+{%         for vrf in router_igmp.host_proxy.vrf %}
+{%             if vrf.name == 'default' %}
+   host-proxy match mroute {{ vrf.match_mroute }}
+{%             endif %}
+{%         endfor %}
+{%     endif %}
 {%     if router_igmp.ssm_aware is arista.avd.defined(true) %}
    ssm aware
+{%     endif %}
+{%     if router_igmp.host_proxy is arista.avd.defined %}
+{%         for vrf in router_igmp.host_proxy.vrf | arista.avd.natural_sort('name') %}
+{%             if vrf.name != 'default' %}
+   !
+   vrf {{ vrf.name }}
+     host-proxy match mroute {{ vrf.match_mroute }}
+{%             endif %}
+{%         endfor %}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
@@ -15,10 +15,12 @@ router igmp
 {%     endif %}
 {%     if router_igmp.vrfs is arista.avd.defined %}
 {%         for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}
+{%             if vrf.name != 'default' %}
    !
    vrf {{ vrf.name }}
-{%             if vrf.name != 'default' and vrf.host_proxy_match_mroute is arista.avd.defined %}
+{%                 if vrf.host_proxy_match_mroute is arista.avd.defined %}
      host-proxy match mroute {{ vrf.host_proxy_match_mroute }}
+{%                 endif %}
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
@@ -8,7 +8,7 @@
 !
 router igmp
 {%     if router_igmp.host_proxy is arista.avd.defined %}
-{%         for vrf in router_igmp.host_proxy.vrf %}
+{%         for vrf in router_igmp.host_proxy.vrfs %}
 {%             if vrf.name == 'default' %}
    host-proxy match mroute {{ vrf.match_mroute }}
 {%             endif %}
@@ -18,7 +18,7 @@ router igmp
    ssm aware
 {%     endif %}
 {%     if router_igmp.host_proxy is arista.avd.defined %}
-{%         for vrf in router_igmp.host_proxy.vrf | arista.avd.natural_sort('name') %}
+{%         for vrf in router_igmp.host_proxy.vrfs | arista.avd.natural_sort('name') %}
 {%             if vrf.name != 'default' %}
    !
    vrf {{ vrf.name }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
@@ -17,7 +17,7 @@ router igmp
 {%         for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}
    !
    vrf {{ vrf.name }}
-{%             if vrf.host_proxy_match_mroute is arista.avd.defined %}
+{%             if vrf.name != 'default' and vrf.host_proxy_match_mroute is arista.avd.defined %}
      host-proxy match mroute {{ vrf.host_proxy_match_mroute }}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
@@ -15,9 +15,9 @@ router igmp
 {%     endif %}
 {%     if router_igmp.vrfs is arista.avd.defined %}
 {%         for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}
-{%             if vrf.name != 'default' and vrf.host_proxy_match_mroute is arista.avd.defined %}
    !
    vrf {{ vrf.name }}
+{%             if vrf.host_proxy_match_mroute is arista.avd.defined %}
      host-proxy match mroute {{ vrf.host_proxy_match_mroute }}
 {%             endif %}
 {%         endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-igmp.j2
@@ -7,22 +7,18 @@
 {% if router_igmp is arista.avd.defined %}
 !
 router igmp
-{%     if router_igmp.host_proxy is arista.avd.defined %}
-{%         for vrf in router_igmp.host_proxy.vrfs %}
-{%             if vrf.name == 'default' %}
-   host-proxy match mroute {{ vrf.match_mroute }}
-{%             endif %}
-{%         endfor %}
+{%     if router_igmp.host_proxy_match_mroute is arista.avd.defined %}
+   host-proxy match mroute {{ router_igmp.host_proxy_match_mroute }}
 {%     endif %}
 {%     if router_igmp.ssm_aware is arista.avd.defined(true) %}
    ssm aware
 {%     endif %}
-{%     if router_igmp.host_proxy is arista.avd.defined %}
-{%         for vrf in router_igmp.host_proxy.vrfs | arista.avd.natural_sort('name') %}
-{%             if vrf.name != 'default' %}
+{%     if router_igmp.vrfs is arista.avd.defined %}
+{%         for vrf in router_igmp.vrfs | arista.avd.natural_sort('name') %}
+{%             if vrf.name != 'default' and vrf.host_proxy_match_mroute is arista.avd.defined %}
    !
    vrf {{ vrf.name }}
-     host-proxy match mroute {{ vrf.match_mroute }}
+     host-proxy match mroute {{ vrf.host_proxy_match_mroute }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

Add host proxy support under router IGMP


## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
proposed data model
```
router_igmp:
  host_proxy_match_mroute:
  vrf:
     - name: PROD
       host_proxy_match_mroute: all
    - name: BLUE
       host_proxy_match_mroute: iif
```

## How to test
see the molecule test included

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
