### PR TITLE
Fix(eos_designs): Ensure VLAN VNIs are not rendered without network_services.l2

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/duplicate-vni-l2vlans-vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/duplicate-vni-l2vlans-vxlan-interface.yml
@@ -32,4 +32,4 @@ tenants:
       - id: 1   # calculated vni would be 10001 (duplicate)
         name: vlan
 
-expected_error_message: "Found duplicate objects with conflicting data while generating configuration for VXLAN VNIs for VLANs. {'id': 1, 'name': None, 'vni': 10001} conflicts with {'id': 111, 'name': None, 'vni': 10001}."
+expected_error_message: "Found duplicate objects with conflicting data while generating configuration for VXLAN VNIs for L2VLANs. {'id': 1, 'name': None, 'vni': 10001} conflicts with {'id': 111, 'name': None, 'vni': 10001}."

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
@@ -91,6 +91,7 @@ wan_carriers:
   - name: ATT
     path_group: INET
 
+# SVI and L2VLAN is inserted to ensure these are *not* rendered.
 tenants:
   - name: TenantA
     vrfs:
@@ -98,8 +99,15 @@ tenants:
         vrf_id: 1
       - name: PROD
         vrf_id: 42
+        svis:
+          - id: 100
+            name: VLAN100
+            ip_address_virtual: 10.0.100.1/24
       - name: IT
         vrf_id: 100
+    l2vlans:
+      - id: 101
+        name: VLAN101
 
 wan_virtual_topologies:
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -196,8 +196,15 @@ tenants:
         vrf_id: 1
       - name: PROD
         vrf_id: 42
+        svis:
+          - id: 100
+            name: VLAN100
+            ip_address_virtual: 10.0.100.1/24
       - name: IT
         vrf_id: 100
+    l2vlans:
+      - id: 101
+        name: VLAN101
   - name: TenantB
     vrfs:
       - name: default

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
@@ -90,6 +90,9 @@ class FilteredTenantsMixin:
         Return sorted and filtered l2vlan list from given tenant.
         Filtering based on l2vlan tags.
         """
+        if not self.network_services_l2:
+            return []
+
         if "l2vlans" not in tenant:
             return []
 
@@ -330,6 +333,9 @@ class FilteredTenantsMixin:
         Filtering based on accepted vlans since eos_designs_facts already
         filtered that on tags and trunk_groups.
         """
+        if not self.network_services_l2:
+            return []
+
         svis: list[dict] = natural_sort(convert_dicts(vrf.get("svis", []), "id"), "id")
         svis = [svi for svi in svis if self.is_accepted_vlan(svi)]
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
@@ -64,25 +64,26 @@ class VxlanInterfaceMixin(UtilsMixin):
             for vrf in tenant["vrfs"]:
                 self._get_vxlan_interface_config_for_vrf(vrf, tenant, vrfs, vlans, vnis)
 
-            for l2vlan in tenant["l2vlans"]:
-                if vlan := self._get_vxlan_interface_config_for_vlan(l2vlan, tenant):
-                    # Duplicate check is not done on the actual list of vlans, but instead on our local "vnis" list.
-                    # This is necessary to find duplicate VNIs across multiple object types.
-                    append_if_not_duplicate(
-                        list_of_dicts=vnis,
-                        primary_key="vni",
-                        new_dict=vlan,
-                        context="VXLAN VNIs for VLANs",
-                        context_keys=["id", "name", "vni"],
-                    )
-                    # Here we append to the actual list of VRFs, so duplication check is on the VLAN ID here.
-                    append_if_not_duplicate(
-                        list_of_dicts=vlans,
-                        primary_key="id",
-                        new_dict=vlan,
-                        context="VXLAN VNIs for L2VLANs",
-                        context_keys=["id", "vni"],
-                    )
+            if self.shared_utils.network_services_l2:
+                for l2vlan in tenant["l2vlans"]:
+                    if vlan := self._get_vxlan_interface_config_for_vlan(l2vlan, tenant):
+                        # Duplicate check is not done on the actual list of vlans, but instead on our local "vnis" list.
+                        # This is necessary to find duplicate VNIs across multiple object types.
+                        append_if_not_duplicate(
+                            list_of_dicts=vnis,
+                            primary_key="vni",
+                            new_dict=vlan,
+                            context="VXLAN VNIs for L2VLANs",
+                            context_keys=["id", "name", "vni"],
+                        )
+                        # Here we append to the actual list of VRFs, so duplication check is on the VLAN ID here.
+                        append_if_not_duplicate(
+                            list_of_dicts=vlans,
+                            primary_key="id",
+                            new_dict=vlan,
+                            context="VXLAN VNIs for L2VLANs",
+                            context_keys=["id", "vni"],
+                        )
 
         if vlans:
             vxlan["vlans"] = vlans
