### PR TITLE
Refactor(eos_designs): Use a specific peer group for WAN-RR

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -146,12 +146,6 @@ router bgp 65000
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.31.1
    bgp listen range 192.168.130.0/24 peer-group WAN-OVERLAY-PEERS remote-as 65000
-   neighbor RR-OVERLAY-PEERS peer group
-   neighbor RR-OVERLAY-PEERS remote-as 65000
-   neighbor RR-OVERLAY-PEERS update-source Dps1
-   neighbor RR-OVERLAY-PEERS bfd
-   neighbor RR-OVERLAY-PEERS send-community
-   neighbor RR-OVERLAY-PEERS maximum-routes 0
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1
@@ -160,24 +154,30 @@ router bgp 65000
    neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
    neighbor WAN-OVERLAY-PEERS send-community
    neighbor WAN-OVERLAY-PEERS maximum-routes 0
-   neighbor 192.168.131.2 peer group RR-OVERLAY-PEERS
+   neighbor WAN-RR-OVERLAY-PEERS peer group
+   neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS bfd
+   neighbor WAN-RR-OVERLAY-PEERS send-community
+   neighbor WAN-RR-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.131.2 peer group WAN-RR-OVERLAY-PEERS
    neighbor 192.168.131.2 description autovpn-rr2
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
       next-hop resolution disabled
    !
    address-family ipv4
-      no neighbor RR-OVERLAY-PEERS activate
       no neighbor WAN-OVERLAY-PEERS activate
+      no neighbor WAN-RR-OVERLAY-PEERS activate
    !
    address-family path-selection
       bgp additional-paths receive
       bgp additional-paths send any
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
    !
    vrf default
       rd 192.168.31.1:1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -147,12 +147,6 @@ router bgp 65000
    no bgp default ipv4-unicast
    bgp cluster-id 192.168.31.2
    bgp listen range 192.168.130.0/24 peer-group WAN-OVERLAY-PEERS remote-as 65000
-   neighbor RR-OVERLAY-PEERS peer group
-   neighbor RR-OVERLAY-PEERS remote-as 65000
-   neighbor RR-OVERLAY-PEERS update-source Dps1
-   neighbor RR-OVERLAY-PEERS bfd
-   neighbor RR-OVERLAY-PEERS send-community
-   neighbor RR-OVERLAY-PEERS maximum-routes 0
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1
@@ -161,24 +155,30 @@ router bgp 65000
    neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
    neighbor WAN-OVERLAY-PEERS send-community
    neighbor WAN-OVERLAY-PEERS maximum-routes 0
-   neighbor 192.168.131.1 peer group RR-OVERLAY-PEERS
+   neighbor WAN-RR-OVERLAY-PEERS peer group
+   neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS bfd
+   neighbor WAN-RR-OVERLAY-PEERS send-community
+   neighbor WAN-RR-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.131.1 peer group WAN-RR-OVERLAY-PEERS
    neighbor 192.168.131.1 description autovpn-rr1
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
       next-hop resolution disabled
    !
    address-family ipv4
-      no neighbor RR-OVERLAY-PEERS activate
       no neighbor WAN-OVERLAY-PEERS activate
+      no neighbor WAN-RR-OVERLAY-PEERS activate
    !
    address-family path-selection
       bgp additional-paths receive
       bgp additional-paths send any
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
    !
    vrf default
       rd 192.168.31.2:1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -282,12 +282,6 @@ router bgp 65000
    bgp cluster-id 192.168.44.2
    bgp listen range 192.168.142.0/24 peer-group WAN-OVERLAY-PEERS remote-as 65000
    bgp listen range 192.168.143.0/24 peer-group WAN-OVERLAY-PEERS remote-as 65000
-   neighbor RR-OVERLAY-PEERS peer group
-   neighbor RR-OVERLAY-PEERS remote-as 65000
-   neighbor RR-OVERLAY-PEERS update-source Dps1
-   neighbor RR-OVERLAY-PEERS bfd
-   neighbor RR-OVERLAY-PEERS send-community
-   neighbor RR-OVERLAY-PEERS maximum-routes 0
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1
@@ -296,36 +290,42 @@ router bgp 65000
    neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
    neighbor WAN-OVERLAY-PEERS send-community
    neighbor WAN-OVERLAY-PEERS maximum-routes 0
