### PR TITLE
Fix(eos_cli_config_gen): sa_filter.out_list generating incorrect value in router-msdp template

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-msdp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-msdp.md
@@ -66,7 +66,7 @@ router msdp
       local-interface Loopback11
       keepalive 10 30
       sa-filter in list ACL1
-      sa-filter out list ACL1
+      sa-filter out list ACL2
       description Some kind of MSDP Peer
       disabled
       sa-limit 1000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-msdp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-msdp.cfg
@@ -27,7 +27,7 @@ router msdp
       local-interface Loopback11
       keepalive 10 30
       sa-filter in list ACL1
-      sa-filter out list ACL1
+      sa-filter out list ACL2
       description Some kind of MSDP Peer
       disabled
       sa-limit 1000

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-msdp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-msdp.j2
@@ -48,7 +48,7 @@ router msdp
       sa-filter in list {{ peer.sa_filter.in_list }}
 {%             endif %}
 {%             if peer.sa_filter.out_list is arista.avd.defined %}
-      sa-filter out list {{ peer.sa_filter.in_list }}
+      sa-filter out list {{ peer.sa_filter.out_list }}
 {%             endif %}
 {%             if peer.description is arista.avd.defined %}
       description {{ peer.description }}


### PR DESCRIPTION
## Change Summary

Fix the template of router-msdp since the sa-filter **out** list was pointing to the variable {{ peer.sa_filter.in_list }} instead of {{ peer.sa_filter.out_list }}

## Related Issue(s)

Fixes #3612 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Fix the variable as following : 
```
{%             if peer.sa_filter.out_list is arista.avd.defined %}
      sa-filter out list {{ peer.sa_filter.out_list }}
{%             endif %}
```

## How to test
The following example of group_vars 
```
router_msdp:
  originator_id_local_interface: Loopback0
  peers:
    - ipv4_address: 10.10.10.10
      local_interface: Loopback0
      mesh_groups:
        - name: ANYCAST-RP
      sa_filter:
        in_list: MSDP-FILTER-IN
        out_list: MSDP-FILTER-OUT
```

should now generate : 
```
router msdp
   originator-id local-interface Loopback0
   !
   peer 10.10.10.10
      mesh-group ANYCAST-RP
      local-interface Loopback0
      sa-filter in list MSDP-FILTER-IN
      sa-filter out list MSDP-FILTER-OUT
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
