### PR TITLE
Feat(eos_designs): Add wan_vni for WAN VRF

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
@@ -22,17 +22,27 @@ router path-selection
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET
    !
-   load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
       path-group INET
    !
-   policy DEFAULT-AVT-POLICY-WITH-CP
+   policy DEFAULT-POLICY
       default-match
-         load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
+         load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      default-match
+         load-balance LB-DEFAULT-POLICY-DEFAULT
       10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
          load-balance LB-CONTROL-PLANE-PROFILE
    !
    vrf default
-      path-selection-policy DEFAULT-AVT-POLICY-WITH-CP
+      path-selection-policy DEFAULT-POLICY-WITH-CP
+   !
+   vrf IT
+      path-selection-policy DEFAULT-POLICY
+   !
+   vrf PROD
+      path-selection-policy DEFAULT-POLICY
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -108,7 +108,6 @@ interface Vxlan1
    vxlan source-interface Dps1
    vxlan udp-port 4789
    vxlan vrf default vni 1
-   vxlan vrf IT vni 100
    vxlan vrf PROD vni 42
 !
 application traffic recognition
@@ -194,13 +193,6 @@ router bgp 65000
       route-target import evpn 1:1
       route-target export evpn 1:1
       route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
-   !
-   vrf IT
-      rd 192.168.30.1:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
-      router-id 192.168.30.1
-      redistribute connected
    !
    vrf PROD
       rd 192.168.30.1:42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -26,37 +26,37 @@ router path-selection
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET
    !
-   load-balance policy LB-DEFAULT-AVT-POLICY-IT
+   load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
       path-group INET priority 2
    !
-   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
+   load-balance policy LB-PROD-AUTOVPN-POLICY-DEFAULT
       path-group INET
    !
-   load-balance policy LB-PROD-AVT-POLICY-VIDEO
+   load-balance policy LB-PROD-AUTOVPN-POLICY-VIDEO
       path-group INET
    !
-   load-balance policy LB-PROD-AVT-POLICY-VOICE
+   load-balance policy LB-PROD-AUTOVPN-POLICY-VOICE
       path-group INET
    !
-   policy DEFAULT-AVT-POLICY-WITH-CP
+   policy DEFAULT-AUTOVPN-POLICY-WITH-CP
       10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
          load-balance LB-CONTROL-PLANE-PROFILE
       20 application-profile IT
-         load-balance LB-DEFAULT-AVT-POLICY-IT
+         load-balance LB-DEFAULT-AUTOVPN-POLICY-IT
    !
-   policy PROD-AVT-POLICY
+   policy PROD-AUTOVPN-POLICY
       default-match
-         load-balance LB-PROD-AVT-POLICY-DEFAULT
+         load-balance LB-PROD-AUTOVPN-POLICY-DEFAULT
       10 application-profile VOICE
-         load-balance LB-PROD-AVT-POLICY-VOICE
+         load-balance LB-PROD-AUTOVPN-POLICY-VOICE
       20 application-profile VIDEO
-         load-balance LB-PROD-AVT-POLICY-VIDEO
+         load-balance LB-PROD-AUTOVPN-POLICY-VIDEO
    !
    vrf default
-      path-selection-policy DEFAULT-AVT-POLICY-WITH-CP
+      path-selection-policy DEFAULT-AUTOVPN-POLICY-WITH-CP
    !
    vrf PROD
-      path-selection-policy PROD-AVT-POLICY
+      path-selection-policy PROD-AUTOVPN-POLICY
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -24,38 +24,38 @@ router path-selection
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET
    !
-   load-balance policy LB-DEFAULT-AVT-POLICY-IT
+   load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
       path-group MPLS
       path-group INET priority 2
    !
-   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
+   load-balance policy LB-PROD-AUTOVPN-POLICY-DEFAULT
       path-group INET
    !
-   load-balance policy LB-PROD-AVT-POLICY-VIDEO
+   load-balance policy LB-PROD-AUTOVPN-POLICY-VIDEO
       path-group INET
    !
-   load-balance policy LB-PROD-AVT-POLICY-VOICE
+   load-balance policy LB-PROD-AUTOVPN-POLICY-VOICE
       path-group INET
    !
-   policy DEFAULT-AVT-POLICY-WITH-CP
+   policy DEFAULT-AUTOVPN-POLICY-WITH-CP
       10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
          load-balance LB-CONTROL-PLANE-PROFILE
       20 application-profile IT
-         load-balance LB-DEFAULT-AVT-POLICY-IT
+         load-balance LB-DEFAULT-AUTOVPN-POLICY-IT
    !
-   policy PROD-AVT-POLICY
+   policy PROD-AUTOVPN-POLICY
       default-match
-         load-balance LB-PROD-AVT-POLICY-DEFAULT
+         load-balance LB-PROD-AUTOVPN-POLICY-DEFAULT
       10 application-profile VOICE
-         load-balance LB-PROD-AVT-POLICY-VOICE
+         load-balance LB-PROD-AUTOVPN-POLICY-VOICE
       20 application-profile VIDEO
-         load-balance LB-PROD-AVT-POLICY-VIDEO
+         load-balance LB-PROD-AUTOVPN-POLICY-VIDEO
    !
    vrf default
-      path-selection-policy DEFAULT-AVT-POLICY-WITH-CP
+      path-selection-policy DEFAULT-AUTOVPN-POLICY-WITH-CP
    !
    vrf PROD
-      path-selection-policy PROD-AVT-POLICY
+      path-selection-policy PROD-AUTOVPN-POLICY
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -24,38 +24,38 @@ router path-selection
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET
    !
-   load-balance policy LB-DEFAULT-AVT-POLICY-IT
+   load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
       path-group MPLS
       path-group INET priority 2
    !
-   load-balance policy LB-PROD-AVT-POLICY-DEFAULT
+   load-balance policy LB-PROD-AUTOVPN-POLICY-DEFAULT
       path-group INET
    !
-   load-balance policy LB-PROD-AVT-POLICY-VIDEO
+   load-balance policy LB-PROD-AUTOVPN-POLICY-VIDEO
       path-group INET
    !
-   load-balance policy LB-PROD-AVT-POLICY-VOICE
+   load-balance policy LB-PROD-AUTOVPN-POLICY-VOICE
       path-group INET
    !
-   policy DEFAULT-AVT-POLICY-WITH-CP
+   policy DEFAULT-AUTOVPN-POLICY-WITH-CP
       10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
          load-balance LB-CONTROL-PLANE-PROFILE
       20 application-profile IT
-         load-balance LB-DEFAULT-AVT-POLICY-IT
+         load-balance LB-DEFAULT-AUTOVPN-POLICY-IT
    !
-   policy PROD-AVT-POLICY
+   policy PROD-AUTOVPN-POLICY
       default-match
-         load-balance LB-PROD-AVT-POLICY-DEFAULT
+         load-balance LB-PROD-AUTOVPN-POLICY-DEFAULT
       10 application-profile VOICE
-         load-balance LB-PROD-AVT-POLICY-VOICE
+         load-balance LB-PROD-AUTOVPN-POLICY-VOICE
       20 application-profile VIDEO
-         load-balance LB-PROD-AVT-POLICY-VIDEO
+         load-balance LB-PROD-AUTOVPN-POLICY-VIDEO
    !
    vrf default
-      path-selection-policy DEFAULT-AVT-POLICY-WITH-CP
+      path-selection-policy DEFAULT-AUTOVPN-POLICY-WITH-CP
    !
    vrf PROD
-      path-selection-policy PROD-AVT-POLICY
+      path-selection-policy PROD-AUTOVPN-POLICY
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -116,8 +116,6 @@ spanning-tree mode none
 no enable password
 no aaa root
 !
-vrf instance IT
-!
 vrf instance MGMT
 !
 vrf instance PROD
@@ -188,7 +186,6 @@ interface Vxlan1
    vxlan source-interface Dps1
    vxlan udp-port 4789
    vxlan vrf default vni 1
-   vxlan vrf IT vni 100
    vxlan vrf PROD vni 42
 !
 application traffic recognition
@@ -207,7 +204,6 @@ application traffic recognition
       192.168.144.1/32
 !
 ip routing
-ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
 !
@@ -277,13 +273,6 @@ router bgp 65000
       route-target import evpn 1:1
       route-target export evpn 1:1
       route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
-   !
-   vrf IT
-      rd 192.168.42.1:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
-      router-id 192.168.42.1
-      redistribute connected
    !
    vrf PROD
       rd 192.168.42.1:42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -48,12 +48,6 @@ router adaptive-virtual-topology
    profile DEFAULT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-POLICY-VIDEO
    !
-   profile DEFAULT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-POLICY-WITH-CP-VIDEO
-   !
    vrf default
       avt policy DEFAULT-POLICY-WITH-CP
       avt profile DEFAULT-POLICY-DEFAULT id 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -12,15 +12,18 @@ flow tracking hardware
 !
 service routing protocols model multi-agent
 !
-hostname cv-pathfinder-edge-no-default-policy
+hostname cv-pathfinder-edge-custom-default-policy
 !
 router adaptive-virtual-topology
    topology role edge
-   region AVD_Land_East id 43
+   region AVD_Land_West id 42
    zone DEFAULT-ZONE id 1
-   site Site511 id 511
+   site Site1 id 1
    !
    policy DEFAULT-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
       !
       match application-profile default
          avt profile DEFAULT-POLICY-DEFAULT
@@ -29,6 +32,9 @@ router adaptive-virtual-topology
       !
       match application-profile CONTROL-PLANE-APPLICATION-PROFILE
          avt profile CONTROL-PLANE-PROFILE
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
       !
       match application-profile default
          avt profile DEFAULT-POLICY-DEFAULT
@@ -39,21 +45,25 @@ router adaptive-virtual-topology
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !
+   profile DEFAULT-POLICY-VIDEO
+      path-selection load-balance LB-DEFAULT-POLICY-VIDEO
+   !
    profile DEFAULT-POLICY-WITH-CP-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-POLICY-WITH-CP-VIDEO
    !
    vrf default
       avt policy DEFAULT-POLICY-WITH-CP
       avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
       avt profile CONTROL-PLANE-PROFILE id 254
-   !
-   vrf IT
-      avt policy DEFAULT-POLICY
-      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf PROD
       avt policy DEFAULT-POLICY
       avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
 !
 router path-selection
    tcp mss ceiling ipv4 ingress
@@ -95,7 +105,10 @@ router path-selection
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
       path-group INET
-      path-group LTE
+      path-group LTE priority 42
+   !
+   load-balance policy LB-DEFAULT-POLICY-VIDEO
+      path-group INET
       path-group MPLS
 !
 spanning-tree mode none
@@ -171,7 +184,7 @@ interface Loopback0
    ip address 192.168.42.1/32
 !
 interface Vxlan1
-   description cv-pathfinder-edge-no-default-policy_VTEP
+   description cv-pathfinder-edge-custom-default-policy_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
    vxlan vrf default vni 1
@@ -186,6 +199,10 @@ application traffic recognition
    application-profile CONTROL-PLANE-APPLICATION-PROFILE
       application CONTROL-PLANE-APPLICATION
    !
+   application-profile VIDEO
+      application CUSTOM-APPLICATION-1
+      application skype
+   !
    field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
       192.168.144.1/32
 !
@@ -194,14 +211,14 @@ ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
 !
-ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.1:511
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.1:1
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.42.0/24 eq 32
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   set extcommunity soo 192.168.42.1:511 additive
+   set extcommunity soo 192.168.42.1:1 additive
 !
 route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
    match extcommunity ECL-EVPN-SOO
@@ -212,7 +229,7 @@ route-map RM-EVPN-SOO-IN deny 10
 route-map RM-EVPN-SOO-IN permit 20
 !
 route-map RM-EVPN-SOO-OUT permit 10
-   set extcommunity soo 192.168.42.1:511 additive
+   set extcommunity soo 192.168.42.1:1 additive
 !
 router bfd
    multihop interval 300 min-rx 300 multiplier 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -66,12 +66,6 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
-   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-   !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -117,6 +117,8 @@ spanning-tree mode none
 no enable password
 no aaa root
 !
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
@@ -175,19 +177,27 @@ interface Ethernet52
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.17.0.3/31
 !
-interface Ethernet52.42
-   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.42_vrf_PROD
+interface Ethernet52.142
+   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.3/31
 !
-interface Ethernet52.100
-   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.100_vrf_IT
+interface Ethernet52.666
+   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.3/31
+!
+interface Ethernet52.1000
+   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.3/31
 !
@@ -200,6 +210,7 @@ interface Vxlan1
    description cv-pathfinder-edge-no-common-path-group_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 166
    vxlan vrf default vni 1
    vxlan vrf IT vni 100
    vxlan vrf PROD vni 42
@@ -247,6 +258,7 @@ application traffic recognition
       42
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
@@ -329,6 +341,16 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.42.2:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.42.2
+      neighbor 172.17.0.2 remote-as 65199
+      neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.2 description site-ha-disabled-leaf_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.42.2:1
       route-target import evpn 1:1
@@ -336,23 +358,23 @@ router bgp 65000
       route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
    !
    vrf IT
-      rd 192.168.42.2:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.42.2:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.42.2
       neighbor 172.17.0.2 remote-as 65199
       neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.2 description site-ha-disabled-leaf_Ethernet2.100_vrf_IT
+      neighbor 172.17.0.2 description site-ha-disabled-leaf_Ethernet2.1000_vrf_IT
       redistribute connected
    !
    vrf PROD
-      rd 192.168.42.2:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.42.2:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.42.2
       neighbor 172.17.0.2 remote-as 65199
       neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.2 description site-ha-disabled-leaf_Ethernet2.42_vrf_PROD
+      neighbor 172.17.0.2 description site-ha-disabled-leaf_Ethernet2.142_vrf_PROD
       redistribute connected
 !
 router traffic-engineering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -41,6 +41,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-AVT-POLICY-DEFAULT
    !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
    policy PROD-AVT-POLICY
       !
       match application-profile VOICE
@@ -61,6 +66,15 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
+   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
    profile PROD-AVT-POLICY-DEFAULT
       path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -69,6 +83,10 @@ router adaptive-virtual-topology
    !
    profile PROD-AVT-POLICY-VOICE
       path-selection load-balance LB-PROD-AVT-POLICY-VOICE
+   !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf default
       avt policy DEFAULT-AVT-POLICY-WITH-CP
@@ -103,6 +121,9 @@ router path-selection
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group Satellite
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -39,9 +39,6 @@ router adaptive-virtual-topology
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !
-   profile DEFAULT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-POLICY-WITH-CP-DEFAULT
-   !
    vrf default
       avt policy DEFAULT-POLICY-WITH-CP
       avt profile DEFAULT-POLICY-DEFAULT id 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -66,12 +66,6 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
-   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-   !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -153,6 +153,8 @@ spanning-tree mode none
 no enable password
 no aaa root
 !
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
@@ -223,19 +225,27 @@ interface Ethernet52
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.17.0.1/31
 !
-interface Ethernet52.42
-   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.42_vrf_PROD
+interface Ethernet52.142
+   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.1/31
 !
-interface Ethernet52.100
-   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.100_vrf_IT
+interface Ethernet52.666
+   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.1/31
+!
+interface Ethernet52.1000
+   description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.1/31
 !
@@ -248,6 +258,7 @@ interface Vxlan1
    description cv-pathfinder-edge_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 166
    vxlan vrf default vni 1
    vxlan vrf IT vni 100
    vxlan vrf PROD vni 42
@@ -296,6 +307,7 @@ application traffic recognition
       42
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
@@ -393,6 +405,16 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.42.1:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.42.1
+      neighbor 172.17.0.0 remote-as 65199
+      neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.0 description site-ha-disabled-leaf_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.42.1:1
       route-target import evpn 1:1
@@ -400,23 +422,23 @@ router bgp 65000
       route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
    !
    vrf IT
-      rd 192.168.42.1:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.42.1:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.42.1
       neighbor 172.17.0.0 remote-as 65199
       neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.0 description site-ha-disabled-leaf_Ethernet1.100_vrf_IT
+      neighbor 172.17.0.0 description site-ha-disabled-leaf_Ethernet1.1000_vrf_IT
       redistribute connected
    !
    vrf PROD
-      rd 192.168.42.1:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.42.1:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.42.1
       neighbor 172.17.0.0 remote-as 65199
       neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.0 description site-ha-disabled-leaf_Ethernet1.42_vrf_PROD
+      neighbor 172.17.0.0 description site-ha-disabled-leaf_Ethernet1.142_vrf_PROD
       redistribute connected
 !
 router traffic-engineering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -41,6 +41,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-AVT-POLICY-DEFAULT
    !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
    policy PROD-AVT-POLICY
       !
       match application-profile VOICE
@@ -61,6 +66,15 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
+   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
    profile PROD-AVT-POLICY-DEFAULT
       path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -69,6 +83,10 @@ router adaptive-virtual-topology
    !
    profile PROD-AVT-POLICY-VOICE
       path-selection load-balance LB-PROD-AVT-POLICY-VOICE
+   !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf default
       avt policy DEFAULT-AVT-POLICY-WITH-CP
@@ -131,6 +149,11 @@ router path-selection
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
       path-group INET
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
+      path-group LTE
       path-group MPLS
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -66,12 +66,6 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
-   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-   !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -41,6 +41,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-AVT-POLICY-DEFAULT
    !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
    policy PROD-AVT-POLICY
       !
       match application-profile VOICE
@@ -61,6 +66,15 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
+   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
    profile PROD-AVT-POLICY-DEFAULT
       path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -69,6 +83,10 @@ router adaptive-virtual-topology
    !
    profile PROD-AVT-POLICY-VOICE
       path-selection load-balance LB-PROD-AVT-POLICY-VOICE
+   !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf default
       avt policy DEFAULT-AVT-POLICY-WITH-CP
@@ -125,6 +143,10 @@ router path-selection
       path-group LAN_HA
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group LAN_HA
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
       path-group INET
       path-group LAN_HA
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -147,6 +147,8 @@ spanning-tree mode none
 no enable password
 no aaa root
 !
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
@@ -209,19 +211,27 @@ interface Ethernet52
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.17.0.5/31
 !
-interface Ethernet52.42
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.42_vrf_PROD
+interface Ethernet52.142
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.5/31
 !
-interface Ethernet52.100
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.100_vrf_IT
+interface Ethernet52.666
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.5/31
+!
+interface Ethernet52.1000
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.5/31
 !
@@ -233,19 +243,27 @@ interface Ethernet53
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.17.0.7/31
 !
-interface Ethernet53.42
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.42_vrf_PROD
+interface Ethernet53.142
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.7/31
 !
-interface Ethernet53.100
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.100_vrf_IT
+interface Ethernet53.666
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.7/31
+!
+interface Ethernet53.1000
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.7/31
 !
@@ -258,6 +276,7 @@ interface Vxlan1
    description cv-pathfinder-edge2A_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 166
    vxlan vrf default vni 1
    vxlan vrf IT vni 100
    vxlan vrf PROD vni 42
@@ -306,6 +325,7 @@ application traffic recognition
       42
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
@@ -425,6 +445,19 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.42.2:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.42.2
+      neighbor 172.17.0.4 remote-as 65199
+      neighbor 172.17.0.4 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.4 description site-ha-enabled-leaf2A_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      neighbor 172.17.0.6 remote-as 65199
+      neighbor 172.17.0.6 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.6 description site-ha-enabled-leaf2B_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.42.2:1
       route-target import evpn 1:1
@@ -432,29 +465,29 @@ router bgp 65000
       route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
    !
    vrf IT
-      rd 192.168.42.2:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.42.2:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.42.2
       neighbor 172.17.0.4 remote-as 65199
       neighbor 172.17.0.4 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.4 description site-ha-enabled-leaf2A_Ethernet1.100_vrf_IT
+      neighbor 172.17.0.4 description site-ha-enabled-leaf2A_Ethernet1.1000_vrf_IT
       neighbor 172.17.0.6 remote-as 65199
       neighbor 172.17.0.6 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.6 description site-ha-enabled-leaf2B_Ethernet1.100_vrf_IT
+      neighbor 172.17.0.6 description site-ha-enabled-leaf2B_Ethernet1.1000_vrf_IT
       redistribute connected
    !
    vrf PROD
-      rd 192.168.42.2:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.42.2:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.42.2
       neighbor 172.17.0.4 remote-as 65199
       neighbor 172.17.0.4 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.4 description site-ha-enabled-leaf2A_Ethernet1.42_vrf_PROD
+      neighbor 172.17.0.4 description site-ha-enabled-leaf2A_Ethernet1.142_vrf_PROD
       neighbor 172.17.0.6 remote-as 65199
       neighbor 172.17.0.6 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.6 description site-ha-enabled-leaf2B_Ethernet1.42_vrf_PROD
+      neighbor 172.17.0.6 description site-ha-enabled-leaf2B_Ethernet1.142_vrf_PROD
       redistribute connected
 !
 router traffic-engineering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -66,12 +66,6 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
-   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-   !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -145,6 +145,8 @@ spanning-tree mode none
 no enable password
 no aaa root
 !
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
@@ -206,19 +208,27 @@ interface Ethernet52
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.17.0.9/31
 !
-interface Ethernet52.42
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.42_vrf_PROD
+interface Ethernet52.142
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.9/31
 !
-interface Ethernet52.100
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.100_vrf_IT
+interface Ethernet52.666
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.9/31
+!
+interface Ethernet52.1000
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.9/31
 !
@@ -230,19 +240,27 @@ interface Ethernet53
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.17.0.11/31
 !
-interface Ethernet53.42
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.42_vrf_PROD
+interface Ethernet53.142
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.11/31
 !
-interface Ethernet53.100
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.100_vrf_IT
+interface Ethernet53.666
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.11/31
+!
+interface Ethernet53.1000
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.11/31
 !
@@ -255,6 +273,7 @@ interface Vxlan1
    description cv-pathfinder-edge2B_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 166
    vxlan vrf default vni 1
    vxlan vrf IT vni 100
    vxlan vrf PROD vni 42
@@ -303,6 +322,7 @@ application traffic recognition
       42
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
@@ -422,6 +442,19 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.42.3:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.42.3
+      neighbor 172.17.0.8 remote-as 65199
+      neighbor 172.17.0.8 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.8 description site-ha-enabled-leaf2A_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      neighbor 172.17.0.10 remote-as 65199
+      neighbor 172.17.0.10 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.10 description site-ha-enabled-leaf2B_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.42.3:1
       route-target import evpn 1:1
@@ -429,29 +462,29 @@ router bgp 65000
       route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
    !
    vrf IT
-      rd 192.168.42.3:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.42.3:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.42.3
       neighbor 172.17.0.8 remote-as 65199
       neighbor 172.17.0.8 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.8 description site-ha-enabled-leaf2A_Ethernet2.100_vrf_IT
+      neighbor 172.17.0.8 description site-ha-enabled-leaf2A_Ethernet2.1000_vrf_IT
       neighbor 172.17.0.10 remote-as 65199
       neighbor 172.17.0.10 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.10 description site-ha-enabled-leaf2B_Ethernet2.100_vrf_IT
+      neighbor 172.17.0.10 description site-ha-enabled-leaf2B_Ethernet2.1000_vrf_IT
       redistribute connected
    !
    vrf PROD