-   neighbor 6.6.6.6 peer group RR-OVERLAY-PEERS
+   neighbor WAN-RR-OVERLAY-PEERS peer group
+   neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS bfd
+   neighbor WAN-RR-OVERLAY-PEERS send-community
+   neighbor WAN-RR-OVERLAY-PEERS maximum-routes 0
+   neighbor 6.6.6.6 peer group WAN-RR-OVERLAY-PEERS
    neighbor 6.6.6.6 description cv-pathfinder-pathfinder3
-   neighbor 192.168.144.3 peer group RR-OVERLAY-PEERS
+   neighbor 192.168.144.3 peer group WAN-RR-OVERLAY-PEERS
    neighbor 192.168.144.3 description cv-pathfinder-pathfinder2
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
       next-hop resolution disabled
    !
    address-family ipv4
-      no neighbor RR-OVERLAY-PEERS activate
       no neighbor WAN-OVERLAY-PEERS activate
+      no neighbor WAN-RR-OVERLAY-PEERS activate
    !
    address-family ipv4 sr-te
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
    !
    address-family link-state
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS missing-policy direction out action deny
+      neighbor WAN-RR-OVERLAY-PEERS activate
       path-selection role consumer propagator
    !
    address-family path-selection
       bgp additional-paths receive
       bgp additional-paths send any
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
    !
    vrf default
       rd 192.168.44.2:1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -295,12 +295,6 @@ router bgp 65000
    bgp cluster-id 192.168.44.3
    bgp listen range 192.168.142.0/24 peer-group WAN-OVERLAY-PEERS remote-as 65000
    bgp listen range 192.168.143.0/24 peer-group WAN-OVERLAY-PEERS remote-as 65000
-   neighbor RR-OVERLAY-PEERS peer group
-   neighbor RR-OVERLAY-PEERS remote-as 65000
-   neighbor RR-OVERLAY-PEERS update-source Dps1
-   neighbor RR-OVERLAY-PEERS bfd
-   neighbor RR-OVERLAY-PEERS send-community
-   neighbor RR-OVERLAY-PEERS maximum-routes 0
    neighbor WAN-OVERLAY-PEERS peer group
    neighbor WAN-OVERLAY-PEERS remote-as 65000
    neighbor WAN-OVERLAY-PEERS update-source Dps1
@@ -309,36 +303,42 @@ router bgp 65000
    neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
    neighbor WAN-OVERLAY-PEERS send-community
    neighbor WAN-OVERLAY-PEERS maximum-routes 0
-   neighbor 6.6.6.6 peer group RR-OVERLAY-PEERS
+   neighbor WAN-RR-OVERLAY-PEERS peer group
+   neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS bfd
+   neighbor WAN-RR-OVERLAY-PEERS send-community
+   neighbor WAN-RR-OVERLAY-PEERS maximum-routes 0
+   neighbor 6.6.6.6 peer group WAN-RR-OVERLAY-PEERS
    neighbor 6.6.6.6 description cv-pathfinder-pathfinder3
-   neighbor 192.168.144.2 peer group RR-OVERLAY-PEERS
+   neighbor 192.168.144.2 peer group WAN-RR-OVERLAY-PEERS
    neighbor 192.168.144.2 description cv-pathfinder-pathfinder1
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
       next-hop resolution disabled
    !
    address-family ipv4
-      no neighbor RR-OVERLAY-PEERS activate
       no neighbor WAN-OVERLAY-PEERS activate
+      no neighbor WAN-RR-OVERLAY-PEERS activate
    !
    address-family ipv4 sr-te
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
    !
    address-family link-state
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS missing-policy direction out action deny
+      neighbor WAN-RR-OVERLAY-PEERS activate
       path-selection role consumer propagator
    !
    address-family path-selection
       bgp additional-paths receive
       bgp additional-paths send any
-      neighbor RR-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
    !
    vrf default
       rd 192.168.44.3:1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -28,7 +28,7 @@ router_bgp:
     maximum_routes: 0
     remote_as: '65000'
     route_reflector_client: true
-  - name: RR-OVERLAY-PEERS
+  - name: WAN-RR-OVERLAY-PEERS
     type: wan
     update_source: Dps1
     bfd: true
@@ -39,7 +39,7 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     next_hop:
       resolution_disabled: true
@@ -47,13 +47,13 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: false
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: false
   address_family_path_selection:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     bgp:
       additional_paths:
@@ -62,7 +62,7 @@ router_bgp:
           any: true
   neighbors:
   - ip_address: 192.168.131.2
