### PR TITLE
Feat(eos_designs):  Replace wan_role checks with helper cached_property utils

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_facts/wan.py
@@ -26,7 +26,7 @@ class WanMixin:
         Return the list of WAN path_groups directly connected to this router, with a list of dictionaries
         containing the (interface, ip_address) in the path_group.
         """
-        if self.shared_utils.wan_role != "server":
+        if not self.shared_utils.is_wan_server:
             return None
 
         return self.shared_utils.wan_local_path_groups

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
@@ -50,7 +50,7 @@ class FilteredTenantsMixin:
                     )
 
         no_vrf_default = all(vrf["name"] != "default" for tenant in filtered_tenants for vrf in tenant["vrfs"])
-        if self.wan_role is not None and no_vrf_default:
+        if self.is_wan_router and no_vrf_default:
             filtered_tenants.append(
                 {
                     "name": "WAN_DEFAULT",
@@ -70,7 +70,7 @@ class FilteredTenantsMixin:
                     "l2vlans": [],
                 }
             )
-        elif self.wan_role:
+        elif self.is_wan_router:
             # It is enough to check only the first occurence of default VRF as some other piece of code
             # checks that if the VRF is in multiple tenants, the configuration is consistent.
             for tenant in filtered_tenants:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/overlay.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/overlay.py
@@ -27,7 +27,7 @@ class OverlayMixin:
         """
         The default is Loopback1 except for WAN devices where the default is Dps1.
         """
-        default_vtep_loopback = "Dps1" if self.wan_role is not None else "Loopback1"
+        default_vtep_loopback = "Dps1" if self.is_wan_router else "Loopback1"
         return get(self.switch_data_combined, "vtep_loopback", default=default_vtep_loopback)
 
     @cached_property

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/overlay.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/overlay.py
@@ -145,7 +145,7 @@ class OverlayMixin:
         TODO: Implement HA logic for WAN
         TODO: Reconsider if suffix should just be :1 for all WAN routers.
         """
-        if self.wan_role:
+        if self.is_wan_router:
             if self.is_cv_pathfinder_edge_or_transit:
                 return f"{self.router_id}:{self.wan_site['id']}"
             return f"{self.router_id}:0"

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -43,24 +43,15 @@ class WanMixin:
 
     @cached_property
     def is_wan_router(self) -> bool:
-        if self.wan_role:
-            return True
-        else:
-            return False
+        return bool(self.wan_role)
 
     @cached_property
     def is_wan_server(self) -> bool:
-        if self.wan_role == "server":
-            return True
-        else:
-            return False
+        return self.wan_role == "server"
 
     @cached_property
     def is_wan_client(self) -> bool:
-        if self.wan_role == "client":
-            return True
-        else:
-            return False
+        return self.wan_role == "client"
 
     @cached_property
     def wan_listen_ranges(self: SharedUtils) -> list:
@@ -199,10 +190,6 @@ class WanMixin:
         """
         if not self.is_wan_server:
             return interface["ip_address"]
-
-
-        if (not self.is_wan_server) != (self.wan_role != "server"):
-            raise Exception("AYUSH wan_role: ", self.wan_role,"is_wan_server" ,self.is_wan_server)
 
         for path_group in self.this_wan_route_server.get("path_groups", []):
             if (found_interface := get_item(path_group["interfaces"], "name", interface["name"])) is None:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -28,7 +28,7 @@ class WanMixin:
 
     @cached_property
     def wan_role(self: SharedUtils) -> str | None:
-        if self.underlay_router is False or self.wan_mode is None:
+        if self.underlay_router is False:
             return None
 
         default_wan_role = get(self.node_type_key_data, "default_wan_role", default=None)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -59,7 +59,7 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
         )
         platform_bgp_update_wait_install = get(self.shared_utils.platform_settings, "feature_support.bgp_update_wait_install", default=True) is True
 
-        if self.shared_utils.wan_role is not None:
+        if self.shared_utils.is_wan_router:
             # Special defaults for WAN routers
             default_maximum_paths = 16
             default_ecmp = None
@@ -532,7 +532,7 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
 
         if (cpu_max_allocation := get(self.shared_utils.switch_data_combined, "data_plane_cpu_allocation_max")) is not None:
             platform["sfe"] = {"data_plane_cpu_allocation_max": cpu_max_allocation}
-        elif self.shared_utils.wan_role == "server":
+        elif self.shared_utils.is_wan_server:
             # For AutoVPN Route Reflectors and Pathfinders, running on CloudEOS, setting
             # this value is required for the solution to work.
             raise AristaAvdMissingVariableError("For AutoVPN RRs and Pathfinders, 'data_plane_cpu_allocation_max' must be set")

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/avdinterfacedescriptions.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/avdinterfacedescriptions.py
@@ -228,7 +228,7 @@ class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
         if self._mpls_lsr is True:
             return "LSR_Router_ID"
 
-        if self.shared_utils.wan_role is not None:
+        if self.shared_utils.is_wan_router:
             return "Router_ID"
 
         # Covers L2LS

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
@@ -20,9 +20,9 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
     @cached_property
     def application_traffic_recognition(self) -> dict | None:
         """
-        Return structured config for application_traffic_recognition if `wan_role` is not None
+        Return structured config for application_traffic_recognition if wan router
         """
-        if not self.shared_utils.wan_role:
+        if not self.shared_utils.is_wan_router:
             return None
 
         filtered_application_classification = self._filtered_application_classification()
@@ -102,7 +102,7 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
         ipv4_applications = get(app_dict, "applications.ipv4_applications", [])
         if get_item(ipv4_applications, "name", self._wan_control_plane_application) is not None:
             return
-        if self.shared_utils.wan_role == "client":
+        if self.shared_utils.is_wan_client:
             app_dict.setdefault("applications", {}).setdefault("ipv4_applications", []).append(
                 {
                     "name": self._wan_control_plane_application,
@@ -120,7 +120,7 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
                     "prefix_values": pathfinder_vtep_ips,
                 }
             )
-        elif self.shared_utils.wan_role == "server":
+        elif self.shared_utils.is_wan_server:
             app_dict.setdefault("applications", {}).setdefault("ipv4_applications", []).append(
                 {
                     "name": self._wan_control_plane_application,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/dps_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/dps_interfaces.py
@@ -21,7 +21,7 @@ class DpsInterfacesMixin(UtilsMixin):
 
         Only used for WAN devices
         """