-      rd 192.168.42.3:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.42.3:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.42.3
       neighbor 172.17.0.8 remote-as 65199
       neighbor 172.17.0.8 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.8 description site-ha-enabled-leaf2A_Ethernet2.42_vrf_PROD
+      neighbor 172.17.0.8 description site-ha-enabled-leaf2A_Ethernet2.142_vrf_PROD
       neighbor 172.17.0.10 remote-as 65199
       neighbor 172.17.0.10 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.10 description site-ha-enabled-leaf2B_Ethernet2.42_vrf_PROD
+      neighbor 172.17.0.10 description site-ha-enabled-leaf2B_Ethernet2.142_vrf_PROD
       redistribute connected
 !
 router traffic-engineering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -41,6 +41,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-AVT-POLICY-DEFAULT
    !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
    policy PROD-AVT-POLICY
       !
       match application-profile VOICE
@@ -61,6 +66,15 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
+   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
    profile PROD-AVT-POLICY-DEFAULT
       path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -69,6 +83,10 @@ router adaptive-virtual-topology
    !
    profile PROD-AVT-POLICY-VOICE
       path-selection load-balance LB-PROD-AVT-POLICY-VOICE
+   !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf default
       avt policy DEFAULT-AVT-POLICY-WITH-CP
@@ -123,6 +141,10 @@ router path-selection
       path-group MPLS priority 42
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group LAN_HA
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
       path-group LAN_HA
       path-group MPLS
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -36,6 +36,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-AVT-POLICY-DEFAULT
    !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
    policy PROD-AVT-POLICY
       !
       match application-profile VOICE
@@ -64,6 +69,15 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
+   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
    profile PROD-AVT-POLICY-DEFAULT
       path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -78,6 +92,10 @@ router adaptive-virtual-topology
    !
    profile TRANSIT-AVT-POLICY-VOICE
       path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
+   !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf default
       avt policy DEFAULT-AVT-POLICY-WITH-CP
@@ -137,6 +155,11 @@ router path-selection
       path-group MPLS priority 42
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
       path-group INET
       path-group LAN_HA
       path-group MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -72,12 +72,6 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
-   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-   !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -55,13 +55,16 @@ router adaptive-virtual-topology
    policy TRANSIT-AVT-POLICY
       !
       match application-profile VOICE
-         avt profile TRANSIT-AVT-POLICY-VOICE
+         avt profile CUSTOM-VOICE-PROFILE-NAME
       !
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
    profile CONTROL-PLANE-PROFILE
       path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   !
+   profile CUSTOM-VOICE-PROFILE-NAME
+      path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -90,9 +93,6 @@ router adaptive-virtual-topology
    profile TRANSIT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile TRANSIT-AVT-POLICY-VOICE
-      path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
-   !
    vrf ATTRACTED-VRF-FROM-UPLINK
       avt policy DEFAULT-POLICY
       avt profile DEFAULT-POLICY-DEFAULT id 1
@@ -117,7 +117,7 @@ router adaptive-virtual-topology
    vrf TRANSIT
       avt policy TRANSIT-AVT-POLICY
       avt profile TRANSIT-AVT-POLICY-DEFAULT id 1
-      avt profile TRANSIT-AVT-POLICY-VOICE id 42
+      avt profile CUSTOM-VOICE-PROFILE-NAME id 42
 !
 router path-selection
    peer dynamic source stun
@@ -147,6 +147,11 @@ router path-selection
       path-group INET
       path-group LAN_HA
       path-group MPLS
+   !
+   load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
+      path-group LAN_HA
+      path-group MPLS
+      path-group INET priority 2
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group Equinix
@@ -186,11 +191,6 @@ router path-selection
       path-group INET
       path-group LAN_HA
       path-group MPLS priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
-      path-group LAN_HA
-      path-group MPLS
-      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -55,13 +55,16 @@ router adaptive-virtual-topology
    policy TRANSIT-AVT-POLICY
       !
       match application-profile VOICE
-         avt profile TRANSIT-AVT-POLICY-VOICE
+         avt profile CUSTOM-VOICE-PROFILE-NAME
       !
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
    profile CONTROL-PLANE-PROFILE
       path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   !
+   profile CUSTOM-VOICE-PROFILE-NAME
+      path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -90,9 +93,6 @@ router adaptive-virtual-topology
    profile TRANSIT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile TRANSIT-AVT-POLICY-VOICE
-      path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
-   !
    vrf ATTRACTED-VRF-FROM-UPLINK
       avt policy DEFAULT-POLICY
       avt profile DEFAULT-POLICY-DEFAULT id 1
@@ -117,7 +117,7 @@ router adaptive-virtual-topology
    vrf TRANSIT
       avt policy TRANSIT-AVT-POLICY
       avt profile TRANSIT-AVT-POLICY-DEFAULT id 1
-      avt profile TRANSIT-AVT-POLICY-VOICE id 42
+      avt profile CUSTOM-VOICE-PROFILE-NAME id 42
 !
 router path-selection
    peer dynamic source stun
@@ -150,6 +150,11 @@ router path-selection
    load-balance policy LB-CONTROL-PLANE-PROFILE
       path-group INET
       path-group LAN_HA
+   !
+   load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
+      path-group LAN_HA
+      path-group MPLS
+      path-group INET priority 2
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group Equinix
@@ -188,11 +193,6 @@ router path-selection
       path-group INET
       path-group LAN_HA
       path-group MPLS priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
-      path-group LAN_HA
-      path-group MPLS
-      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -72,12 +72,6 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
-   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-   !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -36,6 +36,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-AVT-POLICY-DEFAULT
    !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
    policy PROD-AVT-POLICY
       !
       match application-profile VOICE
@@ -64,6 +69,15 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
+   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
    profile PROD-AVT-POLICY-DEFAULT
       path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -78,6 +92,10 @@ router adaptive-virtual-topology
    !
    profile TRANSIT-AVT-POLICY-VOICE
       path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
+   !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf default
       avt policy DEFAULT-AVT-POLICY-WITH-CP
@@ -143,6 +161,10 @@ router path-selection
       path-group INET
       path-group LAN_HA
       path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
+      path-group LAN_HA
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT
       path-group INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -36,6 +36,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-AVT-POLICY-DEFAULT
    !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
    policy PROD-AVT-POLICY
       !
       match application-profile VOICE
@@ -64,6 +69,15 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
+   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
    profile PROD-AVT-POLICY-DEFAULT
       path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -78,6 +92,10 @@ router adaptive-virtual-topology
    !
    profile TRANSIT-AVT-POLICY-VOICE
       path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
+   !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf default
       avt policy DEFAULT-AVT-POLICY-WITH-CP
@@ -147,6 +165,11 @@ router path-selection
       path-group MPLS priority 42
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
       path-group INET
       path-group LAN_HA
       path-group MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -72,12 +72,6 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
-   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-   !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -55,13 +55,16 @@ router adaptive-virtual-topology
    policy TRANSIT-AVT-POLICY
       !
       match application-profile VOICE
-         avt profile TRANSIT-AVT-POLICY-VOICE
+         avt profile CUSTOM-VOICE-PROFILE-NAME
       !
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
    profile CONTROL-PLANE-PROFILE
       path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   !
+   profile CUSTOM-VOICE-PROFILE-NAME
+      path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -90,9 +93,6 @@ router adaptive-virtual-topology
    profile TRANSIT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile TRANSIT-AVT-POLICY-VOICE
-      path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
-   !
    vrf ATTRACTED-VRF-FROM-UPLINK
       avt policy DEFAULT-POLICY
       avt profile DEFAULT-POLICY-DEFAULT id 1
@@ -117,7 +117,7 @@ router adaptive-virtual-topology
    vrf TRANSIT
       avt policy TRANSIT-AVT-POLICY
       avt profile TRANSIT-AVT-POLICY-DEFAULT id 1
-      avt profile TRANSIT-AVT-POLICY-VOICE id 42
+      avt profile CUSTOM-VOICE-PROFILE-NAME id 42
 !
 router path-selection
    peer dynamic source stun
@@ -158,6 +158,11 @@ router path-selection
       path-group LAN_HA
       path-group MPLS
    !
+   load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
+      path-group LAN_HA
+      path-group MPLS
+      path-group INET priority 2
+   !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group Equinix
       path-group INET
@@ -196,11 +201,6 @@ router path-selection
       path-group INET
       path-group LAN_HA
       path-group MPLS priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
-      path-group LAN_HA
-      path-group MPLS
-      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -41,6 +41,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-AVT-POLICY-DEFAULT
    !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
    policy PROD-AVT-POLICY
       !
       match application-profile VOICE
@@ -69,6 +74,15 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
+   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
    profile PROD-AVT-POLICY-DEFAULT
       path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -83,6 +97,10 @@ router adaptive-virtual-topology
    !
    profile TRANSIT-AVT-POLICY-VOICE
       path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
+   !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf default
       avt policy DEFAULT-AVT-POLICY-WITH-CP
@@ -153,6 +171,11 @@ router path-selection
       path-group MPLS priority 42
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
       path-group INET
       path-group LAN_HA
       path-group MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -60,13 +60,16 @@ router adaptive-virtual-topology
    policy TRANSIT-AVT-POLICY
       !
       match application-profile VOICE
-         avt profile TRANSIT-AVT-POLICY-VOICE
+         avt profile CUSTOM-VOICE-PROFILE-NAME
       !
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
    profile CONTROL-PLANE-PROFILE
       path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   !
+   profile CUSTOM-VOICE-PROFILE-NAME
+      path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -95,9 +98,6 @@ router adaptive-virtual-topology
    profile TRANSIT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile TRANSIT-AVT-POLICY-VOICE
-      path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
-   !
    vrf ATTRACTED-VRF-FROM-UPLINK
       avt policy DEFAULT-POLICY
       avt profile DEFAULT-POLICY-DEFAULT id 1
@@ -122,7 +122,7 @@ router adaptive-virtual-topology
    vrf TRANSIT
       avt policy TRANSIT-AVT-POLICY
       avt profile TRANSIT-AVT-POLICY-DEFAULT id 1
-      avt profile TRANSIT-AVT-POLICY-VOICE id 42
+      avt profile CUSTOM-VOICE-PROFILE-NAME id 42
 !
 router path-selection
    tcp mss ceiling ipv4 ingress
@@ -165,6 +165,11 @@ router path-selection
       path-group LAN_HA
       path-group MPLS
    !
+   load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
+      path-group LAN_HA
+      path-group MPLS
+      path-group INET priority 2
+   !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group INET
       path-group LAN_HA
@@ -201,11 +206,6 @@ router path-selection
       path-group INET
       path-group LAN_HA
       path-group MPLS priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
-      path-group LAN_HA
-      path-group MPLS
-      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -77,12 +77,6 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
-   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-   !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -189,9 +189,13 @@ spanning-tree mode none
 no enable password
 no aaa root
 !
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
+!
+vrf instance NOT-WAN-VRF
 !
 vrf instance PROD
 !
@@ -267,19 +271,27 @@ interface Ethernet52
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.17.0.1/31
 !
-interface Ethernet52.42
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.42_vrf_PROD
+interface Ethernet52.142
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.1/31
 !
-interface Ethernet52.100
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.100_vrf_IT
+interface Ethernet52.666
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.1/31
+!
+interface Ethernet52.1000
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.1/31
 !
@@ -292,6 +304,7 @@ interface Vxlan1
    description cv-pathfinder-transit1A_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 166
    vxlan vrf default vni 1
    vxlan vrf IT vni 100
    vxlan vrf PROD vni 42
@@ -341,8 +354,10 @@ application traffic recognition
       42
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
+ip routing vrf NOT-WAN-VRF
 ip routing vrf PROD
 ip routing vrf TRANSIT
 !
@@ -456,6 +471,16 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.43.1:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.43.1
+      neighbor 172.17.0.0 remote-as 65199
+      neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.0 description site-ha-enabled-leaf1_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.43.1:1
       route-target import evpn 1:1
@@ -463,23 +488,27 @@ router bgp 65000
       route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
    !
    vrf IT
-      rd 192.168.43.1:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.43.1:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.43.1
       neighbor 172.17.0.0 remote-as 65199
       neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.0 description site-ha-enabled-leaf1_Ethernet1.100_vrf_IT
+      neighbor 172.17.0.0 description site-ha-enabled-leaf1_Ethernet1.1000_vrf_IT
+      redistribute connected
+   !
+   vrf NOT-WAN-VRF
+      router-id 192.168.43.1
       redistribute connected
    !
    vrf PROD
-      rd 192.168.43.1:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.43.1:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.43.1
       neighbor 172.17.0.0 remote-as 65199
       neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.0 description site-ha-enabled-leaf1_Ethernet1.42_vrf_PROD
+      neighbor 172.17.0.0 description site-ha-enabled-leaf1_Ethernet1.142_vrf_PROD
       redistribute connected
    !
    vrf TRANSIT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -41,6 +41,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-AVT-POLICY-DEFAULT
    !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
    policy PROD-AVT-POLICY
       !
       match application-profile VOICE
@@ -69,6 +74,15 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
+   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+   !
+   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
    profile PROD-AVT-POLICY-DEFAULT
       path-selection load-balance LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -83,6 +97,10 @@ router adaptive-virtual-topology
    !
    profile TRANSIT-AVT-POLICY-VOICE
       path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
+   !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
    !
    vrf default
       avt policy DEFAULT-AVT-POLICY-WITH-CP
@@ -153,6 +171,11 @@ router path-selection
       path-group MPLS priority 42
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
       path-group INET
       path-group LAN_HA
       path-group MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -60,13 +60,16 @@ router adaptive-virtual-topology
    policy TRANSIT-AVT-POLICY
       !
       match application-profile VOICE
-         avt profile TRANSIT-AVT-POLICY-VOICE
+         avt profile CUSTOM-VOICE-PROFILE-NAME
       !
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
    profile CONTROL-PLANE-PROFILE
       path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   !
+   profile CUSTOM-VOICE-PROFILE-NAME
+      path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -95,9 +98,6 @@ router adaptive-virtual-topology
    profile TRANSIT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile TRANSIT-AVT-POLICY-VOICE
-      path-selection load-balance LB-TRANSIT-AVT-POLICY-VOICE
-   !
    vrf ATTRACTED-VRF-FROM-UPLINK
       avt policy DEFAULT-POLICY
       avt profile DEFAULT-POLICY-DEFAULT id 1
@@ -122,7 +122,7 @@ router adaptive-virtual-topology
    vrf TRANSIT
       avt policy TRANSIT-AVT-POLICY
       avt profile TRANSIT-AVT-POLICY-DEFAULT id 1
-      avt profile TRANSIT-AVT-POLICY-VOICE id 42
+      avt profile CUSTOM-VOICE-PROFILE-NAME id 42
 !
 router path-selection
    tcp mss ceiling ipv4 ingress
@@ -165,6 +165,11 @@ router path-selection
       path-group LAN_HA
       path-group MPLS
    !
+   load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
+      path-group LAN_HA
+      path-group MPLS
+      path-group INET priority 2
+   !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group INET
       path-group LAN_HA
@@ -201,11 +206,6 @@ router path-selection
       path-group INET
       path-group LAN_HA
       path-group MPLS priority 2
-   !
-   load-balance policy LB-TRANSIT-AVT-POLICY-VOICE
-      path-group LAN_HA
-      path-group MPLS
-      path-group INET priority 2
 !
 spanning-tree mode none
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -189,9 +189,13 @@ spanning-tree mode none
 no enable password
 no aaa root
 !
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
+!
+vrf instance NOT-WAN-VRF
 !
 vrf instance PROD
 !
@@ -267,19 +271,27 @@ interface Ethernet52
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.17.0.3/31
 !
-interface Ethernet52.42
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.42_vrf_PROD
+interface Ethernet52.142
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.3/31
 !
-interface Ethernet52.100
-   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.100_vrf_IT
+interface Ethernet52.666
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.3/31
+!
+interface Ethernet52.1000
+   description P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.3/31
 !
@@ -292,6 +304,7 @@ interface Vxlan1
    description cv-pathfinder-transit1B_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 166
    vxlan vrf default vni 1
    vxlan vrf IT vni 100
    vxlan vrf PROD vni 42
@@ -341,8 +354,10 @@ application traffic recognition
       42
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
+ip routing vrf NOT-WAN-VRF
 ip routing vrf PROD
 ip routing vrf TRANSIT
 !
@@ -456,6 +471,16 @@ router bgp 65000
       bgp additional-paths send any
       neighbor WAN-OVERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.43.2:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.43.2
+      neighbor 172.17.0.2 remote-as 65199
+      neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.2 description site-ha-enabled-leaf1_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.43.2:1
       route-target import evpn 1:1
@@ -463,23 +488,27 @@ router bgp 65000
       route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
    !
    vrf IT
-      rd 192.168.43.2:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.43.2:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.43.2
       neighbor 172.17.0.2 remote-as 65199
       neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.2 description site-ha-enabled-leaf1_Ethernet2.100_vrf_IT
+      neighbor 172.17.0.2 description site-ha-enabled-leaf1_Ethernet2.1000_vrf_IT
+      redistribute connected
+   !
+   vrf NOT-WAN-VRF
+      router-id 192.168.43.2
       redistribute connected
    !
    vrf PROD
-      rd 192.168.43.2:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.43.2:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.43.2
       neighbor 172.17.0.2 remote-as 65199
       neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.2 description site-ha-enabled-leaf1_Ethernet2.42_vrf_PROD
+      neighbor 172.17.0.2 description site-ha-enabled-leaf1_Ethernet2.142_vrf_PROD
       redistribute connected
    !
    vrf TRANSIT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -77,12 +77,6 @@ router adaptive-virtual-topology
    profile DEFAULT-AVT-POLICY-VIDEO
       path-selection load-balance LB-DEFAULT-AVT-POLICY-VIDEO
    !
-   profile DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-   !
-   profile DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-      path-selection load-balance LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-   !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-disabled-leaf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-disabled-leaf.cfg
@@ -17,6 +17,11 @@ vlan 100
 vlan 101
    name VLAN101
 !
+vlan 666
+   name VLAN666
+!
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
@@ -30,19 +35,27 @@ interface Ethernet1
    no switchport
    ip address 172.17.0.0/31
 !
-interface Ethernet1.42
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.42_vrf_PROD
+interface Ethernet1.142
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.0/31
 !
-interface Ethernet1.100
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.100_vrf_IT
+interface Ethernet1.666
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.0/31
+!
+interface Ethernet1.1000
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.0/31
 !
@@ -53,19 +66,27 @@ interface Ethernet2
    no switchport
    ip address 172.17.0.2/31
 !
-interface Ethernet2.42
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.42_vrf_PROD
+interface Ethernet2.142
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.2/31
 !
-interface Ethernet2.100
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.100_vrf_IT
+interface Ethernet2.666
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.2/31
+!
+interface Ethernet2.1000
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.2/31
 !
@@ -85,19 +106,29 @@ interface Vlan100
    vrf PROD
    ip address virtual 10.0.100.1/24
 !
+interface Vlan666
+   description VLAN666
+   shutdown
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 10.66.66.1
+   ip address virtual 10.66.66.66/24
+!
 interface Vxlan1
    description site-ha-disabled-leaf_VTEP
    vxlan source-interface Loopback1
    vxlan udp-port 4789
    vxlan vlan 100 vni 1100
    vxlan vlan 101 vni 1101
+   vxlan vlan 666 vni 1666
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 666
    vxlan vrf default vni 1
-   vxlan vrf IT vni 100
-   vxlan vrf PROD vni 42
+   vxlan vrf IT vni 1000
+   vxlan vrf PROD vni 142
 !
 ip virtual-router mac-address 00:1c:73:00:00:01
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
@@ -144,6 +175,11 @@ router bgp 65199
       route-target both 1101:1101
       redistribute learned
    !
+   vlan 666
+      rd 192.168.45.4:1666
+      route-target both 1666:1666
+      redistribute learned
+   !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
    !
@@ -151,35 +187,48 @@ router bgp 65199
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.45.4:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.45.4
+      neighbor 172.17.0.1 remote-as 65000
+      neighbor 172.17.0.1 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.1 description cv-pathfinder-edge_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      neighbor 172.17.0.3 remote-as 65000
+      neighbor 172.17.0.3 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.3 description cv-pathfinder-edge-no-common-path-group_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.45.4:1
       route-target import evpn 1:1
       route-target export evpn 1:1
    !
    vrf IT
-      rd 192.168.45.4:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.45.4:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.45.4
       neighbor 172.17.0.1 remote-as 65000
       neighbor 172.17.0.1 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.1 description cv-pathfinder-edge_Ethernet52.100_vrf_IT
+      neighbor 172.17.0.1 description cv-pathfinder-edge_Ethernet52.1000_vrf_IT
       neighbor 172.17.0.3 remote-as 65000
       neighbor 172.17.0.3 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.3 description cv-pathfinder-edge-no-common-path-group_Ethernet52.100_vrf_IT
+      neighbor 172.17.0.3 description cv-pathfinder-edge-no-common-path-group_Ethernet52.1000_vrf_IT
       redistribute connected
    !
    vrf PROD
-      rd 192.168.45.4:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.45.4:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.45.4
       neighbor 172.17.0.1 remote-as 65000
       neighbor 172.17.0.1 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.1 description cv-pathfinder-edge_Ethernet52.42_vrf_PROD
+      neighbor 172.17.0.1 description cv-pathfinder-edge_Ethernet52.142_vrf_PROD
       neighbor 172.17.0.3 remote-as 65000
       neighbor 172.17.0.3 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.3 description cv-pathfinder-edge-no-common-path-group_Ethernet52.42_vrf_PROD
+      neighbor 172.17.0.3 description cv-pathfinder-edge-no-common-path-group_Ethernet52.142_vrf_PROD
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf1.cfg
@@ -17,6 +17,11 @@ vlan 100
 vlan 101
    name VLAN101
 !
+vlan 666
+   name VLAN666
+!
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
@@ -30,19 +35,27 @@ interface Ethernet1
    no switchport
    ip address 172.17.0.0/31
 !
-interface Ethernet1.42
-   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.42_vrf_PROD
+interface Ethernet1.142
+   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.0/31
 !
-interface Ethernet1.100
-   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.100_vrf_IT
+interface Ethernet1.666
+   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.0/31
+!
+interface Ethernet1.1000
+   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.0/31
 !
@@ -53,19 +66,27 @@ interface Ethernet2
    no switchport
    ip address 172.17.0.2/31
 !
-interface Ethernet2.42
-   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.42_vrf_PROD
+interface Ethernet2.142
+   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.2/31
 !
-interface Ethernet2.100
-   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.100_vrf_IT
+interface Ethernet2.666
+   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.2/31
+!
+interface Ethernet2.1000
+   description P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.2/31
 !
@@ -85,19 +106,28 @@ interface Vlan100
    vrf PROD
    ip address virtual 10.0.100.1/24
 !
+interface Vlan666
+   description VLAN666
+   shutdown
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address virtual 10.66.66.66/24
+!
 interface Vxlan1
    description site-ha-enabled-leaf1_VTEP
    vxlan source-interface Loopback1
    vxlan udp-port 4789
    vxlan vlan 100 vni 1100
    vxlan vlan 101 vni 1101
