### PR TITLE
Refactor(deploy_to_cv): Add requirements check and always build workspace

### DIFF
--- a/ansible_collections/arista/avd/roles/deploy_to_cv/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/deploy_to_cv/tasks/main.yml
@@ -7,6 +7,18 @@
     msg: arista.avd.deploy_to_cv is in 'preview mode'. Set 'deploy_to_cv_accept_preview' to use.
   when: deploy_to_cv_accept_preview is not arista.avd.defined
 
+- name: Verify Requirements
+  tags: [always, avd_req]
+  delegate_to: localhost
+  when: avd_requirements is not defined
+  arista.avd.verify_requirements:
+    requirements: "{{ lookup('file', requirements_path ~ '/requirements.txt').splitlines() }}"
+    avd_ignore_requirements: "{{ avd_ignore_requirements | default(false) }}"
+  vars:
+    requirements_path: "{{ (role_path | split('/'))[0:-2] | join('/') }}"
+  run_once: true
+  register: avd_requirements
+
 - name: Deploy device configurations and tags to CloudVision
   run_once: true
   delegate_to: localhost
@@ -24,7 +36,7 @@
     workspace:
       name: "{{ cv_workspace_name | arista.avd.default }}"
       description: "{{ cv_workspace_description | arista.avd.default }}"
-      requested_state: "{{ 'submitted' if cv_submit_workspace else 'pending' }}"
+      requested_state: "{{ 'submitted' if cv_submit_workspace else 'built' }}"
       force: "{{ cv_submit_workspace_force }}"
     change_control:
       name: "{{ cv_change_control_name | arista.avd.default }}"


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
 Add requirements check and always build workspace

## Component(s) name

`arista.avd.deploy_to_cv` role.

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- If `cv_submit_workspace` is `false` build the workspace instead of leaving it pending (to force validation of configs).
- Add requirements check for `deploy_to_cv` role.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested manually.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
