### PR TITLE
Feat(eos_designs): STUN SSL profile support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
@@ -196,14 +196,14 @@ management api http-commands
       no shutdown
 !
 management security
-   ssl profile SSL-STUN
+   ssl profile STUN-DTLS
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
-      certificate SSL-STUN.crt key SSL-STUN.key
+      certificate STUN-DTLS.crt key STUN-DTLS.key
 !
 stun
    client
       server-profile INET-autovpn-rr3-Ethernet1
          ip address 10.7.7.7
-         ssl profile SSL-STUN
+         ssl profile STUN-DTLS
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
@@ -195,9 +195,15 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile SSL-STUN
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate SSL-STUN.crt key SSL-STUN.key
+!
 stun
    client
       server-profile INET-autovpn-rr3-Ethernet1
          ip address 10.7.7.7
+         ssl profile SSL-STUN
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
@@ -197,6 +197,7 @@ management api http-commands
 !
 management security
    ssl profile STUN-DTLS
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate STUN-DTLS.crt key STUN-DTLS.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -288,20 +288,20 @@ management api http-commands
       no shutdown
 !
 management security
-   ssl profile SSL-STUN
+   ssl profile STUN-DTLS
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
-      certificate SSL-STUN.crt key SSL-STUN.key
+      certificate STUN-DTLS.crt key STUN-DTLS.key
 !
 stun
    client
       server-profile INET-cv-pathfinder-pathfinder-Ethernet1
          ip address 10.7.7.7
-         ssl profile SSL-STUN
+         ssl profile STUN-DTLS
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
-         ssl profile SSL-STUN
+         ssl profile STUN-DTLS
       server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
          ip address 172.16.0.1
-         ssl profile SSL-STUN
+         ssl profile STUN-DTLS
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -289,6 +289,7 @@ management api http-commands
 !
 management security
    ssl profile STUN-DTLS
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate STUN-DTLS.crt key STUN-DTLS.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -287,13 +287,21 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile SSL-STUN
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate SSL-STUN.crt key SSL-STUN.key
+!
 stun
    client
       server-profile INET-cv-pathfinder-pathfinder-Ethernet1
          ip address 10.7.7.7
+         ssl profile SSL-STUN
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
+         ssl profile SSL-STUN
       server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
          ip address 172.16.0.1
+         ssl profile SSL-STUN
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -405,6 +405,7 @@ management api http-commands
 !
 management security
    ssl profile profileA
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate profileA.crt key profileA.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -403,4 +403,9 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile profileA
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -284,13 +284,21 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile SSL-STUN
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate SSL-STUN.crt key SSL-STUN.key
+!
 stun
    client
       server-profile INET-cv-pathfinder-pathfinder-Ethernet1
          ip address 10.7.7.7
+         ssl profile SSL-STUN
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
+         ssl profile SSL-STUN
       server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
          ip address 172.16.0.1
+         ssl profile SSL-STUN
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -285,20 +285,20 @@ management api http-commands
       no shutdown
 !
 management security
-   ssl profile SSL-STUN
+   ssl profile STUN-DTLS
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
-      certificate SSL-STUN.crt key SSL-STUN.key
+      certificate STUN-DTLS.crt key STUN-DTLS.key
 !
 stun
    client
       server-profile INET-cv-pathfinder-pathfinder-Ethernet1
          ip address 10.7.7.7
-         ssl profile SSL-STUN
+         ssl profile STUN-DTLS
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
-         ssl profile SSL-STUN
+         ssl profile STUN-DTLS
       server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
          ip address 172.16.0.1
-         ssl profile SSL-STUN
+         ssl profile STUN-DTLS
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -286,6 +286,7 @@ management api http-commands
 !
 management security
    ssl profile STUN-DTLS
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate STUN-DTLS.crt key STUN-DTLS.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -471,13 +471,21 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile profileA
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
 stun
    client
       server-profile INET-cv-pathfinder-pathfinder-Ethernet1
          ip address 10.7.7.7
+         ssl profile profileA
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
+         ssl profile profileA
       server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
          ip address 172.16.0.1
+         ssl profile profileA
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -473,6 +473,7 @@ management api http-commands
 !
 management security
    ssl profile profileA
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate profileA.crt key profileA.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -519,6 +519,7 @@ management api http-commands
 !
 management security
    ssl profile profileA
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate profileA.crt key profileA.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -517,11 +517,18 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile profileA
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
 stun
    client
       server-profile INET-cv-pathfinder-pathfinder-Ethernet1
          ip address 10.7.7.7
+         ssl profile profileA
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
+         ssl profile profileA
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -514,9 +514,15 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile profileA
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
 stun
    client
       server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
          ip address 172.16.0.1
+         ssl profile profileA
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -516,6 +516,7 @@ management api http-commands
 !
 management security
    ssl profile profileA
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate profileA.crt key profileA.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -377,6 +377,7 @@ management api http-commands
 !
 management security
    ssl profile profileA
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate profileA.crt key profileA.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -375,10 +375,16 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile profileA
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
 stun
    server
       local-interface Ethernet1
       local-interface Ethernet2
       local-interface Ethernet3
+      ssl profile profileA
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -378,8 +378,14 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile profileB
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileB.crt key profileB.key
+!
 stun
    server
       local-interface Ethernet1
+      ssl profile profileB
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -380,6 +380,7 @@ management api http-commands
 !
 management security
    ssl profile profileB
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate profileB.crt key profileB.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -394,14 +394,14 @@ management api http-commands
       no shutdown
 !
 management security
-   ssl profile profileC
+   ssl profile profileB
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
-      certificate profileC.crt key profileC.key
+      certificate profileB.crt key profileB.key
 !
 stun
    server
       local-interface Ethernet1
       local-interface Ethernet2
-      ssl profile profileC
+      ssl profile profileB
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -395,6 +395,7 @@ management api http-commands
 !
 management security
    ssl profile profileB
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate profileB.crt key profileB.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -393,9 +393,15 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile profileC
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileC.crt key profileC.key
+!
 stun
    server
       local-interface Ethernet1
       local-interface Ethernet2
+      ssl profile profileC
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -549,6 +549,7 @@ management api http-commands
 !
 management security
    ssl profile profileA
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate profileA.crt key profileA.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -547,13 +547,21 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile profileA
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
 stun
    client
       server-profile INET-cv-pathfinder-pathfinder-Ethernet1
          ip address 10.7.7.7
+         ssl profile profileA
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
+         ssl profile profileA
       server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
          ip address 172.16.0.1
+         ssl profile profileA
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -549,6 +549,7 @@ management api http-commands
 !
 management security
    ssl profile profileA