+   vxlan vlan 666 vni 1666
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 666
    vxlan vrf default vni 1
-   vxlan vrf IT vni 100
-   vxlan vrf PROD vni 42
+   vxlan vrf IT vni 1000
+   vxlan vrf PROD vni 142
 !
 ip virtual-router mac-address 00:1c:73:00:00:01
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
@@ -144,6 +174,11 @@ router bgp 65199
       route-target both 1101:1101
       redistribute learned
    !
+   vlan 666
+      rd 192.168.45.1:1666
+      route-target both 1666:1666
+      redistribute learned
+   !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
    !
@@ -151,35 +186,48 @@ router bgp 65199
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.45.1:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.45.1
+      neighbor 172.17.0.1 remote-as 65000
+      neighbor 172.17.0.1 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.1 description cv-pathfinder-transit1A_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      neighbor 172.17.0.3 remote-as 65000
+      neighbor 172.17.0.3 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.3 description cv-pathfinder-transit1B_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.45.1:1
       route-target import evpn 1:1
       route-target export evpn 1:1
    !
    vrf IT
-      rd 192.168.45.1:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.45.1:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.45.1
       neighbor 172.17.0.1 remote-as 65000
       neighbor 172.17.0.1 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.1 description cv-pathfinder-transit1A_Ethernet52.100_vrf_IT
+      neighbor 172.17.0.1 description cv-pathfinder-transit1A_Ethernet52.1000_vrf_IT
       neighbor 172.17.0.3 remote-as 65000
       neighbor 172.17.0.3 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.3 description cv-pathfinder-transit1B_Ethernet52.100_vrf_IT
+      neighbor 172.17.0.3 description cv-pathfinder-transit1B_Ethernet52.1000_vrf_IT
       redistribute connected
    !
    vrf PROD
-      rd 192.168.45.1:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.45.1:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.45.1
       neighbor 172.17.0.1 remote-as 65000
       neighbor 172.17.0.1 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.1 description cv-pathfinder-transit1A_Ethernet52.42_vrf_PROD
+      neighbor 172.17.0.1 description cv-pathfinder-transit1A_Ethernet52.142_vrf_PROD
       neighbor 172.17.0.3 remote-as 65000
       neighbor 172.17.0.3 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.3 description cv-pathfinder-transit1B_Ethernet52.42_vrf_PROD
+      neighbor 172.17.0.3 description cv-pathfinder-transit1B_Ethernet52.142_vrf_PROD
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf2A.cfg
@@ -17,6 +17,11 @@ vlan 100
 vlan 101
    name VLAN101
 !
+vlan 666
+   name VLAN666
+!
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
@@ -30,19 +35,27 @@ interface Ethernet1
    no switchport
    ip address 172.17.0.4/31
 !
-interface Ethernet1.42
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.42_vrf_PROD
+interface Ethernet1.142
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.4/31
 !
-interface Ethernet1.100
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.100_vrf_IT
+interface Ethernet1.666
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.4/31
+!
+interface Ethernet1.1000
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.4/31
 !
@@ -53,19 +66,27 @@ interface Ethernet2
    no switchport
    ip address 172.17.0.8/31
 !
-interface Ethernet2.42
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.42_vrf_PROD
+interface Ethernet2.142
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.8/31
 !
-interface Ethernet2.100
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.100_vrf_IT
+interface Ethernet2.666
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.8/31
+!
+interface Ethernet2.1000
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.8/31
 !
@@ -85,19 +106,28 @@ interface Vlan100
    vrf PROD
    ip address virtual 10.0.100.1/24
 !
+interface Vlan666
+   description VLAN666
+   shutdown
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address virtual 10.66.66.66/24
+!
 interface Vxlan1
    description site-ha-enabled-leaf2A_VTEP
    vxlan source-interface Loopback1
    vxlan udp-port 4789
    vxlan vlan 100 vni 1100
    vxlan vlan 101 vni 1101
+   vxlan vlan 666 vni 1666
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 666
    vxlan vrf default vni 1
-   vxlan vrf IT vni 100
-   vxlan vrf PROD vni 42
+   vxlan vrf IT vni 1000
+   vxlan vrf PROD vni 142
 !
 ip virtual-router mac-address 00:1c:73:00:00:01
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
@@ -144,6 +174,11 @@ router bgp 65199
       route-target both 1101:1101
       redistribute learned
    !
+   vlan 666
+      rd 192.168.45.2:1666
+      route-target both 1666:1666
+      redistribute learned
+   !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
    !
@@ -151,35 +186,48 @@ router bgp 65199
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.45.2:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.45.2
+      neighbor 172.17.0.5 remote-as 65000
+      neighbor 172.17.0.5 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.5 description cv-pathfinder-edge2A_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      neighbor 172.17.0.9 remote-as 65000
+      neighbor 172.17.0.9 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.9 description cv-pathfinder-edge2B_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.45.2:1
       route-target import evpn 1:1
       route-target export evpn 1:1
    !
    vrf IT
-      rd 192.168.45.2:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.45.2:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.45.2
       neighbor 172.17.0.5 remote-as 65000
       neighbor 172.17.0.5 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.5 description cv-pathfinder-edge2A_Ethernet52.100_vrf_IT
+      neighbor 172.17.0.5 description cv-pathfinder-edge2A_Ethernet52.1000_vrf_IT
       neighbor 172.17.0.9 remote-as 65000
       neighbor 172.17.0.9 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.9 description cv-pathfinder-edge2B_Ethernet52.100_vrf_IT
+      neighbor 172.17.0.9 description cv-pathfinder-edge2B_Ethernet52.1000_vrf_IT
       redistribute connected
    !
    vrf PROD
-      rd 192.168.45.2:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.45.2:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.45.2
       neighbor 172.17.0.5 remote-as 65000
       neighbor 172.17.0.5 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.5 description cv-pathfinder-edge2A_Ethernet52.42_vrf_PROD
+      neighbor 172.17.0.5 description cv-pathfinder-edge2A_Ethernet52.142_vrf_PROD
       neighbor 172.17.0.9 remote-as 65000
       neighbor 172.17.0.9 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.9 description cv-pathfinder-edge2B_Ethernet52.42_vrf_PROD
+      neighbor 172.17.0.9 description cv-pathfinder-edge2B_Ethernet52.142_vrf_PROD
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf2B.cfg
@@ -17,6 +17,11 @@ vlan 100
 vlan 101
    name VLAN101
 !
+vlan 666
+   name VLAN666
+!
+vrf instance ATTRACTED-VRF-FROM-UPLINK
+!
 vrf instance IT
 !
 vrf instance MGMT
@@ -30,19 +35,27 @@ interface Ethernet1
    no switchport
    ip address 172.17.0.6/31
 !
-interface Ethernet1.42
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.42_vrf_PROD
+interface Ethernet1.142
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.6/31
 !
-interface Ethernet1.100
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.100_vrf_IT
+interface Ethernet1.666
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.6/31
+!
+interface Ethernet1.1000
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.6/31
 !
@@ -53,19 +66,27 @@ interface Ethernet2
    no switchport
    ip address 172.17.0.10/31
 !
-interface Ethernet2.42
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.42_vrf_PROD
+interface Ethernet2.142
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.142_vrf_PROD
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 42
+   encapsulation dot1q vlan 142
    vrf PROD
    ip address 172.17.0.10/31
 !
-interface Ethernet2.100
-   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.100_vrf_IT
+interface Ethernet2.666
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.666_vrf_ATTRACTED-VRF-FROM-UPLINK
    no shutdown
    mtu 9214
-   encapsulation dot1q vlan 100
+   encapsulation dot1q vlan 666
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address 172.17.0.10/31
+!
+interface Ethernet2.1000
+   description P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.1000_vrf_IT
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1000
    vrf IT
    ip address 172.17.0.10/31
 !
@@ -85,19 +106,28 @@ interface Vlan100
    vrf PROD
    ip address virtual 10.0.100.1/24
 !
+interface Vlan666
+   description VLAN666
+   shutdown
+   vrf ATTRACTED-VRF-FROM-UPLINK
+   ip address virtual 10.66.66.66/24
+!
 interface Vxlan1
    description site-ha-enabled-leaf2B_VTEP
    vxlan source-interface Loopback1
    vxlan udp-port 4789
    vxlan vlan 100 vni 1100
    vxlan vlan 101 vni 1101
+   vxlan vlan 666 vni 1666
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 666
    vxlan vrf default vni 1
-   vxlan vrf IT vni 100
-   vxlan vrf PROD vni 42
+   vxlan vrf IT vni 1000
+   vxlan vrf PROD vni 142
 !
 ip virtual-router mac-address 00:1c:73:00:00:01
 !
 ip routing
+ip routing vrf ATTRACTED-VRF-FROM-UPLINK
 ip routing vrf IT
 no ip routing vrf MGMT
 ip routing vrf PROD
@@ -144,6 +174,11 @@ router bgp 65199
       route-target both 1101:1101
       redistribute learned
    !
+   vlan 666
+      rd 192.168.45.3:1666
+      route-target both 1666:1666
+      redistribute learned
+   !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
    !
@@ -151,35 +186,48 @@ router bgp 65199
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
    !
+   vrf ATTRACTED-VRF-FROM-UPLINK
+      rd 192.168.45.3:666
+      route-target import evpn 666:666
+      route-target export evpn 666:666
+      router-id 192.168.45.3
+      neighbor 172.17.0.7 remote-as 65000
+      neighbor 172.17.0.7 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.7 description cv-pathfinder-edge2A_Ethernet53.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      neighbor 172.17.0.11 remote-as 65000
+      neighbor 172.17.0.11 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.17.0.11 description cv-pathfinder-edge2B_Ethernet53.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+      redistribute connected
+   !
    vrf default
       rd 192.168.45.3:1
       route-target import evpn 1:1
       route-target export evpn 1:1
    !
    vrf IT
-      rd 192.168.45.3:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
+      rd 192.168.45.3:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
       router-id 192.168.45.3
       neighbor 172.17.0.7 remote-as 65000
       neighbor 172.17.0.7 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.7 description cv-pathfinder-edge2A_Ethernet53.100_vrf_IT
+      neighbor 172.17.0.7 description cv-pathfinder-edge2A_Ethernet53.1000_vrf_IT
       neighbor 172.17.0.11 remote-as 65000
       neighbor 172.17.0.11 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.11 description cv-pathfinder-edge2B_Ethernet53.100_vrf_IT
+      neighbor 172.17.0.11 description cv-pathfinder-edge2B_Ethernet53.1000_vrf_IT
       redistribute connected
    !
    vrf PROD
-      rd 192.168.45.3:42
-      route-target import evpn 42:42
-      route-target export evpn 42:42
+      rd 192.168.45.3:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
       router-id 192.168.45.3
       neighbor 172.17.0.7 remote-as 65000
       neighbor 172.17.0.7 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.7 description cv-pathfinder-edge2A_Ethernet53.42_vrf_PROD
+      neighbor 172.17.0.7 description cv-pathfinder-edge2A_Ethernet53.142_vrf_PROD
       neighbor 172.17.0.11 remote-as 65000
       neighbor 172.17.0.11 peer group IPv4-UNDERLAY-PEERS
-      neighbor 172.17.0.11 description cv-pathfinder-edge2B_Ethernet53.42_vrf_PROD
+      neighbor 172.17.0.11 description cv-pathfinder-edge2B_Ethernet53.142_vrf_PROD
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
@@ -205,23 +205,30 @@ router_path_selection:
       - 10.7.7.7
     ipsec_profile: AUTOVPN
   load_balance_policies:
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
   - name: LB-CONTROL-PLANE-PROFILE
     path_groups:
     - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: INET
   policies:
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
+    default_match:
+      load_balance: LB-DEFAULT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-WITH-CP
     rules:
     - id: 10
       application_profile: CONTROL-PLANE-APPLICATION-PROFILE
       load_balance: LB-CONTROL-PLANE-PROFILE
     default_match:
-      load_balance: LB-DEFAULT-AVT-POLICY-DEFAULT
+      load_balance: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
+  - name: PROD
+    path_selection_policy: DEFAULT-POLICY
+  - name: IT
+    path_selection_policy: DEFAULT-POLICY
   - name: default
-    path_selection_policy: DEFAULT-AVT-POLICY-WITH-CP
+    path_selection_policy: DEFAULT-POLICY-WITH-CP
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -217,43 +217,43 @@ router_path_selection:
   - name: LB-CONTROL-PLANE-PROFILE
     path_groups:
     - name: INET
-  - name: LB-PROD-AVT-POLICY-VOICE
-    path_groups:
-    - name: INET
-  - name: LB-PROD-AVT-POLICY-VIDEO
-    path_groups:
-    - name: INET
-  - name: LB-PROD-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-IT
+  - name: LB-DEFAULT-AUTOVPN-POLICY-IT
     path_groups:
     - name: INET
       priority: 2
+  - name: LB-PROD-AUTOVPN-POLICY-VOICE
+    path_groups:
+    - name: INET
+  - name: LB-PROD-AUTOVPN-POLICY-VIDEO
+    path_groups:
+    - name: INET
+  - name: LB-PROD-AUTOVPN-POLICY-DEFAULT
+    path_groups:
+    - name: INET
   policies:
-  - name: PROD-AVT-POLICY
-    rules:
-    - id: 10
-      application_profile: VOICE
-      load_balance: LB-PROD-AVT-POLICY-VOICE
-    - id: 20
-      application_profile: VIDEO
-      load_balance: LB-PROD-AVT-POLICY-VIDEO
-    default_match:
-      load_balance: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-AUTOVPN-POLICY-WITH-CP
     rules:
     - id: 10
       application_profile: CONTROL-PLANE-APPLICATION-PROFILE
       load_balance: LB-CONTROL-PLANE-PROFILE
     - id: 20
       application_profile: IT
-      load_balance: LB-DEFAULT-AVT-POLICY-IT
+      load_balance: LB-DEFAULT-AUTOVPN-POLICY-IT
+  - name: PROD-AUTOVPN-POLICY
+    rules:
+    - id: 10
+      application_profile: VOICE
+      load_balance: LB-PROD-AUTOVPN-POLICY-VOICE
+    - id: 20
+      application_profile: VIDEO
+      load_balance: LB-PROD-AUTOVPN-POLICY-VIDEO
+    default_match:
+      load_balance: LB-PROD-AUTOVPN-POLICY-DEFAULT
   vrfs:
   - name: default
-    path_selection_policy: DEFAULT-AVT-POLICY-WITH-CP
+    path_selection_policy: DEFAULT-AUTOVPN-POLICY-WITH-CP
   - name: PROD
-    path_selection_policy: PROD-AVT-POLICY
+    path_selection_policy: PROD-AUTOVPN-POLICY
 stun:
   client:
     server_profiles:
@@ -263,9 +263,9 @@ stun:
       ip_address: 10.8.8.8
 application_traffic_recognition:
   application_profiles:
+  - name: IT
   - name: VOICE
   - name: VIDEO
-  - name: IT
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -68,20 +68,6 @@ router_bgp:
         route_targets:
         - '1:1'
         - route-map RM-EVPN-EXPORT-VRF-DEFAULT
-  - name: IT
-    router_id: 192.168.30.1
-    rd: 192.168.30.1:100
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - 100:100
-      export:
-      - address_family: evpn
-        route_targets:
-        - 100:100
-    redistribute_routes:
-    - source_protocol: connected
   - name: PROD
     router_id: 192.168.30.1
     rd: 192.168.30.1:42
@@ -293,7 +279,5 @@ vxlan_interface:
       vrfs:
       - name: default
         vni: 1
-      - name: IT
-        vni: 100
       - name: PROD
         vni: 42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -185,53 +185,53 @@ router_path_selection:
   - name: LB-CONTROL-PLANE-PROFILE
     path_groups:
     - name: INET
-  - name: LB-PROD-AVT-POLICY-VOICE
-    path_groups:
-    - name: INET
-  - name: LB-PROD-AVT-POLICY-VIDEO
-    path_groups:
-    - name: INET
-  - name: LB-PROD-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-IT
+  - name: LB-DEFAULT-AUTOVPN-POLICY-IT
     path_groups:
     - name: MPLS
     - name: INET
       priority: 2
+  - name: LB-PROD-AUTOVPN-POLICY-VOICE
+    path_groups:
+    - name: INET
+  - name: LB-PROD-AUTOVPN-POLICY-VIDEO
+    path_groups:
+    - name: INET
+  - name: LB-PROD-AUTOVPN-POLICY-DEFAULT
+    path_groups:
+    - name: INET
   policies:
-  - name: PROD-AVT-POLICY
-    rules:
-    - id: 10
-      application_profile: VOICE
-      load_balance: LB-PROD-AVT-POLICY-VOICE
-    - id: 20
-      application_profile: VIDEO
-      load_balance: LB-PROD-AVT-POLICY-VIDEO
-    default_match:
-      load_balance: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-AUTOVPN-POLICY-WITH-CP
     rules:
     - id: 10
       application_profile: CONTROL-PLANE-APPLICATION-PROFILE
       load_balance: LB-CONTROL-PLANE-PROFILE
     - id: 20
       application_profile: IT
-      load_balance: LB-DEFAULT-AVT-POLICY-IT
+      load_balance: LB-DEFAULT-AUTOVPN-POLICY-IT
+  - name: PROD-AUTOVPN-POLICY
+    rules:
+    - id: 10
+      application_profile: VOICE
+      load_balance: LB-PROD-AUTOVPN-POLICY-VOICE
+    - id: 20
+      application_profile: VIDEO
+      load_balance: LB-PROD-AUTOVPN-POLICY-VIDEO
+    default_match:
+      load_balance: LB-PROD-AUTOVPN-POLICY-DEFAULT
   vrfs:
   - name: default
-    path_selection_policy: DEFAULT-AVT-POLICY-WITH-CP
+    path_selection_policy: DEFAULT-AUTOVPN-POLICY-WITH-CP
   - name: PROD
-    path_selection_policy: PROD-AVT-POLICY
+    path_selection_policy: PROD-AUTOVPN-POLICY
 stun:
   server:
     local_interfaces:
     - Ethernet1
 application_traffic_recognition:
   application_profiles:
+  - name: IT
   - name: VOICE
   - name: VIDEO
-  - name: IT
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -187,53 +187,53 @@ router_path_selection:
   - name: LB-CONTROL-PLANE-PROFILE
     path_groups:
     - name: INET
-  - name: LB-PROD-AVT-POLICY-VOICE
-    path_groups:
-    - name: INET
-  - name: LB-PROD-AVT-POLICY-VIDEO
-    path_groups:
-    - name: INET
-  - name: LB-PROD-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-IT
+  - name: LB-DEFAULT-AUTOVPN-POLICY-IT
     path_groups:
     - name: MPLS
     - name: INET
       priority: 2
+  - name: LB-PROD-AUTOVPN-POLICY-VOICE
+    path_groups:
+    - name: INET
+  - name: LB-PROD-AUTOVPN-POLICY-VIDEO
+    path_groups:
+    - name: INET
+  - name: LB-PROD-AUTOVPN-POLICY-DEFAULT
+    path_groups:
+    - name: INET
   policies:
-  - name: PROD-AVT-POLICY
-    rules:
-    - id: 10
-      application_profile: VOICE
-      load_balance: LB-PROD-AVT-POLICY-VOICE
-    - id: 20
-      application_profile: VIDEO
-      load_balance: LB-PROD-AVT-POLICY-VIDEO
-    default_match:
-      load_balance: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-AUTOVPN-POLICY-WITH-CP
     rules:
     - id: 10
       application_profile: CONTROL-PLANE-APPLICATION-PROFILE
       load_balance: LB-CONTROL-PLANE-PROFILE
     - id: 20
       application_profile: IT
-      load_balance: LB-DEFAULT-AVT-POLICY-IT
+      load_balance: LB-DEFAULT-AUTOVPN-POLICY-IT
+  - name: PROD-AUTOVPN-POLICY
+    rules:
+    - id: 10
+      application_profile: VOICE
+      load_balance: LB-PROD-AUTOVPN-POLICY-VOICE
+    - id: 20
+      application_profile: VIDEO
+      load_balance: LB-PROD-AUTOVPN-POLICY-VIDEO
+    default_match:
+      load_balance: LB-PROD-AUTOVPN-POLICY-DEFAULT
   vrfs:
   - name: default
-    path_selection_policy: DEFAULT-AVT-POLICY-WITH-CP
+    path_selection_policy: DEFAULT-AUTOVPN-POLICY-WITH-CP
   - name: PROD
-    path_selection_policy: PROD-AVT-POLICY
+    path_selection_policy: PROD-AUTOVPN-POLICY
 stun:
   server:
     local_interfaces:
     - Ethernet1
 application_traffic_recognition:
   application_profiles:
+  - name: IT
   - name: VOICE
   - name: VIDEO
-  - name: IT
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -1,4 +1,4 @@
-hostname: cv-pathfinder-edge-no-default-policy
+hostname: cv-pathfinder-edge-custom-default-policy
 is_deployed: true
 router_bgp:
   as: '65000'
@@ -162,7 +162,7 @@ route_maps:
     match:
     - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
     set:
-    - extcommunity soo 192.168.42.1:511 additive
+    - extcommunity soo 192.168.42.1:1 additive
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10
@@ -176,7 +176,7 @@ route_maps:
   - sequence: 10
     type: permit
     set:
-    - extcommunity soo 192.168.42.1:511 additive
+    - extcommunity soo 192.168.42.1:1 additive
 - name: RM-EVPN-EXPORT-VRF-DEFAULT
   sequence_numbers:
   - sequence: 10
@@ -201,7 +201,7 @@ ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:
   - type: permit
-    extcommunities: soo 192.168.42.1:511
+    extcommunities: soo 192.168.42.1:1
 ip_security:
   ike_policies:
   - name: CP-IKE-POLICY
@@ -240,48 +240,55 @@ ip_security:
 router_adaptive_virtual_topology:
   topology_role: edge
   region:
-    name: AVD_Land_East
-    id: 43
+    name: AVD_Land_West
+    id: 42
   zone:
     name: DEFAULT-ZONE
     id: 1
   site:
-    name: Site511
-    id: 511
+    name: Site1
+    id: 1
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-POLICY-WITH-CP-VIDEO
   - name: DEFAULT-POLICY-WITH-CP-DEFAULT
     load_balance_policy: LB-DEFAULT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-POLICY-VIDEO
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
-  - name: PROD
-    policy: DEFAULT-POLICY
-    profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
-  - name: IT
-    policy: DEFAULT-POLICY
-    profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
     - name: CONTROL-PLANE-PROFILE
       id: 254
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: PROD
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
     - name: DEFAULT-POLICY-DEFAULT
       id: 1
   policies:
-  - name: DEFAULT-POLICY
-    matches:
-    - application_profile: default
-      avt_profile: DEFAULT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-WITH-CP
     matches:
     - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
       avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY
+    matches:
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
     - application_profile: default
       avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
@@ -332,15 +339,19 @@ router_path_selection:
       enabled: true
     ipsec_profile: CP-PROFILE
   load_balance_policies:
-  - name: LB-DEFAULT-POLICY-DEFAULT
-    path_groups:
-    - name: INET
-    - name: MPLS
-    - name: LTE
   - name: LB-CONTROL-PLANE-PROFILE
     path_groups:
     - name: INET
     - name: MPLS
