### PR TITLE
Refactor(eos_cli_config_gen): Insert EOF at the end, if not present in banner string

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/banners_without_eof.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/banners_without_eof.md
@@ -1,0 +1,165 @@
+# banners_without_eof
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [Management SSH](#management-ssh)
+  - [Management Console](#management-console)
+  - [Management API HTTP](#management-api-http)
+- [Management Security](#management-security)
+  - [Management Security Summary](#management-security-summary)
+  - [Management Security Device Configuration](#management-security-device-configuration)
+- [EOS CLI Device Configuration](#eos-cli-device-configuration)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | Description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+### Management SSH
+
+#### IPv4 ACL
+
+| IPv4 ACL | VRF |
+| -------- | --- |
+| ACL-SSH | - |
+| ACL-SSH-VRF | mgt |
+
+#### IPv6 ACL
+
+| IPv6 ACL | VRF |
+| -------- | --- |
+| ACL-SSH6 | - |
+| ACL-SSH-VRF6 | mgt |
+
+#### SSH Timeout and Management
+
+| Idle Timeout | SSH Management |
+| ------------ | -------------- |
+| 15 | Enabled |
+
+#### Max number of SSH sessions limit and per-host limit
+
+| Connection Limit | Max from a single Host |
+| ---------------- | ---------------------- |
+| - | 12 |
+
+#### Ciphers and Algorithms
+
+| Ciphers | Key-exchange methods | MAC algorithms | Hostkey server algorithms |
+|---------|----------------------|----------------|---------------------------|
+| default | default | default | default |
+
+#### VRFs
+
+| VRF | Status |
+| --- | ------ |
+| mgt | Enabled |
+
+#### Management SSH Device Configuration
+
+```eos
+!
+management ssh
+   ip access-group ACL-SSH in
+   ip access-group ACL-SSH-VRF vrf mgt in
+   ipv6 access-group ACL-SSH6 in
+   ipv6 access-group ACL-SSH-VRF6 vrf mgt in
+   idle-timeout 15
+   connection per-host 12
+   no shutdown
+   !
+   vrf mgt
+      no shutdown
+```
+
+### Management Console
+
+#### Management Console Timeout
+
+Management Console Timeout is set to **300** minutes.
+
+#### Management Console Device Configuration
+
+```eos
+!
+management console
+   idle-timeout 300
+```
+
+### Management API HTTP
+
+#### Management API HTTP Summary
+
+| HTTP | HTTPS | Default Services |
+| ---- | ----- | ---------------- |
+| True | True | - |
+
+#### Management API VRF Access
+
+| VRF Name | IPv4 ACL | IPv6 ACL |
+| -------- | -------- | -------- |
+| mgt | ACL-API | - |
+
+#### Management API HTTP Device Configuration
+
+```eos
+!
+management api http-commands
+   protocol https
+   protocol http
+   no shutdown
+   !
+   vrf mgt
+      no shutdown
+      ip access-group ACL-API
+```
+
+## Management Security
+
+### Management Security Summary
+
+| Settings | Value |
+| -------- | ----- |
+| Common password encryption key | True |
+
+### Management Security Device Configuration
+
+```eos
+!
+management security
+   password encryption-key common
+```
+
+## EOS CLI Device Configuration
+
+```eos
+!
+interface Loopback1000
+  description Interface created with eos_cli on device level
+
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/banners_without_eof.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/banners_without_eof.cfg
@@ -1,0 +1,61 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname banners_without_eof
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+banner login
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+!***!!!Unauthorized access prohibited!!!***!
+!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+EOF
+
+!
+banner motd
+.         Switch       : $(hostname)                            .
+.         Site         : DC1                      .
+.         Type info for information about the device            .
+.         Type help for information about the aliases           .
+EOF
+
+!
+management api http-commands
+   protocol https
+   protocol http
+   no shutdown
+   !
+   vrf mgt
+      no shutdown
+      ip access-group ACL-API
+!
+management console
+   idle-timeout 300
+!
+management security
+   password encryption-key common
+!
+management ssh
+   ip access-group ACL-SSH in
+   ip access-group ACL-SSH-VRF vrf mgt in
+   ipv6 access-group ACL-SSH6 in
+   ipv6 access-group ACL-SSH-VRF6 vrf mgt in
+   idle-timeout 15
+   connection per-host 12
+   no shutdown
+   !
+   vrf mgt
+      no shutdown
+!
+interface Loopback1000
+  description Interface created with eos_cli on device level
+
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/banners_without_eof.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/banners_without_eof.yml
@@ -1,0 +1,49 @@
+banners:
+  login: |
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    !***!!!Unauthorized access prohibited!!!***!
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  motd: |
+    .         Switch       : $(hostname)                            .
+    .         Site         : DC1                      .
+    .         Type info for information about the device            .
+    .         Type help for information about the aliases           .
+
+### Management API http ###
+management_api_http:
+  enable_http: true
+  enable_https: true
+  enable_vrfs:
+    - name: mgt
+      access_group: ACL-API
+
+### Management console ###
+management_console:
+  idle_timeout: 300
+
+### Management security ###
+management_security:
+  password:
+    encryption_key_common: true
+
+### Management ssh ###
+management_ssh:
+  access_groups:
+    - name: ACL-SSH
+    - name: ACL-SSH-VRF
+      vrf: mgt
+  ipv6_access_groups:
+    - name: ACL-SSH6
+    - name: ACL-SSH-VRF6
+      vrf: mgt
+  idle_timeout: 15
+  connection:
+    per_host: 12
+  enable: true
+  vrfs:
+    - name: mgt
+      enable: true
+
+eos_cli: |
+  interface Loopback1000
+    description Interface created with eos_cli on device level

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -10,6 +10,7 @@ application-traffic-recognition
 arp
 as-path
 base
+banners_without_eof
 boot
 class-maps
 clock

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/banners.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/banners.j2
@@ -7,10 +7,18 @@
 {% if banners.login is arista.avd.defined %}
 !
 banner login
-{{ banners.login }}
+{%     set login = banners.login %}
+{%     if not (login.strip().endswith('\nEOF') or login.strip().endswith('\nEOF\n')) %}
+{%         set login = login.strip() + "\nEOF\n" %}
+{%     endif %}
+{{ login }}
 {% endif %}
 {% if banners.motd is arista.avd.defined %}
 !
 banner motd
-{{ banners.motd }}
+{%     set motd = banners.motd %}
+{%     if not (motd.strip().endswith('\nEOF') or motd.strip().endswith('\nEOF\n')) %}
+{%         set motd = motd.strip() + "\nEOF\n" %}
+{%     endif %}
+{{ motd }}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/banners.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/banners.j2
@@ -8,8 +8,8 @@
 !
 banner login
 {%     set login = banners.login %}
-{%     if not (login.strip().endswith('\nEOF') or login.strip().endswith('\nEOF\n')) %}
-{%         set login = login.strip() + "\nEOF\n" %}
+{%     if not login.rstrip().endswith('\nEOF') %}
+{%         set login = login.rstrip() + "\nEOF\n" %}
 {%     endif %}
 {{ login }}
 {% endif %}
@@ -17,8 +17,8 @@ banner login
 !
 banner motd
 {%     set motd = banners.motd %}
-{%     if not (motd.strip().endswith('\nEOF') or motd.strip().endswith('\nEOF\n')) %}
-{%         set motd = motd.strip() + "\nEOF\n" %}
+{%     if not (motd.rstrip().endswith('\nEOF')) %}
+{%         set motd = motd.rstrip() + "\nEOF\n" %}
 {%     endif %}
 {{ motd }}
 {% endif %}


### PR DESCRIPTION
## Change Summary

Checking if the **EOF** is present in the last line of banner string, if not then inserting it.

## Related Issue(s)

Fixes #2782  

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Update jinja2 template to check if EOF is present, if not insert it.

## How to test

Try giving banner.login and banner.motd value without "EOF" at the end, it should automatically be inserted in the config.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