+      tls versions 1.2
       trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
       certificate profileA.crt key profileA.key
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -547,13 +547,21 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile profileA
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
 stun
    client
       server-profile INET-cv-pathfinder-pathfinder-Ethernet1
          ip address 10.7.7.7
+         ssl profile profileA
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
+         ssl profile profileA
       server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
          ip address 172.16.0.1
+         ssl profile profileA
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -187,4 +187,10 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile STUN-DTLS
+      tls versions 1.2
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate STUN-DTLS.crt key STUN-DTLS.key
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -193,4 +193,10 @@ management api http-commands
    vrf MGMT
       no shutdown
 !
+management security
+   ssl profile STUN-DTLS
+      tls versions 1.2
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate STUN-DTLS.crt key STUN-DTLS.key
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
@@ -190,6 +190,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
@@ -183,10 +183,10 @@ ip_security:
     profile: AUTOVPN
 management_security:
   ssl_profiles:
-  - name: SSL-STUN
+  - name: STUN-DTLS
     certificate:
-      file: SSL-STUN.crt
-      key: SSL-STUN.key
+      file: STUN-DTLS.crt
+      key: STUN-DTLS.key
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
@@ -244,7 +244,7 @@ stun:
     server_profiles:
     - name: INET-autovpn-rr3-Ethernet1
       ip_address: 10.7.7.7
-      ssl_profile: SSL-STUN
+      ssl_profile: STUN-DTLS
 application_traffic_recognition:
   application_profiles:
   - name: APP-PROFILE-CONTROL-PLANE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
@@ -181,6 +181,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: AUTOVPN
+management_security:
+  ssl_profiles:
+  - name: SSL-STUN
+    certificate:
+      file: SSL-STUN.crt
+      key: SSL-STUN.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_bfd:
   multihop:
     interval: 300
@@ -235,6 +244,7 @@ stun:
     server_profiles:
     - name: INET-autovpn-rr3-Ethernet1
       ip_address: 10.7.7.7
+      ssl_profile: SSL-STUN
 application_traffic_recognition:
   application_profiles:
   - name: APP-PROFILE-CONTROL-PLANE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -225,10 +225,10 @@ ip_security:
     profile: DP-PROFILE
 management_security:
   ssl_profiles:
-  - name: SSL-STUN
+  - name: STUN-DTLS
     certificate:
-      file: SSL-STUN.crt
-      key: SSL-STUN.key
+      file: STUN-DTLS.crt
+      key: STUN-DTLS.key
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
@@ -350,13 +350,13 @@ stun:
     server_profiles:
     - name: INET-cv-pathfinder-pathfinder-Ethernet1
       ip_address: 10.7.7.7
-      ssl_profile: SSL-STUN
+      ssl_profile: STUN-DTLS
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
-      ssl_profile: SSL-STUN
+      ssl_profile: STUN-DTLS
     - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
       ip_address: 172.16.0.1
-      ssl_profile: SSL-STUN
+      ssl_profile: STUN-DTLS
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -223,6 +223,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: SSL-STUN
+    certificate:
+      file: SSL-STUN.crt
+      key: SSL-STUN.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: edge
   region:
@@ -341,10 +350,13 @@ stun:
     server_profiles:
     - name: INET-cv-pathfinder-pathfinder-Ethernet1
       ip_address: 10.7.7.7
+      ssl_profile: SSL-STUN
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
+      ssl_profile: SSL-STUN
     - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
       ip_address: 172.16.0.1
+      ssl_profile: SSL-STUN
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -232,6 +232,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: edge
   region:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -330,6 +330,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: edge
   region:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -339,6 +339,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: edge
   region:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -249,6 +249,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: edge
   region:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -240,6 +240,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: SSL-STUN
+    certificate:
+      file: SSL-STUN.crt
+      key: SSL-STUN.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: edge
   region:
@@ -349,10 +358,13 @@ stun:
     server_profiles:
     - name: INET-cv-pathfinder-pathfinder-Ethernet1
       ip_address: 10.7.7.7
+      ssl_profile: SSL-STUN
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
+      ssl_profile: SSL-STUN
     - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
       ip_address: 172.16.0.1
+      ssl_profile: SSL-STUN
 application_traffic_recognition:
   application_profiles:
   - name: APP-PROFILE-CONTROL-PLANE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -242,10 +242,10 @@ ip_security:
     profile: DP-PROFILE
 management_security:
   ssl_profiles:
-  - name: SSL-STUN
+  - name: STUN-DTLS
     certificate:
-      file: SSL-STUN.crt
-      key: SSL-STUN.key
+      file: STUN-DTLS.crt
+      key: STUN-DTLS.key
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
@@ -358,13 +358,13 @@ stun:
     server_profiles:
     - name: INET-cv-pathfinder-pathfinder-Ethernet1
       ip_address: 10.7.7.7
-      ssl_profile: SSL-STUN
+      ssl_profile: STUN-DTLS
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
-      ssl_profile: SSL-STUN
+      ssl_profile: STUN-DTLS
     - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
       ip_address: 172.16.0.1
-      ssl_profile: SSL-STUN
+      ssl_profile: STUN-DTLS
 application_traffic_recognition:
   application_profiles:
   - name: APP-PROFILE-CONTROL-PLANE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -385,6 +385,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: edge
   region:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -376,6 +376,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: edge
   region:
@@ -552,10 +561,13 @@ stun:
     server_profiles:
     - name: INET-cv-pathfinder-pathfinder-Ethernet1
       ip_address: 10.7.7.7
+      ssl_profile: profileA
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
+      ssl_profile: profileA
     - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
       ip_address: 172.16.0.1
+      ssl_profile: profileA
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -445,6 +445,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: edge
   region:
@@ -609,8 +618,10 @@ stun:
     server_profiles:
     - name: INET-cv-pathfinder-pathfinder-Ethernet1
       ip_address: 10.7.7.7
+      ssl_profile: profileA
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
+      ssl_profile: profileA
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -454,6 +454,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: edge
   region:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -444,6 +444,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: edge
   region:
@@ -605,6 +614,7 @@ stun:
     server_profiles:
     - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
       ip_address: 172.16.0.1
+      ssl_profile: profileA
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -453,6 +453,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: edge
   region:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -206,6 +206,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: pathfinder
   profiles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -496,6 +496,7 @@ metadata:
         value: '999'
   cv_pathfinder:
     role: pathfinder
+    ssl_profile: profileA
     vtep_ip: 192.168.144.1
     interfaces:
     - name: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -197,6 +197,15 @@ ip_security:
       time: 50
       action: clear
     mode: transport
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: pathfinder
   profiles:
