### PR TITLE
Feat(eos_cli_config_gen): Add event-handler trigger on-maintenance.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -46,7 +46,6 @@ interface Management1
 | CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config |
 | evpn-blacklist-recovery | bash | <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging |
 | trigger-on-boot | bash | <code>echo "on-boot"</code> | on-boot |
-| trigger-on-maintenance | bash | <code>echo "on-maintenance"</code> | on-maintenance |
 | trigger-on-maintenance1 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
 | trigger-on-maintenance2 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
 | trigger-on-maintenance3 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
@@ -71,12 +70,8 @@ event-handler trigger-on-boot
    trigger on-boot
    action bash echo "on-boot"
 !
-event-handler trigger-on-maintenance
-   trigger on-maintenance enter interface Ethernet4 all
-   action bash echo "on-maintenance"
-!
 event-handler trigger-on-maintenance1
-   trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 after stage linkdown
+   trigger on-maintenance enter interface Management3 after stage linkdown
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -46,6 +46,9 @@ interface Management1
 | CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config |
 | evpn-blacklist-recovery | bash | <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging |
 | trigger-on-boot | bash | <code>echo "on-boot"</code> | on-boot |
+| trigger-on-maintenance | bash | <code>echo "on-maintenance"</code> | on-maintenance |
+| trigger-on-maintenance1 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
+| trigger-on-maintenance2 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
 
 #### Event Handler Device Configuration
 
@@ -66,4 +69,16 @@ event-handler evpn-blacklist-recovery
 event-handler trigger-on-boot
    trigger on-boot
    action bash echo "on-boot"
+!
+event-handler trigger-on-maintenance
+   trigger on-maintenance enter interface Ethernet 4 all
+   action bash echo "on-maintenance"
+!
+event-handler trigger-on-maintenance1
+   trigger on-maintenance enter bgp 10.0.0.2 after linkdown
+   action bash echo "on-maintenance"
+!
+event-handler trigger-on-maintenance2
+   trigger on-maintenance enter unit unit1 before bgp
+   action bash echo "on-maintenance"
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -71,7 +71,7 @@ event-handler trigger-on-boot
    action bash echo "on-boot"
 !
 event-handler trigger-on-maintenance
-   trigger on-maintenance enter interface Ethernet 4 all
+   trigger on-maintenance enter interface Ethernet4 all
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -49,6 +49,7 @@ interface Management1
 | trigger-on-maintenance | bash | <code>echo "on-maintenance"</code> | on-maintenance |
 | trigger-on-maintenance1 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
 | trigger-on-maintenance2 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
+| trigger-on-maintenance3 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
 
 #### Event Handler Device Configuration
 
@@ -75,10 +76,14 @@ event-handler trigger-on-maintenance
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance1
-   trigger on-maintenance enter bgp 10.0.0.2 after stage linkdown
+   trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 after stage linkdown
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance2
    trigger on-maintenance enter unit unit1 before stage bgp
+   action bash echo "on-maintenance"
+!
+event-handler trigger-on-maintenance3
+   trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 all
    action bash echo "on-maintenance"
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -75,10 +75,10 @@ event-handler trigger-on-maintenance
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance1
-   trigger on-maintenance enter bgp 10.0.0.2 after linkdown
+   trigger on-maintenance enter bgp 10.0.0.2 after stage linkdown
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance2
-   trigger on-maintenance enter unit unit1 before bgp
+   trigger on-maintenance enter unit unit1 before stage bgp
    action bash echo "on-maintenance"
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -28,4 +28,16 @@ event-handler trigger-on-boot
    trigger on-boot
    action bash echo "on-boot"
 !
+event-handler trigger-on-maintenance
+   trigger on-maintenance enter interface Ethernet 4 all
+   action bash echo "on-maintenance"
+!
+event-handler trigger-on-maintenance1
+   trigger on-maintenance enter bgp 10.0.0.2 after linkdown
+   action bash echo "on-maintenance"
+!
+event-handler trigger-on-maintenance2
+   trigger on-maintenance enter unit unit1 before bgp
+   action bash echo "on-maintenance"
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -28,12 +28,8 @@ event-handler trigger-on-boot
    trigger on-boot
    action bash echo "on-boot"
 !
-event-handler trigger-on-maintenance
-   trigger on-maintenance enter interface Ethernet4 all
-   action bash echo "on-maintenance"
-!
 event-handler trigger-on-maintenance1
-   trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 after stage linkdown
+   trigger on-maintenance enter interface Management3 after stage linkdown
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -33,11 +33,11 @@ event-handler trigger-on-maintenance
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance1
-   trigger on-maintenance enter bgp 10.0.0.2 after linkdown
+   trigger on-maintenance enter bgp 10.0.0.2 after stage linkdown
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance2
-   trigger on-maintenance enter unit unit1 before bgp
+   trigger on-maintenance enter unit unit1 before stage bgp
    action bash echo "on-maintenance"
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -33,11 +33,15 @@ event-handler trigger-on-maintenance
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance1
-   trigger on-maintenance enter bgp 10.0.0.2 after stage linkdown
+   trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 after stage linkdown
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance2
    trigger on-maintenance enter unit unit1 before stage bgp
+   action bash echo "on-maintenance"
+!
+event-handler trigger-on-maintenance3
+   trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 all
    action bash echo "on-maintenance"
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -29,7 +29,7 @@ event-handler trigger-on-boot
    action bash echo "on-boot"
 !
 event-handler trigger-on-maintenance
-   trigger on-maintenance enter interface Ethernet 4 all
+   trigger on-maintenance enter interface Ethernet4 all
    action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -37,8 +37,7 @@ event_handlers:
     trigger: on-maintenance
     trigger_on_maintenance:
       operation: enter
-      bgp:
-        peer: 10.0.0.2
+      bgp_peer: 10.0.0.2
       vrf: vrf1
       action: all
     action_type: bash

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -19,9 +19,7 @@ event_handlers:
     trigger: on-maintenance
     trigger_on_maintenance:
       operation: enter
-      interface:
-        interface_type: Ethernet
-        interface_number: 4
+      interface: Ethernet4
       stage: all
     action_type: bash
     action: echo "on-maintenance"
@@ -31,9 +29,7 @@ event_handlers:
       operation: enter
       bgp:
         neighbor_address_ipv4: 10.0.0.2
-      interface:
-        interface_type: Management
-        interface_number: 3
+      interface: Management3
       stage: after
       after_before_stage: linkdown
     action_type: bash

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -15,3 +15,35 @@ event_handlers:
     trigger: on-boot
     action_type: bash
     action: echo "on-boot"
+  - name: trigger-on-maintenance
+    trigger: on-maintenance
+    trigger_on_maintenance:
+      operation: enter
+      interface:
+        interface_type: Ethernet
+        interface_number: 4
+      stage: all
+    action_type: bash
+    action: echo "on-maintenance"
+  - name: trigger-on-maintenance1
+    trigger: on-maintenance
+    trigger_on_maintenance:
+      operation: enter
+      bgp:
+        neighbor_address_ipv4: 10.0.0.2
+      interface:
+        interface_type: Management
+        interface_number: 3
+      stage: after
+      after_before_stage: linkdown
+    action_type: bash
+    action: echo "on-maintenance"
+  - name: trigger-on-maintenance2
+    trigger: on-maintenance
+    trigger_on_maintenance:
+      operation: enter
+      unit: unit1
+      stage: before
+      after_before_stage: bgp
+    action_type: bash
+    action: echo "on-maintenance"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -43,3 +43,13 @@ event_handlers:
       after_before_stage: bgp
     action_type: bash
     action: echo "on-maintenance"
+  - name: trigger-on-maintenance3
+    trigger: on-maintenance
+    trigger_on_maintenance:
+      operation: enter
+      bgp:
+        neighbor_address_ipv4: 10.0.0.2
+      vrf: vrf1
+      stage: all
+    action_type: bash
+    action: echo "on-maintenance"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -38,7 +38,7 @@ event_handlers:
     trigger_on_maintenance:
       operation: enter
       bgp:
-        neighbor_address_ipv4: 10.0.0.2
+        peer: 10.0.0.2
       vrf: vrf1
       action: all
     action_type: bash

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -15,23 +15,13 @@ event_handlers:
     trigger: on-boot
     action_type: bash
     action: echo "on-boot"
-  - name: trigger-on-maintenance
-    trigger: on-maintenance
-    trigger_on_maintenance:
-      operation: enter
-      interface: Ethernet4
-      stage: all
-    action_type: bash
-    action: echo "on-maintenance"
   - name: trigger-on-maintenance1
     trigger: on-maintenance
     trigger_on_maintenance:
       operation: enter
-      bgp:
-        neighbor_address_ipv4: 10.0.0.2
       interface: Management3
-      stage: after
-      after_before_stage: linkdown
+      action: after
+      stage: linkdown
     action_type: bash
     action: echo "on-maintenance"
   - name: trigger-on-maintenance2
@@ -39,8 +29,8 @@ event_handlers:
     trigger_on_maintenance:
       operation: enter
       unit: unit1
