### PR TITLE
Feat(deploy_to_cv): Auto onboard to I&T Studio

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/finalize_workspace_on_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/finalize_workspace_on_cv.py
@@ -39,7 +39,10 @@ async def finalize_workspace_on_cv(workspace: CVWorkspace, cv_client: CVClient) 
     if build_result.status != ResponseStatus.SUCCESS:
         workspace.final_state = "build failed"
         LOGGER.info("finalize_workspace_on_cv: %s", workspace)
-        raise CVWorkspaceBuildFailed(f"Failed to build workspace {workspace.id}: {build_result}")
+        raise CVWorkspaceBuildFailed(
+            f"Failed to build workspace {workspace.id}: {build_result}. "
+            f"See details: https://{cv_client._servers[0]}/cv/provisioning/workspaces?ws={workspace.id}"
+        )
 
     workspace.final_state = "built"
     LOGGER.info("finalize_workspace_on_cv: %s", workspace)

--- a/ansible_collections/arista/avd/roles/deploy_to_cv/README.md
+++ b/ansible_collections/arista/avd/roles/deploy_to_cv/README.md
@@ -25,7 +25,7 @@ Depending on the configured options, the role supports multiple operations:
 
 - Deploys configurations for one or more devices using the "Static Configuration Studio".
 - Deploys device and interface Tags for one or more devices.
-- Updates device hostname in the "Inventory & Topology Studio".
+- Adds missing devices and updates device details for existing devices in the "Inventory & Topology Studio".
 - Creates, builds, submits Workspaces.
 - Creates, approves, starts Change Controls.
 - Deploys special metadata for CV Pathfinder solution.
@@ -196,7 +196,7 @@ By default the role will
     When deploying CloudVision Tag assignments, the builtin behavior is to unassign any other tags
     with the same labels but different values. This is not configurable.
 
-    It is possible to assign _any_ other tag from the devices by setting `cv_strict_tags: true`.
+    It is possible to unassign _any_ other tag from the devices by setting `cv_strict_tags: true`.
     This may remove tags used for studios and other things, so this is *not* recommended.
 
 These settings allow modifying the default behavior as needed. The values below are the default values.


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Auto onboard to I&T Studio

## Component(s) name

`arista.avd.deploy_to_cv`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Up until now the `deploy_to_cv` role/plugin would check if the devices were already added to I&T Studio.
- This changes the behavior to automatically add any missing devices to the studio.
- Because of limitation to the released APIs we cannot do the complete "onboarding" where we add all the LLDP interface info etc. This can come later once the APIs are ready.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Add a new device to AVD inventory and have it stream to CV
- Run deploy_to_cv with verbosity to see the device being added during the play.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
