### PR TITLE
Fix(eos_validate_state): ANTA Handle Pydantic + Python 3.9.7 bug gracefully

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/ansible_eos_device.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/ansible_eos_device.py
@@ -31,9 +31,11 @@ except TypeError as e:
     # Known bug with Python 3.9.7 and Pydantic `conint`, impacting ANTA. Issue: https://github.com/arista-netdevops-community/anta/issues/557
     if "Interval() takes no arguments" in str(e):
         msg = (
-            "The ANTA testing framework, used in the AVD eos_validate_state role, has encountered a compatibility issue with Python 3.9.x. "
-            "Please try a different Python version. For assistance or to report your Python version, please refer to the AVD/ANTA GitHub repositories:\n"
-            "https://github.com/aristanetworks/avd/\nhttps://github.com/arista-netdevops-community/anta"
+            "The ANTA testing framework, utilized in the AVD eos_validate_state role, has identified a compatibility issue with Python 3.9.x. "
+            "We recommend trying a different Python version; 3.9.13 has been confirmed to work, or consider upgrading to version 3.10 or newer.\n"
+            "For further assistance or to report your Python version, please visit the AVD and ANTA GitHub repositories:\n"
+            "https://github.com/aristanetworks/avd/\n"
+            "https://github.com/arista-netdevops-community/anta"
         )
         raise AristaAvdError(msg) from e
     else:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/ansible_eos_device.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/ansible_eos_device.py
@@ -30,7 +30,11 @@ except ImportError:
 except TypeError as e:
     # Known bug with Python 3.9.7 and Pydantic `conint`, impacting ANTA. Issue: https://github.com/arista-netdevops-community/anta/issues/557
     if "Interval() takes no arguments" in str(e):
-        msg = "Encountered a known bug with Pydantic and Python 3.9.7. Please consider upgrading Python or using a different environment."
+        msg = (
+            "The ANTA testing framework, used in the AVD eos_validate_state role, has encountered a compatibility issue with Python 3.9.x. "
+            "Please try a different Python version. For assistance or to report your Python version, please refer to the AVD/ANTA GitHub repositories:\n"
+            "https://github.com/aristanetworks/avd/\nhttps://github.com/arista-netdevops-community/anta"
+        )
         raise AristaAvdError(msg) from e
     else:
         # If the TypeError is not related to the known bug, raise it to avoid silencing other issues

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/anta_tests.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/anta_tests.yml
@@ -18,3 +18,26 @@
   check_mode: false
   when: use_anta | bool
   tags: always
+
+#######################################
+##  Generate reports from ANTA tests ##
+#######################################
+
+- name: Create validation reports from ANTA tests
+  arista.avd.eos_validate_state_reports:
+    csv_report_path: "{{ eos_validate_state_csv_report_path }}"
+    md_report_path: "{{ eos_validate_state_md_report_path }}"
+    validation_report_csv: "{{ validation_report_csv }}"
+    validation_report_md: "{{ validation_report_md }}"
+    only_failed_tests: "{{ only_failed_tests }}"
+    test_results_dir: "{{ test_results_dir }}"
+    # cprofile_file: "eos_validate_state_reports.prof"
+  delegate_to: localhost
+  run_once: true
+  check_mode: false
+  when:
+    - use_anta | bool
+    - validation_report_csv | bool or validation_report_md | bool
+  tags:
+    - always
+    - reports

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/anta_tests.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/anta_tests.yml
@@ -16,7 +16,6 @@
     # cprofile_file: "anta-{{inventory_hostname}}.prof"
   register: anta_results
   check_mode: false
-  when: use_anta | bool
   tags: always
 
 #######################################
@@ -36,7 +35,6 @@
   run_once: true
   check_mode: false
   when:
-    - use_anta | bool
     - validation_report_csv | bool or validation_report_md | bool
   tags:
     - always

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -50,29 +50,6 @@
   tags:
     - always
 
-#######################################
-##  Generate reports from ANTA tests ##
-#######################################
-
-- name: Create validation reports from ANTA tests
-  arista.avd.eos_validate_state_reports:
-    csv_report_path: "{{ eos_validate_state_csv_report_path }}"
-    md_report_path: "{{ eos_validate_state_md_report_path }}"
-    validation_report_csv: "{{ validation_report_csv }}"
-    validation_report_md: "{{ validation_report_md }}"
-    only_failed_tests: "{{ only_failed_tests }}"
-    test_results_dir: "{{ test_results_dir }}"
-    # cprofile_file: "eos_validate_state_reports.prof"
-  delegate_to: localhost
-  run_once: true
-  check_mode: false
-  when:
-    - use_anta | bool
-    - validation_report_csv | bool or validation_report_md | bool
-  tags:
-    - always
-    - reports
-
 ########################################################
 ##  Run eos_validate_state using Ansible assert tests ##
 ########################################################


### PR DESCRIPTION
## Change Summary

- Added try-except block to catch a known bug with Pydantic `conint` and Python 3.9.7, impacting ANTA. The bug manifests when loading Pydantic models using `conint`.

- ANTA related tasks are now grouped in a specific file to avoid loading unnecessary ANTA modules when running validate state in NOT ANTA mode (use_anta=False). 

- Added a condition in `AnsibleEOSDevice` init to catch properly when ANTA is not installed or not imported.
## Related Issue(s)

https://github.com/arista-netdevops-community/anta/issues/557

## Component(s) name

`arista.avd.eos_validate_state` **ANTA Mode**

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
Install Python 3.9.7 with ANTA 0.12.0 and run validate state in ANTA mode to see the bug:
![image](https://github.com/aristanetworks/avd/assets/63206086/6a0be2a8-086c-4c59-bc7d-57235497a887)

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