-      stage: before
-      after_before_stage: bgp
+      action: before
+      stage: bgp
     action_type: bash
     action: echo "on-maintenance"
   - name: trigger-on-maintenance3
@@ -50,6 +40,6 @@ event_handlers:
       bgp:
         neighbor_address_ipv4: 10.0.0.2
       vrf: vrf1
-      stage: all
+      action: all
     action_type: bash
     action: echo "on-maintenance"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -13,13 +13,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified BGP peer. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
@@ -49,6 +49,8 @@
 
         # Configure event trigger condition.
         trigger: <str; "on-boot" | "on-logging" | "on-startup-config" | "on-maintenance">
+
+        # Settings required for trigger 'on-maintenance'.
         trigger_on_maintenance:
           operation: <str; "enter" | "exit"; required>
 
@@ -57,7 +59,7 @@
             neighbor_address_ipv4: <str>
             neighbor_address_ipv6: <str>
             peer_group_name: <str>
-          stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf">
+          stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf"; required>
 
           # Action is triggered after/before specified stage.
           after_before_stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -19,7 +19,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> | Stages of maintenance operation. "vrf" stage can be defined for "bgp" only. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Stages of maintenance operation. "vrf" stage can be defined for "bgp" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
@@ -59,7 +59,7 @@
             peer_group_name: <str>
 
           # Stages of maintenance operation. "vrf" stage can be defined for "bgp" only.
-          stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf"; required>
+          stage: <str; "after" | "before" | "all" | "begin" | "end"; required>
 
           # Action is triggered after/before specified stage.
           after_before_stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -19,12 +19,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> | Stages of maintenance operation. "vrf" stage can be defined for "bgp" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_type</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_type") | String | Required |  | Valid Values:<br>- <code>Ethernet</code><br>- <code>Fabric</code><br>- <code>Loopback</code><br>- <code>Management</code><br>- <code>Port-Channel</code><br>- <code>Tunnel</code><br>- <code>Vlan</code><br>- <code>Vxlan</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_number</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_number") | Integer | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking.<br> |
@@ -59,6 +57,8 @@
             neighbor_address_ipv4: <str>
             neighbor_address_ipv6: <str>
             peer_group_name: <str>
+
+          # Stages of maintenance operation. "vrf" stage can be defined for "bgp" only.
           stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf"; required>
 
           # Action is triggered after/before specified stage.
@@ -68,9 +68,7 @@
           vrf: <str>
 
           # Trigger condition occurs on maintenance operation of specified interface.
-          interface:
-            interface_type: <str; "Ethernet" | "Fabric" | "Loopback" | "Management" | "Port-Channel" | "Tunnel" | "Vlan" | "Vxlan"; required>
-            interface_number: <int; required>
+          interface: <str>
 
           # Name of unit. Trigger condition occurs on maintenance operation of specified unit
           unit: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -19,9 +19,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Stages of maintenance operation. "vrf" stage can be defined for "bgp" only. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].trigger_on_maintenance.action") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Action for maintenance operation. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
@@ -58,13 +58,13 @@
             neighbor_address_ipv6: <str>
             peer_group_name: <str>
 
-          # Stages of maintenance operation. "vrf" stage can be defined for "bgp" only.
-          stage: <str; "after" | "before" | "all" | "begin" | "end"; required>
+          # Action for maintenance operation.
+          action: <str; "after" | "before" | "all" | "begin" | "end"; required>
 
           # Action is triggered after/before specified stage.
-          after_before_stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">
+          stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">
 
-          # VRF name.
+          # VRF name. VRF can be defined for "bgp" only.
           vrf: <str>
 
           # Trigger condition occurs on maintenance operation of specified interface.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -15,8 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified BGP peer. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp_peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name.<br>Trigger condition occurs on maintenance operation of specified BGP peer. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].trigger_on_maintenance.action") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Action for maintenance operation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp" only. |
@@ -50,11 +49,9 @@
         trigger_on_maintenance:
           operation: <str; "enter" | "exit"; required>
 
+          # Ipv4/Ipv6 address or peer group name.
           # Trigger condition occurs on maintenance operation of specified BGP peer.
-          bgp:
-
-            # Ipv4/Ipv6 address or peer group name.
-            peer: <str>
+          bgp_peer: <str>
 
           # Action for maintenance operation.
           action: <str; "after" | "before" | "all" | "begin" | "end"; required>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -18,7 +18,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp_peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name.<br>Trigger condition occurs on maintenance operation of specified BGP peer. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].trigger_on_maintenance.action") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Action for maintenance operation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp" only. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp_peer" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
@@ -59,7 +59,7 @@
           # Action is triggered after/before specified stage.
           stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">
 
-          # VRF name. VRF can be defined for "bgp" only.
+          # VRF name. VRF can be defined for "bgp_peer" only.
           vrf: <str>
 
           # Trigger condition occurs on maintenance operation of specified interface.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -15,17 +15,17 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified BGP peer. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_type</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_type") | String | Required |  | Valid Values:<br>- <code>Ethernet</code><br>- <code>Fabric</code><br>- <code>Loopback</code><br>- <code>Management</code><br>- <code>Port-Channel</code><br>- <code>Tunnel</code><br>- <code>Vlan</code><br>- <code>Vxlan</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_number</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_number") | Integer | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking.<br> |
 
@@ -51,6 +51,8 @@
         trigger: <str; "on-boot" | "on-logging" | "on-startup-config" | "on-maintenance">
         trigger_on_maintenance:
           operation: <str; "enter" | "exit"; required>
+
+          # Trigger condition occurs on maintenance operation of specified BGP peer.
           bgp:
             neighbor_address_ipv4: <str>
             neighbor_address_ipv6: <str>
@@ -62,11 +64,13 @@
 
           # VRF name.
           vrf: <str>
+
+          # Trigger condition occurs on maintenance operation of specified interface.
           interface:
             interface_type: <str; "Ethernet" | "Fabric" | "Loopback" | "Management" | "Port-Channel" | "Tunnel" | "Vlan" | "Vxlan"; required>
             interface_number: <int; required>
 
-          # Name of unit.
+          # Name of unit. Trigger condition occurs on maintenance operation of specified unit
           unit: <str>
 
         # Regular expression to use for searching log messages. Required for on-logging trigger

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -12,7 +12,20 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code> | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_type</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_type") | String | Required |  | Valid Values:<br>- <code>Ethernet</code><br>- <code>Fabric</code><br>- <code>Loopback</code><br>- <code>Management</code><br>- <code>Port-Channel</code><br>- <code>Tunnel</code><br>- <code>Vlan</code><br>- <code>Vxlan</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_number</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_number") | Integer | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking.<br> |
 
@@ -35,7 +48,26 @@
         delay: <int>
 
         # Configure event trigger condition.
-        trigger: <str; "on-boot" | "on-logging" | "on-startup-config">
+        trigger: <str; "on-boot" | "on-logging" | "on-startup-config" | "on-maintenance">
+        trigger_on_maintenance:
+          operation: <str; "enter" | "exit"; required>
+          bgp:
+            neighbor_address_ipv4: <str>
+            neighbor_address_ipv6: <str>
+            peer_group_name: <str>
+          stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf">
+
+          # Action is triggered after/before specified stage.
+          after_before_stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">
+
+          # VRF name.
+          vrf: <str>
+          interface:
+            interface_type: <str; "Ethernet" | "Fabric" | "Loopback" | "Management" | "Port-Channel" | "Tunnel" | "Vlan" | "Vxlan"; required>
+            interface_number: <int; required>
+
+          # Name of unit.
+          unit: <str>
 
         # Regular expression to use for searching log messages. Required for on-logging trigger
         regex: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -16,9 +16,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified BGP peer. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].trigger_on_maintenance.action") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Action for maintenance operation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp" only. |
@@ -54,9 +52,9 @@
 
           # Trigger condition occurs on maintenance operation of specified BGP peer.
           bgp:
-            neighbor_address_ipv4: <str>
-            neighbor_address_ipv6: <str>
-            peer_group_name: <str>
+
+            # Ipv4/Ipv6 address or peer group name.
+            peer: <str>
 
           # Action for maintenance operation.
           action: <str; "after" | "before" | "all" | "begin" | "end"; required>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5509,6 +5509,7 @@
               },
               "stage": {
                 "type": "string",
+                "description": "Stages of maintenance operation. \"vrf\" stage can be defined for \"bgp\" only.",
                 "enum": [
                   "after",
                   "before",
@@ -5536,36 +5537,8 @@
                 "title": "VRF"
               },
               "interface": {
+                "type": "string",
                 "description": "Trigger condition occurs on maintenance operation of specified interface.",
-                "type": "object",
-                "properties": {
-                  "interface_type": {
-                    "type": "string",
-                    "enum": [
-                      "Ethernet",
-                      "Fabric",
-                      "Loopback",
-                      "Management",
-                      "Port-Channel",
-                      "Tunnel",
-                      "Vlan",
-                      "Vxlan"
-                    ],
-                    "title": "Interface Type"
-                  },
-                  "interface_number": {
-                    "type": "integer",
-                    "title": "Interface Number"
-                  }
-                },
-                "required": [
-                  "interface_type",
-                  "interface_number"
-                ],
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
                 "title": "Interface"
               },
               "unit": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5467,9 +5467,118 @@
             "enum": [
               "on-boot",
               "on-logging",
-              "on-startup-config"
+              "on-startup-config",
+              "on-maintenance"
             ],
             "title": "Trigger"
+          },
+          "trigger_on_maintenance": {
+            "type": "object",
+            "properties": {
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "enter",
+                  "exit"
+                ],
+                "title": "Operation"
+              },
+              "bgp": {
+                "type": "object",
+                "properties": {
+                  "neighbor_address_ipv4": {
+                    "type": "string",
+                    "title": "Neighbor Address IPv4"
+                  },
+                  "neighbor_address_ipv6": {
+                    "type": "string",
+                    "title": "Neighbor Address IPv6"
+                  },
+                  "peer_group_name": {
+                    "type": "string",
+                    "title": "Peer Group Name"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "BGP"
+              },
+              "stage": {
+                "type": "string",
+                "enum": [
+                  "after",
+                  "before",
+                  "all",
+                  "begin",
+                  "end",
+                  "vrf"
+                ],
+                "title": "Stage"
+              },
+              "after_before_stage": {
+                "type": "string",
+                "description": "Action is triggered after/before specified stage.",
+                "enum": [
+                  "bgp",
+                  "linkdown",
+                  "mlag",
+                  "ratemon"
+                ],
+                "title": "After Before Stage"
+              },
+              "vrf": {
+                "type": "string",
+                "description": "VRF name.",
+                "title": "VRF"
+              },
+              "interface": {
+                "type": "object",
+                "properties": {
+                  "interface_type": {
+                    "type": "string",
+                    "enum": [
+                      "Ethernet",
+                      "Fabric",
+                      "Loopback",
+                      "Management",
+                      "Port-Channel",
+                      "Tunnel",
+                      "Vlan",
+                      "Vxlan"
+                    ],
+                    "title": "Interface Type"
+                  },
+                  "interface_number": {
+                    "type": "integer",
+                    "title": "Interface Number"
+                  }
+                },
+                "required": [
+                  "interface_type",
+                  "interface_number"
+                ],
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Interface"
+              },
+              "unit": {
+                "type": "string",
+                "description": "Name of unit.",
+                "title": "Unit"
+              }
+            },
+            "required": [
+              "operation"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Trigger On Maintenance"
           },
           "regex": {
             "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5514,7 +5514,7 @@
               },
               "vrf": {
                 "type": "string",
-                "description": "VRF name. VRF can be defined for \"bgp\" only.",
+                "description": "VRF name. VRF can be defined for \"bgp_peer\" only.",
                 "title": "VRF"
               },
               "interface": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5507,9 +5507,9 @@
                 },
                 "title": "BGP"
               },
-              "stage": {
+              "action": {
                 "type": "string",
-                "description": "Stages of maintenance operation. \"vrf\" stage can be defined for \"bgp\" only.",
+                "description": "Action for maintenance operation.",
                 "enum": [
                   "after",
                   "before",
@@ -5517,9 +5517,9 @@
                   "begin",
                   "end"
                 ],
-                "title": "Stage"
+                "title": "Action"
               },
-              "after_before_stage": {
+              "stage": {
                 "type": "string",
                 "description": "Action is triggered after/before specified stage.",
                 "enum": [
@@ -5528,11 +5528,11 @@
                   "mlag",
                   "ratemon"
                 ],
-                "title": "After Before Stage"
+                "title": "Stage"
               },
               "vrf": {
                 "type": "string",
-                "description": "VRF name.",
+                "description": "VRF name. VRF can be defined for \"bgp\" only.",
                 "title": "VRF"
               },
               "interface": {
@@ -5548,7 +5548,7 @@
             },
             "required": [
               "operation",
-              "stage"
+              "action"
             ],
             "additionalProperties": false,
             "patternProperties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5488,17 +5488,10 @@
                 "description": "Trigger condition occurs on maintenance operation of specified BGP peer.",
                 "type": "object",
                 "properties": {
-                  "neighbor_address_ipv4": {
+                  "peer": {
                     "type": "string",
-                    "title": "Neighbor Address IPv4"
-                  },
-                  "neighbor_address_ipv6": {
-                    "type": "string",
-                    "title": "Neighbor Address IPv6"
-                  },
-                  "peer_group_name": {
-                    "type": "string",
-                    "title": "Peer Group Name"
+                    "description": "Ipv4/Ipv6 address or peer group name.",
+                    "title": "Peer"
                   }
                 },
                 "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5473,6 +5473,7 @@
             "title": "Trigger"
           },
           "trigger_on_maintenance": {
+            "description": "Settings required for trigger 'on-maintenance'.",
             "type": "object",
             "properties": {
               "operation": {
@@ -5574,7 +5575,8 @@
               }
             },
             "required": [
-              "operation"
+              "operation",
+              "stage"
             ],
             "additionalProperties": false,
             "patternProperties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5515,8 +5515,7 @@
                   "before",
                   "all",
                   "begin",
-                  "end",
-                  "vrf"
+                  "end"
                 ],
                 "title": "Stage"
               },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5484,21 +5484,10 @@
                 ],
                 "title": "Operation"
               },