+  - name: LB-DEFAULT-POLICY-VIDEO
+    path_groups:
+    - name: MPLS
+    - name: INET
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
+    - name: LTE
+      priority: 42
 router_traffic_engineering:
   enabled: true
 stun:
@@ -354,6 +365,10 @@ stun:
       ip_address: 172.16.0.1
 application_traffic_recognition:
   application_profiles:
+  - name: VIDEO
+    applications:
+    - name: CUSTOM-APPLICATION-1
+    - name: skype
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION
@@ -375,7 +390,7 @@ dps_interfaces:
     hardware: WAN-FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
-    description: cv-pathfinder-edge-no-default-policy_VTEP
+    description: cv-pathfinder-edge-custom-default-policy_VTEP
     vxlan:
       udp_port: 4789
       source_interface: Dps1
@@ -392,11 +407,11 @@ metadata:
     - name: Role
       value: edge
     - name: Region
-      value: AVD_Land_East
+      value: AVD_Land_West
     - name: Zone
       value: DEFAULT-ZONE
     - name: Site
-      value: Site511
+      value: Site1
     interface_tags:
     - interface: Ethernet1
       tags:
@@ -425,9 +440,9 @@ metadata:
   cv_pathfinder:
     role: edge
     vtep_ip: 192.168.255.1
-    region: AVD_Land_East
+    region: AVD_Land_West
     zone: DEFAULT-ZONE
-    site: Site511
+    site: Site1
     interfaces:
     - name: Ethernet1
       carrier: ATT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -75,20 +75,6 @@ router_bgp:
         route_targets:
         - '1:1'
         - route-map RM-EVPN-EXPORT-VRF-DEFAULT
-  - name: IT
-    router_id: 192.168.42.1
-    rd: 192.168.42.1:100
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - 100:100
-      export:
-      - address_family: evpn
-        route_targets:
-        - 100:100
-    redistribute_routes:
-    - source_protocol: connected
   - name: PROD
     router_id: 192.168.42.1
     rd: 192.168.42.1:42
@@ -111,9 +97,6 @@ spanning_tree:
 vrfs:
 - name: MGMT
   ip_routing: false
-- name: IT
-  tenant: TenantA
-  ip_routing: true
 - name: PROD
   tenant: TenantA
   ip_routing: true
@@ -397,8 +380,6 @@ vxlan_interface:
       vrfs:
       - name: default
         vni: 1
-      - name: IT
-        vni: 100
       - name: PROD
         vni: 42
 metadata:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -234,10 +234,6 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-POLICY-WITH-CP-DEFAULT
   - name: DEFAULT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-POLICY-VIDEO
   - name: DEFAULT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -343,20 +343,16 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-AVT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: DEFAULT-AVT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
     load_balance_policy: LB-PROD-AVT-POLICY-VIDEO
   - name: PROD-AVT-POLICY-DEFAULT
     load_balance_policy: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: DEFAULT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -343,6 +343,10 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
@@ -353,6 +357,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -379,7 +385,20 @@ router_adaptive_virtual_topology:
       id: 3
     - name: DEFAULT-AVT-POLICY-DEFAULT
       id: 1
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
   policies:
+  - name: DEFAULT-AVT-POLICY-WITH-CP
+    matches:
+    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
+      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-AVT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY
     matches:
     - application_profile: VOICE
@@ -394,14 +413,10 @@ router_adaptive_virtual_topology:
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
       avt_profile: DEFAULT-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
-    - application_profile: VIDEO
-      avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
-      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -422,26 +437,29 @@ router_path_selection:
   - name: LB-CONTROL-PLANE-PROFILE
     path_groups:
     - name: Satellite
+  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: LB-PROD-AVT-POLICY-VOICE
     jitter: 42
   - name: LB-PROD-AVT-POLICY-VIDEO
     loss_rate: '42.0'
   - name: LB-PROD-AVT-POLICY-DEFAULT
-  - name: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: Satellite
 router_traffic_engineering:
   enabled: true
 application_traffic_recognition:
   application_profiles:
-  - name: VOICE
-    applications:
-    - name: CUSTOM-VOICE-APPLICATION
   - name: VIDEO
     categories:
     - name: VIDEO1
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+  - name: VOICE
+    applications:
+    - name: CUSTOM-VOICE-APPLICATION
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -48,17 +48,17 @@ router_bgp:
     - ip_address: 172.17.0.2
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-disabled-leaf_Ethernet2.100_vrf_IT
-    rd: 192.168.42.2:100
+      description: site-ha-disabled-leaf_Ethernet2.1000_vrf_IT
+    rd: 192.168.42.2:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -67,17 +67,36 @@ router_bgp:
     - ip_address: 172.17.0.2
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-disabled-leaf_Ethernet2.42_vrf_PROD
-    rd: 192.168.42.2:42
+      description: site-ha-disabled-leaf_Ethernet2.142_vrf_PROD
+    rd: 192.168.42.2:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.42.2
+    neighbors:
+    - ip_address: 172.17.0.2
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65199'
+      description: site-ha-disabled-leaf_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.42.2:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -132,6 +151,9 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
+  ip_routing: true
 management_api_http:
   enable_vrfs:
   - name: MGMT
@@ -148,26 +170,37 @@ ethernet_interfaces:
   ip_address: 172.17.0.3/31
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
-- name: Ethernet52.100
+- name: Ethernet52.1000
   peer: site-ha-disabled-leaf
-  peer_interface: Ethernet2.100
+  peer_interface: Ethernet2.1000
   peer_type: l3leaf
   vrf: IT
-  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.100_vrf_IT
+  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.3/31
-- name: Ethernet52.42
+- name: Ethernet52.142
   peer: site-ha-disabled-leaf
-  peer_interface: Ethernet2.42
+  peer_interface: Ethernet2.142
   peer_type: l3leaf
   vrf: PROD
-  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.42_vrf_PROD
+  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.3/31
+- name: Ethernet52.666
+  peer: site-ha-disabled-leaf
+  peer_interface: Ethernet2.666
+  peer_type: l3leaf
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.3/31
 - name: Ethernet1
@@ -468,6 +501,8 @@ vxlan_interface:
         vni: 100
       - name: PROD
         vni: 42
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 166
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -253,8 +253,6 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
   - name: DEFAULT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
-  - name: DEFAULT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-POLICY-WITH-CP-DEFAULT
   vrfs:
   - name: PROD
     policy: DEFAULT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -385,20 +385,16 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-AVT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: DEFAULT-AVT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
     load_balance_policy: LB-PROD-AVT-POLICY-VIDEO
   - name: PROD-AVT-POLICY-DEFAULT
     load_balance_policy: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: DEFAULT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -58,17 +58,17 @@ router_bgp:
     - ip_address: 172.17.0.0
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-disabled-leaf_Ethernet1.100_vrf_IT
-    rd: 192.168.42.1:100
+      description: site-ha-disabled-leaf_Ethernet1.1000_vrf_IT
+    rd: 192.168.42.1:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -77,17 +77,36 @@ router_bgp:
     - ip_address: 172.17.0.0
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-disabled-leaf_Ethernet1.42_vrf_PROD
-    rd: 192.168.42.1:42
+      description: site-ha-disabled-leaf_Ethernet1.142_vrf_PROD
+    rd: 192.168.42.1:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.42.1
+    neighbors:
+    - ip_address: 172.17.0.0
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65199'
+      description: site-ha-disabled-leaf_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.42.1:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -142,6 +161,9 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
+  ip_routing: true
 management_api_http:
   enable_vrfs:
   - name: MGMT
@@ -158,26 +180,37 @@ ethernet_interfaces:
   ip_address: 172.17.0.1/31
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
-- name: Ethernet52.100
+- name: Ethernet52.1000
   peer: site-ha-disabled-leaf
-  peer_interface: Ethernet1.100
+  peer_interface: Ethernet1.1000
   peer_type: l3leaf
   vrf: IT
-  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.100_vrf_IT
+  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.1/31
-- name: Ethernet52.42
+- name: Ethernet52.142
   peer: site-ha-disabled-leaf
-  peer_interface: Ethernet1.42
+  peer_interface: Ethernet1.142
   peer_type: l3leaf
   vrf: PROD
-  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.42_vrf_PROD
+  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.1/31
+- name: Ethernet52.666
+  peer: site-ha-disabled-leaf
+  peer_interface: Ethernet1.666
+  peer_type: l3leaf
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.1/31
 - name: Ethernet1
@@ -573,6 +606,8 @@ vxlan_interface:
         vni: 100
       - name: PROD
         vni: 42
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 166
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -385,6 +385,10 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
@@ -395,6 +399,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -421,7 +427,20 @@ router_adaptive_virtual_topology:
       id: 3
     - name: DEFAULT-AVT-POLICY-DEFAULT
       id: 1
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
   policies:
+  - name: DEFAULT-AVT-POLICY-WITH-CP
+    matches:
+    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
+      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-AVT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY
     matches:
     - application_profile: VOICE
@@ -436,14 +455,10 @@ router_adaptive_virtual_topology:
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
       avt_profile: DEFAULT-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
-    - application_profile: VIDEO
-      avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
-      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -496,6 +511,15 @@ router_path_selection:
     path_groups:
     - name: INET
     - name: MPLS
+  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+    path_groups:
+    - name: MPLS
+    - name: INET
+  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
+    - name: MPLS
+      priority: 42
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: MPLS
@@ -514,15 +538,11 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-DEFAULT-AVT-POLICY-VIDEO
-    path_groups:
-    - name: MPLS
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+  - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: INET
     - name: MPLS
-      priority: 42
+    - name: LTE
 router_traffic_engineering:
   enabled: true
 stun:
@@ -536,15 +556,15 @@ stun:
       ip_address: 172.16.0.1
 application_traffic_recognition:
   application_profiles:
-  - name: VOICE
-    applications:
-    - name: CUSTOM-VOICE-APPLICATION
   - name: VIDEO
     categories:
     - name: VIDEO1
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+  - name: VOICE
+    applications:
+    - name: CUSTOM-VOICE-APPLICATION
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -458,20 +458,16 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-AVT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: DEFAULT-AVT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
     load_balance_policy: LB-PROD-AVT-POLICY-VIDEO
   - name: PROD-AVT-POLICY-DEFAULT
     load_balance_policy: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: DEFAULT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -458,6 +458,10 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
@@ -468,6 +472,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -494,7 +500,20 @@ router_adaptive_virtual_topology:
       id: 3
     - name: DEFAULT-AVT-POLICY-DEFAULT
       id: 1
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
   policies:
+  - name: DEFAULT-AVT-POLICY-WITH-CP
+    matches:
+    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
+      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-AVT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY
     matches:
     - application_profile: VOICE
@@ -509,14 +528,10 @@ router_adaptive_virtual_topology:
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
       avt_profile: DEFAULT-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
-    - application_profile: VIDEO
-      avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
-      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -561,6 +576,14 @@ router_path_selection:
     path_groups:
     - name: LAN_HA
     - name: INET
+  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -577,11 +600,7 @@ router_path_selection:
     path_groups:
     - name: LAN_HA
     - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-VIDEO
-    path_groups:
-    - name: LAN_HA
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+  - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
     - name: INET
@@ -596,15 +615,15 @@ stun:
       ip_address: 10.9.9.9
 application_traffic_recognition:
   application_profiles:
-  - name: VOICE
-    applications:
-    - name: CUSTOM-VOICE-APPLICATION
   - name: VIDEO
     categories:
     - name: VIDEO1
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+  - name: VOICE
+    applications:
+    - name: CUSTOM-VOICE-APPLICATION
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -64,21 +64,21 @@ router_bgp:
     - ip_address: 172.17.0.4
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf2A_Ethernet1.100_vrf_IT
+      description: site-ha-enabled-leaf2A_Ethernet1.1000_vrf_IT
     - ip_address: 172.17.0.6
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf2B_Ethernet1.100_vrf_IT
-    rd: 192.168.42.2:100
+      description: site-ha-enabled-leaf2B_Ethernet1.1000_vrf_IT
+    rd: 192.168.42.2:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -87,21 +87,44 @@ router_bgp:
     - ip_address: 172.17.0.4
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf2A_Ethernet1.42_vrf_PROD
+      description: site-ha-enabled-leaf2A_Ethernet1.142_vrf_PROD
     - ip_address: 172.17.0.6
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf2B_Ethernet1.42_vrf_PROD
-    rd: 192.168.42.2:42
+      description: site-ha-enabled-leaf2B_Ethernet1.142_vrf_PROD
+    rd: 192.168.42.2:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.42.2
+    neighbors:
+    - ip_address: 172.17.0.4
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65199'
+      description: site-ha-enabled-leaf2A_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    - ip_address: 172.17.0.6
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65199'
+      description: site-ha-enabled-leaf2B_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.42.2:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -156,6 +179,9 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
+  ip_routing: true
 management_api_http:
   enable_vrfs:
   - name: MGMT
@@ -172,26 +198,37 @@ ethernet_interfaces:
   ip_address: 172.17.0.5/31
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
-- name: Ethernet52.100
+- name: Ethernet52.1000
   peer: site-ha-enabled-leaf2A
-  peer_interface: Ethernet1.100
+  peer_interface: Ethernet1.1000
   peer_type: l3leaf
   vrf: IT
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.100_vrf_IT
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.5/31
-- name: Ethernet52.42
+- name: Ethernet52.142
   peer: site-ha-enabled-leaf2A
-  peer_interface: Ethernet1.42
+  peer_interface: Ethernet1.142
   peer_type: l3leaf
   vrf: PROD
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.42_vrf_PROD
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.5/31
+- name: Ethernet52.666
+  peer: site-ha-enabled-leaf2A
+  peer_interface: Ethernet1.666
+  peer_type: l3leaf
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.5/31
 - name: Ethernet53
@@ -205,26 +242,37 @@ ethernet_interfaces:
   ip_address: 172.17.0.7/31
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
-- name: Ethernet53.100
+- name: Ethernet53.1000
   peer: site-ha-enabled-leaf2B
-  peer_interface: Ethernet1.100
+  peer_interface: Ethernet1.1000
   peer_type: l3leaf
   vrf: IT
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.100_vrf_IT
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.7/31
-- name: Ethernet53.42
+- name: Ethernet53.142
   peer: site-ha-enabled-leaf2B
-  peer_interface: Ethernet1.42
+  peer_interface: Ethernet1.142
   peer_type: l3leaf
   vrf: PROD
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.42_vrf_PROD
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.7/31
+- name: Ethernet53.666
+  peer: site-ha-enabled-leaf2B
+  peer_interface: Ethernet1.666
+  peer_type: l3leaf
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.7/31
 - name: Ethernet1
@@ -618,6 +666,8 @@ vxlan_interface:
         vni: 100
       - name: PROD
         vni: 42
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 166
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -64,21 +64,21 @@ router_bgp:
     - ip_address: 172.17.0.8
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf2A_Ethernet2.100_vrf_IT
+      description: site-ha-enabled-leaf2A_Ethernet2.1000_vrf_IT
     - ip_address: 172.17.0.10
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf2B_Ethernet2.100_vrf_IT
-    rd: 192.168.42.3:100
+      description: site-ha-enabled-leaf2B_Ethernet2.1000_vrf_IT
+    rd: 192.168.42.3:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -87,21 +87,44 @@ router_bgp:
     - ip_address: 172.17.0.8
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf2A_Ethernet2.42_vrf_PROD
+      description: site-ha-enabled-leaf2A_Ethernet2.142_vrf_PROD
     - ip_address: 172.17.0.10
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf2B_Ethernet2.42_vrf_PROD
-    rd: 192.168.42.3:42
+      description: site-ha-enabled-leaf2B_Ethernet2.142_vrf_PROD
+    rd: 192.168.42.3:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.42.3
+    neighbors:
+    - ip_address: 172.17.0.8
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65199'
+      description: site-ha-enabled-leaf2A_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    - ip_address: 172.17.0.10
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65199'
+      description: site-ha-enabled-leaf2B_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.42.3:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -156,6 +179,9 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
+  ip_routing: true
 management_api_http:
   enable_vrfs:
   - name: MGMT
@@ -172,26 +198,37 @@ ethernet_interfaces:
   ip_address: 172.17.0.9/31
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
-- name: Ethernet52.100
+- name: Ethernet52.1000
   peer: site-ha-enabled-leaf2A
-  peer_interface: Ethernet2.100
+  peer_interface: Ethernet2.1000
   peer_type: l3leaf
   vrf: IT
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.100_vrf_IT
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.9/31
-- name: Ethernet52.42
+- name: Ethernet52.142
   peer: site-ha-enabled-leaf2A
-  peer_interface: Ethernet2.42
+  peer_interface: Ethernet2.142
   peer_type: l3leaf
   vrf: PROD
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.42_vrf_PROD
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.9/31
+- name: Ethernet52.666
+  peer: site-ha-enabled-leaf2A
+  peer_interface: Ethernet2.666
+  peer_type: l3leaf
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2A_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.9/31
 - name: Ethernet53
@@ -205,26 +242,37 @@ ethernet_interfaces:
   ip_address: 172.17.0.11/31
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
-- name: Ethernet53.100
+- name: Ethernet53.1000
   peer: site-ha-enabled-leaf2B
-  peer_interface: Ethernet2.100
+  peer_interface: Ethernet2.1000
   peer_type: l3leaf
   vrf: IT
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.100_vrf_IT
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.11/31
-- name: Ethernet53.42
+- name: Ethernet53.142
   peer: site-ha-enabled-leaf2B
-  peer_interface: Ethernet2.42
+  peer_interface: Ethernet2.142
   peer_type: l3leaf
   vrf: PROD
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.42_vrf_PROD
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.11/31
+- name: Ethernet53.666
+  peer: site-ha-enabled-leaf2B
+  peer_interface: Ethernet2.666
+  peer_type: l3leaf
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF2B_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.11/31
 - name: Ethernet2
@@ -612,6 +660,8 @@ vxlan_interface:
         vni: 100
       - name: PROD
         vni: 42
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 166
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -457,20 +457,16 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-AVT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: DEFAULT-AVT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
     load_balance_policy: LB-PROD-AVT-POLICY-VIDEO
   - name: PROD-AVT-POLICY-DEFAULT
     load_balance_policy: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: DEFAULT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -457,6 +457,10 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
@@ -467,6 +471,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -493,7 +499,20 @@ router_adaptive_virtual_topology:
       id: 3
     - name: DEFAULT-AVT-POLICY-DEFAULT
       id: 1
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
   policies:
+  - name: DEFAULT-AVT-POLICY-WITH-CP
+    matches:
+    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
+      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-AVT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY
     matches:
     - application_profile: VOICE
@@ -508,14 +527,10 @@ router_adaptive_virtual_topology:
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
       avt_profile: DEFAULT-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
-    - application_profile: VIDEO
-      avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
-      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -557,6 +572,15 @@ router_path_selection:
     path_groups:
     - name: LAN_HA
     - name: MPLS
+  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+    path_groups:
+    - name: LAN_HA
+    - name: MPLS
+  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: MPLS
+      priority: 42
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -572,15 +596,10 @@ router_path_selection:
     - name: LAN_HA
     - name: MPLS
       priority: 2
-  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
     - name: MPLS
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: LAN_HA
-    - name: MPLS
-      priority: 42
 router_traffic_engineering:
   enabled: true
 stun:
@@ -590,15 +609,15 @@ stun:
       ip_address: 172.16.0.1
 application_traffic_recognition:
   application_profiles:
-  - name: VOICE
-    applications:
-    - name: CUSTOM-VOICE-APPLICATION
   - name: VIDEO
     categories:
     - name: VIDEO1
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+  - name: VOICE
+    applications:
+    - name: CUSTOM-VOICE-APPLICATION
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -213,8 +213,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
-  - name: TRANSIT-AVT-POLICY-VOICE
-    load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: CUSTOM-VOICE-PROFILE-NAME
+    load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-DEFAULT
@@ -248,7 +248,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: TRANSIT-AVT-POLICY-VOICE
+    - name: CUSTOM-VOICE-PROFILE-NAME
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
@@ -283,7 +283,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT-AVT-POLICY
     matches:
     - application_profile: VOICE
-      avt_profile: TRANSIT-AVT-POLICY-VOICE
+      avt_profile: CUSTOM-VOICE-PROFILE-NAME
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY
@@ -358,7 +358,7 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: LB-CUSTOM-VOICE-PROFILE-NAME
     path_groups:
     - name: LAN_HA
     - name: MPLS
@@ -639,7 +639,7 @@ metadata:
       vni: 66
       avts:
       - id: 42
-        name: TRANSIT-AVT-POLICY-VOICE
+        name: CUSTOM-VOICE-PROFILE-NAME
         pathgroups:
         - name: LAN_HA
           preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -559,7 +559,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: PROD
-      vni: 42
+      vni: 142
       avts:
       - constraints:
           jitter: 42
@@ -593,7 +593,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: IT
-      vni: 100
+      vni: 1000
       avts:
       - id: 3
         name: DEFAULT-AVT-POLICY-VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -199,6 +199,10 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
@@ -213,6 +217,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -246,7 +252,20 @@ router_adaptive_virtual_topology:
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
   policies:
+  - name: DEFAULT-AVT-POLICY-WITH-CP
+    matches:
+    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
+      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-AVT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY
     matches:
     - application_profile: VOICE
@@ -267,14 +286,10 @@ router_adaptive_virtual_topology:
       avt_profile: TRANSIT-AVT-POLICY-VOICE
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
-    - application_profile: VIDEO
-      avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
-      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -310,6 +325,18 @@ router_path_selection:
     - name: LAN_HA
     - name: INET
     - name: MPLS
+  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+    path_groups:
+    - name: LAN_HA
+    - name: MPLS
+    - name: INET
+  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+    - name: Equinix
+    - name: MPLS
+      priority: 42
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -331,18 +358,6 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-DEFAULT-AVT-POLICY-VIDEO
-    path_groups:
-    - name: LAN_HA
-    - name: MPLS
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: LAN_HA
-    - name: INET
-    - name: Equinix
-    - name: MPLS
-      priority: 42
   - name: LB-TRANSIT-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -355,6 +370,11 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+    - name: MPLS
 router_traffic_engineering:
   enabled: true
 stun:
@@ -365,15 +385,15 @@ stun:
     - Ethernet3
 application_traffic_recognition:
   application_profiles:
-  - name: VOICE
-    applications:
-    - name: CUSTOM-VOICE-APPLICATION
   - name: VIDEO
     categories:
     - name: VIDEO1
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+  - name: VOICE
+    applications:
+    - name: CUSTOM-VOICE-APPLICATION
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION
@@ -636,3 +656,15 @@ metadata:
           preference: preferred
         - name: MPLS
           preference: alternate
+    - name: ATTRACTED-VRF-FROM-UPLINK
+      vni: 666
+      avts:
+      - id: 1
+        name: DEFAULT-POLICY-DEFAULT
+        pathgroups:
+        - name: LAN_HA
+          preference: preferred
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -199,20 +199,16 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-AVT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: DEFAULT-AVT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
     load_balance_policy: LB-PROD-AVT-POLICY-VIDEO
   - name: PROD-AVT-POLICY-DEFAULT
     load_balance_policy: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: DEFAULT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: CUSTOM-VOICE-PROFILE-NAME
     load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -213,6 +213,10 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
