### PR TITLE
Fix: Fixing eos_designs_unit_tests molecule scenario for node_type.l3interfaces.ip_address

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/autovpn-edge-no-default-policy.yml
@@ -46,7 +46,7 @@ wan_edge:
         - name: Ethernet1
           wan_carrier: Comcast
           wan_circuit_id: 666
-          ip: dhcp
+          ip_address: dhcp
           set_default_route: true
 
 wan_path_groups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-no-default-policy.yml
@@ -59,15 +59,15 @@ wan_edge:
           wan_carrier: ATT
           wan_circuit_id: 666
           set_default_route: true
-          ip: dhcp
+          ip_address: dhcp
         - name: Ethernet2
           wan_carrier: Colt
           wan_circuit_id: 10555
-          ip: 172.15.5.5/31
+          ip_address: 172.15.5.5/31
         - name: Ethernet3
           wan_carrier: Comcast-5G
           wan_circuit_id: AF830
-          ip: 172.20.20.20/31
+          ip_address: 172.20.20.20/31
           connected_to_pathfinder: False
 
 wan_path_groups:


### PR DESCRIPTION
## Change Summary

Fixing molecule tests for node_type.l3interfaces.ip_address

## Component(s) name

`arista.avd.eos_designs`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