-              "bgp": {
-                "description": "Trigger condition occurs on maintenance operation of specified BGP peer.",
-                "type": "object",
-                "properties": {
-                  "peer": {
-                    "type": "string",
-                    "description": "Ipv4/Ipv6 address or peer group name.",
-                    "title": "Peer"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "BGP"
+              "bgp_peer": {
+                "description": "Ipv4/Ipv6 address or peer group name.\nTrigger condition occurs on maintenance operation of specified BGP peer.",
+                "type": "string",
+                "title": "BGP Peer"
               },
               "action": {
                 "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5484,6 +5484,7 @@
                 "title": "Operation"
               },
               "bgp": {
+                "description": "Trigger condition occurs on maintenance operation of specified BGP peer.",
                 "type": "object",
                 "properties": {
                   "neighbor_address_ipv4": {
@@ -5534,6 +5535,7 @@
                 "title": "VRF"
               },
               "interface": {
+                "description": "Trigger condition occurs on maintenance operation of specified interface.",
                 "type": "object",
                 "properties": {
                   "interface_type": {
@@ -5567,7 +5569,7 @@
               },
               "unit": {
                 "type": "string",
-                "description": "Name of unit.",
+                "description": "Name of unit. Trigger condition occurs on maintenance operation of specified unit",
                 "title": "Unit"
               }
             },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3399,12 +3399,9 @@ keys:
                 BGP peer.
               type: dict
               keys:
-                neighbor_address_ipv4:
+                peer:
                   type: str
-                neighbor_address_ipv6:
-                  type: str
-                peer_group_name:
-                  type: str
+                  description: Ipv4/Ipv6 address or peer group name.
             action:
               type: str
               required: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3405,18 +3405,17 @@ keys:
                   type: str
                 peer_group_name:
                   type: str
-            stage:
+            action:
               type: str
               required: true
-              description: Stages of maintenance operation. "vrf" stage can be defined
-                for "bgp" only.
+              description: Action for maintenance operation.
               valid_values:
               - after
               - before
               - all
               - begin
               - end
-            after_before_stage:
+            stage:
               type: str
               description: Action is triggered after/before specified stage.
               valid_values:
@@ -3426,7 +3425,7 @@ keys:
               - ratemon
             vrf:
               type: str
-              description: VRF name.
+              description: VRF name. VRF can be defined for "bgp" only.
             interface:
               type: str
               description: Trigger condition occurs on maintenance operation of specified

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3420,7 +3420,7 @@ keys:
               - ratemon
             vrf:
               type: str
-              description: VRF name. VRF can be defined for "bgp" only.
+              description: VRF name. VRF can be defined for "bgp_peer" only.
             interface:
               type: str
               description: Trigger condition occurs on maintenance operation of specified

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3408,6 +3408,8 @@ keys:
             stage:
               type: str
               required: true
+              description: Stages of maintenance operation. "vrf" stage can be defined
+                for "bgp" only.
               valid_values:
               - after
               - before
@@ -3427,27 +3429,9 @@ keys:
               type: str
               description: VRF name.
             interface:
+              type: str
               description: Trigger condition occurs on maintenance operation of specified
                 interface.
-              type: dict
-              keys:
-                interface_type:
-                  type: str
-                  required: true
-                  valid_values:
-                  - Ethernet
-                  - Fabric
-                  - Loopback
-                  - Management
-                  - Port-Channel
-                  - Tunnel
-                  - Vlan
-                  - Vxlan
-                interface_number:
-                  type: int
-                  convert_types:
-                  - str
-                  required: true
             unit:
               type: str
               description: Name of unit. Trigger condition occurs on maintenance operation

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3394,14 +3394,12 @@ keys:
               valid_values:
               - enter
               - exit
-            bgp:
-              description: Trigger condition occurs on maintenance operation of specified
-                BGP peer.
-              type: dict
-              keys:
-                peer:
-                  type: str
-                  description: Ipv4/Ipv6 address or peer group name.
+            bgp_peer:
+              description: 'Ipv4/Ipv6 address or peer group name.
+
+                Trigger condition occurs on maintenance operation of specified BGP
+                peer.'
+              type: str
             action:
               type: str
               required: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3385,6 +3385,7 @@ keys:
           - on-startup-config
           - on-maintenance
         trigger_on_maintenance:
+          description: Settings required for trigger 'on-maintenance'.
           type: dict
           keys:
             operation:
@@ -3406,6 +3407,7 @@ keys:
                   type: str
             stage:
               type: str
+              required: true
               valid_values:
               - after
               - before

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3416,7 +3416,6 @@ keys:
               - all
               - begin
               - end
-              - vrf
             after_before_stage:
               type: str
               description: Action is triggered after/before specified stage.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3394,6 +3394,8 @@ keys:
               - enter
               - exit
             bgp:
+              description: Trigger condition occurs on maintenance operation of specified
+                BGP peer.
               type: dict
               keys:
                 neighbor_address_ipv4:
@@ -3423,6 +3425,8 @@ keys:
               type: str
               description: VRF name.
             interface:
+              description: Trigger condition occurs on maintenance operation of specified
+                interface.
               type: dict
               keys:
                 interface_type:
@@ -3444,7 +3448,8 @@ keys:
                   required: true
             unit:
               type: str
-              description: Name of unit.
+              description: Name of unit. Trigger condition occurs on maintenance operation
+                of specified unit
         regex:
           type: str
           description: 'Regular expression to use for searching log messages. Required

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3383,6 +3383,68 @@ keys:
           - on-boot
           - on-logging
           - on-startup-config
+          - on-maintenance
+        trigger_on_maintenance:
+          type: dict
+          keys:
+            operation:
+              type: str
+              required: true
+              valid_values:
+              - enter
+              - exit
+            bgp:
+              type: dict
+              keys:
+                neighbor_address_ipv4:
+                  type: str
+                neighbor_address_ipv6:
+                  type: str
+                peer_group_name:
+                  type: str
+            stage:
+              type: str
+              valid_values:
+              - after
+              - before
+              - all
+              - begin
+              - end
+              - vrf
+            after_before_stage:
+              type: str
+              description: Action is triggered after/before specified stage.
+              valid_values:
+              - bgp
+              - linkdown
+              - mlag
+              - ratemon
+            vrf:
+              type: str
+              description: VRF name.
+            interface:
+              type: dict
+              keys:
+                interface_type:
+                  type: str
+                  required: true
+                  valid_values:
+                  - Ethernet
+                  - Fabric
+                  - Loopback
+                  - Management
+                  - Port-Channel
+                  - Tunnel
+                  - Vlan
+                  - Vxlan
+                interface_number:
+                  type: int
+                  convert_types:
+                  - str
+                  required: true
+            unit:
+              type: str
+              description: Name of unit.
         regex:
           type: str
           description: 'Regular expression to use for searching log messages. Required

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -66,6 +66,7 @@ keys:
             stage:
               type: str
               required: true
+              description: Stages of maintenance operation. "vrf" stage can be defined for "bgp" only.
               valid_values:
               - after
               - before
@@ -85,26 +86,8 @@ keys:
               type: str
               description: VRF name.
             interface:
+              type: str
               description: Trigger condition occurs on maintenance operation of specified interface.
-              type: dict
-              keys:
-                interface_type:
-                  type: str
-                  required: true
-                  valid_values:
-                  - Ethernet
-                  - Fabric
-                  - Loopback
-                  - Management
-                  - Port-Channel
-                  - Tunnel
-                  - Vlan
-                  - Vxlan
-                interface_number:
-                  type: int
-                  convert_types:
-                  - str
-                  required: true
             unit:
               type: str
               description: Name of unit. Trigger condition occurs on maintenance operation of specified unit

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -53,6 +53,7 @@ keys:
               - "enter"
               - "exit"
             bgp:
+              description: Trigger condition occurs on maintenance operation of specified BGP peer.
               type: dict
               keys:
                 neighbor_address_ipv4:
@@ -82,6 +83,7 @@ keys:
               type: str
               description: VRF name.
             interface:
+              description: Trigger condition occurs on maintenance operation of specified interface.
               type: dict
               keys:
                 interface_type:
@@ -103,7 +105,7 @@ keys:
                   required: true
             unit:
               type: str
-              description: Name of unit.
+              description: Name of unit. Trigger condition occurs on maintenance operation of specified unit
         regex:
           type: str
           description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -44,6 +44,7 @@ keys:
           - on-startup-config
           - on-maintenance
         trigger_on_maintenance:
+          description: Settings required for trigger 'on-maintenance'.
           type: dict
           keys:
             operation:
@@ -64,6 +65,7 @@ keys:
                   type: str
             stage:
               type: str
+              required: true
               valid_values:
               - after
               - before

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -53,13 +53,11 @@ keys:
               valid_values:
               - "enter"
               - "exit"
-            bgp:
-              description: Trigger condition occurs on maintenance operation of specified BGP peer.
-              type: dict
-              keys:
-                peer:
-                  type: str
-                  description: Ipv4/Ipv6 address or peer group name.
+            bgp_peer:
+              description: |-
+                Ipv4/Ipv6 address or peer group name.
+                Trigger condition occurs on maintenance operation of specified BGP peer.
+              type: str
             action:
               type: str
               required: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -42,6 +42,68 @@ keys:
           - on-boot
           - on-logging
           - on-startup-config
+          - on-maintenance
+        trigger_on_maintenance:
+          type: dict
+          keys:
+            operation:
+              type: str
+              required: true
+              valid_values:
+              - "enter"
+              - "exit"
+            bgp:
+              type: dict
+              keys:
+                neighbor_address_ipv4:
+                  type: str
+                neighbor_address_ipv6:
+                  type: str
+                peer_group_name:
+                  type: str
+            stage:
+              type: str
+              valid_values:
+              - after
+              - before
+              - all
+              - begin
+              - end
+              - vrf
+            after_before_stage:
+              type: str
+              description: Action is triggered after/before specified stage.
+              valid_values:
+              - "bgp"
+              - "linkdown"
+              - "mlag"
+              - "ratemon"
+            vrf:
+              type: str
+              description: VRF name.
+            interface:
+              type: dict
+              keys:
+                interface_type:
+                  type: str
+                  required: true
+                  valid_values:
+                  - Ethernet
+                  - Fabric
+                  - Loopback
+                  - Management
+                  - Port-Channel
+                  - Tunnel
+                  - Vlan
+                  - Vxlan
+                interface_number:
+                  type: int
+                  convert_types:
+                  - str
+                  required: true
+            unit:
+              type: str
+              description: Name of unit.
         regex:
           type: str
           description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -73,7 +73,6 @@ keys:
               - all
               - begin
               - end
-              - vrf
             after_before_stage:
               type: str
               description: Action is triggered after/before specified stage.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -63,17 +63,17 @@ keys:
                   type: str
                 peer_group_name:
                   type: str
-            stage:
+            action:
               type: str
               required: true
-              description: Stages of maintenance operation. "vrf" stage can be defined for "bgp" only.
+              description: Action for maintenance operation.
               valid_values:
               - after
               - before
               - all
               - begin
               - end
-            after_before_stage:
+            stage:
               type: str
               description: Action is triggered after/before specified stage.
               valid_values:
@@ -83,7 +83,7 @@ keys:
               - "ratemon"
             vrf:
               type: str
-              description: VRF name.
+              description: VRF name. VRF can be defined for "bgp" only.
             interface:
               type: str
               description: Trigger condition occurs on maintenance operation of specified interface.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -57,12 +57,9 @@ keys:
               description: Trigger condition occurs on maintenance operation of specified BGP peer.
               type: dict
               keys:
-                neighbor_address_ipv4:
+                peer:
                   type: str
-                neighbor_address_ipv6:
-                  type: str
-                peer_group_name:
-                  type: str
+                  description: Ipv4/Ipv6 address or peer group name.
             action:
               type: str
               required: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -78,7 +78,7 @@ keys:
               - "ratemon"
             vrf:
               type: str
-              description: VRF name. VRF can be defined for "bgp" only.
+              description: VRF name. VRF can be defined for "bgp_peer" only.
             interface:
               type: str
               description: Trigger condition occurs on maintenance operation of specified interface.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -21,8 +21,8 @@ event-handler {{ handler.name }}
 {%                     elif handler.trigger_on_maintenance.bgp.peer_group_name is arista.avd.defined %}
 {%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.peer_group_name %}
 {%                     endif %}
-{%                 elif handler.trigger_on_maintenance.interface.interface_type is arista.avd.defined and handler.trigger_on_maintenance.interface.interface_number is arista.avd.defined %}
-{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " interface " ~ handler.trigger_on_maintenance.interface.interface_type ~ " " ~ handler.trigger_on_maintenance.interface.interface_number %}
+{%                 elif handler.trigger_on_maintenance.interface is arista.avd.defined %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " interface " ~ handler.trigger_on_maintenance.interface %}
 {%                 elif handler.trigger_on_maintenance.unit is arista.avd.defined %}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " unit " ~ handler.trigger_on_maintenance.unit %}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -11,7 +11,7 @@ event-handler {{ handler.name }}
 {%         if handler.trigger is arista.avd.defined %}
 {%             if handler.trigger is arista.avd.defined("on-maintenance")
                   and handler.trigger_on_maintenance.operation is arista.avd.defined
-                  and handler.trigger_on_maintenance.stage is arista.avd.defined %}
+                  and handler.trigger_on_maintenance.action is arista.avd.defined %}
 {%                 set trigger_on_manitenance_cli =  "trigger " ~ handler.trigger ~ " " ~ handler.trigger_on_maintenance.operation %}
 {%                 if handler.trigger_on_maintenance.bgp is arista.avd.defined %}
 {%                     if handler.trigger_on_maintenance.bgp.neighbor_address_ipv4 is arista.avd.defined %}
@@ -29,13 +29,13 @@ event-handler {{ handler.name }}
 {%                 elif handler.trigger_on_maintenance.unit is arista.avd.defined %}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " unit " ~ handler.trigger_on_maintenance.unit %}
 {%                 endif %}
-{%                 if handler.trigger_on_maintenance.stage is arista.avd.defined("after") or handler.trigger_on_maintenance.stage is arista.avd.defined("before") %}
-{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " " ~ handler.trigger_on_maintenance.stage ~ " stage " ~ handler.trigger_on_maintenance.after_before_stage %}
-{%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("all") %}
+{%                 if handler.trigger_on_maintenance.action is arista.avd.defined("after") or handler.trigger_on_maintenance.action is arista.avd.defined("before") %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " " ~ handler.trigger_on_maintenance.action ~ " stage " ~ handler.trigger_on_maintenance.stage %}
+{%                 elif handler.trigger_on_maintenance.action is arista.avd.defined("all") %}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " all" %}
-{%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("begin") %}
+{%                 elif handler.trigger_on_maintenance.action is arista.avd.defined("begin") %}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " begin" %}
-{%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("end") %}
+{%                 elif handler.trigger_on_maintenance.action is arista.avd.defined("end") %}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " end" %}
 {%                 endif %}
    {{ trigger_on_manitenance_cli }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -21,6 +21,9 @@ event-handler {{ handler.name }}
 {%                     elif handler.trigger_on_maintenance.bgp.peer_group_name is arista.avd.defined %}
 {%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.peer_group_name %}
 {%                     endif %}
+{%                     if handler.trigger_on_maintenance.vrf is arista.avd.defined %}
+{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " vrf " ~ handler.trigger_on_maintenance.vrf %}
+{%                     endif %}
 {%                 elif handler.trigger_on_maintenance.interface is arista.avd.defined %}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " interface " ~ handler.trigger_on_maintenance.interface %}
 {%                 elif handler.trigger_on_maintenance.unit is arista.avd.defined %}
