### PR TITLE
Refactor(eos_designs): Add wan_circuit_id in metadata

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -397,4 +397,5 @@ metadata:
     interfaces:
     - name: Ethernet1
       carrier: Inmrasat
+      circuit_id: S512
       pathgroup: Satellite

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -393,12 +393,15 @@ metadata:
     interfaces:
     - name: Ethernet1
       carrier: ATT
+      circuit_id: '666'
       pathgroup: INET
     - name: Ethernet2
       carrier: Colt
+      circuit_id: '10555'
       pathgroup: MPLS
     - name: Ethernet3
       carrier: Comcast-5G
+      circuit_id: AF830
       pathgroup: LTE
     pathfinders:
     - vtep_ip: 192.168.144.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -495,12 +495,15 @@ metadata:
     interfaces:
     - name: Ethernet1
       carrier: ATT
+      circuit_id: '666'
       pathgroup: INET
     - name: Ethernet2
       carrier: Colt
+      circuit_id: '10555'
       pathgroup: MPLS
     - name: Ethernet3
       carrier: Comcast-5G
+      circuit_id: AF830
       pathgroup: LTE
     pathfinders:
     - vtep_ip: 192.168.144.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -444,14 +444,17 @@ metadata:
     interfaces:
     - name: Ethernet1
       carrier: Bouygues_Telecom
+      circuit_id: '777'
       pathgroup: INET
       public_ip: 10.7.7.7
     - name: Ethernet2
       carrier: Colt
+      circuit_id: '10000'
       pathgroup: MPLS
       public_ip: 172.16.0.1
     - name: Ethernet3
       carrier: Another-ISP
+      circuit_id: '999'
       pathgroup: INET
       public_ip: 10.9.9.9
     pathgroups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -440,6 +440,7 @@ metadata:
     interfaces:
     - name: Ethernet1
       carrier: Orange
+      circuit_id: '888'
       pathgroup: INET
       public_ip: 10.8.8.8
     pathgroups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -464,10 +464,12 @@ metadata:
     interfaces:
     - name: Ethernet1
       carrier: SFR
+      circuit_id: '999'
       pathgroup: INET
       public_ip: 10.9.9.9
     - name: Ethernet2
       carrier: ATT-MPLS
+      circuit_id: '10999'
       pathgroup: MPLS
       public_ip: 172.19.9.9
     pathgroups:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
@@ -523,6 +523,7 @@ metadata:
       pathgroup: INET
     - name: Ethernet2.42
       carrier: Colt
+      circuit_id: '10666'
       pathgroup: MPLS
     pathfinders:
     - vtep_ip: 192.168.144.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -100,7 +100,6 @@ wan_transit:
       l3_interfaces:
         - name: Ethernet1.42
           wan_carrier: Comcast
-          wan_circuit_id: 667
           set_default_route: true
           ip_address: dhcp
         - name: Ethernet2.42

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -110,11 +110,14 @@ class WanMixin:
                 local_carriers_dict[interface_carrier]["interfaces"] = []
 
             local_carriers_dict[interface_carrier]["interfaces"].append(
-                {
-                    "name": get(interface, "name", required=True),
-                    "ip_address": self.get_public_ip_for_wan_interface(interface),
-                    "connected_to_pathfinder": get(interface, "connected_to_pathfinder", default=True),
-                }
+                strip_empties_from_dict(
+                    {
+                        "name": get(interface, "name", required=True),
+                        "ip_address": self.get_public_ip_for_wan_interface(interface),
+                        "connected_to_pathfinder": get(interface, "connected_to_pathfinder", default=True),
+                        "wan_circuit_id": get(interface, "wan_circuit_id"),
+                    }
+                )
             )
 
         return list(local_carriers_dict.values())


### PR DESCRIPTION
## Change Summary

wan_circuit_id is missing from metadata today- this is fixing it

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
cf summary

## How to test
molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