-    peer_group: RR-OVERLAY-PEERS
+    peer_group: WAN-RR-OVERLAY-PEERS
     peer: autovpn-rr2
     description: autovpn-rr2
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -28,7 +28,7 @@ router_bgp:
     maximum_routes: 0
     remote_as: '65000'
     route_reflector_client: true
-  - name: RR-OVERLAY-PEERS
+  - name: WAN-RR-OVERLAY-PEERS
     type: wan
     update_source: Dps1
     bfd: true
@@ -39,7 +39,7 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     next_hop:
       resolution_disabled: true
@@ -47,13 +47,13 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: false
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: false
   address_family_path_selection:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     bgp:
       additional_paths:
@@ -62,7 +62,7 @@ router_bgp:
           any: true
   neighbors:
   - ip_address: 192.168.131.1
-    peer_group: RR-OVERLAY-PEERS
+    peer_group: WAN-RR-OVERLAY-PEERS
     peer: autovpn-rr1
     description: autovpn-rr1
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -31,7 +31,7 @@ router_bgp:
     maximum_routes: 0
     remote_as: '65000'
     route_reflector_client: true
-  - name: RR-OVERLAY-PEERS
+  - name: WAN-RR-OVERLAY-PEERS
     type: wan
     update_source: Dps1
     bfd: true
@@ -42,7 +42,7 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     next_hop:
       resolution_disabled: true
@@ -50,13 +50,13 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: false
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: false
   address_family_ipv4_sr_te:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
   address_family_link_state:
     peer_groups:
@@ -64,7 +64,7 @@ router_bgp:
       activate: true
       missing_policy:
         direction_out_action: deny
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     path_selection:
       roles:
@@ -74,7 +74,7 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     bgp:
       additional_paths:
@@ -83,11 +83,11 @@ router_bgp:
           any: true
   neighbors:
   - ip_address: 192.168.144.3
-    peer_group: RR-OVERLAY-PEERS
+    peer_group: WAN-RR-OVERLAY-PEERS
     peer: cv-pathfinder-pathfinder2
     description: cv-pathfinder-pathfinder2
   - ip_address: 6.6.6.6
-    peer_group: RR-OVERLAY-PEERS
+    peer_group: WAN-RR-OVERLAY-PEERS
     peer: cv-pathfinder-pathfinder3
     description: cv-pathfinder-pathfinder3
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -31,7 +31,7 @@ router_bgp:
     maximum_routes: 0
     remote_as: '65000'
     route_reflector_client: true
-  - name: RR-OVERLAY-PEERS
+  - name: WAN-RR-OVERLAY-PEERS
     type: wan
     update_source: Dps1
     bfd: true
@@ -42,7 +42,7 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     next_hop:
       resolution_disabled: true
@@ -50,13 +50,13 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: false
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: false
   address_family_ipv4_sr_te:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
   address_family_link_state:
     peer_groups:
@@ -64,7 +64,7 @@ router_bgp:
       activate: true
       missing_policy:
         direction_out_action: deny
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     path_selection:
       roles:
@@ -74,7 +74,7 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: true
-    - name: RR-OVERLAY-PEERS
+    - name: WAN-RR-OVERLAY-PEERS
       activate: true
     bgp:
       additional_paths:
@@ -83,11 +83,11 @@ router_bgp:
           any: true
   neighbors:
   - ip_address: 192.168.144.2
-    peer_group: RR-OVERLAY-PEERS
+    peer_group: WAN-RR-OVERLAY-PEERS
     peer: cv-pathfinder-pathfinder1
     description: cv-pathfinder-pathfinder1
   - ip_address: 6.6.6.6
-    peer_group: RR-OVERLAY-PEERS
+    peer_group: WAN-RR-OVERLAY-PEERS
     peer: cv-pathfinder-pathfinder3
     description: cv-pathfinder-pathfinder3
   vrfs:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/bgp_peer_groups.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/bgp_peer_groups.py
@@ -40,6 +40,7 @@ class BgpPeerGroupsMixin:
             ("rr_overlay_peers", "RR-OVERLAY-PEERS", True),
             ("ipvpn_gateway_peers", "IPVPN-GATEWAY-PEERS", True),
             ("wan_overlay_peers", "WAN-OVERLAY-PEERS", True),