@@ -34,8 +37,6 @@ event-handler {{ handler.name }}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " begin" %}
 {%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("end") %}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " end" %}
-{%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("vrf") %}
-{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " vrf " ~ handler.trigger_on_maintenance.vrf %}
 {%                 endif %}
    {{ trigger_on_manitenance_cli }}
 {%             else %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -14,12 +14,8 @@ event-handler {{ handler.name }}
                   and handler.trigger_on_maintenance.action is arista.avd.defined %}
 {%                 set trigger_on_manitenance_cli =  "trigger " ~ handler.trigger ~ " " ~ handler.trigger_on_maintenance.operation %}
 {%                 if handler.trigger_on_maintenance.bgp is arista.avd.defined %}
-{%                     if handler.trigger_on_maintenance.bgp.neighbor_address_ipv4 is arista.avd.defined %}
-{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.neighbor_address_ipv4 %}
-{%                     elif handler.trigger_on_maintenance.bgp.neighbor_address_ipv6 is arista.avd.defined %}
-{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.neighbor_address_ipv6 %}
-{%                     elif handler.trigger_on_maintenance.bgp.peer_group_name is arista.avd.defined %}
-{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.peer_group_name %}
+{%                     if handler.trigger_on_maintenance.bgp.peer is arista.avd.defined %}
+{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.peer %}
 {%                     endif %}
 {%                     if handler.trigger_on_maintenance.vrf is arista.avd.defined %}
 {%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " vrf " ~ handler.trigger_on_maintenance.vrf %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -27,7 +27,7 @@ event-handler {{ handler.name }}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " unit " ~ handler.trigger_on_maintenance.unit %}
 {%                 endif %}
 {%                 if handler.trigger_on_maintenance.stage is arista.avd.defined("after") or handler.trigger_on_maintenance.stage is arista.avd.defined("before") %}