@@ -227,6 +231,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -260,7 +266,20 @@ router_adaptive_virtual_topology:
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
   policies:
+  - name: DEFAULT-AVT-POLICY-WITH-CP
+    matches:
+    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
+      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-AVT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY
     matches:
     - application_profile: VOICE
@@ -281,14 +300,10 @@ router_adaptive_virtual_topology:
       avt_profile: TRANSIT-AVT-POLICY-VOICE
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
-    - application_profile: VIDEO
-      avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
-      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -329,6 +344,18 @@ router_path_selection:
     path_groups:
     - name: LAN_HA
     - name: INET
+  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+    path_groups:
+    - name: LAN_HA
+    - name: MPLS
+    - name: INET
+  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+    - name: Equinix
+    - name: MPLS
+      priority: 42
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -350,18 +377,6 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-DEFAULT-AVT-POLICY-VIDEO
-    path_groups:
-    - name: LAN_HA
-    - name: MPLS
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: LAN_HA
-    - name: INET
-    - name: Equinix
-    - name: MPLS
-      priority: 42
   - name: LB-TRANSIT-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -374,6 +389,10 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
 router_traffic_engineering:
   enabled: true
 stun:
@@ -382,15 +401,15 @@ stun:
     - Ethernet1
 application_traffic_recognition:
   application_profiles:
-  - name: VOICE
-    applications:
-    - name: CUSTOM-VOICE-APPLICATION
   - name: VIDEO
     categories:
     - name: VIDEO1
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+  - name: VOICE
+    applications:
+    - name: CUSTOM-VOICE-APPLICATION
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION
@@ -625,3 +644,13 @@ metadata:
           preference: preferred
         - name: MPLS
           preference: alternate
+    - name: ATTRACTED-VRF-FROM-UPLINK
+      vni: 666
+      avts:
+      - id: 1
+        name: DEFAULT-POLICY-DEFAULT
+        pathgroups:
+        - name: LAN_HA
+          preference: preferred
+        - name: INET
+          preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -548,7 +548,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: PROD
-      vni: 42
+      vni: 142
       avts:
       - constraints:
           jitter: 42
@@ -582,7 +582,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: IT
-      vni: 100
+      vni: 1000
       avts:
       - id: 3
         name: DEFAULT-AVT-POLICY-VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -227,8 +227,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
-  - name: TRANSIT-AVT-POLICY-VOICE
-    load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: CUSTOM-VOICE-PROFILE-NAME
+    load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-DEFAULT
@@ -262,7 +262,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: TRANSIT-AVT-POLICY-VOICE
+    - name: CUSTOM-VOICE-PROFILE-NAME
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
@@ -297,7 +297,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT-AVT-POLICY
     matches:
     - application_profile: VOICE
-      avt_profile: TRANSIT-AVT-POLICY-VOICE
+      avt_profile: CUSTOM-VOICE-PROFILE-NAME
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY
@@ -377,7 +377,7 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: LB-CUSTOM-VOICE-PROFILE-NAME
     path_groups:
     - name: LAN_HA
     - name: MPLS
@@ -627,7 +627,7 @@ metadata:
       vni: 66
       avts:
       - id: 42
-        name: TRANSIT-AVT-POLICY-VOICE
+        name: CUSTOM-VOICE-PROFILE-NAME
         pathgroups:
         - name: LAN_HA
           preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -213,20 +213,16 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-AVT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: DEFAULT-AVT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
     load_balance_policy: LB-PROD-AVT-POLICY-VIDEO
   - name: PROD-AVT-POLICY-DEFAULT
     load_balance_policy: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: DEFAULT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: CUSTOM-VOICE-PROFILE-NAME
     load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -234,8 +234,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
-  - name: TRANSIT-AVT-POLICY-VOICE
-    load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: CUSTOM-VOICE-PROFILE-NAME
+    load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-DEFAULT
@@ -269,7 +269,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: TRANSIT-AVT-POLICY-VOICE
+    - name: CUSTOM-VOICE-PROFILE-NAME
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
@@ -304,7 +304,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT-AVT-POLICY
     matches:
     - application_profile: VOICE
-      avt_profile: TRANSIT-AVT-POLICY-VOICE
+      avt_profile: CUSTOM-VOICE-PROFILE-NAME
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY
@@ -392,7 +392,7 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: LB-CUSTOM-VOICE-PROFILE-NAME
     path_groups:
     - name: LAN_HA
     - name: MPLS
@@ -659,7 +659,7 @@ metadata:
       vni: 66
       avts:
       - id: 42
-        name: TRANSIT-AVT-POLICY-VOICE
+        name: CUSTOM-VOICE-PROFILE-NAME
         pathgroups:
         - name: LAN_HA
           preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -220,6 +220,10 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
@@ -234,6 +238,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -267,7 +273,20 @@ router_adaptive_virtual_topology:
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
   policies:
+  - name: DEFAULT-AVT-POLICY-WITH-CP
+    matches:
+    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
+      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-AVT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY
     matches:
     - application_profile: VOICE
@@ -288,14 +307,10 @@ router_adaptive_virtual_topology:
       avt_profile: TRANSIT-AVT-POLICY-VOICE
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
-    - application_profile: VIDEO
-      avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
-      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -344,6 +359,18 @@ router_path_selection:
     - name: LAN_HA
     - name: INET
     - name: MPLS
+  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+    path_groups:
+    - name: LAN_HA
+    - name: MPLS
+    - name: INET
+  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+    - name: Equinix
+    - name: MPLS
+      priority: 42
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -365,18 +392,6 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-DEFAULT-AVT-POLICY-VIDEO
-    path_groups:
-    - name: LAN_HA
-    - name: MPLS
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: LAN_HA
-    - name: INET
-    - name: Equinix
-    - name: MPLS
-      priority: 42
   - name: LB-TRANSIT-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -389,6 +404,11 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+    - name: MPLS
 router_traffic_engineering:
   enabled: true
 stun:
@@ -398,15 +418,15 @@ stun:
     - Ethernet2
 application_traffic_recognition:
   application_profiles:
-  - name: VOICE
-    applications:
-    - name: CUSTOM-VOICE-APPLICATION
   - name: VIDEO
     categories:
     - name: VIDEO1
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+  - name: VOICE
+    applications:
+    - name: CUSTOM-VOICE-APPLICATION
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION
@@ -656,3 +676,15 @@ metadata:
           preference: preferred
         - name: MPLS
           preference: alternate
+    - name: ATTRACTED-VRF-FROM-UPLINK
+      vni: 666
+      avts:
+      - id: 1
+        name: DEFAULT-POLICY-DEFAULT
+        pathgroups:
+        - name: LAN_HA
+          preference: preferred
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -579,7 +579,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: PROD
-      vni: 42
+      vni: 142
       avts:
       - constraints:
           jitter: 42
@@ -613,7 +613,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: IT
-      vni: 100
+      vni: 1000
       avts:
       - id: 3
         name: DEFAULT-AVT-POLICY-VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -220,20 +220,16 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-AVT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: DEFAULT-AVT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
     load_balance_policy: LB-PROD-AVT-POLICY-VIDEO
   - name: PROD-AVT-POLICY-DEFAULT
     load_balance_policy: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: DEFAULT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: CUSTOM-VOICE-PROFILE-NAME
     load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -434,6 +434,10 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
@@ -448,6 +452,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -481,7 +487,20 @@ router_adaptive_virtual_topology:
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
   policies:
+  - name: DEFAULT-AVT-POLICY-WITH-CP
+    matches:
+    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
+      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-AVT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY
     matches:
     - application_profile: VOICE
@@ -502,14 +521,10 @@ router_adaptive_virtual_topology:
       avt_profile: TRANSIT-AVT-POLICY-VOICE
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
-    - application_profile: VIDEO
-      avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
-      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -566,6 +581,17 @@ router_path_selection:
     - name: LAN_HA
     - name: INET
     - name: MPLS
+  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+    path_groups:
+    - name: LAN_HA
+    - name: MPLS
+    - name: INET
+  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+    - name: MPLS
+      priority: 42
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -586,17 +612,6 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-DEFAULT-AVT-POLICY-VIDEO
-    path_groups:
-    - name: LAN_HA
-    - name: MPLS
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: LAN_HA
-    - name: INET
-    - name: MPLS
-      priority: 42
   - name: LB-TRANSIT-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -609,6 +624,11 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+    - name: MPLS
 router_traffic_engineering:
   enabled: true
 stun:
@@ -622,15 +642,15 @@ stun:
       ip_address: 172.16.0.1
 application_traffic_recognition:
   application_profiles:
-  - name: VOICE
-    applications:
-    - name: CUSTOM-VOICE-APPLICATION
   - name: VIDEO
     categories:
     - name: VIDEO1
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+  - name: VOICE
+    applications:
+    - name: CUSTOM-VOICE-APPLICATION
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -448,8 +448,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
-  - name: TRANSIT-AVT-POLICY-VOICE
-    load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: CUSTOM-VOICE-PROFILE-NAME
+    load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-DEFAULT
@@ -483,7 +483,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: TRANSIT-AVT-POLICY-VOICE
+    - name: CUSTOM-VOICE-PROFILE-NAME
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
@@ -518,7 +518,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT-AVT-POLICY
     matches:
     - application_profile: VOICE
-      avt_profile: TRANSIT-AVT-POLICY-VOICE
+      avt_profile: CUSTOM-VOICE-PROFILE-NAME
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY
@@ -612,7 +612,7 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: LB-CUSTOM-VOICE-PROFILE-NAME
     path_groups:
     - name: LAN_HA
     - name: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -59,17 +59,17 @@ router_bgp:
     - ip_address: 172.17.0.0
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf1_Ethernet1.100_vrf_IT
-    rd: 192.168.43.1:100
+      description: site-ha-enabled-leaf1_Ethernet1.1000_vrf_IT
+    rd: 192.168.43.1:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -78,17 +78,36 @@ router_bgp:
     - ip_address: 172.17.0.0
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf1_Ethernet1.42_vrf_PROD
-    rd: 192.168.43.1:42
+      description: site-ha-enabled-leaf1_Ethernet1.142_vrf_PROD
+    rd: 192.168.43.1:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.43.1
+    neighbors:
+    - ip_address: 172.17.0.0
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65199'
+      description: site-ha-enabled-leaf1_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.43.1:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -103,6 +122,10 @@ router_bgp:
         route_targets:
         - '1:1'
         - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+  - name: NOT-WAN-VRF
+    router_id: 192.168.43.1
+    redistribute_routes:
+    - source_protocol: connected
   - name: TRANSIT
     router_id: 192.168.43.1
     rd: 192.168.43.1:66
@@ -157,8 +180,14 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: NOT-WAN-VRF
+  tenant: TenantB
+  ip_routing: true
 - name: TRANSIT
   tenant: TenantB
+  ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
   ip_routing: true
 management_api_http:
   enable_vrfs:
@@ -176,26 +205,37 @@ ethernet_interfaces:
   ip_address: 172.17.0.1/31
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
-- name: Ethernet52.100
+- name: Ethernet52.1000
   peer: site-ha-enabled-leaf1
-  peer_interface: Ethernet1.100
+  peer_interface: Ethernet1.1000
   peer_type: l3leaf
   vrf: IT
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.100_vrf_IT
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.1/31
-- name: Ethernet52.42
+- name: Ethernet52.142
   peer: site-ha-enabled-leaf1
-  peer_interface: Ethernet1.42
+  peer_interface: Ethernet1.142
   peer_type: l3leaf
   vrf: PROD
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.42_vrf_PROD
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.1/31
+- name: Ethernet52.666
+  peer: site-ha-enabled-leaf1
+  peer_interface: Ethernet1.666
+  peer_type: l3leaf
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet1.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.1/31
 - name: Ethernet1.42
@@ -654,6 +694,8 @@ vxlan_interface:
         vni: 42
       - name: TRANSIT
         vni: 66
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 166
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -434,20 +434,16 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-AVT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: DEFAULT-AVT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
     load_balance_policy: LB-PROD-AVT-POLICY-VIDEO
   - name: PROD-AVT-POLICY-DEFAULT
     load_balance_policy: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: DEFAULT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: CUSTOM-VOICE-PROFILE-NAME
     load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -59,17 +59,17 @@ router_bgp:
     - ip_address: 172.17.0.2
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf1_Ethernet2.100_vrf_IT
-    rd: 192.168.43.2:100
+      description: site-ha-enabled-leaf1_Ethernet2.1000_vrf_IT
+    rd: 192.168.43.2:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -78,17 +78,36 @@ router_bgp:
     - ip_address: 172.17.0.2
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65199'
-      description: site-ha-enabled-leaf1_Ethernet2.42_vrf_PROD
-    rd: 192.168.43.2:42
+      description: site-ha-enabled-leaf1_Ethernet2.142_vrf_PROD
+    rd: 192.168.43.2:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.43.2
+    neighbors:
+    - ip_address: 172.17.0.2
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65199'
+      description: site-ha-enabled-leaf1_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.43.2:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -103,6 +122,10 @@ router_bgp:
         route_targets:
         - '1:1'
         - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+  - name: NOT-WAN-VRF
+    router_id: 192.168.43.2
+    redistribute_routes:
+    - source_protocol: connected
   - name: TRANSIT
     router_id: 192.168.43.2
     rd: 192.168.43.2:66
@@ -157,8 +180,14 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: NOT-WAN-VRF
+  tenant: TenantB
+  ip_routing: true
 - name: TRANSIT
   tenant: TenantB
+  ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
   ip_routing: true
 management_api_http:
   enable_vrfs:
@@ -176,26 +205,37 @@ ethernet_interfaces:
   ip_address: 172.17.0.3/31
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
-- name: Ethernet52.100
+- name: Ethernet52.1000
   peer: site-ha-enabled-leaf1
-  peer_interface: Ethernet2.100
+  peer_interface: Ethernet2.1000
   peer_type: l3leaf
   vrf: IT
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.100_vrf_IT
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.3/31
-- name: Ethernet52.42
+- name: Ethernet52.142
   peer: site-ha-enabled-leaf1
-  peer_interface: Ethernet2.42
+  peer_interface: Ethernet2.142
   peer_type: l3leaf
   vrf: PROD
-  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.42_vrf_PROD
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.3/31
+- name: Ethernet52.666
+  peer: site-ha-enabled-leaf1
+  peer_interface: Ethernet2.666
+  peer_type: l3leaf
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_SITE-HA-ENABLED-LEAF1_Ethernet2.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.3/31
 - name: Ethernet1.42
@@ -654,6 +694,8 @@ vxlan_interface:
         vni: 42
       - name: TRANSIT
         vni: 66
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 166
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -434,6 +434,10 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
+  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
@@ -448,6 +452,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
@@ -481,7 +487,20 @@ router_adaptive_virtual_topology:
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
   policies:
+  - name: DEFAULT-AVT-POLICY-WITH-CP
+    matches:
+    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
+      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-AVT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY
     matches:
     - application_profile: VOICE
@@ -502,14 +521,10 @@ router_adaptive_virtual_topology:
       avt_profile: TRANSIT-AVT-POLICY-VOICE
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-WITH-CP
+  - name: DEFAULT-POLICY
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
-    - application_profile: VIDEO
-      avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
-      avt_profile: DEFAULT-AVT-POLICY-DEFAULT
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -566,6 +581,17 @@ router_path_selection:
     - name: LAN_HA
     - name: INET
     - name: MPLS
+  - name: LB-DEFAULT-AVT-POLICY-VIDEO
+    path_groups:
+    - name: LAN_HA
+    - name: MPLS
+    - name: INET
+  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+    - name: MPLS
+      priority: 42
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -586,17 +612,6 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-DEFAULT-AVT-POLICY-VIDEO
-    path_groups:
-    - name: LAN_HA
-    - name: MPLS
-    - name: INET
-  - name: LB-DEFAULT-AVT-POLICY-DEFAULT
-    path_groups:
-    - name: LAN_HA
-    - name: INET
-    - name: MPLS
-      priority: 42
   - name: LB-TRANSIT-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -609,6 +624,11 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: LAN_HA
+    - name: INET
+    - name: MPLS
 router_traffic_engineering:
   enabled: true
 stun:
@@ -622,15 +642,15 @@ stun:
       ip_address: 172.16.0.1
 application_traffic_recognition:
   application_profiles:
-  - name: VOICE
-    applications:
-    - name: CUSTOM-VOICE-APPLICATION
   - name: VIDEO
     categories:
     - name: VIDEO1
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+  - name: VOICE
+    applications:
+    - name: CUSTOM-VOICE-APPLICATION
   - name: CONTROL-PLANE-APPLICATION-PROFILE
     applications:
     - name: CONTROL-PLANE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -448,8 +448,8 @@ router_adaptive_virtual_topology:
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
-  - name: TRANSIT-AVT-POLICY-VOICE
-    load_balance_policy: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: CUSTOM-VOICE-PROFILE-NAME
+    load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT
     load_balance_policy: LB-TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-DEFAULT
@@ -483,7 +483,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: TRANSIT-AVT-POLICY-VOICE
+    - name: CUSTOM-VOICE-PROFILE-NAME
       id: 42
     - name: TRANSIT-AVT-POLICY-DEFAULT
       id: 1
@@ -518,7 +518,7 @@ router_adaptive_virtual_topology:
   - name: TRANSIT-AVT-POLICY
     matches:
     - application_profile: VOICE
-      avt_profile: TRANSIT-AVT-POLICY-VOICE
+      avt_profile: CUSTOM-VOICE-PROFILE-NAME
     - application_profile: default
       avt_profile: TRANSIT-AVT-POLICY-DEFAULT
   - name: DEFAULT-POLICY
@@ -612,7 +612,7 @@ router_path_selection:
     - name: INET
     - name: MPLS
       priority: 2
-  - name: LB-TRANSIT-AVT-POLICY-VOICE
+  - name: LB-CUSTOM-VOICE-PROFILE-NAME
     path_groups:
     - name: LAN_HA
     - name: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -434,20 +434,16 @@ router_adaptive_virtual_topology:
   profiles:
   - name: CONTROL-PLANE-PROFILE
     load_balance_policy: LB-CONTROL-PLANE-PROFILE
-  - name: DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-VIDEO
-  - name: DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-WITH-CP-DEFAULT
+  - name: DEFAULT-AVT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
+  - name: DEFAULT-AVT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD-AVT-POLICY-VOICE
     load_balance_policy: LB-PROD-AVT-POLICY-VOICE
   - name: PROD-AVT-POLICY-VIDEO
     load_balance_policy: LB-PROD-AVT-POLICY-VIDEO
   - name: PROD-AVT-POLICY-DEFAULT
     load_balance_policy: LB-PROD-AVT-POLICY-DEFAULT
-  - name: DEFAULT-AVT-POLICY-VIDEO
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
-  - name: DEFAULT-AVT-POLICY-DEFAULT
-    load_balance_policy: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: CUSTOM-VOICE-PROFILE-NAME
     load_balance_policy: LB-CUSTOM-VOICE-PROFILE-NAME
   - name: TRANSIT-AVT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/site-ha-disabled-leaf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/site-ha-disabled-leaf.yml
@@ -50,21 +50,21 @@ router_bgp:
     - ip_address: 172.17.0.1
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge_Ethernet52.100_vrf_IT
+      description: cv-pathfinder-edge_Ethernet52.1000_vrf_IT
     - ip_address: 172.17.0.3
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge-no-common-path-group_Ethernet52.100_vrf_IT
-    rd: 192.168.45.4:100
+      description: cv-pathfinder-edge-no-common-path-group_Ethernet52.1000_vrf_IT
+    rd: 192.168.45.4:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -73,21 +73,44 @@ router_bgp:
     - ip_address: 172.17.0.1
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge_Ethernet52.42_vrf_PROD
+      description: cv-pathfinder-edge_Ethernet52.142_vrf_PROD
     - ip_address: 172.17.0.3
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge-no-common-path-group_Ethernet52.42_vrf_PROD
-    rd: 192.168.45.4:42
+      description: cv-pathfinder-edge-no-common-path-group_Ethernet52.142_vrf_PROD
+    rd: 192.168.45.4:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.45.4
+    neighbors:
+    - ip_address: 172.17.0.1
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65000'
+      description: cv-pathfinder-edge_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    - ip_address: 172.17.0.3
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65000'
+      description: cv-pathfinder-edge-no-common-path-group_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.45.4:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -122,6 +145,14 @@ router_bgp:
       - 1101:1101
     redistribute_routes:
     - learned
+  - id: 666
+    tenant: TenantC
+    rd: 192.168.45.4:1666
+    route_targets:
+      both:
+      - 1666:1666
+    redistribute_routes:
+    - learned
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -138,6 +169,9 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
+  ip_routing: true
 management_api_http:
   enable_vrfs:
   - name: MGMT
@@ -152,26 +186,37 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.0/31
-- name: Ethernet1.100
+- name: Ethernet1.1000
   peer: cv-pathfinder-edge
-  peer_interface: Ethernet52.100
+  peer_interface: Ethernet52.1000
   peer_type: wan_router
   vrf: IT
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.100_vrf_IT
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.0/31
-- name: Ethernet1.42
+- name: Ethernet1.142
   peer: cv-pathfinder-edge
-  peer_interface: Ethernet52.42
+  peer_interface: Ethernet52.142
   peer_type: wan_router
   vrf: PROD
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.42_vrf_PROD
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.0/31
+- name: Ethernet1.666
+  peer: cv-pathfinder-edge
+  peer_interface: Ethernet52.666
+  peer_type: wan_router
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.0/31
 - name: Ethernet2
@@ -183,26 +228,37 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.2/31
-- name: Ethernet2.100
+- name: Ethernet2.1000
   peer: cv-pathfinder-edge-no-common-path-group
-  peer_interface: Ethernet52.100
+  peer_interface: Ethernet52.1000
   peer_type: wan_router
   vrf: IT
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.100_vrf_IT
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.2/31
-- name: Ethernet2.42
+- name: Ethernet2.142
   peer: cv-pathfinder-edge-no-common-path-group
-  peer_interface: Ethernet52.42
+  peer_interface: Ethernet52.142
   peer_type: wan_router
   vrf: PROD
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.42_vrf_PROD
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.2/31
+- name: Ethernet2.666
+  peer: cv-pathfinder-edge-no-common-path-group
+  peer_interface: Ethernet52.666
+  peer_type: wan_router
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE-NO-COMMON-PATH-GROUP_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.2/31
 loopback_interfaces:
@@ -240,6 +296,9 @@ vlans:
 - id: 101
   name: VLAN101
   tenant: TenantA
+- id: 666
+  name: VLAN666
+  tenant: TenantC
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:01
@@ -250,6 +309,13 @@ vlan_interfaces:
   shutdown: true
   ip_address_virtual: 10.0.100.1/24
   vrf: PROD
+- name: Vlan666
+  tenant: TenantC
+  description: VLAN666
+  shutdown: true
+  ip_address: 10.66.66.1
+  ip_address_virtual: 10.66.66.66/24
+  vrf: ATTRACTED-VRF-FROM-UPLINK
 vxlan_interface:
   Vxlan1:
     description: site-ha-disabled-leaf_VTEP