@@ -383,6 +392,7 @@ stun:
     - Ethernet1
     - Ethernet2
     - Ethernet3
+    ssl_profile: profileA
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -218,6 +218,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: pathfinder
   profiles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -494,6 +494,7 @@ metadata:
         value: '888'
   cv_pathfinder:
     role: pathfinder
+    ssl_profile: profileB
     vtep_ip: 192.168.144.2
     interfaces:
     - name: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -209,6 +209,15 @@ ip_security:
       time: 50
       action: clear
     mode: transport
+management_security:
+  ssl_profiles:
+  - name: profileB
+    certificate:
+      file: profileB.crt
+      key: profileB.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: pathfinder
   profiles:
@@ -397,6 +406,7 @@ stun:
   server:
     local_interfaces:
     - Ethernet1
+    ssl_profile: profileB
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -219,10 +219,10 @@ ip_security:
     mode: transport
 management_security:
   ssl_profiles:
-  - name: profileC
+  - name: profileB
     certificate:
-      file: profileC.crt
-      key: profileC.key
+      file: profileB.crt
+      key: profileB.key
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
@@ -424,7 +424,7 @@ stun:
     local_interfaces:
     - Ethernet1
     - Ethernet2
-    ssl_profile: profileC
+    ssl_profile: profileB
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -217,6 +217,15 @@ ip_security:
       time: 50
       action: clear
     mode: transport
+management_security:
+  ssl_profiles:
+  - name: profileC
+    certificate:
+      file: profileC.crt
+      key: profileC.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: pathfinder
   profiles:
@@ -415,6 +424,7 @@ stun:
     local_interfaces:
     - Ethernet1
     - Ethernet2
+    ssl_profile: profileC
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -520,6 +520,7 @@ metadata:
         value: '10999'
   cv_pathfinder:
     role: pathfinder
+    ssl_profile: profileB
     vtep_ip: 192.168.144.3
     interfaces:
     - name: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -226,6 +226,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: pathfinder
   profiles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -422,6 +422,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: transit region
   region:
@@ -635,10 +644,13 @@ stun:
     server_profiles:
     - name: INET-cv-pathfinder-pathfinder-Ethernet1
       ip_address: 10.7.7.7
+      ssl_profile: profileA
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
+      ssl_profile: profileA
     - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
       ip_address: 172.16.0.1
+      ssl_profile: profileA
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -431,6 +431,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: transit region
   region:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -422,6 +422,15 @@ ip_security:
     mode: transport
   key_controller:
     profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
 router_adaptive_virtual_topology:
   topology_role: transit region
   region:
@@ -635,10 +644,13 @@ stun:
     server_profiles:
     - name: INET-cv-pathfinder-pathfinder-Ethernet1
       ip_address: 10.7.7.7
+      ssl_profile: profileA
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
+      ssl_profile: profileA
     - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
       ip_address: 172.16.0.1
+      ssl_profile: profileA
 application_traffic_recognition:
   application_profiles:
   - name: VIDEO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -431,6 +431,7 @@ management_security:
     trust_certificate:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_adaptive_virtual_topology:
   topology_role: transit region
   region:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -195,6 +195,16 @@ ip_security:
     mode: transport
   key_controller:
     profile: CP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: STUN-DTLS
+    certificate:
+      file: STUN-DTLS.crt
+      key: STUN-DTLS.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -204,6 +204,16 @@ ip_security:
     mode: transport
   key_controller:
     profile: CP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: STUN-DTLS
+    certificate:
+      file: STUN-DTLS.crt
+      key: STUN-DTLS.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
@@ -12,17 +12,17 @@ bgp_peer_groups:
     listen_range_prefixes:
       - 192.168.130.0/24
 
+wan_stun_dtls_disable: true
+
 wan_route_servers:
   # Testing having the interface configured with DHCP
   - hostname: autovpn-rr1
-    disable_stun_ssl: true
     path_groups:
       - name: INET
         interfaces:
           - name: Ethernet1
             ip_address: 10.7.7.7/31
   - hostname: autovpn-rr2
-    disable_stun_ssl: true
 
 wan_ipsec_profiles:
   control_plane:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
@@ -15,12 +15,14 @@ bgp_peer_groups:
 wan_route_servers:
   # Testing having the interface configured with DHCP
   - hostname: autovpn-rr1
+    disable_stun_ssl: true
     path_groups:
       - name: INET
         interfaces:
           - name: Ethernet1
             ip_address: 10.7.7.7/31
   - hostname: autovpn-rr2
+    disable_stun_ssl: true
 
 wan_ipsec_profiles:
   control_plane:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_MULTI_RR_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_MULTI_RR_TESTS.yml
@@ -1,12 +1,12 @@
 ---
 # Inherit most of the variables from CV_PATHFINDERS_TESTS
 
+wan_stun_dtls_profile_name: profileB
+
 wan_route_servers:
   # Not testing the overloading
   - hostname: cv-pathfinder-pathfinder1
-    stun_ssl_profile: profileB
   - hostname: cv-pathfinder-pathfinder2
-    stun_ssl_profile: profileC
   # This one is not in the inventory pathfinder1 & 2
   - hostname: cv-pathfinder-pathfinder3
     vtep_ip: 6.6.6.6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_MULTI_RR_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_MULTI_RR_TESTS.yml
@@ -4,7 +4,9 @@
 wan_route_servers:
   # Not testing the overloading
   - hostname: cv-pathfinder-pathfinder1
+    stun_ssl_profile: profileB
   - hostname: cv-pathfinder-pathfinder2
+    stun_ssl_profile: profileC
   # This one is not in the inventory pathfinder1 & 2
   - hostname: cv-pathfinder-pathfinder3
     vtep_ip: 6.6.6.6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -30,6 +30,7 @@ bgp_peer_groups:
 wan_route_servers:
   # Not testing the overloading
   - hostname: cv-pathfinder-pathfinder
+    stun_ssl_profile: profileA
 
 wan_ipsec_profiles:
   control_plane:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -27,10 +27,11 @@ bgp_peer_groups:
       - 192.168.142.0/24
       - 192.168.143.0/24
 
+wan_stun_dtls_profile_name: profileA
+
 wan_route_servers:
   # Not testing the overloading
   - hostname: cv-pathfinder-pathfinder
-    stun_ssl_profile: profileA
 
 wan_ipsec_profiles:
   control_plane:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -333,11 +333,7 @@ class WanMixin:
             wan_rs_result_dict = {
                 "vtep_ip": vtep_ip,
                 "wan_path_groups": [path_group for path_group in wan_path_groups if self.should_connect_to_wan_rs([path_group["name"]])],
-                "disable_stun_ssl": get(wan_rs_dict, "disable_stun_ssl", default=False),
             }