-{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " " ~ handler.trigger_on_maintenance.stage ~ " " ~ handler.trigger_on_maintenance.after_before_stage %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " " ~ handler.trigger_on_maintenance.stage ~ " stage " ~ handler.trigger_on_maintenance.after_before_stage %}
 {%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("all") %}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " all" %}
 {%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("begin") %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -10,18 +10,16 @@
 event-handler {{ handler.name }}
 {%         if handler.trigger is arista.avd.defined %}
 {%             if handler.trigger is arista.avd.defined("on-maintenance")
-                  and handler.trigger_on_maintenance is arista.avd.defined
                   and handler.trigger_on_maintenance.operation is arista.avd.defined
                   and handler.trigger_on_maintenance.stage is arista.avd.defined %}
 {%                 set trigger_on_manitenance_cli =  "trigger " ~ handler.trigger ~ " " ~ handler.trigger_on_maintenance.operation %}
 {%                 if handler.trigger_on_maintenance.bgp is arista.avd.defined %}
-{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " %}
 {%                     if handler.trigger_on_maintenance.bgp.neighbor_address_ipv4 is arista.avd.defined %}
-{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ handler.trigger_on_maintenance.bgp.neighbor_address_ipv4 %}
+{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.neighbor_address_ipv4 %}
 {%                     elif handler.trigger_on_maintenance.bgp.neighbor_address_ipv6 is arista.avd.defined %}
-{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ handler.trigger_on_maintenance.bgp.neighbor_address_ipv6 %}
+{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.neighbor_address_ipv6 %}
 {%                     elif handler.trigger_on_maintenance.bgp.peer_group_name is arista.avd.defined %}
-{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ handler.trigger_on_maintenance.bgp.peer_group_name %}
+{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.peer_group_name %}
 {%                     endif %}
 {%                 elif handler.trigger_on_maintenance.interface.interface_type is arista.avd.defined and handler.trigger_on_maintenance.interface.interface_number is arista.avd.defined %}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " interface " ~ handler.trigger_on_maintenance.interface.interface_type ~ " " ~ handler.trigger_on_maintenance.interface.interface_number %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -13,10 +13,8 @@ event-handler {{ handler.name }}
                   and handler.trigger_on_maintenance.operation is arista.avd.defined
                   and handler.trigger_on_maintenance.action is arista.avd.defined %}
 {%                 set trigger_on_manitenance_cli =  "trigger " ~ handler.trigger ~ " " ~ handler.trigger_on_maintenance.operation %}
-{%                 if handler.trigger_on_maintenance.bgp is arista.avd.defined %}
-{%                     if handler.trigger_on_maintenance.bgp.peer is arista.avd.defined %}
-{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp.peer %}
-{%                     endif %}
+{%                 if handler.trigger_on_maintenance.bgp_peer is arista.avd.defined %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " ~ handler.trigger_on_maintenance.bgp_peer %}
 {%                     if handler.trigger_on_maintenance.vrf is arista.avd.defined %}
 {%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " vrf " ~ handler.trigger_on_maintenance.vrf %}
 {%                     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -9,7 +9,40 @@
 !
 event-handler {{ handler.name }}
 {%         if handler.trigger is arista.avd.defined %}
+{%             if handler.trigger is arista.avd.defined("on-maintenance")
+                  and handler.trigger_on_maintenance is arista.avd.defined
+                  and handler.trigger_on_maintenance.operation is arista.avd.defined
+                  and handler.trigger_on_maintenance.stage is arista.avd.defined %}
+{%                 set trigger_on_manitenance_cli =  "trigger " ~ handler.trigger ~ " " ~ handler.trigger_on_maintenance.operation %}
+{%                 if handler.trigger_on_maintenance.bgp is arista.avd.defined %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " bgp " %}
+{%                     if handler.trigger_on_maintenance.bgp.neighbor_address_ipv4 is arista.avd.defined %}
+{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ handler.trigger_on_maintenance.bgp.neighbor_address_ipv4 %}
+{%                     elif handler.trigger_on_maintenance.bgp.neighbor_address_ipv6 is arista.avd.defined %}
+{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ handler.trigger_on_maintenance.bgp.neighbor_address_ipv6 %}
+{%                     elif handler.trigger_on_maintenance.bgp.peer_group_name is arista.avd.defined %}
+{%                         set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ handler.trigger_on_maintenance.bgp.peer_group_name %}
+{%                     endif %}
+{%                 elif handler.trigger_on_maintenance.interface.interface_type is arista.avd.defined and handler.trigger_on_maintenance.interface.interface_number is arista.avd.defined %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " interface " ~ handler.trigger_on_maintenance.interface.interface_type ~ " " ~ handler.trigger_on_maintenance.interface.interface_number %}
+{%                 elif handler.trigger_on_maintenance.unit is arista.avd.defined %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " unit " ~ handler.trigger_on_maintenance.unit %}
+{%                 endif %}
+{%                 if handler.trigger_on_maintenance.stage is arista.avd.defined("after") or handler.trigger_on_maintenance.stage is arista.avd.defined("before") %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " " ~ handler.trigger_on_maintenance.stage ~ " " ~ handler.trigger_on_maintenance.after_before_stage %}
+{%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("all") %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " all" %}
+{%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("begin") %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " begin" %}
+{%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("end") %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " end" %}
+{%                 elif handler.trigger_on_maintenance.stage is arista.avd.defined("vrf") %}
+{%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " vrf " ~ handler.trigger_on_maintenance.vrf %}
+{%                 endif %}
+   {{ trigger_on_manitenance_cli }}
+{%             else %}
    trigger {{ handler.trigger }}
+{%             endif %}
 {%             if handler.regex is arista.avd.defined %}
       regex {{ handler.regex }}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -19,9 +19,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Stages of maintenance operation. "vrf" stage can be defined for "bgp" only. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].trigger_on_maintenance.action") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Action for maintenance operation. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
@@ -96,13 +96,13 @@
             neighbor_address_ipv6: <str>
             peer_group_name: <str>
 
-          # Stages of maintenance operation. "vrf" stage can be defined for "bgp" only.
-          stage: <str; "after" | "before" | "all" | "begin" | "end"; required>
+          # Action for maintenance operation.
+          action: <str; "after" | "before" | "all" | "begin" | "end"; required>
 
           # Action is triggered after/before specified stage.
-          after_before_stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">
+          stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">
 
-          # VRF name.
+          # VRF name. VRF can be defined for "bgp" only.
           vrf: <str>
 
           # Trigger condition occurs on maintenance operation of specified interface.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -13,13 +13,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified BGP peer. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
@@ -87,6 +87,8 @@
 
         # Configure event trigger condition.
         trigger: <str; "on-boot" | "on-logging" | "on-startup-config" | "on-maintenance">
+
+        # Settings required for trigger 'on-maintenance'.
         trigger_on_maintenance:
           operation: <str; "enter" | "exit"; required>
 
@@ -95,7 +97,7 @@
             neighbor_address_ipv4: <str>
             neighbor_address_ipv6: <str>
             peer_group_name: <str>
-          stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf">
+          stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf"; required>
 
           # Action is triggered after/before specified stage.
           after_before_stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -19,7 +19,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> | Stages of maintenance operation. "vrf" stage can be defined for "bgp" only. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Stages of maintenance operation. "vrf" stage can be defined for "bgp" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
@@ -97,7 +97,7 @@
             peer_group_name: <str>
 
           # Stages of maintenance operation. "vrf" stage can be defined for "bgp" only.
-          stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf"; required>
+          stage: <str; "after" | "before" | "all" | "begin" | "end"; required>
 
           # Action is triggered after/before specified stage.
           after_before_stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -15,17 +15,17 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified BGP peer. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_type</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_type") | String | Required |  | Valid Values:<br>- <code>Ethernet</code><br>- <code>Fabric</code><br>- <code>Loopback</code><br>- <code>Management</code><br>- <code>Port-Channel</code><br>- <code>Tunnel</code><br>- <code>Vlan</code><br>- <code>Vxlan</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_number</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_number") | Integer | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking.<br> |
     | [<samp>ipv6_mgmt_destination_networks</samp>](## "ipv6_mgmt_destination_networks") | List, items: String |  |  |  | List of IPv6 prefixes to configure as static routes towards the OOB IPv6 Management interface gateway.<br>Replaces the default route.<br> |
@@ -89,6 +89,8 @@
         trigger: <str; "on-boot" | "on-logging" | "on-startup-config" | "on-maintenance">
         trigger_on_maintenance:
           operation: <str; "enter" | "exit"; required>
+
+          # Trigger condition occurs on maintenance operation of specified BGP peer.
           bgp:
             neighbor_address_ipv4: <str>
             neighbor_address_ipv6: <str>
@@ -100,11 +102,13 @@
 
           # VRF name.
           vrf: <str>
+
+          # Trigger condition occurs on maintenance operation of specified interface.
           interface:
             interface_type: <str; "Ethernet" | "Fabric" | "Loopback" | "Management" | "Port-Channel" | "Tunnel" | "Vlan" | "Vxlan"; required>
             interface_number: <int; required>
 
-          # Name of unit.
+          # Name of unit. Trigger condition occurs on maintenance operation of specified unit
           unit: <str>
 
         # Regular expression to use for searching log messages. Required for on-logging trigger

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -18,7 +18,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp_peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name.<br>Trigger condition occurs on maintenance operation of specified BGP peer. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].trigger_on_maintenance.action") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Action for maintenance operation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp" only. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp_peer" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
@@ -97,7 +97,7 @@
           # Action is triggered after/before specified stage.
           stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">
 
-          # VRF name. VRF can be defined for "bgp" only.
+          # VRF name. VRF can be defined for "bgp_peer" only.
           vrf: <str>
 
           # Trigger condition occurs on maintenance operation of specified interface.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -15,8 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified BGP peer. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp_peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name.<br>Trigger condition occurs on maintenance operation of specified BGP peer. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].trigger_on_maintenance.action") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Action for maintenance operation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp" only. |
@@ -88,11 +87,9 @@
         trigger_on_maintenance:
           operation: <str; "enter" | "exit"; required>
 
+          # Ipv4/Ipv6 address or peer group name.
           # Trigger condition occurs on maintenance operation of specified BGP peer.
-          bgp:
-
-            # Ipv4/Ipv6 address or peer group name.
-            peer: <str>
+          bgp_peer: <str>
 
           # Action for maintenance operation.
           action: <str; "after" | "before" | "all" | "begin" | "end"; required>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -16,9 +16,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified BGP peer. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].trigger_on_maintenance.action") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code> | Action for maintenance operation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp" only. |
@@ -92,9 +90,9 @@
 
           # Trigger condition occurs on maintenance operation of specified BGP peer.
           bgp:
-            neighbor_address_ipv4: <str>
-            neighbor_address_ipv6: <str>
-            peer_group_name: <str>
+
+            # Ipv4/Ipv6 address or peer group name.
+            peer: <str>
 
           # Action for maintenance operation.
           action: <str; "after" | "before" | "all" | "begin" | "end"; required>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -12,7 +12,20 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code> | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "event_handlers.[].trigger_on_maintenance.bgp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String |  |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_type</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_type") | String | Required |  | Valid Values:<br>- <code>Ethernet</code><br>- <code>Fabric</code><br>- <code>Loopback</code><br>- <code>Management</code><br>- <code>Port-Channel</code><br>- <code>Tunnel</code><br>- <code>Vlan</code><br>- <code>Vxlan</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_number</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_number") | Integer | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking.<br> |
     | [<samp>ipv6_mgmt_destination_networks</samp>](## "ipv6_mgmt_destination_networks") | List, items: String |  |  |  | List of IPv6 prefixes to configure as static routes towards the OOB IPv6 Management interface gateway.<br>Replaces the default route.<br> |
@@ -73,7 +86,26 @@
         delay: <int>
 
         # Configure event trigger condition.
-        trigger: <str; "on-boot" | "on-logging" | "on-startup-config">
+        trigger: <str; "on-boot" | "on-logging" | "on-startup-config" | "on-maintenance">
+        trigger_on_maintenance:
+          operation: <str; "enter" | "exit"; required>
+          bgp:
+            neighbor_address_ipv4: <str>
+            neighbor_address_ipv6: <str>
+            peer_group_name: <str>
+          stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf">
+
+          # Action is triggered after/before specified stage.
+          after_before_stage: <str; "bgp" | "linkdown" | "mlag" | "ratemon">
+
+          # VRF name.
+          vrf: <str>
+          interface:
+            interface_type: <str; "Ethernet" | "Fabric" | "Loopback" | "Management" | "Port-Channel" | "Tunnel" | "Vlan" | "Vxlan"; required>
+            interface_number: <int; required>
+
+          # Name of unit.
+          unit: <str>
 
         # Regular expression to use for searching log messages. Required for on-logging trigger
         regex: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -19,12 +19,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv4</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_address_ipv6</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.neighbor_address_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_group_name</samp>](## "event_handlers.[].trigger_on_maintenance.bgp.peer_group_name") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;stage</samp>](## "event_handlers.[].trigger_on_maintenance.stage") | String | Required |  | Valid Values:<br>- <code>after</code><br>- <code>before</code><br>- <code>all</code><br>- <code>begin</code><br>- <code>end</code><br>- <code>vrf</code> | Stages of maintenance operation. "vrf" stage can be defined for "bgp" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;after_before_stage</samp>](## "event_handlers.[].trigger_on_maintenance.after_before_stage") | String |  |  | Valid Values:<br>- <code>bgp</code><br>- <code>linkdown</code><br>- <code>mlag</code><br>- <code>ratemon</code> | Action is triggered after/before specified stage. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | Dictionary |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_type</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_type") | String | Required |  | Valid Values:<br>- <code>Ethernet</code><br>- <code>Fabric</code><br>- <code>Loopback</code><br>- <code>Management</code><br>- <code>Port-Channel</code><br>- <code>Tunnel</code><br>- <code>Vlan</code><br>- <code>Vxlan</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_number</samp>](## "event_handlers.[].trigger_on_maintenance.interface.interface_number") | Integer | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking.<br> |
@@ -97,6 +95,8 @@
             neighbor_address_ipv4: <str>
             neighbor_address_ipv6: <str>
             peer_group_name: <str>
+
+          # Stages of maintenance operation. "vrf" stage can be defined for "bgp" only.
           stage: <str; "after" | "before" | "all" | "begin" | "end" | "vrf"; required>
 
           # Action is triggered after/before specified stage.
@@ -106,9 +106,7 @@
           vrf: <str>
 
           # Trigger condition occurs on maintenance operation of specified interface.
-          interface:
-            interface_type: <str; "Ethernet" | "Fabric" | "Loopback" | "Management" | "Port-Channel" | "Tunnel" | "Vlan" | "Vxlan"; required>
-            interface_number: <int; required>
+          interface: <str>
 
           # Name of unit. Trigger condition occurs on maintenance operation of specified unit
           unit: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4843,6 +4843,7 @@
               },
               "stage": {
                 "type": "string",
+                "description": "Stages of maintenance operation. \"vrf\" stage can be defined for \"bgp\" only.",
                 "enum": [
                   "after",
                   "before",
@@ -4870,36 +4871,8 @@
                 "title": "VRF"
               },
               "interface": {
+                "type": "string",
                 "description": "Trigger condition occurs on maintenance operation of specified interface.",
-                "type": "object",
-                "properties": {
-                  "interface_type": {
-                    "type": "string",
-                    "enum": [
-                      "Ethernet",
-                      "Fabric",
-                      "Loopback",
-                      "Management",
-                      "Port-Channel",
-                      "Tunnel",
-                      "Vlan",
-                      "Vxlan"
-                    ],
-                    "title": "Interface Type"
-                  },
-                  "interface_number": {
-                    "type": "integer",
-                    "title": "Interface Number"
-                  }
-                },
-                "required": [
-                  "interface_type",
-                  "interface_number"
-                ],
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
                 "title": "Interface"
               },
               "unit": {
@@ -21299,6 +21272,7 @@
                         },
                         "stage": {
                           "type": "string",
+                          "description": "Stages of maintenance operation. \"vrf\" stage can be defined for \"bgp\" only.",
                           "enum": [
                             "after",
                             "before",
@@ -21326,36 +21300,8 @@
                           "title": "VRF"
                         },
                         "interface": {
+                          "type": "string",
                           "description": "Trigger condition occurs on maintenance operation of specified interface.",
-                          "type": "object",
-                          "properties": {
-                            "interface_type": {
-                              "type": "string",
-                              "enum": [
-                                "Ethernet",
-                                "Fabric",
-                                "Loopback",
-                                "Management",
-                                "Port-Channel",
-                                "Tunnel",
-                                "Vlan",
-                                "Vxlan"
-                              ],
-                              "title": "Interface Type"
-                            },
-                            "interface_number": {
-                              "type": "integer",
-                              "title": "Interface Number"
-                            }
-                          },
-                          "required": [
-                            "interface_type",
-                            "interface_number"
-                          ],
-                          "additionalProperties": false,
-                          "patternProperties": {
-                            "^_.+$": {}
-                          },
                           "title": "Interface"
                         },
                         "unit": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4807,6 +4807,7 @@
             "title": "Trigger"
           },
           "trigger_on_maintenance": {
+            "description": "Settings required for trigger 'on-maintenance'.",
             "type": "object",
             "properties": {
               "operation": {
@@ -4908,7 +4909,8 @@
               }
             },
             "required": [
-              "operation"
+              "operation",
+              "stage"
             ],
             "additionalProperties": false,
             "patternProperties": {
@@ -21261,6 +21263,7 @@
                       "title": "Trigger"
                     },
                     "trigger_on_maintenance": {
+                      "description": "Settings required for trigger 'on-maintenance'.",
                       "type": "object",
                       "properties": {
                         "operation": {
@@ -21362,7 +21365,8 @@
                         }
                       },
                       "required": [
-                        "operation"
+                        "operation",
+                        "stage"
                       ],
                       "additionalProperties": false,
                       "patternProperties": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4818,21 +4818,10 @@
                 ],
                 "title": "Operation"
               },
-              "bgp": {
-                "description": "Trigger condition occurs on maintenance operation of specified BGP peer.",
-                "type": "object",
-                "properties": {
-                  "peer": {
-                    "type": "string",
-                    "description": "Ipv4/Ipv6 address or peer group name.",
-                    "title": "Peer"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "BGP"
+              "bgp_peer": {
+                "description": "Ipv4/Ipv6 address or peer group name.\nTrigger condition occurs on maintenance operation of specified BGP peer.",
+                "type": "string",
+                "title": "BGP Peer"
               },
               "action": {
                 "type": "string",
@@ -21239,21 +21228,10 @@
                           ],
                           "title": "Operation"
                         },
-                        "bgp": {
-                          "description": "Trigger condition occurs on maintenance operation of specified BGP peer.",
-                          "type": "object",
-                          "properties": {
-                            "peer": {
-                              "type": "string",
-                              "description": "Ipv4/Ipv6 address or peer group name.",
-                              "title": "Peer"
-                            }
-                          },
-                          "additionalProperties": false,
-                          "patternProperties": {
-                            "^_.+$": {}
-                          },
-                          "title": "BGP"
+                        "bgp_peer": {
+                          "description": "Ipv4/Ipv6 address or peer group name.\nTrigger condition occurs on maintenance operation of specified BGP peer.",
+                          "type": "string",
+                          "title": "BGP Peer"
                         },
                         "action": {
                           "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4848,7 +4848,7 @@
               },
               "vrf": {
                 "type": "string",
-                "description": "VRF name. VRF can be defined for \"bgp\" only.",
+                "description": "VRF name. VRF can be defined for \"bgp_peer\" only.",
                 "title": "VRF"
               },
               "interface": {
@@ -21258,7 +21258,7 @@
                         },
                         "vrf": {
                           "type": "string",
-                          "description": "VRF name. VRF can be defined for \"bgp\" only.",
+                          "description": "VRF name. VRF can be defined for \"bgp_peer\" only.",
                           "title": "VRF"
                         },
                         "interface": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4801,9 +4801,118 @@
             "enum": [
               "on-boot",
               "on-logging",
-              "on-startup-config"
+              "on-startup-config",
+              "on-maintenance"
             ],
             "title": "Trigger"
+          },
+          "trigger_on_maintenance": {
+            "type": "object",
+            "properties": {
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "enter",
+                  "exit"
+                ],
+                "title": "Operation"
+              },
+              "bgp": {
+                "type": "object",
+                "properties": {
+                  "neighbor_address_ipv4": {
+                    "type": "string",
+                    "title": "Neighbor Address IPv4"
+                  },
+                  "neighbor_address_ipv6": {
+                    "type": "string",
+                    "title": "Neighbor Address IPv6"
+                  },
+                  "peer_group_name": {
+                    "type": "string",
+                    "title": "Peer Group Name"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "BGP"
+              },
+              "stage": {
+                "type": "string",
+                "enum": [
+                  "after",
+                  "before",
+                  "all",
+                  "begin",
+                  "end",
+                  "vrf"
+                ],
+                "title": "Stage"
+              },
+              "after_before_stage": {
+                "type": "string",
+                "description": "Action is triggered after/before specified stage.",
+                "enum": [
+                  "bgp",
+                  "linkdown",
+                  "mlag",
+                  "ratemon"
+                ],
+                "title": "After Before Stage"
+              },
+              "vrf": {
+                "type": "string",
+                "description": "VRF name.",
+                "title": "VRF"
+              },
+              "interface": {
+                "type": "object",
+                "properties": {
+                  "interface_type": {
+                    "type": "string",
+                    "enum": [
+                      "Ethernet",
+                      "Fabric",
+                      "Loopback",
+                      "Management",
+                      "Port-Channel",
+                      "Tunnel",
+                      "Vlan",
+                      "Vxlan"
+                    ],
+                    "title": "Interface Type"
+                  },
+                  "interface_number": {
+                    "type": "integer",
+                    "title": "Interface Number"
+                  }
+                },
+                "required": [
+                  "interface_type",
+                  "interface_number"
+                ],
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Interface"
+              },
+              "unit": {
+                "type": "string",
+                "description": "Name of unit.",
+                "title": "Unit"
+              }
+            },
+            "required": [
+              "operation"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Trigger On Maintenance"
           },
           "regex": {
             "type": "string",
@@ -21144,9 +21253,118 @@
                       "enum": [
                         "on-boot",
                         "on-logging",
-                        "on-startup-config"
+                        "on-startup-config",
+                        "on-maintenance"
                       ],
                       "title": "Trigger"
+                    },
+                    "trigger_on_maintenance": {
+                      "type": "object",
+                      "properties": {
+                        "operation": {
+                          "type": "string",
+                          "enum": [
+                            "enter",
+                            "exit"
+                          ],
+                          "title": "Operation"
+                        },
+                        "bgp": {
+                          "type": "object",
+                          "properties": {
+                            "neighbor_address_ipv4": {
+                              "type": "string",
+                              "title": "Neighbor Address IPv4"
+                            },
+                            "neighbor_address_ipv6": {
+                              "type": "string",
+                              "title": "Neighbor Address IPv6"
+                            },
+                            "peer_group_name": {
+                              "type": "string",
+                              "title": "Peer Group Name"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "BGP"
+                        },
+                        "stage": {
+                          "type": "string",
+                          "enum": [
+                            "after",
+                            "before",
+                            "all",
+                            "begin",
+                            "end",
+                            "vrf"
+                          ],
+                          "title": "Stage"
+                        },
+                        "after_before_stage": {
+                          "type": "string",
+                          "description": "Action is triggered after/before specified stage.",
+                          "enum": [
+                            "bgp",
+                            "linkdown",
+                            "mlag",
+                            "ratemon"
+                          ],
+                          "title": "After Before Stage"
+                        },
+                        "vrf": {
+                          "type": "string",
+                          "description": "VRF name.",
+                          "title": "VRF"
+                        },
+                        "interface": {
+                          "type": "object",
+                          "properties": {
+                            "interface_type": {
+                              "type": "string",
+                              "enum": [
+                                "Ethernet",
+                                "Fabric",
+                                "Loopback",
+                                "Management",
+                                "Port-Channel",
+                                "Tunnel",
+                                "Vlan",
+                                "Vxlan"
+                              ],
+                              "title": "Interface Type"
+                            },
+                            "interface_number": {
+                              "type": "integer",
+                              "title": "Interface Number"
+                            }
+                          },
+                          "required": [
+                            "interface_type",
+                            "interface_number"
+                          ],
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Interface"
+                        },
+                        "unit": {
+                          "type": "string",
+                          "description": "Name of unit.",
+                          "title": "Unit"
+                        }
+                      },
+                      "required": [
+                        "operation"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Trigger On Maintenance"
                     },
                     "regex": {
                       "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4849,8 +4849,7 @@
                   "before",
                   "all",
                   "begin",
-                  "end",
-                  "vrf"
+                  "end"
                 ],
                 "title": "Stage"
               },
@@ -21278,8 +21277,7 @@
                             "before",
                             "all",
                             "begin",
-                            "end",
-                            "vrf"
+                            "end"
                           ],
                           "title": "Stage"
                         },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4818,6 +4818,7 @@
                 "title": "Operation"
               },
               "bgp": {
+                "description": "Trigger condition occurs on maintenance operation of specified BGP peer.",
                 "type": "object",
                 "properties": {
                   "neighbor_address_ipv4": {
@@ -4868,6 +4869,7 @@
                 "title": "VRF"
               },
               "interface": {
+                "description": "Trigger condition occurs on maintenance operation of specified interface.",
                 "type": "object",
                 "properties": {
                   "interface_type": {
@@ -4901,7 +4903,7 @@
               },
               "unit": {
                 "type": "string",
-                "description": "Name of unit.",
+                "description": "Name of unit. Trigger condition occurs on maintenance operation of specified unit",
                 "title": "Unit"
               }
             },
@@ -21270,6 +21272,7 @@
                           "title": "Operation"
                         },
                         "bgp": {
+                          "description": "Trigger condition occurs on maintenance operation of specified BGP peer.",
                           "type": "object",
                           "properties": {
                             "neighbor_address_ipv4": {
@@ -21320,6 +21323,7 @@
                           "title": "VRF"
                         },
                         "interface": {
+                          "description": "Trigger condition occurs on maintenance operation of specified interface.",
                           "type": "object",
                           "properties": {
                             "interface_type": {
@@ -21353,7 +21357,7 @@
                         },
                         "unit": {
                           "type": "string",
-                          "description": "Name of unit.",
+                          "description": "Name of unit. Trigger condition occurs on maintenance operation of specified unit",
                           "title": "Unit"
                         }
                       },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4841,9 +4841,9 @@
                 },
                 "title": "BGP"
               },
-              "stage": {
+              "action": {
                 "type": "string",
-                "description": "Stages of maintenance operation. \"vrf\" stage can be defined for \"bgp\" only.",
+                "description": "Action for maintenance operation.",
                 "enum": [
                   "after",
                   "before",
@@ -4851,9 +4851,9 @@
                   "begin",
                   "end"
                 ],
-                "title": "Stage"
+                "title": "Action"
               },
-              "after_before_stage": {
+              "stage": {
                 "type": "string",
                 "description": "Action is triggered after/before specified stage.",
                 "enum": [
@@ -4862,11 +4862,11 @@
                   "mlag",
                   "ratemon"
                 ],
-                "title": "After Before Stage"
+                "title": "Stage"
               },
               "vrf": {
                 "type": "string",
-                "description": "VRF name.",
+                "description": "VRF name. VRF can be defined for \"bgp\" only.",
                 "title": "VRF"
               },
               "interface": {
@@ -4882,7 +4882,7 @@
             },
             "required": [
               "operation",
-              "stage"
+              "action"
             ],
             "additionalProperties": false,
             "patternProperties": {
@@ -21269,9 +21269,9 @@
                           },
                           "title": "BGP"
                         },
-                        "stage": {
+                        "action": {
                           "type": "string",
-                          "description": "Stages of maintenance operation. \"vrf\" stage can be defined for \"bgp\" only.",
+                          "description": "Action for maintenance operation.",
                           "enum": [
                             "after",
                             "before",
@@ -21279,9 +21279,9 @@
                             "begin",
                             "end"
                           ],
-                          "title": "Stage"
+                          "title": "Action"
                         },
-                        "after_before_stage": {
+                        "stage": {
                           "type": "string",
                           "description": "Action is triggered after/before specified stage.",
                           "enum": [
@@ -21290,11 +21290,11 @@
                             "mlag",
                             "ratemon"
                           ],
-                          "title": "After Before Stage"
+                          "title": "Stage"
                         },
                         "vrf": {
                           "type": "string",
-                          "description": "VRF name.",
+                          "description": "VRF name. VRF can be defined for \"bgp\" only.",
                           "title": "VRF"
                         },
                         "interface": {
@@ -21310,7 +21310,7 @@
                       },
                       "required": [
                         "operation",
-                        "stage"
+                        "action"
                       ],
                       "additionalProperties": false,
                       "patternProperties": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4822,17 +4822,10 @@
                 "description": "Trigger condition occurs on maintenance operation of specified BGP peer.",
                 "type": "object",
                 "properties": {
-                  "neighbor_address_ipv4": {
+                  "peer": {
                     "type": "string",
-                    "title": "Neighbor Address IPv4"
-                  },
-                  "neighbor_address_ipv6": {
-                    "type": "string",
-                    "title": "Neighbor Address IPv6"
-                  },
-                  "peer_group_name": {
-                    "type": "string",
-                    "title": "Peer Group Name"
+                    "description": "Ipv4/Ipv6 address or peer group name.",
+                    "title": "Peer"
                   }
                 },
                 "additionalProperties": false,
@@ -21250,17 +21243,10 @@
                           "description": "Trigger condition occurs on maintenance operation of specified BGP peer.",
                           "type": "object",
                           "properties": {
-                            "neighbor_address_ipv4": {
+                            "peer": {
                               "type": "string",
-                              "title": "Neighbor Address IPv4"
-                            },
-                            "neighbor_address_ipv6": {
-                              "type": "string",
-                              "title": "Neighbor Address IPv6"
-                            },
-                            "peer_group_name": {
-                              "type": "string",
-                              "title": "Peer Group Name"
+                              "description": "Ipv4/Ipv6 address or peer group name.",
+                              "title": "Peer"
                             }
                           },
                           "additionalProperties": false,


### PR DESCRIPTION
## Change Summary

Add event-handler trigger "on-maintenance".

## Related Issue(s)

Fixes #2951 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adding an option for "on-maintenance" in event-handlers.trigger and updated the data-model for the same.

## How to test

Add input trigger on-maintenance:
```
- name: trigger-on-maintenance
    trigger: on-maintenance
    trigger_on_maintenance:
      operation: enter
      interface:
        interface_type: Ethernet
        interface_number: 4
      stage: all
    action_type: bash
    action: echo "on-maintenance"
```

Check the output config:

```
!
event-handler trigger-on-maintenance
   trigger on-maintenance enter interface Ethernet 4 all
   action bash echo "on-maintenance"
```
Test the config on EOS CLI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