@@ -261,10 +327,14 @@ vxlan_interface:
         vni: 1100
       - id: 101
         vni: 1101
+      - id: 666
+        vni: 1666
       vrfs:
       - name: default
         vni: 1
       - name: IT
-        vni: 100
+        vni: 1000
       - name: PROD
-        vni: 42
+        vni: 142
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 666

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/site-ha-enabled-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/site-ha-enabled-leaf1.yml
@@ -50,21 +50,21 @@ router_bgp:
     - ip_address: 172.17.0.1
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-transit1A_Ethernet52.100_vrf_IT
+      description: cv-pathfinder-transit1A_Ethernet52.1000_vrf_IT
     - ip_address: 172.17.0.3
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-transit1B_Ethernet52.100_vrf_IT
-    rd: 192.168.45.1:100
+      description: cv-pathfinder-transit1B_Ethernet52.1000_vrf_IT
+    rd: 192.168.45.1:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -73,21 +73,44 @@ router_bgp:
     - ip_address: 172.17.0.1
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-transit1A_Ethernet52.42_vrf_PROD
+      description: cv-pathfinder-transit1A_Ethernet52.142_vrf_PROD
     - ip_address: 172.17.0.3
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-transit1B_Ethernet52.42_vrf_PROD
-    rd: 192.168.45.1:42
+      description: cv-pathfinder-transit1B_Ethernet52.142_vrf_PROD
+    rd: 192.168.45.1:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.45.1
+    neighbors:
+    - ip_address: 172.17.0.1
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65000'
+      description: cv-pathfinder-transit1A_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    - ip_address: 172.17.0.3
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65000'
+      description: cv-pathfinder-transit1B_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.45.1:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -122,6 +145,14 @@ router_bgp:
       - 1101:1101
     redistribute_routes:
     - learned
+  - id: 666
+    tenant: TenantC
+    rd: 192.168.45.1:1666
+    route_targets:
+      both:
+      - 1666:1666
+    redistribute_routes:
+    - learned
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -138,6 +169,9 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
+  ip_routing: true
 management_api_http:
   enable_vrfs:
   - name: MGMT
@@ -152,26 +186,37 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.0/31
-- name: Ethernet1.100
+- name: Ethernet1.1000
   peer: cv-pathfinder-transit1A
-  peer_interface: Ethernet52.100
+  peer_interface: Ethernet52.1000
   peer_type: wan_router
   vrf: IT
-  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.100_vrf_IT
+  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.0/31
-- name: Ethernet1.42
+- name: Ethernet1.142
   peer: cv-pathfinder-transit1A
-  peer_interface: Ethernet52.42
+  peer_interface: Ethernet52.142
   peer_type: wan_router
   vrf: PROD
-  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.42_vrf_PROD
+  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.0/31
+- name: Ethernet1.666
+  peer: cv-pathfinder-transit1A
+  peer_interface: Ethernet52.666
+  peer_type: wan_router
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1A_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.0/31
 - name: Ethernet2
@@ -183,26 +228,37 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.2/31
-- name: Ethernet2.100
+- name: Ethernet2.1000
   peer: cv-pathfinder-transit1B
-  peer_interface: Ethernet52.100
+  peer_interface: Ethernet52.1000
   peer_type: wan_router
   vrf: IT
-  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.100_vrf_IT
+  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.2/31
-- name: Ethernet2.42
+- name: Ethernet2.142
   peer: cv-pathfinder-transit1B
-  peer_interface: Ethernet52.42
+  peer_interface: Ethernet52.142
   peer_type: wan_router
   vrf: PROD
-  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.42_vrf_PROD
+  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.2/31
+- name: Ethernet2.666
+  peer: cv-pathfinder-transit1B
+  peer_interface: Ethernet52.666
+  peer_type: wan_router
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_CV-PATHFINDER-TRANSIT1B_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.2/31
 loopback_interfaces:
@@ -240,6 +296,9 @@ vlans:
 - id: 101
   name: VLAN101
   tenant: TenantA
+- id: 666
+  name: VLAN666
+  tenant: TenantC
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:01
@@ -250,6 +309,12 @@ vlan_interfaces:
   shutdown: true
   ip_address_virtual: 10.0.100.1/24
   vrf: PROD
+- name: Vlan666
+  tenant: TenantC
+  description: VLAN666
+  shutdown: true
+  ip_address_virtual: 10.66.66.66/24
+  vrf: ATTRACTED-VRF-FROM-UPLINK
 vxlan_interface:
   Vxlan1:
     description: site-ha-enabled-leaf1_VTEP
@@ -261,10 +326,14 @@ vxlan_interface:
         vni: 1100
       - id: 101
         vni: 1101
+      - id: 666
+        vni: 1666
       vrfs:
       - name: default
         vni: 1
       - name: IT
-        vni: 100
+        vni: 1000
       - name: PROD
-        vni: 42
+        vni: 142
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 666

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/site-ha-enabled-leaf2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/site-ha-enabled-leaf2A.yml
@@ -50,21 +50,21 @@ router_bgp:
     - ip_address: 172.17.0.5
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge2A_Ethernet52.100_vrf_IT
+      description: cv-pathfinder-edge2A_Ethernet52.1000_vrf_IT
     - ip_address: 172.17.0.9
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge2B_Ethernet52.100_vrf_IT
-    rd: 192.168.45.2:100
+      description: cv-pathfinder-edge2B_Ethernet52.1000_vrf_IT
+    rd: 192.168.45.2:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -73,21 +73,44 @@ router_bgp:
     - ip_address: 172.17.0.5
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge2A_Ethernet52.42_vrf_PROD
+      description: cv-pathfinder-edge2A_Ethernet52.142_vrf_PROD
     - ip_address: 172.17.0.9
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge2B_Ethernet52.42_vrf_PROD
-    rd: 192.168.45.2:42
+      description: cv-pathfinder-edge2B_Ethernet52.142_vrf_PROD
+    rd: 192.168.45.2:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.45.2
+    neighbors:
+    - ip_address: 172.17.0.5
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65000'
+      description: cv-pathfinder-edge2A_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    - ip_address: 172.17.0.9
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65000'
+      description: cv-pathfinder-edge2B_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.45.2:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -122,6 +145,14 @@ router_bgp:
       - 1101:1101
     redistribute_routes:
     - learned
+  - id: 666
+    tenant: TenantC
+    rd: 192.168.45.2:1666
+    route_targets:
+      both:
+      - 1666:1666
+    redistribute_routes:
+    - learned
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -138,6 +169,9 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
+  ip_routing: true
 management_api_http:
   enable_vrfs:
   - name: MGMT
@@ -152,26 +186,37 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.4/31
-- name: Ethernet1.100
+- name: Ethernet1.1000
   peer: cv-pathfinder-edge2A
-  peer_interface: Ethernet52.100
+  peer_interface: Ethernet52.1000
   peer_type: wan_router
   vrf: IT
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.100_vrf_IT
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.4/31
-- name: Ethernet1.42
+- name: Ethernet1.142
   peer: cv-pathfinder-edge2A
-  peer_interface: Ethernet52.42
+  peer_interface: Ethernet52.142
   peer_type: wan_router
   vrf: PROD
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.42_vrf_PROD
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.4/31
+- name: Ethernet1.666
+  peer: cv-pathfinder-edge2A
+  peer_interface: Ethernet52.666
+  peer_type: wan_router
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.4/31
 - name: Ethernet2
@@ -183,26 +228,37 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.8/31
-- name: Ethernet2.100
+- name: Ethernet2.1000
   peer: cv-pathfinder-edge2B
-  peer_interface: Ethernet52.100
+  peer_interface: Ethernet52.1000
   peer_type: wan_router
   vrf: IT
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.100_vrf_IT
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.8/31
-- name: Ethernet2.42
+- name: Ethernet2.142
   peer: cv-pathfinder-edge2B
-  peer_interface: Ethernet52.42
+  peer_interface: Ethernet52.142
   peer_type: wan_router
   vrf: PROD
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.42_vrf_PROD
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.8/31
+- name: Ethernet2.666
+  peer: cv-pathfinder-edge2B
+  peer_interface: Ethernet52.666
+  peer_type: wan_router
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet52.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.8/31
 loopback_interfaces:
@@ -240,6 +296,9 @@ vlans:
 - id: 101
   name: VLAN101
   tenant: TenantA
+- id: 666
+  name: VLAN666
+  tenant: TenantC
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:01
@@ -250,6 +309,12 @@ vlan_interfaces:
   shutdown: true
   ip_address_virtual: 10.0.100.1/24
   vrf: PROD
+- name: Vlan666
+  tenant: TenantC
+  description: VLAN666
+  shutdown: true
+  ip_address_virtual: 10.66.66.66/24
+  vrf: ATTRACTED-VRF-FROM-UPLINK
 vxlan_interface:
   Vxlan1:
     description: site-ha-enabled-leaf2A_VTEP
@@ -261,10 +326,14 @@ vxlan_interface:
         vni: 1100
       - id: 101
         vni: 1101
+      - id: 666
+        vni: 1666
       vrfs:
       - name: default
         vni: 1
       - name: IT
-        vni: 100
+        vni: 1000
       - name: PROD
-        vni: 42
+        vni: 142
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 666

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/site-ha-enabled-leaf2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/site-ha-enabled-leaf2B.yml
@@ -50,21 +50,21 @@ router_bgp:
     - ip_address: 172.17.0.7
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge2A_Ethernet53.100_vrf_IT
+      description: cv-pathfinder-edge2A_Ethernet53.1000_vrf_IT
     - ip_address: 172.17.0.11
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge2B_Ethernet53.100_vrf_IT
-    rd: 192.168.45.3:100
+      description: cv-pathfinder-edge2B_Ethernet53.1000_vrf_IT
+    rd: 192.168.45.3:1000
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
       export:
       - address_family: evpn
         route_targets:
-        - 100:100
+        - 1000:1000
     redistribute_routes:
     - source_protocol: connected
   - name: PROD
@@ -73,21 +73,44 @@ router_bgp:
     - ip_address: 172.17.0.7
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge2A_Ethernet53.42_vrf_PROD
+      description: cv-pathfinder-edge2A_Ethernet53.142_vrf_PROD
     - ip_address: 172.17.0.11
       peer_group: IPv4-UNDERLAY-PEERS
       remote_as: '65000'
-      description: cv-pathfinder-edge2B_Ethernet53.42_vrf_PROD
-    rd: 192.168.45.3:42
+      description: cv-pathfinder-edge2B_Ethernet53.142_vrf_PROD
+    rd: 192.168.45.3:142
     route_targets:
       import:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
       export:
       - address_family: evpn
         route_targets:
-        - '42:42'
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+  - name: ATTRACTED-VRF-FROM-UPLINK
+    router_id: 192.168.45.3
+    neighbors:
+    - ip_address: 172.17.0.7
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65000'
+      description: cv-pathfinder-edge2A_Ethernet53.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    - ip_address: 172.17.0.11
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65000'
+      description: cv-pathfinder-edge2B_Ethernet53.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+    rd: 192.168.45.3:666
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 666:666
+      export:
+      - address_family: evpn
+        route_targets:
+        - 666:666
     redistribute_routes:
     - source_protocol: connected
   - name: default
@@ -122,6 +145,14 @@ router_bgp:
       - 1101:1101
     redistribute_routes:
     - learned
+  - id: 666
+    tenant: TenantC
+    rd: 192.168.45.3:1666
+    route_targets:
+      both:
+      - 1666:1666
+    redistribute_routes:
+    - learned
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -138,6 +169,9 @@ vrfs:
 - name: PROD
   tenant: TenantA
   ip_routing: true
+- name: ATTRACTED-VRF-FROM-UPLINK
+  tenant: TenantC
+  ip_routing: true
 management_api_http:
   enable_vrfs:
   - name: MGMT
@@ -152,26 +186,37 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.6/31
-- name: Ethernet1.100
+- name: Ethernet1.1000
   peer: cv-pathfinder-edge2A
-  peer_interface: Ethernet53.100
+  peer_interface: Ethernet53.1000
   peer_type: wan_router
   vrf: IT
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.100_vrf_IT
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.6/31
-- name: Ethernet1.42
+- name: Ethernet1.142
   peer: cv-pathfinder-edge2A
-  peer_interface: Ethernet53.42
+  peer_interface: Ethernet53.142
   peer_type: wan_router
   vrf: PROD
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.42_vrf_PROD
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.6/31
+- name: Ethernet1.666
+  peer: cv-pathfinder-edge2A
+  peer_interface: Ethernet53.666
+  peer_type: wan_router
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2A_Ethernet53.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.6/31
 - name: Ethernet2
@@ -183,26 +228,37 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.10/31
-- name: Ethernet2.100
+- name: Ethernet2.1000
   peer: cv-pathfinder-edge2B
-  peer_interface: Ethernet53.100
+  peer_interface: Ethernet53.1000
   peer_type: wan_router
   vrf: IT
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.100_vrf_IT
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.1000_vrf_IT
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 100
+  encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.10/31
-- name: Ethernet2.42
+- name: Ethernet2.142
   peer: cv-pathfinder-edge2B
-  peer_interface: Ethernet53.42
+  peer_interface: Ethernet53.142
   peer_type: wan_router
   vrf: PROD
-  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.42_vrf_PROD
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.142_vrf_PROD
   shutdown: false
   type: l3dot1q
-  encapsulation_dot1q_vlan: 42
+  encapsulation_dot1q_vlan: 142
+  mtu: 9214
+  ip_address: 172.17.0.10/31
+- name: Ethernet2.666
+  peer: cv-pathfinder-edge2B
+  peer_interface: Ethernet53.666
+  peer_type: wan_router
+  vrf: ATTRACTED-VRF-FROM-UPLINK
+  description: P2P_LINK_TO_CV-PATHFINDER-EDGE2B_Ethernet53.666_vrf_ATTRACTED-VRF-FROM-UPLINK
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.10/31
 loopback_interfaces:
@@ -240,6 +296,9 @@ vlans:
 - id: 101
   name: VLAN101
   tenant: TenantA
+- id: 666
+  name: VLAN666
+  tenant: TenantC
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:1c:73:00:00:01
@@ -250,6 +309,12 @@ vlan_interfaces:
   shutdown: true
   ip_address_virtual: 10.0.100.1/24
   vrf: PROD
+- name: Vlan666
+  tenant: TenantC
+  description: VLAN666
+  shutdown: true
+  ip_address_virtual: 10.66.66.66/24
+  vrf: ATTRACTED-VRF-FROM-UPLINK
 vxlan_interface:
   Vxlan1:
     description: site-ha-enabled-leaf2B_VTEP
@@ -261,10 +326,14 @@ vxlan_interface:
         vni: 1100
       - id: 101
         vni: 1101
+      - id: 666
+        vni: 1666
       vrfs:
       - name: default
         vni: 1
       - name: IT
-        vni: 100
+        vni: 1000
       - name: PROD
-        vni: 42
+        vni: 142
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 666

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
@@ -100,14 +100,18 @@ tenants:
     vrfs:
       - name: default
         vrf_id: 1
+        # Testing VRF default without wan_vni set to check it is inserted and
+        # does not explode
       - name: PROD
         vrf_id: 42
+        wan_vni: 42
         svis:
           - id: 100
             name: VLAN100
             ip_address_virtual: 10.0.100.1/24
       - name: IT
         vrf_id: 100
+        wan_vni: 100
     l2vlans:
       - id: 101
         name: VLAN101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
@@ -100,18 +100,14 @@ tenants:
     vrfs:
       - name: default
         vrf_id: 1
-        # Testing VRF default without wan_vni set to check it is inserted and
-        # does not explode
       - name: PROD
         vrf_id: 42
-        wan_vni: 42
         svis:
           - id: 100
             name: VLAN100
             ip_address_virtual: 10.0.100.1/24
       - name: IT
         vrf_id: 100
-        wan_vni: 100
     l2vlans:
       - id: 101
         name: VLAN101
@@ -119,11 +115,13 @@ tenants:
 wan_virtual_topologies:
   vrfs:
     - name: default
-      policy: DEFAULT-AVT-POLICY
+      policy: DEFAULT-AUTOVPN-POLICY
+      wan_vni: 1
     - name: PROD
-      policy: PROD-AVT-POLICY
+      policy: PROD-AUTOVPN-POLICY
+      wan_vni: 42
   policies:
-    - name: PROD-AVT-POLICY
+    - name: PROD-AUTOVPN-POLICY
       default_virtual_topology:
         path_groups:
           - names: [INET]
@@ -137,7 +135,7 @@ wan_virtual_topologies:
           path_groups:
             - names: [INET]
               preference: preferred
-    - name: DEFAULT-AVT-POLICY
+    - name: DEFAULT-AUTOVPN-POLICY
       default_virtual_topology:
         drop_unmatched: true
       application_virtual_topologies:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
@@ -108,6 +108,7 @@ tenants:
             ip_address_virtual: 10.0.100.1/24
       - name: IT
         vrf_id: 100
+        address_families: []
     l2vlans:
       - id: 101
         name: VLAN101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -278,18 +278,23 @@ tenants:
     vrfs:
       - name: default
         vrf_id: 1
+        wan_vni: 1
+        # Checking static route on VRF default is redistributed in a route-map
         static_routes:
           - destination_address_prefix: 66.66.66.0/24
             gateway: 172.17.0.0
             nodes: [cv-pathfinder-edge]
       - name: PROD
-        vrf_id: 42
+        # Showing that wan_vni and vrf_id can be different. `vrf_id` influences the subinterface id.
+        vrf_id: 142
+        wan_vni: 42
         svis:
           - id: 100
             name: VLAN100
             ip_address_virtual: 10.0.100.1/24
       - name: IT
-        vrf_id: 100
+        vrf_id: 1000
+        wan_vni: 100
     l2vlans:
       - id: 101
         name: VLAN101
@@ -297,8 +302,28 @@ tenants:
     vrfs:
       - name: default
         vrf_id: 1
+        wan_vni: 1
       - name: TRANSIT
         vrf_id: 66
+        wan_vni: 66
+      # Test that a VRF with address_families: [] on a WAN router is not configured on Vxlan1 interface nor BGP
+      - name: NOT-WAN-VRF
+        vrf_id: 13
+        address_families: []
+  - name: TenantC
+    mac_vrf_vni_base: 1000
+    vrfs:
+      # Test adding a VRF on an uplink switch and seeing it configured on the WAN routers
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vrf_id: 666
+        wan_vni: 166
+        svis:
+          - id: 666
+            name: VLAN666
+            ip_address_virtual: 10.66.66.66/24
+            nodes:
+              - node: site-ha-disabled-leaf
+                ip_address: 10.66.66.1
 
 wan_virtual_topologies:
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -278,7 +278,6 @@ tenants:
     vrfs:
       - name: default
         vrf_id: 1
-        wan_vni: 1
         # Checking static route on VRF default is redistributed in a route-map
         static_routes:
           - destination_address_prefix: 66.66.66.0/24
@@ -287,14 +286,12 @@ tenants:
       - name: PROD
         # Showing that wan_vni and vrf_id can be different. `vrf_id` influences the subinterface id.
         vrf_id: 142
-        wan_vni: 42
         svis:
           - id: 100
             name: VLAN100
             ip_address_virtual: 10.0.100.1/24
       - name: IT
         vrf_id: 1000
-        wan_vni: 100
     l2vlans:
       - id: 101
         name: VLAN101
@@ -302,10 +299,8 @@ tenants:
     vrfs:
       - name: default
         vrf_id: 1
-        wan_vni: 1
       - name: TRANSIT
         vrf_id: 66
-        wan_vni: 66
       # Test that a VRF with address_families: [] on a WAN router is not configured on Vxlan1 interface nor BGP
       - name: NOT-WAN-VRF
         vrf_id: 13
@@ -316,7 +311,6 @@ tenants:
       # Test adding a VRF on an uplink switch and seeing it configured on the WAN routers
       - name: ATTRACTED-VRF-FROM-UPLINK
         vrf_id: 666
-        wan_vni: 166
         svis:
           - id: 666
             name: VLAN666
@@ -329,14 +323,20 @@ wan_virtual_topologies:
   vrfs:
     - name: default
       policy: DEFAULT-AVT-POLICY
+      wan_vni: 1
     - name: PROD
       policy: PROD-AVT-POLICY
+      wan_vni: 42
     # Testing reusing the same policy as default VRF
     - name: IT
       policy: DEFAULT-AVT-POLICY
+      wan_vni: 100
     # Testing a VRF only on transit and not edge
     - name: TRANSIT
       policy: TRANSIT-AVT-POLICY
+      wan_vni: 66
+    - name: ATTRACTED-VRF-FROM-UPLINK
+      wan_vni: 166
   policies:
     - name: PROD-AVT-POLICY
       default_virtual_topology:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -386,6 +386,7 @@ wan_virtual_topologies:
             preference: alternate
       application_virtual_topologies:
         - application_profile: VOICE
+          name: CUSTOM-VOICE-PROFILE-NAME
           path_groups:
             - names: [MPLS]
               preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/autovpn-edge-no-default-policy.yml
@@ -73,10 +73,12 @@ tenants:
         vrf_id: 1
       - name: PROD
         vrf_id: 42
-        wan_vni: 42
       - name: IT
         vrf_id: 100
-        wan_vni: 100
 
-# empty
-wan_virtual_topologies: null
+wan_virtual_topologies:
+  vrfs:
+    - name: PROD
+      wan_vni: 42
+    - name: IT
+      wan_vni: 100

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/autovpn-edge-no-default-policy.yml
@@ -73,8 +73,10 @@ tenants:
         vrf_id: 1
       - name: PROD
         vrf_id: 42
+        wan_vni: 42
       - name: IT
         vrf_id: 100
+        wan_vni: 100
 
 # empty
 wan_virtual_topologies: null

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-custom-default-policy.yml
@@ -44,6 +44,7 @@ wan_router:
     vtep_loopback_ipv4_pool: 192.168.255.0/24
     filter:
       always_include_vrfs_in_tenants: [TenantA]
+      deny_vrfs: [IT]
   nodes:
     - name: cv-pathfinder-edge-custom-default-policy
       cv_pathfinder_region: AVD_Land_West

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-custom-default-policy.yml
@@ -12,17 +12,9 @@ cv_pathfinder_regions:
     id: 42
     description: AVD Region
     sites:
-      - name: Site422
-        id: 422
-        location: Somewhere
-  - name: AVD_Land_East
-    id: 43
-    description: AVD Region
-    sites:
-      - name: Site511
-        id: 511
-      - name: Site512
-        id: 512
+      - name: Site1
+        id: 1
+        location: one place
 
 bgp_peer_groups:
   wan_overlay_peers:
@@ -53,9 +45,9 @@ wan_router:
     filter:
       always_include_vrfs_in_tenants: [TenantA]
   nodes:
-    - name: cv-pathfinder-edge-no-default-policy
-      cv_pathfinder_region: AVD_Land_East
-      cv_pathfinder_site: Site511
+    - name: cv-pathfinder-edge-custom-default-policy
+      cv_pathfinder_region: AVD_Land_West
+      cv_pathfinder_site: Site1
       id: 1
       l3_interfaces:
         - name: Ethernet1
@@ -121,7 +113,33 @@ tenants:
 
 wan_virtual_topologies:
   vrfs:
+    # No policy for default or PROD, going to use DEFAULT-POLICY
+    # overwrite DEFAULT-POLICY below
+    - name: default
+      wan_vni: 1
     - name: PROD
       wan_vni: 42
-    - name: IT
-      wan_vni: 100
+  policies:
+    # Name of the DEFAULT-POLICY being overwritten
+    - name: DEFAULT-POLICY
+      default_virtual_topology:
+        path_groups:
+          - names: [INET]
+          - names: [LTE]
+            preference: 42
+      application_virtual_topologies:
+        - application_profile: VIDEO
+          path_groups:
+            - names: [MPLS, INET]
+              preference: preferred
+          id: 3
+
+application_classification:
+  application_profiles:
+    - name: VIDEO
+      # Testing categories filtering
+      applications:
+        # Testing applications in application-profiles filtering
+        - name: CUSTOM-APPLICATION-1
+        # Builtin application that should not raise
+        - name: skype

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-no-default-policy.yml
@@ -116,7 +116,9 @@ tenants:
         vrf_id: 1
       - name: PROD
         vrf_id: 42
+        wan_vni: 42
       - name: IT
         vrf_id: 100
+        wan_vni: 100
 
 wan_virtual_topologies: null

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -320,6 +320,7 @@ all:
               hosts:
                 autovpn-edge-no-default-policy:
                 cv-pathfinder-edge-no-default-policy:
+                cv-pathfinder-edge-custom-default-policy:
         UPLINK_P2P_VRFS_TESTS:
           hosts:
             UPLINK_P2P_VRFS_TESTS_SPINE1:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/wan.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
+
 if TYPE_CHECKING:
     from .eos_designs_facts import EosDesignsFacts
 
@@ -30,3 +32,31 @@ class WanMixin:
             return None
 
         return self.shared_utils.wan_local_path_groups
+
+    @cached_property
+    def wan_router_uplink_vrfs(self: EosDesignsFacts) -> list[str] | None:
+        """
+        Exposed in avd_switch_facts
+
+        Return the list of VRF names present on uplink switches.
+        These VRFs will be attracted (configured) on WAN "clients" (edge/transit) unless filtered.
+
+        Note that if the attracted VRFs do not have 'wan_vni' set, the code for interface Vxlan1 will raise an error.
+        """
+        if not self.shared_utils.is_wan_client or self.shared_utils.uplink_type != "p2p-vrfs":
+            return None
+
+        # Partially recreating logic from 'uplinks', but since this fact is used to build 'filtered_tenants',
+        # which in turn is used to build 'uplinks', we cannot reuse 'uplinks' (recursion)
+
+        # Since uplinks logic silently skips extra entries in uplink vars, we only need to parse shortest list.
+        min_length = min(len(self._uplink_switch_interfaces), len(self._uplink_interfaces), len(self.shared_utils.uplink_switches))
+        # Using set to only get unique uplink switches
+        unique_uplink_switches = set(self.shared_utils.uplink_switches[:min_length])
+
+        vrfs = set()
+        for uplink_switch in unique_uplink_switches:
+            uplink_switch_facts = self.shared_utils.get_peer_facts(uplink_switch)
+            vrfs.update(uplink_switch_facts.shared_utils.vrfs)
+
+        return natural_sort(vrfs) or None

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
@@ -57,7 +57,6 @@ class FilteredTenantsMixin:
                     "vrfs": [
                         {
                             "name": "default",
-                            "wan_vni": 1,
                             "vrf_id": 1,
                             "svis": [],
                             "l3_interfaces": [],
@@ -82,10 +81,6 @@ class FilteredTenantsMixin:
                         raise AristaAvdError(
                             "WAN configuration requires EVPN to be enabled for VRF 'default'. Got 'address_families: {vrf_default['address_families']}."
                         )
-                # Injecting `wan_vni` on WAN routers if it is missing to make sure that VRF default is always included
-                # on the WAN.
-                if vrf_default.get("wan_vni") is None:
-                    vrf_default["wan_vni"] = 1
                 break
 
         return natural_sort(filtered_tenants, "name")

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
@@ -57,6 +57,7 @@ class FilteredTenantsMixin:
                     "vrfs": [
                         {
                             "name": "default",
+                            "wan_vni": 1,
                             "vrf_id": 1,
                             "svis": [],
                             "l3_interfaces": [],
@@ -81,6 +82,10 @@ class FilteredTenantsMixin:
                         raise AristaAvdError(
                             "WAN configuration requires EVPN to be enabled for VRF 'default'. Got 'address_families: {vrf_default['address_families']}."
                         )
+                # Injecting `wan_vni` on WAN routers if it is missing to make sure that VRF default is always included
+                # on the WAN.
+                if vrf_default.get("wan_vni") is None:
+                    vrf_default["wan_vni"] = 1
                 break
 
         return natural_sort(filtered_tenants, "name")
@@ -171,15 +176,31 @@ class FilteredTenantsMixin:
             not self.filter_deny_vrfs or vrf["name"] not in self.filter_deny_vrfs
         )
 
+    def is_forced_vrf(self: SharedUtils, vrf: dict) -> bool:
+        """
+        Returns True if the given VRF name should be configured even without any loopbacks or SVIs etc.
+
+        There can be various causes for this:
+        - The VRF is part of a tenant set under 'always_include_vrfs_in_tenants'
+        - 'always_include_vrfs_in_tenants' is set to ['all']
+        - This is a WAN router and the VRF present on the uplink switch.
+          Note that if the attracted VRF does not have a wan_vni configured, the code for interface Vxlan1 will raise an error.
+        """
+        if "all" in self.always_include_vrfs_in_tenants or vrf["tenant"] in self.always_include_vrfs_in_tenants:
+            return True
+
+        if self.is_wan_client and vrf["name"] in (self.get_switch_fact("wan_router_uplink_vrfs", required=False) or []):
+            return True
+
+        return False
+
     def filtered_vrfs(self: SharedUtils, tenant: dict) -> list[dict]:
         """
         Return sorted and filtered vrf list from given tenant.
-        Filtering based on svi tags, l3interfaces and filter.always_include_vrfs_in_tenants.
+        Filtering based on svi tags, l3interfaces, loopbacks or self.is_forced_vrf() check.
         Keys of VRF data model will be converted to lists.
         """
         filtered_vrfs = []
-
-        always_include_vrfs_in_tenants = get(self.switch_data_combined, "filter.always_include_vrfs_in_tenants", default=[])
 
         vrfs: list[dict] = natural_sort(convert_dicts(tenant.get("vrfs", []), "name"), "name")
         for original_vrf in vrfs:
@@ -254,13 +275,7 @@ class FilteredTenantsMixin:
                 )
             ]
 
-            if (
-                vrf["svis"]
-                or vrf["l3_interfaces"]
-                or vrf["loopbacks"]
-                or "all" in always_include_vrfs_in_tenants
-                or tenant["name"] in always_include_vrfs_in_tenants
-            ):
+            if vrf["svis"] or vrf["l3_interfaces"] or vrf["loopbacks"] or self.is_forced_vrf(vrf):
                 filtered_vrfs.append(vrf)
 
         return filtered_vrfs

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
@@ -80,6 +80,10 @@ class MiscMixin:
         return get(self.switch_data_combined, "filter.tenants", default=["all"])
 
     @cached_property
+    def always_include_vrfs_in_tenants(self: SharedUtils) -> list:
+        return get(self.switch_data_combined, "filter.always_include_vrfs_in_tenants", default=[])
+
+    @cached_property
     def igmp_snooping_enabled(self: SharedUtils) -> bool:
         default_igmp_snooping_enabled = get(self.hostvars, "default_igmp_snooping_enabled", default=True)
         return get(self.switch_data_combined, "igmp_snooping_enabled", default=default_igmp_snooping_enabled) is True

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
@@ -17,6 +17,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].address_families.[]") | String |  |  | Valid Values:<br>- <code>evpn</code><br>- <code>vpn-ipv4</code><br>- <code>vpn-ipv6</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "<network_services_keys.name>.[].vrfs.[].description") | String |  |  |  | VRF description. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf_vni</samp>](## "<network_services_keys.name>.[].vrfs.[].vrf_vni") | Integer |  |  | Min: 1<br>Max: 16777215 | Required if "vrf_id" is not set.<br>The VRF VNI range is not limited, but if vrf_id is not set, "vrf_vni" is used for calculating MLAG iBGP peering vlan id.<br>"vrf_vni" may also be used for VRF RD/RT ID. See "overlay_rd_type" and "overlay_rt_type" for details.<br>See "mlag_ibgp_peering_vrfs.base_vlan" for details.<br>If vrf_vni > 10000 make sure to adjust "mac_vrf_vni_base" accordingly to avoid overlap.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;wan_vni</samp>](## "<network_services_keys.name>.[].vrfs.[].wan_vni") | Integer |  |  | Min: 1<br>Max: 255 | Required for VRFs carried over AutoVPN or CV Pathfinder WAN.<br><br>A VRF can have a different VNI in the Datacenters and in the WAN.<br>Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with<br>`wan_vni` set to `1`.<br>In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf_id</samp>](## "<network_services_keys.name>.[].vrfs.[].vrf_id") | Integer |  |  |  | Required if "vrf_vni" is not set.<br>"vrf_id" is used as default value for "vrf_vni" and "ospf.process_id" unless those are set.<br>"vrf_id" may also be used for VRF RD/RT ID. See "overlay_rd_type" and "overlay_rt_type" for details.<br>"vrf_id" is preferred over "vrf_vni" for MLAG iBGP peering vlan, see "mlag_ibgp_peering_vrfs.base_vlan" for details.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rd_override</samp>](## "<network_services_keys.name>.[].vrfs.[].rd_override") | String |  |  |  | By default, the VRF RD will be derived from the pattern defined in `overlay_rd_type`.<br>The rd_override allows us to override this value and statically define it.<br><br>rd_override supports two formats:<br>  - A single number will be used in the RD assigned number subfield (second part of the RD).<br>  - A full RD string with colon seperator which will override the full RD.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rt_override</samp>](## "<network_services_keys.name>.[].vrfs.[].rt_override") | String |  |  |  | By default, the VRF RT will be derived from the pattern defined in `overlay_rt_type`.<br>The rt_override allows us to override this value and statically define it.<br><br>rt_override supports two formats:<br>  - A single number will be used in the RT assigned number subfield (second part of the RT).<br>  - A full RT string with colon seperator which will override the full RT.<br> |
@@ -114,6 +115,14 @@
             # See "mlag_ibgp_peering_vrfs.base_vlan" for details.
             # If vrf_vni > 10000 make sure to adjust "mac_vrf_vni_base" accordingly to avoid overlap.
             vrf_vni: <int; 1-16777215>
+
+            # Required for VRFs carried over AutoVPN or CV Pathfinder WAN.
+            #
+            # A VRF can have a different VNI in the Datacenters and in the WAN.
+            # Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with
+            # `wan_vni` set to `1`.
+            # In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.
+            wan_vni: <int; 1-255>
 
             # Required if "vrf_vni" is not set.
             # "vrf_id" is used as default value for "vrf_vni" and "ospf.process_id" unless those are set.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
@@ -17,7 +17,6 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].address_families.[]") | String |  |  | Valid Values:<br>- <code>evpn</code><br>- <code>vpn-ipv4</code><br>- <code>vpn-ipv6</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "<network_services_keys.name>.[].vrfs.[].description") | String |  |  |  | VRF description. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf_vni</samp>](## "<network_services_keys.name>.[].vrfs.[].vrf_vni") | Integer |  |  | Min: 1<br>Max: 16777215 | Required if "vrf_id" is not set.<br>The VRF VNI range is not limited, but if vrf_id is not set, "vrf_vni" is used for calculating MLAG iBGP peering vlan id.<br>"vrf_vni" may also be used for VRF RD/RT ID. See "overlay_rd_type" and "overlay_rt_type" for details.<br>See "mlag_ibgp_peering_vrfs.base_vlan" for details.<br>If vrf_vni > 10000 make sure to adjust "mac_vrf_vni_base" accordingly to avoid overlap.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;wan_vni</samp>](## "<network_services_keys.name>.[].vrfs.[].wan_vni") | Integer |  |  | Min: 1<br>Max: 255 | Required for VRFs carried over AutoVPN or CV Pathfinder WAN.<br><br>A VRF can have a different VNI in the Datacenters and in the WAN.<br>Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with<br>`wan_vni` set to `1`.<br>In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf_id</samp>](## "<network_services_keys.name>.[].vrfs.[].vrf_id") | Integer |  |  |  | Required if "vrf_vni" is not set.<br>"vrf_id" is used as default value for "vrf_vni" and "ospf.process_id" unless those are set.<br>"vrf_id" may also be used for VRF RD/RT ID. See "overlay_rd_type" and "overlay_rt_type" for details.<br>"vrf_id" is preferred over "vrf_vni" for MLAG iBGP peering vlan, see "mlag_ibgp_peering_vrfs.base_vlan" for details.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rd_override</samp>](## "<network_services_keys.name>.[].vrfs.[].rd_override") | String |  |  |  | By default, the VRF RD will be derived from the pattern defined in `overlay_rd_type`.<br>The rd_override allows us to override this value and statically define it.<br><br>rd_override supports two formats:<br>  - A single number will be used in the RD assigned number subfield (second part of the RD).<br>  - A full RD string with colon seperator which will override the full RD.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rt_override</samp>](## "<network_services_keys.name>.[].vrfs.[].rt_override") | String |  |  |  | By default, the VRF RT will be derived from the pattern defined in `overlay_rt_type`.<br>The rt_override allows us to override this value and statically define it.<br><br>rt_override supports two formats:<br>  - A single number will be used in the RT assigned number subfield (second part of the RT).<br>  - A full RT string with colon seperator which will override the full RT.<br> |
@@ -115,14 +114,6 @@
             # See "mlag_ibgp_peering_vrfs.base_vlan" for details.
             # If vrf_vni > 10000 make sure to adjust "mac_vrf_vni_base" accordingly to avoid overlap.
             vrf_vni: <int; 1-16777215>
-
-            # Required for VRFs carried over AutoVPN or CV Pathfinder WAN.
-            #
-            # A VRF can have a different VNI in the Datacenters and in the WAN.
-            # Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with
-            # `wan_vni` set to `1`.
-            # In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.
-            wan_vni: <int; 1-255>
 
             # Required if "vrf_vni" is not set.
             # "vrf_id" is used as default value for "vrf_vni" and "ospf.process_id" unless those are set.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