-
-            if ssl_profile := get(wan_rs_dict, "stun_ssl_profile"):
-                wan_rs_result_dict["stun_ssl_profile"] = ssl_profile
 
             # If no common path-group then skip
             # TODO - this may need to change when `import` path-groups is available

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-structure.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-structure.md
@@ -9,16 +9,12 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>&lt;node_type_keys.key&gt;</samp>](## "<node_type_keys.key>") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;defaults</samp>](## "<node_type_keys.key>.defaults") | Dictionary |  |  |  | Define variables for all nodes of this type. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "<node_type_keys.key>.defaults.ssl_profile") | String |  |  |  | ssl_profile_name will be used as a name for cert,<br>keys which will be internally created by CVP and pushed to respective devices.<br>Used for communication with stun server. |
     | [<samp>&nbsp;&nbsp;node_groups</samp>](## "<node_type_keys.key>.node_groups") | List, items: Dictionary |  |  |  | Define variables related to all nodes part of this group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "<node_type_keys.key>.node_groups.[].group") | String | Required, Unique |  |  | The Node Group Name is used for MLAG domain unless set with 'mlag_domain_id'.<br>The Node Group Name is also used for peer description on downstream switches' uplinks.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "<node_type_keys.key>.node_groups.[].nodes") | List, items: Dictionary |  |  |  | Define variables per node. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ssl_profile") | String |  |  |  | ssl_profile_name will be used as a name for cert,<br>keys which will be internally created by CVP and pushed to respective devices.<br>Used for communication with stun server. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "<node_type_keys.key>.node_groups.[].ssl_profile") | String |  |  |  | ssl_profile_name will be used as a name for cert,<br>keys which will be internally created by CVP and pushed to respective devices.<br>Used for communication with stun server. |
     | [<samp>&nbsp;&nbsp;nodes</samp>](## "<node_type_keys.key>.nodes") | List, items: Dictionary |  |  |  | Define variables per node. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "<node_type_keys.key>.nodes.[].ssl_profile") | String |  |  |  | ssl_profile_name will be used as a name for cert,<br>keys which will be internally created by CVP and pushed to respective devices.<br>Used for communication with stun server. |
 
 === "YAML"
 
@@ -27,11 +23,6 @@
 
       # Define variables for all nodes of this type.
       defaults:
-
-        # ssl_profile_name will be used as a name for cert,
-        # keys which will be internally created by CVP and pushed to respective devices.
-        # Used for communication with stun server.
-        ssl_profile: <str>
 
       # Define variables related to all nodes part of this group.
       node_groups:
@@ -46,24 +37,9 @@
               # The Node Name is used as "hostname".
             - name: <str; required; unique>
 
-              # ssl_profile_name will be used as a name for cert,
-              # keys which will be internally created by CVP and pushed to respective devices.
-              # Used for communication with stun server.
-              ssl_profile: <str>
-
-          # ssl_profile_name will be used as a name for cert,
-          # keys which will be internally created by CVP and pushed to respective devices.
-          # Used for communication with stun server.
-          ssl_profile: <str>
-
       # Define variables per node.
       nodes:
 
           # The Node Name is used as "hostname".
         - name: <str; required; unique>
-
-          # ssl_profile_name will be used as a name for cert,
-          # keys which will be internally created by CVP and pushed to respective devices.
-          # Used for communication with stun server.
-          ssl_profile: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-structure.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-structure.md
@@ -9,12 +9,16 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>&lt;node_type_keys.key&gt;</samp>](## "<node_type_keys.key>") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;defaults</samp>](## "<node_type_keys.key>.defaults") | Dictionary |  |  |  | Define variables for all nodes of this type. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "<node_type_keys.key>.defaults.ssl_profile") | String |  |  |  | ssl_profile_name will be used as a name for cert,<br>keys which will be internally created by CVP and pushed to respective devices.<br>Used for communication with stun server. |
     | [<samp>&nbsp;&nbsp;node_groups</samp>](## "<node_type_keys.key>.node_groups") | List, items: Dictionary |  |  |  | Define variables related to all nodes part of this group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "<node_type_keys.key>.node_groups.[].group") | String | Required, Unique |  |  | The Node Group Name is used for MLAG domain unless set with 'mlag_domain_id'.<br>The Node Group Name is also used for peer description on downstream switches' uplinks.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "<node_type_keys.key>.node_groups.[].nodes") | List, items: Dictionary |  |  |  | Define variables per node. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].ssl_profile") | String |  |  |  | ssl_profile_name will be used as a name for cert,<br>keys which will be internally created by CVP and pushed to respective devices.<br>Used for communication with stun server. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "<node_type_keys.key>.node_groups.[].ssl_profile") | String |  |  |  | ssl_profile_name will be used as a name for cert,<br>keys which will be internally created by CVP and pushed to respective devices.<br>Used for communication with stun server. |
     | [<samp>&nbsp;&nbsp;nodes</samp>](## "<node_type_keys.key>.nodes") | List, items: Dictionary |  |  |  | Define variables per node. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "<node_type_keys.key>.nodes.[].ssl_profile") | String |  |  |  | ssl_profile_name will be used as a name for cert,<br>keys which will be internally created by CVP and pushed to respective devices.<br>Used for communication with stun server. |
 
 === "YAML"
 
@@ -23,6 +27,11 @@
 
       # Define variables for all nodes of this type.
       defaults:
+
+        # ssl_profile_name will be used as a name for cert,
+        # keys which will be internally created by CVP and pushed to respective devices.
+        # Used for communication with stun server.
+        ssl_profile: <str>
 
       # Define variables related to all nodes part of this group.
       node_groups:
@@ -37,9 +46,24 @@
               # The Node Name is used as "hostname".
             - name: <str; required; unique>
 
+              # ssl_profile_name will be used as a name for cert,
+              # keys which will be internally created by CVP and pushed to respective devices.
+              # Used for communication with stun server.
+              ssl_profile: <str>
+
+          # ssl_profile_name will be used as a name for cert,
+          # keys which will be internally created by CVP and pushed to respective devices.
+          # Used for communication with stun server.
+          ssl_profile: <str>
+
       # Define variables per node.
       nodes:
 
           # The Node Name is used as "hostname".
         - name: <str; required; unique>
+
+          # ssl_profile_name will be used as a name for cert,
+          # keys which will be internally created by CVP and pushed to respective devices.
+          # Used for communication with stun server.
+          ssl_profile: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
@@ -28,8 +28,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "wan_route_servers.[].path_groups.[].interfaces") | List, items: Dictionary | Required |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "wan_route_servers.[].path_groups.[].interfaces.[].name") | String | Required, Unique |  |  | Interface name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "wan_route_servers.[].path_groups.[].interfaces.[].ip_address") | String |  |  |  | The public IP address of the Route Reflector for this path-group. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disable_stun_ssl</samp>](## "wan_route_servers.[].disable_stun_ssl") | Boolean |  | `False` |  | Set this to true in case of AutoVPN or cv-pathfinder without CloudVision.<br>In case of AutoVPN if this is set to `false`, user needs to deploy the ssl certificates manually into devices. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;stun_ssl_profile</samp>](## "wan_route_servers.[].stun_ssl_profile") | String |  | `SSL-STUN` |  | stun_ssl_profile will be used as the name for the certificate and keys used for communication with stun server.<br>When using CV Pathfinder integration with CVaaS, the certificates and keys will be created by CVP and pushed to respective devices. |
+    | [<samp>wan_stun_dtls_disable</samp>](## "wan_stun_dtls_disable") | Boolean |  | `False` |  | PREVIEW: This key is currently not supported<br><br>WAN STUN connections will be authenticated and secured with DTLS by default.<br>For CV-Pathfinder deployments CloudVision will automatically deploy certificates on the devices.<br>In case of AutoVPN the certificates must be deployed manually to all devices.<br><br>For LAB environments this can be disabled, if there are no certificates available.<br>This should NOT be disabled for a WAN network connected to the internet, since it will leave the STUN service exposed with no authentication. |
+    | [<samp>wan_stun_dtls_profile_name</samp>](## "wan_stun_dtls_profile_name") | String |  | `STUN-DTLS` |  | PREVIEW: This key is currently not supported<br><br>Name of SSL profile used for DTLS on WAN STUN connections. |
     | [<samp>wan_transit</samp>](## "wan_transit") <span style="color:red">removed</span> | Dictionary |  |  |  | The `wan_transit` node type was introduced and removed while the AVD WAN feature was in PREVIEW MODE.<br>Migrate your existing transit nodes to using `wan_router` node_type and set<br>`cv_pathfinder_transit_mode: region` under node settings.<span style="color:red">This key was removed. Support was removed in AVD version 4.6.0-dev1. Use <samp>node_type `wan_router` and set `cv_pathfinder_transit_mode: region` under node settings</samp> instead.</span> |
 
 === "YAML"
@@ -105,11 +105,18 @@
                 # The public IP address of the Route Reflector for this path-group.
                 ip_address: <str>
 
-        # Set this to true in case of AutoVPN or cv-pathfinder without CloudVision.
-        # In case of AutoVPN if this is set to `false`, user needs to deploy the ssl certificates manually into devices.
-        disable_stun_ssl: <bool; default=False>
+    # PREVIEW: This key is currently not supported
+    #
+    # WAN STUN connections will be authenticated and secured with DTLS by default.
+    # For CV-Pathfinder deployments CloudVision will automatically deploy certificates on the devices.
+    # In case of AutoVPN the certificates must be deployed manually to all devices.
+    #
+    # For LAB environments this can be disabled, if there are no certificates available.
+    # This should NOT be disabled for a WAN network connected to the internet, since it will leave the STUN service exposed with no authentication.
+    wan_stun_dtls_disable: <bool; default=False>
 
-        # stun_ssl_profile will be used as the name for the certificate and keys used for communication with stun server.
-        # When using CV Pathfinder integration with CVaaS, the certificates and keys will be created by CVP and pushed to respective devices.
-        stun_ssl_profile: <str; default="SSL-STUN">
+    # PREVIEW: This key is currently not supported
+    #
+    # Name of SSL profile used for DTLS on WAN STUN connections.
+    wan_stun_dtls_profile_name: <str; default="STUN-DTLS">
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
@@ -29,7 +29,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "wan_route_servers.[].path_groups.[].interfaces.[].name") | String | Required, Unique |  |  | Interface name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "wan_route_servers.[].path_groups.[].interfaces.[].ip_address") | String |  |  |  | The public IP address of the Route Reflector for this path-group. |
     | [<samp>wan_stun_dtls_disable</samp>](## "wan_stun_dtls_disable") | Boolean |  | `False` |  | PREVIEW: This key is currently not supported<br><br>WAN STUN connections will be authenticated and secured with DTLS by default.<br>For CV-Pathfinder deployments CloudVision will automatically deploy certificates on the devices.<br>In case of AutoVPN the certificates must be deployed manually to all devices.<br><br>For LAB environments this can be disabled, if there are no certificates available.<br>This should NOT be disabled for a WAN network connected to the internet, since it will leave the STUN service exposed with no authentication. |
-    | [<samp>wan_stun_dtls_profile_name</samp>](## "wan_stun_dtls_profile_name") | String |  | `STUN-DTLS` |  | PREVIEW: This key is currently not supported<br><br>Name of SSL profile used for DTLS on WAN STUN connections. |
+    | [<samp>wan_stun_dtls_profile_name</samp>](## "wan_stun_dtls_profile_name") | String |  | `STUN-DTLS` |  | PREVIEW: This key is currently not supported<br><br>Name of the SSL profile used for DTLS on WAN STUN connections.<br><br>When using automatic ceritficate deployment via CloudVision this name must be the same on all WAN routers. |
     | [<samp>wan_transit</samp>](## "wan_transit") <span style="color:red">removed</span> | Dictionary |  |  |  | The `wan_transit` node type was introduced and removed while the AVD WAN feature was in PREVIEW MODE.<br>Migrate your existing transit nodes to using `wan_router` node_type and set<br>`cv_pathfinder_transit_mode: region` under node settings.<span style="color:red">This key was removed. Support was removed in AVD version 4.6.0-dev1. Use <samp>node_type `wan_router` and set `cv_pathfinder_transit_mode: region` under node settings</samp> instead.</span> |
 
 === "YAML"
@@ -117,6 +117,8 @@
 
     # PREVIEW: This key is currently not supported
     #
-    # Name of SSL profile used for DTLS on WAN STUN connections.
+    # Name of the SSL profile used for DTLS on WAN STUN connections.
+    #
+    # When using automatic ceritficate deployment via CloudVision this name must be the same on all WAN routers.
     wan_stun_dtls_profile_name: <str; default="STUN-DTLS">
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
@@ -28,6 +28,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "wan_route_servers.[].path_groups.[].interfaces") | List, items: Dictionary | Required |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "wan_route_servers.[].path_groups.[].interfaces.[].name") | String | Required, Unique |  |  | Interface name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "wan_route_servers.[].path_groups.[].interfaces.[].ip_address") | String |  |  |  | The public IP address of the Route Reflector for this path-group. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disable_stun_ssl</samp>](## "wan_route_servers.[].disable_stun_ssl") | Boolean |  | `False` |  | Set this to true in case of AutoVPN or cv-pathfinder without CloudVision.<br>In case of AutoVPN if this is set to `false`, user needs to deploy the ssl certificates manually into devices. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;stun_ssl_profile</samp>](## "wan_route_servers.[].stun_ssl_profile") | String |  | `SSL-STUN` |  | stun_ssl_profile will be used as the name for the certificate and keys used for communication with stun server.<br>When using CV Pathfinder integration with CVaaS, the certificates and keys will be created by CVP and pushed to respective devices. |
     | [<samp>wan_transit</samp>](## "wan_transit") <span style="color:red">removed</span> | Dictionary |  |  |  | The `wan_transit` node type was introduced and removed while the AVD WAN feature was in PREVIEW MODE.<br>Migrate your existing transit nodes to using `wan_router` node_type and set<br>`cv_pathfinder_transit_mode: region` under node settings.<span style="color:red">This key was removed. Support was removed in AVD version 4.6.0-dev1. Use <samp>node_type `wan_router` and set `cv_pathfinder_transit_mode: region` under node settings</samp> instead.</span> |
 
 === "YAML"
@@ -102,4 +104,12 @@
 
                 # The public IP address of the Route Reflector for this path-group.
                 ip_address: <str>
+
+        # Set this to true in case of AutoVPN or cv-pathfinder without CloudVision.
+        # In case of AutoVPN if this is set to `false`, user needs to deploy the ssl certificates manually into devices.
+        disable_stun_ssl: <bool; default=False>
+
+        # stun_ssl_profile will be used as the name for the certificate and keys used for communication with stun server.
+        # When using CV Pathfinder integration with CVaaS, the certificates and keys will be created by CVP and pushed to respective devices.
+        stun_ssl_profile: <str; default="SSL-STUN">
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
@@ -32,7 +32,7 @@ class CvPathfinderMixin:
         if self.shared_utils.is_cv_pathfinder_server:
             return {
                 "role": self.shared_utils.cv_pathfinder_role,
-                "ssl_profile": None,  # TODO: Pick up ssl profile from self.shared_utils.this_wan_route_server.ssl_profile_name
+                "ssl_profile": self.shared_utils.wan_stun_dtls_profile_name,
                 "vtep_ip": self.shared_utils.vtep_ip,
                 "interfaces": self._metadata_interfaces(),
                 "pathgroups": self._metadata_pathgroups(),

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/avdstructuredconfig.py
@@ -8,6 +8,7 @@ from .flow_tracking import FlowTrackingMixin
 from .ip_extcommunity_lists import IpExtCommunityListsMixin
 from .ip_security import IpSecurityMixin
 from .management_cvx import ManagementCvxMixin
+from .management_security import ManagementSecurityMixin
 from .route_maps import RouteMapsMixin
 from .router_adaptive_virtual_topology import RouterAdaptiveVirtualTopologyMixin
 from .router_bfd import RouterBfdMixin
@@ -24,6 +25,7 @@ class AvdStructuredConfigOverlay(
     IpExtCommunityListsMixin,
     IpSecurityMixin,
     ManagementCvxMixin,
+    ManagementSecurityMixin,
     RouterAdaptiveVirtualTopologyMixin,
     RouterBfdMixin,
     RouterBgpMixin,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/management_security.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/management_security.py
@@ -1,0 +1,45 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from functools import cached_property
+
+from .utils import UtilsMixin
+
+
+class ManagementSecurityMixin(UtilsMixin):
+    """
+    Mixin Class used to generate structured config for one key.
+    Class should only be used as Mixin to a AvdStructuredConfig class
+    """
+
+    @cached_property
+    def management_security(self) -> dict | None:
+        if not self.shared_utils.stun_ssl_profiles():
+            return None
+
+        management_security = {}
+        ssl_profiles = []
+        ssl_profiles.extend(self._get_stun_ssl_profiles())
+
+        if ssl_profiles:
+            management_security["ssl_profiles"] = ssl_profiles
+
+        return management_security
+
+    def _get_stun_ssl_profiles(self) -> list:
+        ssl_profiles = self.shared_utils.stun_ssl_profiles()
+        stun_ssl_profiles = []
+        for ssl_profile in ssl_profiles:
+            stun_ssl_profiles.append(
+                {
+                    "name": ssl_profile,
+                    "certificate": {
+                        "file": ssl_profile + ".crt",
+                        "key": ssl_profile + ".key",
+                    },
+                    "trust_certificate": {"certificates": ["aristaDeviceCertProvisionerDefaultRootCA.crt"]},
+                }
+            )
+        return stun_ssl_profiles

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/management_security.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/management_security.py
@@ -33,6 +33,7 @@ class ManagementSecurityMixin(UtilsMixin):
                         "key": f"{profile_name}.key",
                     },
                     "trust_certificate": {"certificates": ["aristaDeviceCertProvisionerDefaultRootCA.crt"]},
+                    "tls_versions": "1.2",
                 }
             ]
         }

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/stun.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/stun.py
@@ -28,9 +28,10 @@ class StunMixin(UtilsMixin):
         if self.shared_utils.is_wan_server:
             local_interfaces = [wan_interface["name"] for wan_interface in self.shared_utils.wan_interfaces]
             stun["server"] = {"local_interfaces": local_interfaces}
+            if self.shared_utils.stun_ssl_profiles():
+                stun["server"]["ssl_profile"] = self.shared_utils.stun_ssl_profiles()[0]
 
         if self.shared_utils.is_wan_client:
             if server_profiles := list(itertools.chain.from_iterable(self._stun_server_profiles.values())):
                 stun["client"] = {"server_profiles": server_profiles}
-
         return stun or None

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/stun.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/stun.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import itertools
 from functools import cached_property
 
+from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_empties_from_dict
+
 from .utils import UtilsMixin
 
 
@@ -27,11 +29,12 @@ class StunMixin(UtilsMixin):
         stun = {}
         if self.shared_utils.is_wan_server:
             local_interfaces = [wan_interface["name"] for wan_interface in self.shared_utils.wan_interfaces]
-            stun["server"] = {"local_interfaces": local_interfaces}
-            if self.shared_utils.stun_ssl_profiles():
-                stun["server"]["ssl_profile"] = self.shared_utils.stun_ssl_profiles()[0]
+            stun["server"] = {
+                "local_interfaces": local_interfaces,
+                "ssl_profile": self.shared_utils.wan_stun_dtls_profile_name,
+            }
 
         if self.shared_utils.is_wan_client:
             if server_profiles := list(itertools.chain.from_iterable(self._stun_server_profiles.values())):
                 stun["client"] = {"server_profiles": server_profiles}
-        return stun or None
+        return strip_empties_from_dict(stun) or None

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
@@ -275,11 +275,15 @@ class UtilsMixin:
         """
         stun_server_profiles = {}
         for wan_route_server, data in self.shared_utils.filtered_wan_route_servers.items():
+            ssl_profile = {}
+            if not get(data, "disable_stun_ssl"):
+                ssl_profile = {"ssl_profile": get(data, "stun_ssl_profile", default="SSL-STUN")}
             for path_group in data.get("wan_path_groups", []):
                 stun_server_profiles.setdefault(path_group["name"], []).extend(
                     {
                         "name": self._stun_server_profile_name(wan_route_server, path_group["name"], get(interface_dict, "name", required=True)),
                         "ip_address": get(interface_dict, "ip_address", required=True).split("/")[0],
+                        **ssl_profile,
                     }
                     for interface_dict in get(path_group, "interfaces", required=True)
                 )

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
@@ -275,15 +275,12 @@ class UtilsMixin:
         """
         stun_server_profiles = {}
         for wan_route_server, data in self.shared_utils.filtered_wan_route_servers.items():
-            ssl_profile = {}
-            if not get(data, "disable_stun_ssl"):
-                ssl_profile = {"ssl_profile": get(data, "stun_ssl_profile", default="SSL-STUN")}
             for path_group in data.get("wan_path_groups", []):
                 stun_server_profiles.setdefault(path_group["name"], []).extend(
                     {
                         "name": self._stun_server_profile_name(wan_route_server, path_group["name"], get(interface_dict, "name", required=True)),
                         "ip_address": get(interface_dict, "ip_address", required=True).split("/")[0],
-                        **ssl_profile,
+                        "ssl_profile": self.shared_utils.wan_stun_dtls_profile_name,
                     }
                     for interface_dict in get(path_group, "interfaces", required=True)
                 )

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24877,7 +24877,7 @@
     "wan_stun_dtls_profile_name": {
       "type": "string",
       "default": "STUN-DTLS",
-      "description": "PREVIEW: This key is currently not supported\n\nName of SSL profile used for DTLS on WAN STUN connections.",
+      "description": "PREVIEW: This key is currently not supported\n\nName of the SSL profile used for DTLS on WAN STUN connections.\n\nWhen using automatic ceritficate deployment via CloudVision this name must be the same on all WAN routers.",
       "title": "Wan STUN Dtls Profile Name"
     },
     "wan_virtual_topologies": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24856,6 +24856,18 @@
               }
             },
             "title": "Path Groups"
+          },
+          "disable_stun_ssl": {
+            "type": "boolean",
+            "default": false,
+            "description": "Set this to true in case of AutoVPN or cv-pathfinder without CloudVision.\nIn case of AutoVPN if this is set to `false`, user needs to deploy the ssl certificates manually into devices.",
+            "title": "Disable STUN SSL"
+          },
+          "stun_ssl_profile": {
+            "type": "string",
+            "description": "stun_ssl_profile will be used as the name for the certificate and keys used for communication with stun server.\nWhen using CV Pathfinder integration with CVaaS, the certificates and keys will be created by CVP and pushed to respective devices.",
+            "default": "SSL-STUN",
+            "title": "STUN SSL Profile"
           }
         },
         "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24856,18 +24856,6 @@
               }
             },
             "title": "Path Groups"