-        if not self.shared_utils.wan_role:
+        if not self.shared_utils.is_wan_router:
             return None
 
         dps1 = {

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/route_maps.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/route_maps.py
@@ -92,7 +92,7 @@ class RouteMapsMixin(UtilsMixin):
         if not self._vrf_default_evpn:
             return None
 
-        if not any([self._vrf_default_ipv4_subnets, self._vrf_default_ipv4_static_routes["static_routes"], self.shared_utils.wan_role]):
+        if not any([self._vrf_default_ipv4_subnets, self._vrf_default_ipv4_static_routes["static_routes"], self.shared_utils.is_wan_router]):
             return None
 
         route_maps = strip_empties_from_list(
@@ -154,7 +154,7 @@ class RouteMapsMixin(UtilsMixin):
         * for WAN routers, all the routes matching the SOO (which includes the two above)
         """
         sequence_numbers = []
-        if self.shared_utils.wan_role:
+        if self.shared_utils.is_wan_router:
             sequence_numbers.append(
                 {
                     "sequence": 10,
@@ -196,7 +196,7 @@ class RouteMapsMixin(UtilsMixin):
         """
         sequence_numbers = []
 
-        if self.shared_utils.wan_role:
+        if self.shared_utils.is_wan_router:
             return None
 
         if self._vrf_default_ipv4_subnets:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
@@ -23,7 +23,7 @@ class RouterPathSelectionMixin(UtilsMixin):
         Return structured config for router path-selection (DPS)
         """
 
-        if not self.shared_utils.wan_role:
+        if not self.shared_utils.is_wan_router:
             return None
 
         router_path_selection = {

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -242,7 +242,7 @@ class UtilsMixin:
                 at_least_one_priority_1_found = True
             for path_group_name in policy_entry.get("names"):
                 # Skip path-group on this device if not present on the router except for pathfinders
-                if path_group_name not in wan_local_path_group_names and self.shared_utils.wan_role != "server":
+                if path_group_name not in wan_local_path_group_names and not self.shared_utils.is_wan_server:
                     continue
 
                 path_group = {
@@ -294,7 +294,7 @@ class UtilsMixin:
         """
         Return a list of WAN router path-selection load-balance policies based on the local path-groups.
         """
-        if not self.shared_utils.wan_role:
+        if not self.shared_utils.is_wan_router:
             return []
 
         # Control plane Load Balancing policy - if not configured, render the default one.
@@ -356,7 +356,7 @@ class UtilsMixin:
 
         for avt_vrf in get(self._hostvars, "wan_virtual_topologies.vrfs", []):
             vrf_name = avt_vrf["name"]
-            if vrf_name in self.shared_utils.vrfs or self.shared_utils.wan_role == "server":
+            if vrf_name in self.shared_utils.vrfs or self.shared_utils.is_wan_server:
                 # TODO check that the policy exists or raise
                 wan_vrf = {
                     "name": vrf_name,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
@@ -33,7 +33,7 @@ class VxlanInterfaceMixin(UtilsMixin):
         This function also detects duplicate VNIs and raise an error in case of duplicates between
         all Network Services deployed on this device.
         """
-        if not (self.shared_utils.overlay_vtep or self.shared_utils.wan_role):
+        if not (self.shared_utils.overlay_vtep or self.shared_utils.is_wan_router):
             return None
 
         vxlan = {
@@ -146,7 +146,7 @@ class VxlanInterfaceMixin(UtilsMixin):
                 vrf_data = {"name": vrf_name, "vni": vni}
 
                 # TODO need to handle this better from a design point of view
-                if self.shared_utils.wan_role and vni > 255:
+                if self.shared_utils.is_wan_router and vni > 255:
                     raise AristaAvdError("VNI for WAN with DPS use cases cannot be > 255, got '{vni}' for vrf '{vrf_name}' in tenant '{tenant['name']}'.")
 
                 if get(vrf, "_evpn_l3_multicast_enabled"):

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/avdstructuredconfig.py
@@ -59,7 +59,7 @@ class AvdStructuredConfigOverlay(
                 self.shared_utils.overlay_evpn,
                 self.shared_utils.overlay_vpn_ipv4,
                 self.shared_utils.overlay_vpn_ipv6,
-                self.shared_utils.wan_role,
+                self.shared_utils.is_wan_router,
             ]
         ):
             return super().render()

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/ip_extcommunity_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/ip_extcommunity_lists.py
@@ -22,7 +22,7 @@ class IpExtCommunityListsMixin(UtilsMixin):
         if self.shared_utils.overlay_routing_protocol != "ibgp":
             return None
 
-        if self.shared_utils.evpn_role == "server" and not self.shared_utils.wan_role:
+        if self.shared_utils.evpn_role == "server" and not self.shared_utils.is_wan_router:
             return None
 
         if self.shared_utils.overlay_vtep:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/ip_security.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/ip_security.py
@@ -27,7 +27,7 @@ class IpSecurityMixin(UtilsMixin):
         """
         # TODO - in future, the default algo/dh groups value must be clarified
 
-        if not self.shared_utils.wan_role:
+        if not self.shared_utils.is_wan_router:
             return None
 
         wan_ipsec_profiles = get(self._hostvars, "wan_ipsec_profiles", required=True)
@@ -35,7 +35,7 @@ class IpSecurityMixin(UtilsMixin):
         # Structure initialization
         ip_security = {"ike_policies": [], "sa_policies": [], "profiles": []}
 
-        if self.shared_utils.wan_role == "client" and (data_plane := get(wan_ipsec_profiles, "data_plane")) is not None:
+        if self.shared_utils.is_wan_client and (data_plane := get(wan_ipsec_profiles, "data_plane")) is not None:
             self._append_data_plane(ip_security, data_plane)
         control_plane = get(wan_ipsec_profiles, "control_plane", required=True)
         self._append_control_plane(ip_security, control_plane)
@@ -116,7 +116,7 @@ class IpSecurityMixin(UtilsMixin):
         """
         Return a key_controller structure if the device is not a RR or pathfinder
         """
-        if self.shared_utils.wan_role != "client":
+        if self.shared_utils.is_wan_server:
             return None
 
         return {"profile": profile_name}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_path_selection.py
@@ -23,7 +23,7 @@ class RouterPathSelectionMixin(UtilsMixin):
         Return structured config for router path-selection (DPS)
         """
 
-        if not self.shared_utils.wan_role:
+        if not self.shared_utils.is_wan_router:
             return None
 
         router_path_selection = {
@@ -31,7 +31,7 @@ class RouterPathSelectionMixin(UtilsMixin):
             "path_groups": self._get_path_groups(),
         }
 
-        if self.shared_utils.wan_role == "server":
+        if self.shared_utils.is_wan_server:
             router_path_selection["peer_dynamic_source"] = "stun"
 
         return strip_empties_from_dict(router_path_selection)
@@ -57,7 +57,7 @@ class RouterPathSelectionMixin(UtilsMixin):
         """
         path_groups = []
 
-        if self.shared_utils.wan_role == "server":
+        if self.shared_utils.is_wan_server:
             # Configure all path-groups on Pathfinders and AutoVPN RRs
             path_groups_to_configure = self.shared_utils.wan_path_groups
         else:
@@ -110,7 +110,7 @@ class RouterPathSelectionMixin(UtilsMixin):
         for interface in path_group.get("interfaces", []):
             local_interface = {"name": get(interface, "name", required=True)}
 
-            if self.shared_utils.wan_role == "client" and self.shared_utils.should_connect_to_wan_rs([path_group_name]):
+            if self.shared_utils.is_wan_client and self.shared_utils.should_connect_to_wan_rs([path_group_name]):
                 stun_server_profiles = self._stun_server_profiles.get(path_group_name, [])
                 if stun_server_profiles:
                     local_interface["stun"] = {"server_profiles": [profile["name"] for profile in stun_server_profiles]}
@@ -123,7 +123,7 @@ class RouterPathSelectionMixin(UtilsMixin):
         """
         TODO support ip_local and ipsec ?
         """
-        if self.shared_utils.wan_role != "client":
+        if not self.shared_utils.is_wan_client:
             return None
         return {"enabled": True}
 
@@ -131,7 +131,7 @@ class RouterPathSelectionMixin(UtilsMixin):
         """
         Retrieves the static peers to configure for a given path-group based on the connected nodes.
         """
-        if not self.shared_utils.wan_role:
+        if not self.shared_utils.is_wan_router:
             return None
 
         static_peers = []

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/stun.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/stun.py
@@ -21,15 +21,15 @@ class StunMixin(UtilsMixin):
         Return structured config for stun
         """
 
-        if not self.shared_utils.wan_role:
+        if not self.shared_utils.is_wan_router:
             return None
 
         stun = {}
-        if self.shared_utils.wan_role == "server":
+        if self.shared_utils.is_wan_server:
             local_interfaces = [wan_interface["name"] for wan_interface in self.shared_utils.wan_interfaces]
             stun["server"] = {"local_interfaces": local_interfaces}
 
-        if self.shared_utils.wan_role == "client":
+        if self.shared_utils.is_wan_client:
             if server_profiles := list(itertools.chain.from_iterable(self._stun_server_profiles.values())):
                 stun["client"] = {"server_profiles": server_profiles}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
@@ -260,7 +260,7 @@ class UtilsMixin:
 
     @cached_property
     def _is_wan_server_with_peers(self) -> bool:
-        return self.shared_utils.wan_role == "server" and len(self.shared_utils.filtered_wan_route_servers) > 0
+        return self.shared_utils.is_wan_server and len(self.shared_utils.filtered_wan_route_servers) > 0
 
     def _stun_server_profile_name(self, wan_route_server_name: str, path_group_name: str, interface_name: str) -> str:
         """

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/prefix_lists.py
@@ -19,7 +19,7 @@ class PrefixListsMixin(UtilsMixin):
         """
         Return structured config for prefix_lists
         """
-        if self.shared_utils.underlay_bgp is not True and not self.shared_utils.wan_role:
+        if self.shared_utils.underlay_bgp is not True and not self.shared_utils.is_wan_router:
             return None
 
         if self.shared_utils.overlay_routing_protocol == "none":
@@ -31,10 +31,10 @@ class PrefixListsMixin(UtilsMixin):
         # IPv4 - PL-LOOPBACKS-EVPN-OVERLAY
         sequence_numbers = [{"sequence": 10, "action": f"permit {self.shared_utils.loopback_ipv4_pool} eq 32"}]
 
-        if self.shared_utils.overlay_vtep and self.shared_utils.vtep_loopback.lower() != "loopback0" and not self.shared_utils.wan_role:
+        if self.shared_utils.overlay_vtep and self.shared_utils.vtep_loopback.lower() != "loopback0" and not self.shared_utils.is_wan_router:
             sequence_numbers.append({"sequence": 20, "action": f"permit {self.shared_utils.vtep_loopback_ipv4_pool} eq 32"})
 
-        if self.shared_utils.vtep_vvtep_ip is not None and self.shared_utils.network_services_l3 is True and not self.shared_utils.wan_role:
+        if self.shared_utils.vtep_vvtep_ip is not None and self.shared_utils.network_services_l3 is True and not self.shared_utils.is_wan_router:
             sequence_numbers.append({"sequence": 30, "action": f"permit {self.shared_utils.vtep_vvtep_ip}"})
 
         prefix_lists = [{"name": "PL-LOOPBACKS-EVPN-OVERLAY", "sequence_numbers": sequence_numbers}]
@@ -59,7 +59,7 @@ class PrefixListsMixin(UtilsMixin):
         if self.shared_utils.underlay_ipv6 is not True:
             return None
 
-        if self.shared_utils.overlay_routing_protocol == "none" and not self.shared_utils.wan_role:
+        if self.shared_utils.overlay_routing_protocol == "none" and not self.shared_utils.is_wan_router:
             return None
 
         if not self.shared_utils.underlay_filter_redistribute_connected:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/route_maps.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/route_maps.py
@@ -23,7 +23,7 @@ class RouteMapsMixin(UtilsMixin):
         - Route map for connected routes redistribution in BGP
         - Route map to filter peer AS in underlay
         """
-        if not self.shared_utils.underlay_bgp and not self.shared_utils.wan_role:
+        if not self.shared_utils.underlay_bgp and not self.shared_utils.is_wan_router:
             return None
 
         route_maps = []

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
@@ -23,7 +23,7 @@ class RouterBgpMixin(UtilsMixin):
         """
 
         if not self.shared_utils.underlay_bgp:
-            if self.shared_utils.wan_role:
+            if self.shared_utils.is_wan_router:
                 # Configure redistribute connected with or without route-map in case it the underlay is not BGP.
                 # TODO: Currently only implemented for WAN routers but should probably be
                 # implemented for anything with EVPN services in default VRF.


### PR DESCRIPTION
## Change Summary
Introduced 3 properties: is_wan_router, is_wan_server, is_wan_client

Replaced:
  wan_role is not None -> is_wan_router
  wan_role is None -> not is_wan_router
  
  wan_role == server -> is_wan_server
  wan_role != server -> not is_wan_server
  and so on.

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Replace wan_role based checks with more defined functions

## How to test
no changes in output after running molecule 

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