@@ -11,7 +11,7 @@
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "wan_virtual_topologies.vrfs") | List, items: Dictionary |  |  |  | Map a VRF that exists in network_services to an AVT policy.<br>TODO: missing default VRF behavior |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "wan_virtual_topologies.vrfs.[].name") | String | Required, Unique |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;policy</samp>](## "wan_virtual_topologies.vrfs.[].policy") | String |  | `DEFAULT-POLICY` |  | Name of the policy to apply to this VRF.<br>It is possible to overwrite the default policy for all VRFs using it<br>by redefining it in the `wan_virtual_topologies.policies` list using the<br>default name `DEFAULT-POLICY`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;wan_vni</samp>](## "wan_virtual_topologies.vrfs.[].wan_vni") | Integer | Required |  | Min: 1<br>Max: 255 | Required for VRFs carried over AutoVPN or CV Pathfinder WAN.<br><br>A VRF can have a different VNI in the Datacenters and in the WAN.<br>Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with<br>`wan_vni` set to `1`.<br>In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;wan_vni</samp>](## "wan_virtual_topologies.vrfs.[].wan_vni") | Integer | Required |  | Min: 1<br>Max: 255 | Required for VRFs carried over AutoVPN or CV Pathfinder WAN.<br><br>A VRF can have different VNIs between the Datacenters and the WAN.<br>Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with<br>`wan_vni` set to `1`.<br>In addition either `vrf_id` or `vrf_vni` must be set to enforce consistent route-targets across domains. |
     | [<samp>&nbsp;&nbsp;control_plane_virtual_topology</samp>](## "wan_virtual_topologies.control_plane_virtual_topology") | Dictionary |  |  |  | Always injected into the default VRF policy as the first entry.<br><br>By default, if no path-groups are specified, all locally available path-groups<br>are used in the generated load-balance policy.<br>ID is hardcoded to 254 for the AVT profile in CV Pathfinder mode. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.name") | String |  |  |  | Optional name, if not set `CONTROL-PLANE-PROFILE` is used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.traffic_class") | Integer |  |  | Min: 0<br>Max: 7 | Set traffic-class for matched traffic. |
@@ -79,10 +79,10 @@
 
           # Required for VRFs carried over AutoVPN or CV Pathfinder WAN.
           #
-          # A VRF can have a different VNI in the Datacenters and in the WAN.
+          # A VRF can have different VNIs between the Datacenters and the WAN.
           # Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with
           # `wan_vni` set to `1`.
-          # In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.
+          # In addition either `vrf_id` or `vrf_vni` must be set to enforce consistent route-targets across domains.
           wan_vni: <int; 1-255; required>
 
       # Always injected into the default VRF policy as the first entry.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
@@ -10,7 +10,8 @@
     | [<samp>wan_virtual_topologies</samp>](## "wan_virtual_topologies") | Dictionary |  |  |  | PREVIEW: WAN Preview<br><br>Configure Virtual Topologies for CV Pathfinder and AutoVPN.<br><br>Auto create a control plane profile/policy/application and enforce it being first in the default VRF. |
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "wan_virtual_topologies.vrfs") | List, items: Dictionary |  |  |  | Map a VRF that exists in network_services to an AVT policy.<br>TODO: missing default VRF behavior |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "wan_virtual_topologies.vrfs.[].name") | String | Required, Unique |  |  | VRF name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;policy</samp>](## "wan_virtual_topologies.vrfs.[].policy") | String |  |  |  | Name of the AVT policy to apply to this VRF. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;policy</samp>](## "wan_virtual_topologies.vrfs.[].policy") | String |  | `DEFAULT-POLICY` |  | Name of the policy to apply to this VRF.<br>It is possible to overwrite the default policy for all VRFs using it<br>by redefining it in the `wan_virtual_topologies.policies` list using the<br>default name `DEFAULT-POLICY`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;wan_vni</samp>](## "wan_virtual_topologies.vrfs.[].wan_vni") | Integer | Required |  | Min: 1<br>Max: 255 | Required for VRFs carried over AutoVPN or CV Pathfinder WAN.<br><br>A VRF can have a different VNI in the Datacenters and in the WAN.<br>Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with<br>`wan_vni` set to `1`.<br>In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.<br> |
     | [<samp>&nbsp;&nbsp;control_plane_virtual_topology</samp>](## "wan_virtual_topologies.control_plane_virtual_topology") | Dictionary |  |  |  | Always injected into the default VRF policy as the first entry.<br><br>By default, if no path-groups are specified, all locally available path-groups<br>are used in the generated load-balance policy.<br>ID is hardcoded to 254 for the AVT profile in CV Pathfinder mode. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.name") | String |  |  |  | Optional name, if not set `CONTROL-PLANE-PROFILE` is used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.traffic_class") | Integer |  |  | Min: 0<br>Max: 7 | Set traffic-class for matched traffic. |
@@ -70,8 +71,19 @@
           # VRF name.
         - name: <str; required; unique>
 
-          # Name of the AVT policy to apply to this VRF.
-          policy: <str>
+          # Name of the policy to apply to this VRF.
+          # It is possible to overwrite the default policy for all VRFs using it
+          # by redefining it in the `wan_virtual_topologies.policies` list using the
+          # default name `DEFAULT-POLICY`.
+          policy: <str; default="DEFAULT-POLICY">
+
+          # Required for VRFs carried over AutoVPN or CV Pathfinder WAN.
+          #
+          # A VRF can have a different VNI in the Datacenters and in the WAN.
+          # Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with
+          # `wan_vni` set to `1`.
+          # In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.
+          wan_vni: <int; 1-255; required>
 
       # Always injected into the default VRF policy as the first entry.
       #

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
@@ -142,7 +142,6 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
         input_application_classification = get(self._hostvars, "application_classification", {})
         # Application profiles first
         application_profiles = []
-        # TODO inject "application_profile": "CONTROL-PLANE-APPLICATION-PROFILE",
 
         def _append_object_to_list_of_dicts(path: str, obj_name: str, list_of_dicts: list, message: str | None = None, required=True) -> None:
             """

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_adaptive_virtual_topology.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_adaptive_virtual_topology.py
@@ -77,8 +77,9 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
         control_plane_virtual_topology = get(self._hostvars, "wan_virtual_topologies.control_plane_virtual_topology", default={"id": 254})
 
         for avt_policy in self._filtered_wan_policies:
+            policy_name = avt_policy["name"]
             cv_pathfinder_policy = {
-                "name": avt_policy["name"],
+                "name": policy_name,
                 "matches": [],
             }
 
@@ -93,7 +94,7 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
                     }
                 )
                 # TODO - refactor logic so that we don't need this as this is not very good looking
-                avt_policy["name"] = avt_policy["original_name"]
+                policy_name = avt_policy["original_name"]
 
             for application_virtual_topology in get(avt_policy, "application_virtual_topologies", []):
                 application_profile = get(application_virtual_topology, "application_profile", required=True)
@@ -103,7 +104,7 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
                         "avt_profile": get(
                             application_virtual_topology,
                             "name",
-                            default=self._default_profile_name(avt_policy["name"], application_virtual_topology["application_profile"]),
+                            default=self._default_profile_name(policy_name, application_virtual_topology["application_profile"]),
                         ),
                         "traffic_class": get(application_virtual_topology, "traffic_class"),
                         "dscp": get(application_virtual_topology, "dscp"),
@@ -118,7 +119,7 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
                 cv_pathfinder_policy["matches"].append(
                     {
                         "application_profile": application_profile,
-                        "avt_profile": get(default_virtual_topology, "name", default=self._default_profile_name(avt_policy["name"], "DEFAULT")),
+                        "avt_profile": get(default_virtual_topology, "name", default=self._default_profile_name(policy_name, "DEFAULT")),
                         "traffic_class": get(default_virtual_topology, "traffic_class"),
                         "dscp": get(default_virtual_topology, "dscp"),
                         # Storing id as _id to avoid schema validation and be able to pick up in VRFs

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
@@ -53,8 +53,9 @@ class RouterPathSelectionMixin(UtilsMixin):
 
         for policy in self._filtered_wan_policies:
             rule_id_offset = 0
+            policy_name = policy["name"]
             autovpn_policy = {
-                "name": policy["name"],
+                "name": policy_name,
             }
 
             if get(policy, "is_default", default=False):
@@ -66,14 +67,14 @@ class RouterPathSelectionMixin(UtilsMixin):
                     }
                 )
                 rule_id_offset = 1
-                # Eurk
-                policy["name"] = policy["original_name"]
+                # TODO - refactor logic so that we don't need this as this is not very good looking
+                policy_name = policy["original_name"]
 
             for rule_id, application_virtual_topology in enumerate(get(policy, "application_virtual_topologies", []), start=1):
                 name = get(
                     application_virtual_topology,
                     "name",
-                    default=self._default_profile_name(policy["name"], application_virtual_topology["application_profile"]),
+                    default=self._default_profile_name(policy_name, application_virtual_topology["application_profile"]),
                 )
                 application_profile = get(application_virtual_topology, "application_profile", required=True)
                 autovpn_policy.setdefault("rules", []).append(
@@ -88,7 +89,7 @@ class RouterPathSelectionMixin(UtilsMixin):
                 name = get(
                     default_virtual_topology,
                     "name",
-                    default=self._default_profile_name(policy["name"], "DEFAULT"),
+                    default=self._default_profile_name(policy_name, "DEFAULT"),
                 )
                 autovpn_policy["default_match"] = {"load_balance": self.shared_utils.generate_lb_policy_name(name)}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
@@ -53,9 +53,8 @@ class RouterPathSelectionMixin(UtilsMixin):
 
         for policy in self._filtered_wan_policies:
             rule_id_offset = 0
-            policy_name = policy["name"]
             autovpn_policy = {
-                "name": policy_name,
+                "name": policy["name"],
             }
 
             if get(policy, "is_default", default=False):
@@ -67,14 +66,12 @@ class RouterPathSelectionMixin(UtilsMixin):
                     }
                 )
                 rule_id_offset = 1
-                # TODO - refactor logic so that we don't need this as this is not very good looking
-                policy_name = policy["original_name"]
 
             for rule_id, application_virtual_topology in enumerate(get(policy, "application_virtual_topologies", []), start=1):
                 name = get(
                     application_virtual_topology,
                     "name",
-                    default=self._default_profile_name(policy_name, application_virtual_topology["application_profile"]),
+                    default=self._default_profile_name(policy["profile_prefix"], application_virtual_topology["application_profile"]),
                 )
                 application_profile = get(application_virtual_topology, "application_profile", required=True)
                 autovpn_policy.setdefault("rules", []).append(
@@ -89,7 +86,7 @@ class RouterPathSelectionMixin(UtilsMixin):
                 name = get(
                     default_virtual_topology,
                     "name",
-                    default=self._default_profile_name(policy_name, "DEFAULT"),
+                    default=self._default_profile_name(policy["profile_prefix"], "DEFAULT"),
                 )
                 autovpn_policy["default_match"] = {"load_balance": self.shared_utils.generate_lb_policy_name(name)}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -205,13 +205,6 @@ class UtilsMixin:
         """
         return "CONTROL-PLANE-APPLICATION-PROFILE"
 
-    @cached_property
-    def _wan_policy_key(self) -> str:
-        """
-        The key for policies is different for AutoVPN and CV Pathfinder
-        """
-        return "policy" if self.shared_utils.wan_mode == "cv-pathfinder" else "path_selection_policy"
-
     def _generate_wan_load_balance_policy(self, name: str, input_dict: dict, context_path: str) -> dict:
         """
         Generate and return a router path-selection load-balance policy. If HA is enabled, inject the HA path-group with priority 1.
@@ -306,23 +299,29 @@ class UtilsMixin:
             default={"path_groups": [{"names": self._local_path_groups_connected_to_pathfinder}]},
         )
 
-        wan_load_balance_policies = [
-            self._generate_wan_load_balance_policy(
-                self.shared_utils.generate_lb_policy_name(self._wan_control_plane_profile),
-                control_plane_virtual_topology,
-                self._default_vrf_policy["name"],
-            )
-        ]
+        wan_load_balance_policies = []
+
         for policy in self._filtered_wan_policies:
+            policy_name = policy["name"]
+            if get(policy, "is_default", default=False):
+                # for the default policy, need to render the control_plane_virtual_topology
+                wan_load_balance_policies.append(
+                    self._generate_wan_load_balance_policy(
+                        self.shared_utils.generate_lb_policy_name(self._wan_control_plane_profile),
+                        control_plane_virtual_topology,
+                        policy["original_name"],
+                    )
+                )
+                policy_name = policy["original_name"]
             for application_virtual_topology in get(policy, "application_virtual_topologies", []):
                 # TODO add internet exit once supported
                 name = get(
                     application_virtual_topology,
                     "name",
-                    default=self._default_profile_name(policy["name"], application_virtual_topology["application_profile"]),
+                    default=self._default_profile_name(policy_name, application_virtual_topology["application_profile"]),
                 )
                 context_path = (
-                    f"wan_virtual_topologies.policies[{policy['name']}].application_virtual_topologies[{application_virtual_topology['application_profile']}]"
+                    f"wan_virtual_topologies.policies[{policy_name}].application_virtual_topologies[{application_virtual_topology['application_profile']}]"
                 )
                 append_if_not_duplicate(
                     list_of_dicts=wan_load_balance_policies,
@@ -335,10 +334,10 @@ class UtilsMixin:
                 )
 
             default_virtual_topology = get(
-                policy, "default_virtual_topology", required=True, org_key=f"wan_virtual_topologies.policies[{policy['name']}].default_virtual_toplogy"
+                policy, "default_virtual_topology", required=True, org_key=f"wan_virtual_topologies.policies[{policy_name}].default_virtual_toplogy"
             )
             if not get(default_virtual_topology, "drop_unmatched", default=False):
-                name = get(default_virtual_topology, "name", default=self._default_profile_name(policy["name"], "DEFAULT"))
+                name = get(default_virtual_topology, "name", default=self._default_profile_name(policy_name, "DEFAULT"))
                 context_path = f"wan_virtual_topologies.policies[{policy['name']}].default_virtual_topology"
 
                 # Verify that path_groups are set or raise
@@ -366,13 +365,15 @@ class UtilsMixin:
         """
         wan_vrfs = []
 
-        for avt_vrf in get(self._hostvars, "wan_virtual_topologies.vrfs", []):
-            vrf_name = avt_vrf["name"]
+        for vrf in get(self._hostvars, "wan_virtual_topologies.vrfs", []):
+            vrf_name = vrf["name"]
             if vrf_name in self.shared_utils.vrfs or self.shared_utils.is_wan_server:
-                # TODO check that the policy exists or raise
                 wan_vrf = {
                     "name": vrf_name,
-                    self._wan_policy_key: get(avt_vrf, "policy", required=True),
+                    "policy": get(vrf, "policy", default="DEFAULT-POLICY"),
+                    "wan_vni": get(
+                        vrf, "wan_vni", required=True, org_key=f"Required `wan_vni` is missing for VRF {vrf_name} under `wan_virtual_topologies.vrfs`."
+                    ),
                 }
 
                 wan_vrfs.append(wan_vrf)
@@ -382,71 +383,70 @@ class UtilsMixin:
             wan_vrfs.append(
                 {
                     "name": "default",
-                    self._wan_policy_key: f"{self._default_vrf_policy['name']}-WITH-CP",
+                    "policy": f"{self._default_avt_policy['name']}-WITH-CP",
+                    "wan_vni": 1,
+                    "original_policy": self._default_avt_policy["name"],
                 }
             )
         else:
-            vrf_default[self._wan_policy_key] = f"{vrf_default[self._wan_policy_key]}-WITH-CP"
+            vrf_default["original_policy"] = vrf_default["policy"]
+            vrf_default["policy"] = f"{vrf_default['policy']}-WITH-CP"
 
         return wan_vrfs
+
+    @cached_property
+    def _wan_policies(self) -> list:
+        """ """
+        policies = get(self._hostvars, "wan_virtual_topologies.policies", default=[])
+        # If not overwritten, inject the DEFAULT-POLICY in case it is required for one of the VRFs
+        if get_item(policies, "name", "DEFAULT-POLICY") is None:
+            policies.append(self._default_avt_policy)
+
+        return policies
 
     @cached_property
     def _filtered_wan_policies(self) -> list:
         """
         Loop through all the VRFs defined under `wan_virtual_topologies.vrfs` and returns a list of policies to configure on this device.
-
         inject the default_vrf_policy
         """
-        policies = get(self._hostvars, "wan_virtual_topologies.policies", default=[])
-        # Need to handle VRF default differently
-        filtered_policies = [
-            get_item(
-                policies,
+        # to track the names already injected
+        filtered_policy_names = []
+        filtered_policies = []
+        for vrf in self._filtered_wan_vrfs:
+            # Need to handle VRF default differently and lookup for the original policy
+            lookup_name = get(vrf, "original_policy", default=vrf["policy"])
+            vrf_policy = get_item(
+                self._wan_policies,
                 "name",
-                wan_vrf[self._wan_policy_key],
+                lookup_name,
                 required=True,
                 custom_error_msg=(
-                    f"The policy {wan_vrf[self._wan_policy_key]} applied to vrf {wan_vrf['name']} under `wan_virtual_topologies.vrfs` is not "
+                    f"The policy {lookup_name} applied to vrf {vrf['name']} under `wan_virtual_topologies.vrfs` is not "
                     "defined under `wan_virtual_topologies.policies`."
                 ),
             )
-            for wan_vrf in self._filtered_wan_vrfs
-            if wan_vrf["name"] != "default"
-        ]
-        filtered_policies.append(self._default_vrf_policy)
+
+            if vrf["name"] == "default":
+                vrf_policy = vrf_policy.copy()
+                vrf_policy["is_default"] = True
+                vrf_policy["original_name"] = lookup_name
+                vrf_policy["name"] = f"{vrf_policy['name']}-WITH-CP"
+
+            if vrf_policy["name"] not in filtered_policy_names:
+                filtered_policy_names.append(vrf_policy["name"])
+                filtered_policies.append(vrf_policy)
+
         return filtered_policies
 
     @cached_property
-    def _default_vrf_policy(self) -> dict:
+    def _default_avt_policy(self) -> dict:
         """
-        Retrieves the name of the policy used for the default VRF and appending -WITH-CP to its name.
-
-        If not policy is defined for VRF default under 'wan_virtual_topologies.vrfs', use a default policy named DEFAULT-AVT-POLICY-WITH-CP where all
-        traffic is matched in the default category and distributed amongst all path-groups.
+        If no policy is defined for a VRF under 'wan_virtual_topologies.vrfs', a default policy named DEFAULT-POLICY is used
+        where all traffic is matched in the default category and distributed amongst all path-groups.
         """
-        vrfs = get(self._hostvars, "wan_virtual_topologies.vrfs", [])
-        default_vrf = get_item(vrfs, "name", "default", default={})
-
-        if (vrf_default_policy := get(default_vrf, "policy")) is not None:
-            policies = get(self._hostvars, "wan_virtual_topologies.policies", default=[])
-            # copy is safe here as we change only the name
-            default_policy = get_item(
-                policies,
-                "name",
-                vrf_default_policy,
-                required=True,
-                custom_error_msg=(
-                    f"The policy {vrf_default_policy} defined for vrf default under 'wan_virtual_topologies.vrfs' "
-                    "is not defined under 'wan_virtual_topologies.policies'."
-                ),
-            ).copy()
-        else:
-            wan_local_path_group_names = [path_group["name"] for path_group in self.shared_utils.wan_local_path_groups]
-            default_policy = {"name": "DEFAULT-AVT-POLICY", "default_virtual_topology": {"path_groups": [{"names": wan_local_path_group_names}]}}
-
-        default_policy["is_default"] = True
-
-        return default_policy
+        wan_local_path_group_names = [path_group["name"] for path_group in self.shared_utils.wan_local_path_groups]
+        return {"name": "DEFAULT-POLICY", "default_virtual_topology": {"path_groups": [{"names": wan_local_path_group_names}]}}
 
     def _default_profile_name(self, profile_name: str, application_profile: str) -> str:
         """

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import ipaddress
 from functools import cached_property
 
+from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort
 from ansible_collections.arista.avd.plugins.plugin_utils.eos_designs_shared_utils import SharedUtils
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError, AristaAvdMissingVariableError
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import append_if_not_duplicate, default, get, get_item
@@ -120,7 +121,7 @@ class UtilsMixin:
             redistribute_in_overlay = False
 
         return {
-            "static_routes": list(vrf_default_ipv4_static_routes),
+            "static_routes": natural_sort(vrf_default_ipv4_static_routes),
             "redistribute_in_underlay": redistribute_in_underlay,
             "redistribute_in_overlay": redistribute_in_overlay,
         }

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -370,7 +370,7 @@ class UtilsMixin:
             if vrf_name in self.shared_utils.vrfs or self.shared_utils.is_wan_server:
                 wan_vrf = {
                     "name": vrf_name,
-                    "policy": get(vrf, "policy", default="DEFAULT-POLICY"),
+                    "policy": get(vrf, "policy", default=self._default_wan_policy["name"]),
                     "wan_vni": get(
                         vrf, "wan_vni", required=True, org_key=f"Required `wan_vni` is missing for VRF {vrf_name} under `wan_virtual_topologies.vrfs`."
                     ),
@@ -383,9 +383,9 @@ class UtilsMixin:
             wan_vrfs.append(
                 {
                     "name": "default",
-                    "policy": f"{self._default_avt_policy['name']}-WITH-CP",
+                    "policy": f"{self._default_wan_policy['name']}-WITH-CP",
                     "wan_vni": 1,
-                    "original_policy": self._default_avt_policy["name"],
+                    "original_policy": self._default_wan_policy["name"],
                 }
             )
         else:
@@ -398,9 +398,9 @@ class UtilsMixin:
     def _wan_policies(self) -> list:
         """ """
         policies = get(self._hostvars, "wan_virtual_topologies.policies", default=[])
-        # If not overwritten, inject the DEFAULT-POLICY in case it is required for one of the VRFs
-        if get_item(policies, "name", "DEFAULT-POLICY") is None:
-            policies.append(self._default_avt_policy)
+        # If not overwritten, inject the default policy in case it is required for one of the VRFs
+        if get_item(policies, "name", self._default_wan_policy["name"]) is None:
+            policies.append(self._default_wan_policy)
 
         return policies
 
@@ -440,7 +440,7 @@ class UtilsMixin:
         return filtered_policies
 
     @cached_property
-    def _default_avt_policy(self) -> dict:
+    def _default_wan_policy(self) -> dict:
         """
         If no policy is defined for a VRF under 'wan_virtual_topologies.vrfs', a default policy named DEFAULT-POLICY is used
         where all traffic is matched in the default category and distributed amongst all path-groups.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
@@ -148,9 +148,10 @@ class VxlanInterfaceMixin(UtilsMixin):
                     "wan_vni",
                     required=True,
                     org_key=(
-                        f"VRF {vrf_name} in tenant {tenant['name']} does not have a `wan_vni` defined. "
-                        "If this VRF was not intended to be extended over WAN, set 'address_families: []' under the VRF definition."
-                        "If not intended on the WAN router, use the VRF filter"
+                        f"The VRF '{vrf_name}' does not have a `wan_vni` defined under 'wan_virtual_topologies'. "
+                        "If this VRF was not intended to be extended over the WAN, but still required to be configured on the WAN router, "
+                        "set 'address_families: []' under the VRF definition."
+                        "If this VRF was not intended to be configured on the WAN router, use the VRF filter 'deny_vrfs' under the node settings."
                     ),
                 )
             else:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24884,17 +24884,26 @@
               },
               "policy": {
                 "type": "string",
-                "description": "Name of the AVT policy to apply to this VRF.",
+                "description": "Name of the policy to apply to this VRF.\nIt is possible to overwrite the default policy for all VRFs using it\nby redefining it in the `wan_virtual_topologies.policies` list using the\ndefault name `DEFAULT-POLICY`.",
+                "default": "DEFAULT-POLICY",
                 "title": "Policy"
+              },
+              "wan_vni": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 255,
+                "description": "Required for VRFs carried over AutoVPN or CV Pathfinder WAN.\n\nA VRF can have a different VNI in the Datacenters and in the WAN.\nNote that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with\n`wan_vni` set to `1`.\nIn addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.\n",
+                "title": "Wan Vni"
               }
             },
+            "required": [
+              "wan_vni",
+              "name"
+            ],
             "additionalProperties": false,
             "patternProperties": {
               "^_.+$": {}
-            },
-            "required": [
-              "name"
-            ]
+            }
           },
           "title": "VRFs"
         },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24892,7 +24892,7 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 255,
-                "description": "Required for VRFs carried over AutoVPN or CV Pathfinder WAN.\n\nA VRF can have a different VNI in the Datacenters and in the WAN.\nNote that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with\n`wan_vni` set to `1`.\nIn addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.\n",
+                "description": "Required for VRFs carried over AutoVPN or CV Pathfinder WAN.\n\nA VRF can have different VNIs between the Datacenters and the WAN.\nNote that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with\n`wan_vni` set to `1`.\nIn addition either `vrf_id` or `vrf_vni` must be set to enforce consistent route-targets across domains.",
                 "title": "Wan Vni"
               }
             },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -4989,6 +4989,27 @@ $defs:
                   to avoid overlap.
 
                   '
+              wan_vni:
+                type: int
+                convert_types:
+                - str
+                min: 1
+                max: 255
+                description: 'Required for VRFs carried over AutoVPN or CV Pathfinder
+                  WAN.
+
+
+                  A VRF can have a different VNI in the Datacenters and in the WAN.
+
+                  Note that if no VRF default is configured for WAN, AVD will automatically
+                  inject the VRF default with
+
+                  `wan_vni` set to `1`.
+
+                  In addition either `vrf_id` or `vrf_vni` must be set to enforce
+                  consistant route-targets across domains.
+
+                  '
               vrf_id:
                 type: int
                 convert_types:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3722,7 +3722,38 @@ keys:
               description: VRF name.
             policy:
               type: str
-              description: Name of the AVT policy to apply to this VRF.
+              description: 'Name of the policy to apply to this VRF.
+
+                It is possible to overwrite the default policy for all VRFs using
+                it
+
+                by redefining it in the `wan_virtual_topologies.policies` list using
+                the
+
+                default name `DEFAULT-POLICY`.'
+              default: DEFAULT-POLICY
+            wan_vni:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 255
+              required: true
+              description: 'Required for VRFs carried over AutoVPN or CV Pathfinder
+                WAN.
+
+
+                A VRF can have a different VNI in the Datacenters and in the WAN.
+
+                Note that if no VRF default is configured for WAN, AVD will automatically
+                inject the VRF default with
+
+                `wan_vni` set to `1`.
+
+                In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant
+                route-targets across domains.
+
+                '
       control_plane_virtual_topology:
         type: dict
         description: 'Always injected into the default VRF policy as the first entry.
@@ -4987,27 +5018,6 @@ $defs:
 
                   If vrf_vni > 10000 make sure to adjust "mac_vrf_vni_base" accordingly
                   to avoid overlap.
-
-                  '
-              wan_vni:
-                type: int
-                convert_types:
-                - str
-                min: 1
-                max: 255
-                description: 'Required for VRFs carried over AutoVPN or CV Pathfinder
-                  WAN.
-
-
-                  A VRF can have a different VNI in the Datacenters and in the WAN.
-
-                  Note that if no VRF default is configured for WAN, AVD will automatically
-                  inject the VRF default with
-
-                  `wan_vni` set to `1`.
-
-                  In addition either `vrf_id` or `vrf_vni` must be set to enforce
-                  consistant route-targets across domains.
 
                   '
               vrf_id:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3743,17 +3743,15 @@ keys:
                 WAN.
 
 
-                A VRF can have a different VNI in the Datacenters and in the WAN.
+                A VRF can have different VNIs between the Datacenters and the WAN.
 
                 Note that if no VRF default is configured for WAN, AVD will automatically
                 inject the VRF default with
 
                 `wan_vni` set to `1`.
 
-                In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant
-                route-targets across domains.
-
-                '
+                In addition either `vrf_id` or `vrf_vni` must be set to enforce consistent
+                route-targets across domains.'
       control_plane_virtual_topology:
         type: dict
         description: 'Always injected into the default VRF policy as the first entry.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
@@ -280,6 +280,19 @@ $defs:
                   "vrf_vni" may also be used for VRF RD/RT ID. See "overlay_rd_type" and "overlay_rt_type" for details.
                   See "mlag_ibgp_peering_vrfs.base_vlan" for details.
                   If vrf_vni > 10000 make sure to adjust "mac_vrf_vni_base" accordingly to avoid overlap.
+              wan_vni:
+                type: int
+                convert_types:
+                  - str
+                min: 1
+                max: 255
+                description: |
+                  Required for VRFs carried over AutoVPN or CV Pathfinder WAN.
+
+                  A VRF can have a different VNI in the Datacenters and in the WAN.
+                  Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with
+                  `wan_vni` set to `1`.
+                  In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.
               vrf_id:
                 type: int
                 convert_types:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_network_services.schema.yml
@@ -280,19 +280,6 @@ $defs:
                   "vrf_vni" may also be used for VRF RD/RT ID. See "overlay_rd_type" and "overlay_rt_type" for details.
                   See "mlag_ibgp_peering_vrfs.base_vlan" for details.
                   If vrf_vni > 10000 make sure to adjust "mac_vrf_vni_base" accordingly to avoid overlap.
-              wan_vni:
-                type: int
-                convert_types:
-                  - str
-                min: 1
-                max: 255
-                description: |
-                  Required for VRFs carried over AutoVPN or CV Pathfinder WAN.
-
-                  A VRF can have a different VNI in the Datacenters and in the WAN.
-                  Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with
-                  `wan_vni` set to `1`.
-                  In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.
               vrf_id:
                 type: int
                 convert_types:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_virtual_topologies.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_virtual_topologies.schema.yml
@@ -51,13 +51,13 @@ keys:
               min: 1
               max: 255
               required: true
-              description: |
+              description: |-
                 Required for VRFs carried over AutoVPN or CV Pathfinder WAN.
 
-                A VRF can have a different VNI in the Datacenters and in the WAN.
+                A VRF can have different VNIs between the Datacenters and the WAN.
                 Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with
                 `wan_vni` set to `1`.
-                In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.
+                In addition either `vrf_id` or `vrf_vni` must be set to enforce consistent route-targets across domains.
       control_plane_virtual_topology:
         type: dict
         description: |-

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_virtual_topologies.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_virtual_topologies.schema.yml
@@ -31,7 +31,33 @@ keys:
               description: VRF name.
             policy:
               type: str
-              description: Name of the AVT policy to apply to this VRF.
+              description: |-
+                Name of the policy to apply to this VRF.
+                It is possible to overwrite the default policy for all VRFs using it
+                by redefining it in the `wan_virtual_topologies.policies` list using the
+                default name `DEFAULT-POLICY`.
+              default: DEFAULT-POLICY
+            wan_vni:
+              # The `wan_vni` is under here rather than `tenants.vrfs` as it as
+              # initially planned for 2 reasons:
+              # 1. This allow to keep a consistent WAN VNI ID in a more
+              #    effective way, as otherwise this wan_vni key would have had
+              #    to be aligned in every tenant where the VRF is defined.
+              # 2. This is used in the WAN metadata for pathfinder nodes to pick
+              #    up WAN VRFs and their VNI.
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 255
+              required: true
+              description: |
+                Required for VRFs carried over AutoVPN or CV Pathfinder WAN.
+
+                A VRF can have a different VNI in the Datacenters and in the WAN.
+                Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with
+                `wan_vni` set to `1`.
+                In addition either `vrf_id` or `vrf_vni` must be set to enforce consistant route-targets across domains.
       control_plane_virtual_topology:
         type: dict
         description: |-


### PR DESCRIPTION
## Change Summary

The behavior is that a VRF is not added to the WAN if no `wan_vni` is configured.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

* Adding a `wan_vni` 

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### Question for reviewers:

- [ ] `vrf_id` ? 

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