-          },
-          "disable_stun_ssl": {
-            "type": "boolean",
-            "default": false,
-            "description": "Set this to true in case of AutoVPN or cv-pathfinder without CloudVision.\nIn case of AutoVPN if this is set to `false`, user needs to deploy the ssl certificates manually into devices.",
-            "title": "Disable STUN SSL"
-          },
-          "stun_ssl_profile": {
-            "type": "string",
-            "description": "stun_ssl_profile will be used as the name for the certificate and keys used for communication with stun server.\nWhen using CV Pathfinder integration with CVaaS, the certificates and keys will be created by CVP and pushed to respective devices.",
-            "default": "SSL-STUN",
-            "title": "STUN SSL Profile"
           }
         },
         "additionalProperties": false,
@@ -24879,6 +24867,18 @@
         ]
       },
       "title": "Wan Route Servers"
+    },
+    "wan_stun_dtls_disable": {
+      "type": "boolean",
+      "default": false,
+      "description": "PREVIEW: This key is currently not supported\n\nWAN STUN connections will be authenticated and secured with DTLS by default.\nFor CV-Pathfinder deployments CloudVision will automatically deploy certificates on the devices.\nIn case of AutoVPN the certificates must be deployed manually to all devices.\n\nFor LAB environments this can be disabled, if there are no certificates available.\nThis should NOT be disabled for a WAN network connected to the internet, since it will leave the STUN service exposed with no authentication.",
+      "title": "Wan STUN Dtls Disable"
+    },
+    "wan_stun_dtls_profile_name": {
+      "type": "string",
+      "default": "STUN-DTLS",
+      "description": "PREVIEW: This key is currently not supported\n\nName of SSL profile used for DTLS on WAN STUN connections.",
+      "title": "Wan STUN Dtls Profile Name"
     },
     "wan_virtual_topologies": {
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3717,7 +3717,11 @@ keys:
     description: 'PREVIEW: This key is currently not supported
 
 
-      Name of SSL profile used for DTLS on WAN STUN connections.'
+      Name of the SSL profile used for DTLS on WAN STUN connections.
+
+
+      When using automatic ceritficate deployment via CloudVision this name must be
+      the same on all WAN routers.'
   wan_transit:
     documentation_options:
       table: wan-settings

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3689,22 +3689,35 @@ keys:
                       type: str
                       description: The public IP address of the Route Reflector for
                         this path-group.
-        disable_stun_ssl:
-          type: bool
-          default: false
-          description: 'Set this to true in case of AutoVPN or cv-pathfinder without
-            CloudVision.
+  wan_stun_dtls_disable:
+    type: bool
+    documentation_options:
+      table: wan-settings
+    default: false
+    description: 'PREVIEW: This key is currently not supported
 
-            In case of AutoVPN if this is set to `false`, user needs to deploy the
-            ssl certificates manually into devices.'
-        stun_ssl_profile:
-          type: str
-          description: 'stun_ssl_profile will be used as the name for the certificate
-            and keys used for communication with stun server.
 
-            When using CV Pathfinder integration with CVaaS, the certificates and
-            keys will be created by CVP and pushed to respective devices.'
-          default: SSL-STUN
+      WAN STUN connections will be authenticated and secured with DTLS by default.
+
+      For CV-Pathfinder deployments CloudVision will automatically deploy certificates
+      on the devices.
+
+      In case of AutoVPN the certificates must be deployed manually to all devices.
+
+
+      For LAB environments this can be disabled, if there are no certificates available.
+
+      This should NOT be disabled for a WAN network connected to the internet, since
+      it will leave the STUN service exposed with no authentication.'
+  wan_stun_dtls_profile_name:
+    type: str
+    documentation_options:
+      table: wan-settings
+    default: STUN-DTLS
+    description: 'PREVIEW: This key is currently not supported
+
+
+      Name of SSL profile used for DTLS on WAN STUN connections.'
   wan_transit:
     documentation_options:
       table: wan-settings
@@ -7793,14 +7806,6 @@ $defs:
 
               This setting is useful on virtual Route Reflectors and Pathfinders where
               more CPU cores should be allocated for control plane.'
-          ssl_profile:
-            type: str
-            description: 'ssl_profile_name will be used as a name for cert,
-
-              keys which will be internally created by CVP and pushed to respective
-              devices.
-
-              Used for communication with stun server.'
       node_groups:
         type: list
         description: Define variables related to all nodes part of this group.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3689,6 +3689,22 @@ keys:
                       type: str
                       description: The public IP address of the Route Reflector for
                         this path-group.
+        disable_stun_ssl:
+          type: bool
+          default: false
+          description: 'Set this to true in case of AutoVPN or cv-pathfinder without
+            CloudVision.
+
+            In case of AutoVPN if this is set to `false`, user needs to deploy the
+            ssl certificates manually into devices.'
+        stun_ssl_profile:
+          type: str
+          description: 'stun_ssl_profile will be used as the name for the certificate
+            and keys used for communication with stun server.
+
+            When using CV Pathfinder integration with CVaaS, the certificates and
+            keys will be created by CVP and pushed to respective devices.'
+          default: SSL-STUN
   wan_transit:
     documentation_options:
       table: wan-settings
@@ -7777,6 +7793,14 @@ $defs:
 
               This setting is useful on virtual Route Reflectors and Pathfinders where
               more CPU cores should be allocated for control plane.'
+          ssl_profile:
+            type: str
+            description: 'ssl_profile_name will be used as a name for cert,
+
+              keys which will be internally created by CVP and pushed to respective
+              devices.
+
+              Used for communication with stun server.'
       node_groups:
         type: list
         description: Define variables related to all nodes part of this group.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
@@ -1285,12 +1285,6 @@ $defs:
             description: |-
               Set the maximum number of CPU used for the data plane.
               This setting is useful on virtual Route Reflectors and Pathfinders where more CPU cores should be allocated for control plane.
-          ssl_profile:
-            type: str
-            description: |-
-              ssl_profile_name will be used as a name for cert,
-              keys which will be internally created by CVP and pushed to respective devices.
-              Used for communication with stun server.
       node_groups:
         type: list
         description: Define variables related to all nodes part of this group.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
@@ -1285,6 +1285,12 @@ $defs:
             description: |-
               Set the maximum number of CPU used for the data plane.
               This setting is useful on virtual Route Reflectors and Pathfinders where more CPU cores should be allocated for control plane.
+          ssl_profile:
+            type: str
+            description: |-
+              ssl_profile_name will be used as a name for cert,
+              keys which will be internally created by CVP and pushed to respective devices.
+              Used for communication with stun server.
       node_groups:
         type: list
         description: Define variables related to all nodes part of this group.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_route_servers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_route_servers.schema.yml
@@ -52,15 +52,3 @@ keys:
                     ip_address:
                       type: str
                       description: The public IP address of the Route Reflector for this path-group.
-        disable_stun_ssl:
-          type: bool
-          default: false
-          description: |-
-            Set this to true in case of AutoVPN or cv-pathfinder without CloudVision.
-            In case of AutoVPN if this is set to `false`, user needs to deploy the ssl certificates manually into devices.
-        stun_ssl_profile:
-          type: str
-          description: |-
-            stun_ssl_profile will be used as the name for the certificate and keys used for communication with stun server.
-            When using CV Pathfinder integration with CVaaS, the certificates and keys will be created by CVP and pushed to respective devices.
-          default: SSL-STUN

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_route_servers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_route_servers.schema.yml
@@ -52,3 +52,15 @@ keys:
                     ip_address:
                       type: str
                       description: The public IP address of the Route Reflector for this path-group.
+        disable_stun_ssl:
+          type: bool
+          default: false
+          description: |-
+            Set this to true in case of AutoVPN or cv-pathfinder without CloudVision.
+            In case of AutoVPN if this is set to `false`, user needs to deploy the ssl certificates manually into devices.
+        stun_ssl_profile:
+          type: str
+          description: |-
+            stun_ssl_profile will be used as the name for the certificate and keys used for communication with stun server.
+            When using CV Pathfinder integration with CVaaS, the certificates and keys will be created by CVP and pushed to respective devices.
+          default: SSL-STUN

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_stun_dtls_disable.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_stun_dtls_disable.schema.yml
@@ -1,0 +1,22 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  wan_stun_dtls_disable:
+    type: bool
+    documentation_options:
+      table: wan-settings
+    default: false
+    description: |-
+      PREVIEW: This key is currently not supported
+
+      WAN STUN connections will be authenticated and secured with DTLS by default.
+      For CV-Pathfinder deployments CloudVision will automatically deploy certificates on the devices.
+      In case of AutoVPN the certificates must be deployed manually to all devices.
+
+      For LAB environments this can be disabled, if there are no certificates available.
+      This should NOT be disabled for a WAN network connected to the internet, since it will leave the STUN service exposed with no authentication.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_stun_dtls_profile_name.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_stun_dtls_profile_name.schema.yml
@@ -14,4 +14,6 @@ keys:
     description: |-
       PREVIEW: This key is currently not supported
 
-      Name of SSL profile used for DTLS on WAN STUN connections.
+      Name of the SSL profile used for DTLS on WAN STUN connections.
+
+      When using automatic ceritficate deployment via CloudVision this name must be the same on all WAN routers.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_stun_dtls_profile_name.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_stun_dtls_profile_name.schema.yml
@@ -1,0 +1,17 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  wan_stun_dtls_profile_name:
+    type: str
+    documentation_options:
+      table: wan-settings
+    default: STUN-DTLS
+    description: |-
+      PREVIEW: This key is currently not supported
+
+      Name of SSL profile used for DTLS on WAN STUN connections.


### PR DESCRIPTION
## Change Summary
Support of ssl profile for stun communication.

## Related Issue(s)

Fixes #3526 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Adding ssl profile element under the wan_rr node type and wan_route_servers. 
One needs to provide the ssl_profile under wan_route_servers in the case where the route server is not part of the same inventory. 
Ssl profile can be provided to any one of the peer route servers and will be applicable for all in the same inventory.

## How to test
Tested using molecule.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