@@ -101,25 +102,26 @@ class VxlanInterfaceMixin(UtilsMixin):
         """
         In place updates of the vlans, vnis and vrfs list
         """
-        for svi in vrf["svis"]:
-            if vlan := self._get_vxlan_interface_config_for_vlan(svi, tenant):
-                # Duplicate check is not done on the actual list of vlans, but instead on our local "vnis" list.
-                # This is necessary to find duplicate VNIs across multiple object types.
-                append_if_not_duplicate(
-                    list_of_dicts=vnis,
-                    primary_key="vni",
-                    new_dict=vlan,
-                    context="VXLAN VNIs for SVIs",
-                    context_keys=["id", "name", "vni"],
-                )
-                # Here we append to the actual list of VRFs, so duplication check is on the VLAN ID here.
-                append_if_not_duplicate(
-                    list_of_dicts=vlans,
-                    primary_key="id",
-                    new_dict=vlan,
-                    context="VXLAN VNIs for SVIs",
-                    context_keys=["id", "vni"],
-                )
+        if self.shared_utils.network_services_l2:
+            for svi in vrf["svis"]:
+                if vlan := self._get_vxlan_interface_config_for_vlan(svi, tenant):
+                    # Duplicate check is not done on the actual list of vlans, but instead on our local "vnis" list.
+                    # This is necessary to find duplicate VNIs across multiple object types.
+                    append_if_not_duplicate(
+                        list_of_dicts=vnis,
+                        primary_key="vni",
+                        new_dict=vlan,
+                        context="VXLAN VNIs for SVIs",
+                        context_keys=["id", "name", "vni"],
+                    )
+                    # Here we append to the actual list of VRFs, so duplication check is on the VLAN ID here.
+                    append_if_not_duplicate(
+                        list_of_dicts=vlans,
+                        primary_key="id",
+                        new_dict=vlan,
+                        context="VXLAN VNIs for SVIs",
+                        context_keys=["id", "vni"],
+                    )
 
         if self.shared_utils.network_services_l3 and self.shared_utils.overlay_evpn_vxlan:
             vrf_name = vrf["name"]

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
@@ -64,26 +64,28 @@ class VxlanInterfaceMixin(UtilsMixin):
             for vrf in tenant["vrfs"]:
                 self._get_vxlan_interface_config_for_vrf(vrf, tenant, vrfs, vlans, vnis)
 
-            if self.shared_utils.network_services_l2:
-                for l2vlan in tenant["l2vlans"]:
-                    if vlan := self._get_vxlan_interface_config_for_vlan(l2vlan, tenant):
-                        # Duplicate check is not done on the actual list of vlans, but instead on our local "vnis" list.
-                        # This is necessary to find duplicate VNIs across multiple object types.
-                        append_if_not_duplicate(
-                            list_of_dicts=vnis,
-                            primary_key="vni",
-                            new_dict=vlan,
-                            context="VXLAN VNIs for L2VLANs",
-                            context_keys=["id", "name", "vni"],
-                        )
-                        # Here we append to the actual list of VRFs, so duplication check is on the VLAN ID here.
-                        append_if_not_duplicate(
-                            list_of_dicts=vlans,
-                            primary_key="id",
-                            new_dict=vlan,
-                            context="VXLAN VNIs for L2VLANs",
-                            context_keys=["id", "vni"],
-                        )
+            if not self.shared_utils.network_services_l2:
+                continue
+
+            for l2vlan in tenant["l2vlans"]:
+                if vlan := self._get_vxlan_interface_config_for_vlan(l2vlan, tenant):
+                    # Duplicate check is not done on the actual list of vlans, but instead on our local "vnis" list.
+                    # This is necessary to find duplicate VNIs across multiple object types.
+                    append_if_not_duplicate(
+                        list_of_dicts=vnis,
+                        primary_key="vni",
+                        new_dict=vlan,
+                        context="VXLAN VNIs for L2VLANs",
+                        context_keys=["id", "name", "vni"],
+                    )
+                    # Here we append to the actual list of VRFs, so duplication check is on the VLAN ID here.
+                    append_if_not_duplicate(
+                        list_of_dicts=vlans,
+                        primary_key="id",
+                        new_dict=vlan,
+                        context="VXLAN VNIs for L2VLANs",
+                        context_keys=["id", "vni"],
+                    )
 
         if vlans:
             vxlan["vlans"] = vlans


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Ensure VLAN VNIs are not rendered without network_services.l2

## Related Issue(s)

On WAN Edge we only have network_services_l3 set, but VNIs were still rendered for VLANs.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Remove SVIs & L2VLANs from filtered tenants if network_services.l2 is not true.
- Add extra safeguard for VXLAN interface code since future uplink types will bring back SVIs to filtered_tenants.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added L2VLAN and SVI to WAN test cases to reproduce the issue and confirm the fix.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