+            ("wan_rr_overlay_peers", "WAN-RR-OVERLAY-PEERS", True),
         ]
 
         bgp_peer_groups = {}

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
@@ -54,11 +54,6 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.password") | String |  |  |  | Type 7 encrypted password. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
-    | [<samp>&nbsp;&nbsp;wan_rr_overlay_peers</samp>](## "bgp_peer_groups.wan_rr_overlay_peers") | Dictionary |  |  |  | Configuration options for the peer-group created to peer between<br>AutoVPN RRs or CV-Pathfinders. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.name") | String |  | `WAN-RR-OVERLAY-PEERS` |  | Name of peer group. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.password") | String |  |  |  | Type 7 encrypted password. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.bfd") | Boolean |  | `True` |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;IPv4_UNDERLAY_PEERS</samp>](## "bgp_peer_groups.IPv4_UNDERLAY_PEERS") <span style="color:red">removed</span> | Dictionary |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 4.0.0. Use <samp>bgp_peer_groups.ipv4_underlay_peers</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;MLAG_IPv4_UNDERLAY_PEER</samp>](## "bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER") <span style="color:red">removed</span> | Dictionary |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 4.0.0. Use <samp>bgp_peer_groups.mlag_ipv4_underlay_peer</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;EVPN_OVERLAY_PEERS</samp>](## "bgp_peer_groups.EVPN_OVERLAY_PEERS") <span style="color:red">removed</span> | Dictionary |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 4.0.0. Use <samp>bgp_peer_groups.evpn_overlay_peers</samp> instead.</span> |
@@ -170,20 +165,6 @@
 
         # Name of peer group.
         name: <str; default="IPVPN-GATEWAY-PEERS">
-
-        # Type 7 encrypted password.
-        password: <str>
-        bfd: <bool; default=True>
-
-        # Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-        structured_config: <dict>
-
-      # Configuration options for the peer-group created to peer between
-      # AutoVPN RRs or CV-Pathfinders.
-      wan_rr_overlay_peers:
-
-        # Name of peer group.
-        name: <str; default="WAN-RR-OVERLAY-PEERS">
 
         # Type 7 encrypted password.
         password: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
@@ -54,6 +54,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.password") | String |  |  |  | Type 7 encrypted password. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
+    | [<samp>&nbsp;&nbsp;wan_rr_overlay_peers</samp>](## "bgp_peer_groups.wan_rr_overlay_peers") | Dictionary |  |  |  | Configuration options for the peer-group created to peer between<br>AutoVPN RRs or CV-Pathfinders. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.name") | String |  | `WAN-RR-OVERLAY-PEERS` |  | Name of peer group. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.bfd") | Boolean |  | `True` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;IPv4_UNDERLAY_PEERS</samp>](## "bgp_peer_groups.IPv4_UNDERLAY_PEERS") <span style="color:red">removed</span> | Dictionary |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 4.0.0. Use <samp>bgp_peer_groups.ipv4_underlay_peers</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;MLAG_IPv4_UNDERLAY_PEER</samp>](## "bgp_peer_groups.MLAG_IPv4_UNDERLAY_PEER") <span style="color:red">removed</span> | Dictionary |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 4.0.0. Use <samp>bgp_peer_groups.mlag_ipv4_underlay_peer</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;EVPN_OVERLAY_PEERS</samp>](## "bgp_peer_groups.EVPN_OVERLAY_PEERS") <span style="color:red">removed</span> | Dictionary |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 4.0.0. Use <samp>bgp_peer_groups.evpn_overlay_peers</samp> instead.</span> |
@@ -165,6 +170,20 @@
 
         # Name of peer group.
         name: <str; default="IPVPN-GATEWAY-PEERS">
+
+        # Type 7 encrypted password.
+        password: <str>
+        bfd: <bool; default=True>
+
+        # Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
+        structured_config: <dict>
+
+      # Configuration options for the peer-group created to peer between
+      # AutoVPN RRs or CV-Pathfinders.
+      wan_rr_overlay_peers:
+
+        # Name of peer group.
+        name: <str; default="WAN-RR-OVERLAY-PEERS">
 
         # Type 7 encrypted password.
         password: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-bgp-peer-groups.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-bgp-peer-groups.md
@@ -15,6 +15,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;listen_range_prefixes</samp>](## "bgp_peer_groups.wan_overlay_peers.listen_range_prefixes") | List, items: String |  |  |  | Only used for nodes where `wan_role` is `server` like AutoVPN RRs and Pathfinders.<br>For clients, AVD will raise an error if the Loopback0 IP is not in any listen range. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "bgp_peer_groups.wan_overlay_peers.listen_range_prefixes.[]") | String |  |  |  | The prefixes to use in listen_range. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.wan_overlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
+    | [<samp>&nbsp;&nbsp;wan_rr_overlay_peers</samp>](## "bgp_peer_groups.wan_rr_overlay_peers") | Dictionary |  |  |  | PREVIEW: This key is currently not supported<br>Configuration options for the peer-group created to peer between<br>AutoVPN RRs or CV-Pathfinders. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.name") | String |  | `WAN-RR-OVERLAY-PEERS` |  | Name of peer group. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.bfd") | Boolean |  | `True` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
 
 === "YAML"
 
@@ -39,6 +44,21 @@
 
             # The prefixes to use in listen_range.
           - <str>
+
+        # Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
+        structured_config: <dict>
+
+      # PREVIEW: This key is currently not supported
+      # Configuration options for the peer-group created to peer between
+      # AutoVPN RRs or CV-Pathfinders.
+      wan_rr_overlay_peers:
+
+        # Name of peer group.
+        name: <str; default="WAN-RR-OVERLAY-PEERS">
+
+        # Type 7 encrypted password.
+        password: <str>
+        bfd: <bool; default=True>
 
         # Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
         structured_config: <dict>

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -3270,6 +3270,353 @@
             "^_.+$": {}
           },
           "title": "Wan Overlay Peers"
+        },
+        "wan_rr_overlay_peers": {
+          "type": "object",
+          "description": "Configuration options for the peer-group created to peer between\nAutoVPN RRs or CV-Pathfinders.",
+          "properties": {
+            "name": {
+              "type": "string",
+              "default": "WAN-RR-OVERLAY-PEERS",
+              "description": "Name of peer group.",
+              "title": "Name"
+            },
+            "password": {
+              "type": "string",
+              "description": "Type 7 encrypted password.",
+              "title": "Password"
+            },
+            "bfd": {
+              "type": "boolean",
+              "default": true,
+              "title": "BFD"
+            },
+            "structured_config": {
+              "type": "object",
+              "description": "Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "description": "Peer-group name",
+                  "title": "Name"
+                },
+                "type": {
+                  "type": "string",
+                  "description": "Key only used for documentation or validation purposes",
+                  "title": "Type"
+                },
+                "remote_as": {
+                  "type": "string",
+                  "description": "BGP AS <1-4294967295> or AS number in asdot notation \"<1-65535>.<0-65535>\"",
+                  "title": "Remote As"
+                },
+                "local_as": {
+                  "type": "string",
+                  "description": "BGP AS <1-4294967295> or AS number in asdot notation \"<1-65535>.<0-65535>\"",
+                  "title": "Local As"
+                },
+                "description": {
+                  "type": "string",
+                  "title": "Description"
+                },
+                "shutdown": {
+                  "type": "boolean",
+                  "title": "Shutdown"
+                },
+                "as_path": {
+                  "type": "object",
+                  "description": "BGP AS-PATH options",
+                  "properties": {
+                    "remote_as_replace_out": {
+                      "type": "boolean",
+                      "description": "Replace AS number with local AS number",
+                      "title": "Remote As Replace Out"
+                    },
+                    "prepend_own_disabled": {
+                      "type": "boolean",
+                      "description": "Disable prepending own AS number to AS path",
+                      "title": "Prepend Own Disabled"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "As Path"
+                },
+                "remove_private_as": {
+                  "type": "object",
+                  "description": "Remove private AS numbers in outbound AS path",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "title": "Enabled"
+                    },
+                    "all": {
+                      "type": "boolean",
+                      "title": "All"
+                    },
+                    "replace_as": {
+                      "type": "boolean",
+                      "title": "Replace As"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Remove Private As"
+                },
+                "remove_private_as_ingress": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "title": "Enabled"
+                    },
+                    "replace_as": {
+                      "type": "boolean",
+                      "title": "Replace As"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Remove Private As Ingress"
+                },
+                "peer_filter": {
+                  "type": "string",
+                  "description": "Peer-filter name\nnote: `bgp_listen_range_prefix` and `peer_filter` should not be mixed with\nthe new `listen_ranges` key above to avoid conflicts.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>listen_ranges</samp> instead.",
+                  "deprecated": true,
+                  "title": "Peer Filter"
+                },
+                "next_hop_unchanged": {
+                  "type": "boolean",
+                  "title": "Next Hop Unchanged"
+                },
+                "update_source": {
+                  "type": "string",
+                  "description": "IP address or interface name",
+                  "title": "Update Source"
+                },
+                "route_reflector_client": {
+                  "type": "boolean",
+                  "title": "Route Reflector Client"
+                },
+                "bfd": {
+                  "type": "boolean",
+                  "description": "Enable BFD.",
+                  "title": "BFD"
+                },
+                "bfd_timers": {
+                  "type": "object",
+                  "description": "Override default BFD timers. BFD must be enabled with `bfd: true`.",
+                  "properties": {
+                    "interval": {
+                      "type": "integer",
+                      "minimum": 50,
+                      "maximum": 60000,
+                      "description": "Interval in milliseconds.",
+                      "title": "Interval"
+                    },
+                    "min_rx": {
+                      "type": "integer",
+                      "minimum": 50,
+                      "maximum": 60000,
+                      "description": "Rate in milliseconds.",
+                      "title": "Min RX"
+                    },
+                    "multiplier": {
+                      "type": "integer",
+                      "minimum": 3,
+                      "maximum": 50,
+                      "title": "Multiplier"
+                    }
+                  },
+                  "required": [
+                    "interval",
+                    "min_rx",
+                    "multiplier"
+                  ],
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "BFD Timers"
+                },
+                "ebgp_multihop": {
+                  "type": "integer",
+                  "minimum": 1,
+                  "maximum": 255,
+                  "description": "Time-to-live in range of hops",
+                  "title": "Ebgp Multihop"
+                },
+                "next_hop_self": {
+                  "type": "boolean",
+                  "title": "Next Hop Self"
+                },
+                "password": {
+                  "type": "string",
+                  "title": "Password"
+                },
+                "passive": {
+                  "type": "boolean",
+                  "title": "Passive"
+                },
+                "default_originate": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "title": "Enabled"
+                    },
+                    "always": {
+                      "type": "boolean",
+                      "title": "Always"
+                    },
+                    "route_map": {
+                      "type": "string",
+                      "description": "Route-map name",
+                      "title": "Route Map"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Default Originate"
+                },
+                "send_community": {
+                  "type": "string",
+                  "description": "'all' or a combination of 'standard', 'extended', 'large' and 'link-bandwidth (w/options)'",
+                  "title": "Send Community"
+                },
+                "maximum_routes": {
+                  "type": "integer",
+                  "description": "Maximum number of routes (0 means unlimited)",
+                  "minimum": 0,
+                  "maximum": 4294967294,
+                  "title": "Maximum Routes"
+                },
+                "maximum_routes_warning_limit": {
+                  "type": "string",
+                  "description": "Maximum number of routes after which a warning is issued (0 means never warn) or\nPercentage of maximum number of routes at which to warn (\"<1-100> percent\")\n",
+                  "title": "Maximum Routes Warning Limit"
+                },
+                "maximum_routes_warning_only": {
+                  "type": "boolean",
+                  "title": "Maximum Routes Warning Only"
+                },
+                "link_bandwidth": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "title": "Enabled"
+                    },
+                    "default": {
+                      "type": "string",
+                      "description": "nn.nn(K|M|G) link speed in bits/second",
+                      "title": "Default"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Link Bandwidth"
+                },
+                "allowas_in": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "title": "Enabled"
+                    },
+                    "times": {
+                      "type": "integer",
+                      "description": "Number of local ASNs allowed in a BGP update",
+                      "minimum": 1,
+                      "maximum": 10,
+                      "title": "Times"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Allowas In"
+                },
+                "weight": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 65535,
+                  "title": "Weight"
+                },
+                "timers": {
+                  "type": "string",
+                  "description": "BGP Keepalive and Hold Timer values in seconds as string \"<0-3600> <0-3600>\"",
+                  "title": "Timers"
+                },
+                "rib_in_pre_policy_retain": {
+                  "type": "object",
+                  "properties": {
+                    "enabled": {
+                      "type": "boolean",
+                      "title": "Enabled"
+                    },
+                    "all": {
+                      "type": "boolean",
+                      "title": "All"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Rib In Pre Policy Retain"
+                },
+                "route_map_in": {
+                  "type": "string",
+                  "description": "Inbound route-map name",
+                  "title": "Route Map In"
+                },
+                "route_map_out": {
+                  "type": "string",
+                  "description": "Outbound route-map name",
+                  "title": "Route Map Out"
+                },
+                "bgp_listen_range_prefix": {
+                  "type": "string",
+                  "description": "IP prefix range\nnote: `bgp_listen_range_prefix` and `peer_filter` should not be mixed with\nthe new `listen_ranges` key above to avoid conflicts.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>listen_ranges</samp> instead.",
+                  "deprecated": true,
+                  "title": "BGP Listen Range Prefix"
+                },
+                "session_tracker": {
+                  "type": "string",
+                  "title": "Session Tracker"
+                },
+                "ttl_maximum_hops": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 254,
+                  "description": "Maximum number of hops.",
+                  "title": "TTL Maximum Hops"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Structured Config"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Wan Rr Overlay Peers"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -3273,7 +3273,7 @@
         },
         "wan_rr_overlay_peers": {
           "type": "object",
-          "description": "Configuration options for the peer-group created to peer between\nAutoVPN RRs or CV-Pathfinders.",
+          "description": "PREVIEW: This key is currently not supported\nConfiguration options for the peer-group created to peer between\nAutoVPN RRs or CV-Pathfinders.",
           "properties": {
             "name": {
               "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -374,7 +374,11 @@ keys:
             $ref: eos_cli_config_gen#/keys/router_bgp/keys/peer_groups/items/
       wan_rr_overlay_peers:
         type: dict
-        description: 'Configuration options for the peer-group created to peer between
+        documentation_options:
+          table: wan-bgp-peer-groups
+        description: 'PREVIEW: This key is currently not supported
+
+          Configuration options for the peer-group created to peer between
 
           AutoVPN RRs or CV-Pathfinders.'
         keys:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -372,6 +372,29 @@ keys:
             documentation_options:
               hide_keys: true
             $ref: eos_cli_config_gen#/keys/router_bgp/keys/peer_groups/items/
+      wan_rr_overlay_peers:
+        type: dict
+        description: 'Configuration options for the peer-group created to peer between
+
+          AutoVPN RRs or CV-Pathfinders.'
+        keys:
+          name:
+            type: str
+            default: WAN-RR-OVERLAY-PEERS
+            description: Name of peer group.
+          password:
+            type: str
+            description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: true
+          structured_config:
+            type: dict
+            description: Custom structured config added under router_bgp.peer_groups.[name=<name>]
+              for eos_cli_config_gen.
+            documentation_options:
+              hide_keys: true
+            $ref: eos_cli_config_gen#/keys/router_bgp/keys/peer_groups/items/
       IPv4_UNDERLAY_PEERS:
         type: dict
         deprecation:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_peer_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_peer_groups.schema.yml
@@ -178,6 +178,28 @@ keys:
             documentation_options:
               hide_keys: true
             $ref: "eos_cli_config_gen#/keys/router_bgp/keys/peer_groups/items/"
+      wan_rr_overlay_peers:
+        type: dict
+        description: |-
+          Configuration options for the peer-group created to peer between
+          AutoVPN RRs or CV-Pathfinders.
+        keys:
+          name:
+            type: str
+            default: WAN-RR-OVERLAY-PEERS
+            description: Name of peer group.
+          password:
+            type: str
+            description: Type 7 encrypted password.
+          bfd:
+            type: bool
+            default: True
+          structured_config:
+            type: dict
+            description: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
+            documentation_options:
+              hide_keys: true
+            $ref: "eos_cli_config_gen#/keys/router_bgp/keys/peer_groups/items/"
       IPv4_UNDERLAY_PEERS:
         type: dict
         deprecation:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_peer_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/bgp_peer_groups.schema.yml
@@ -180,7 +180,10 @@ keys:
             $ref: "eos_cli_config_gen#/keys/router_bgp/keys/peer_groups/items/"
       wan_rr_overlay_peers:
         type: dict
+        documentation_options:
+          table: wan-bgp-peer-groups
         description: |-
+          PREVIEW: This key is currently not supported
           Configuration options for the peer-group created to peer between
           AutoVPN RRs or CV-Pathfinders.
         keys:


### PR DESCRIPTION
## Change Summary

the WAN-RR were made to use the RR-OVERLAY-PEERS peer-group for BGP but this leads to potential issue if trying to configur MPLS route servers capabilities on a WAN-RR as the two BGP peering configuration would be conflicting (TTL 1 for WAN #3587 and BFD #3586).

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Create a special key `wan_rr_overlay_peers`

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
