### PR TITLE
Refactor(eos_designs): Grouping name generation of  WAN profiles and policies

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -359,7 +359,7 @@ class WanMixin:
         )
 
     @cached_property
-    def wan_ha_flow_tracker_name(self: SharedUtils) -> str:
+    def wan_flow_tracker_name(self: SharedUtils) -> str:
         """
         Return the name of the WAN flow tracking object
         Used in both network services, underlay and overlay python modules.
@@ -463,3 +463,9 @@ class WanMixin:
             ip_addresses.append(f"{ip_address}/{prefix_length}")
 
         return ip_addresses
+
+    def generate_lb_policy_name(self: SharedUtils, name: str) -> str:
+        """
+        Returns LB-{name}
+        """
+        return f"LB-{name}"

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
@@ -159,7 +159,7 @@ class CvPathfinderMixin:
                         ],
                     }
                     for profile in vrf["profiles"]
-                    for lb_policy in [get_item(load_balance_policies, "name", f"LB-{profile['name']}", required=True)]
+                    for lb_policy in [get_item(load_balance_policies, "name", self.shared_utils.generate_lb_policy_name(profile["name"]), required=True)]
                 ],
             }
             for vrf in avt_vrfs

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/dps_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/dps_interfaces.py
@@ -38,6 +38,6 @@ class DpsInterfacesMixin(UtilsMixin):
         # When needed - need a default value if different than IPv4
 
         if self.shared_utils.cv_pathfinder_role:
-            dps1["flow_tracker"] = {"hardware": self.shared_utils.wan_ha_flow_tracker_name}
+            dps1["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
         return [dps1]

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_adaptive_virtual_topology.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_adaptive_virtual_topology.py
@@ -105,7 +105,9 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
                     {
                         "application_profile": application_profile,
                         "avt_profile": get(
-                            application_virtual_topology, "name", default=f"{avt_policy['name']}-{application_virtual_topology['application_profile']}"
+                            application_virtual_topology,
+                            "name",
+                            default=self._default_profile_name(avt_policy["name"], application_virtual_topology["application_profile"]),
                         ),
                         "traffic_class": get(application_virtual_topology, "traffic_class"),
                         "dscp": get(application_virtual_topology, "dscp"),
@@ -120,7 +122,7 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
                 cv_pathfinder_policy["matches"].append(
                     {
                         "application_profile": application_profile,
-                        "avt_profile": get(default_virtual_topology, "name", default=f"{avt_policy['name']}-DEFAULT"),
+                        "avt_profile": get(default_virtual_topology, "name", default=self._default_profile_name(avt_policy["name"], "DEFAULT")),
                         "traffic_class": get(default_virtual_topology, "traffic_class"),
                         "dscp": get(default_virtual_topology, "dscp"),
                         # Storing id as _id to avoid schema validation and be able to pick up in VRFs
@@ -155,29 +157,39 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
             return []
 
         # Control Plan profile
-        cv_pathfinder_profiles = [{"name": self._wan_control_plane_profile, "load_balance_policy": f"LB-{self._wan_control_plane_profile}"}]
+        cv_pathfinder_profiles = [
+            {"name": self._wan_control_plane_profile, "load_balance_policy": self.shared_utils.generate_lb_policy_name(self._wan_control_plane_profile)}
+        ]
         for avt_policy in self._filtered_wan_policies:
             for application_virtual_topology in get(avt_policy, "application_virtual_topologies", []):
-                name = get(application_virtual_topology, "name", default=f"{avt_policy['name']}-{application_virtual_topology['application_profile']}")
+                name = get(
+                    application_virtual_topology,
+                    "name",
+                    default=self._default_profile_name(avt_policy["name"], application_virtual_topology["application_profile"]),
+                )
                 append_if_not_duplicate(
                     list_of_dicts=cv_pathfinder_profiles,
                     primary_key="name",
                     new_dict={
                         "name": name,
-                        "load_balance_policy": f"LB-{name}",
+                        "load_balance_policy": self.shared_utils.generate_lb_policy_name(name),
                     },
                     context="Router Adaptive Virtual Topology profiles.",
                     context_keys=["name"],
                 )
             default_virtual_topology = get(avt_policy, "default_virtual_topology", required=True)
             if not get(default_virtual_topology, "drop_unmatched", default=False):
-                name = get(default_virtual_topology, "name", default=f"{avt_policy['name']}-DEFAULT")
+                name = get(
+                    default_virtual_topology,
+                    "name",
+                    default=self._default_profile_name(avt_policy["name"], "DEFAULT"),
+                )
                 append_if_not_duplicate(
                     list_of_dicts=cv_pathfinder_profiles,
                     primary_key="name",
                     new_dict={
                         "name": name,
-                        "load_balance_policy": f"LB-{name}",
+                        "load_balance_policy": self.shared_utils.generate_lb_policy_name(name),
                     },
                     context="Router Adaptive Virtual Topology profiles.",
                     context_keys=["name"],

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
@@ -66,25 +66,33 @@ class RouterPathSelectionMixin(UtilsMixin):
                     {
                         "id": 10,
                         "application_profile": self._wan_control_plane_application_profile,
-                        "load_balance": f"LB-{self._wan_control_plane_profile}",
+                        "load_balance": self.shared_utils.generate_lb_policy_name(self._wan_control_plane_profile),
                     }
                 )
                 rule_id_offset = 1
 
             for rule_id, application_virtual_topology in enumerate(get(policy, "application_virtual_topologies", []), start=1):
-                name = get(application_virtual_topology, "name", default=f"{policy['name']}-{application_virtual_topology['application_profile']}")
+                name = get(
+                    application_virtual_topology,
+                    "name",
+                    default=self._default_profile_name(policy["name"], application_virtual_topology["application_profile"]),
+                )
                 application_profile = get(application_virtual_topology, "application_profile", required=True)
                 autovpn_policy.setdefault("rules", []).append(
                     {
                         "id": 10 * (rule_id + rule_id_offset),
                         "application_profile": application_profile,
-                        "load_balance": f"LB-{name}",
+                        "load_balance": self.shared_utils.generate_lb_policy_name(name),
                     }
                 )
             default_virtual_topology = get(policy, "default_virtual_topology", required=True)
             if not get(default_virtual_topology, "drop_unmatched", default=False):
-                name = get(default_virtual_topology, "name", default=f"{policy['name']}-DEFAULT")
-                autovpn_policy["default_match"] = {"load_balance": f"LB-{name}"}
+                name = get(
+                    default_virtual_topology,
+                    "name",
+                    default=self._default_profile_name(policy["name"], "DEFAULT"),
+                )
+                autovpn_policy["default_match"] = {"load_balance": self.shared_utils.generate_lb_policy_name(name)}
 
             autovpn_policies.append(autovpn_policy)
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -306,19 +306,29 @@ class UtilsMixin:
         )
 
         wan_load_balance_policies = [
-            self._generate_wan_load_balance_policy(f"LB-{self._wan_control_plane_profile}", control_plane_virtual_topology, self._default_vrf_policy["name"])
+            self._generate_wan_load_balance_policy(
+                self.shared_utils.generate_lb_policy_name(self._wan_control_plane_profile),
+                control_plane_virtual_topology,
+                self._default_vrf_policy["name"],
+            )
         ]
         for policy in self._filtered_wan_policies:
             for application_virtual_topology in get(policy, "application_virtual_topologies", []):
                 # TODO add internet exit once supported
-                name = get(application_virtual_topology, "name", default=f"{policy['name']}-{application_virtual_topology['application_profile']}")
+                name = get(
+                    application_virtual_topology,
+                    "name",
+                    default=self._default_profile_name(policy["name"], application_virtual_topology["application_profile"]),
+                )
                 context_path = (
                     f"wan_virtual_topologies.policies[{policy['name']}].application_virtual_topologies[{application_virtual_topology['application_profile']}]"
                 )
                 append_if_not_duplicate(
                     list_of_dicts=wan_load_balance_policies,
                     primary_key="name",
-                    new_dict=self._generate_wan_load_balance_policy(f"LB-{name}", application_virtual_topology, context_path),
+                    new_dict=self._generate_wan_load_balance_policy(
+                        self.shared_utils.generate_lb_policy_name(name), application_virtual_topology, context_path
+                    ),
                     context="Router Path-Selection Load-Balance policies.",
                     context_keys=["name"],
                 )
@@ -327,7 +337,7 @@ class UtilsMixin:
                 policy, "default_virtual_topology", required=True, org_key=f"wan_virtual_topologies.policies[{policy['name']}].default_virtual_toplogy"
             )
             if not get(default_virtual_topology, "drop_unmatched", default=False):
-                name = get(default_virtual_topology, "name", default=f"{policy['name']}-DEFAULT")
+                name = get(default_virtual_topology, "name", default=self._default_profile_name(policy["name"], "DEFAULT"))
                 context_path = f"wan_virtual_topologies.policies[{policy['name']}].default_virtual_topology"
 
                 # Verify that path_groups are set or raise
@@ -341,7 +351,7 @@ class UtilsMixin:
                 append_if_not_duplicate(
                     list_of_dicts=wan_load_balance_policies,
                     primary_key="name",
-                    new_dict=self._generate_wan_load_balance_policy(f"LB-{name}", default_virtual_topology, context_path),
+                    new_dict=self._generate_wan_load_balance_policy(self.shared_utils.generate_lb_policy_name(name), default_virtual_topology, context_path),
                     context="Router Path-Selection Load-Balance policies.",
                     context_keys=["name"],
                 )
@@ -436,3 +446,11 @@ class UtilsMixin:
         default_policy["is_default"] = True
 
         return default_policy
+
+    def _default_profile_name(self, profile_name: str, application_profile: str) -> str:
+        """
+        Helper function to consistently return the default name of a profile
+
+        Returns {profile_name}-{application_profile}
+        """
+        return f"{profile_name}-{application_profile}"

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/flow_tracking.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/flow_tracking.py
@@ -28,7 +28,7 @@ class FlowTrackingMixin(UtilsMixin):
             "hardware": {
                 "trackers": [
                     {
-                        "name": self.shared_utils.wan_ha_flow_tracker_name,
+                        "name": self.shared_utils.wan_flow_tracker_name,
                         "record_export": {"on_inactive_timeout": 70000, "on_interval": 5000},
                         "exporters": [{"name": "DPI-EXPORTER", "collector": {"host": "127.0.0.1"}, "local_interface": "Loopback0", "template_interval": 5000}],
                     }

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
@@ -112,7 +112,7 @@ class EthernetInterfacesMixin(UtilsMixin):
 
                 # Configuring flow tracking on LAN interfaces
                 if self.shared_utils.wan_mode == "cv-pathfinder" and self.shared_utils.wan_role == "client":
-                    ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_ha_flow_tracker_name}
+                    ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                 # Structured Config
                 ethernet_interface["struct_cfg"] = link.get("structured_config")
@@ -185,7 +185,7 @@ class EthernetInterfacesMixin(UtilsMixin):
 
                     # Configuring flow tracking on LAN interfaces
                     if self.shared_utils.wan_mode == "cv-pathfinder" and self.shared_utils.wan_role == "client":
-                        ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_ha_flow_tracker_name}
+                        ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                     ethernet_subinterface = {key: value for key, value in ethernet_subinterface.items() if value is not None}
                     append_if_not_duplicate(
@@ -227,7 +227,7 @@ class EthernetInterfacesMixin(UtilsMixin):
 
                 # Configuring flow tracking on LAN interfaces
                 if self.shared_utils.wan_mode == "cv-pathfinder" and self.shared_utils.wan_role == "client":
-                    ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_ha_flow_tracker_name}
+                    ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                 append_if_not_duplicate(
                     list_of_dicts=ethernet_interfaces,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -181,6 +181,6 @@ class UtilsMixin:
             interface["dhcp_client_accept_default_route"] = True
 
         if self.shared_utils.cv_pathfinder_role:
-            interface["flow_tracker"] = {"hardware": self.shared_utils.wan_ha_flow_tracker_name}
+            interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
         return strip_empties_from_dict(interface)


### PR DESCRIPTION
## Change Summary

Default Profile and Load Balance policy names are begin generated all over the place in the various python file, this PR aims at generating these defaults in one place to make sure that, would a change in default naming be required, it can be updated in only one place and still work. (Ease of maintainability)

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
* one shared_utils function to generate default Load Balancing policy names
* one network_services/utils.py function to generate profile names

## How to test

Molecule outputs MUST not change for WAN_TESTS

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
