### PR TITLE
Refactor(eos_designs): Remove switch-focused config from WAN Routers

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
@@ -1,9 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
-transceiver qsfp default-mode 4x10G
-!
 service routing protocols model multi-agent
 !
 hostname autovpn-edge-no-default-policy

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -1,9 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
-transceiver qsfp default-mode 4x10G
-!
 service routing protocols model multi-agent
 !
 hostname autovpn-edge

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -1,9 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
-transceiver qsfp default-mode 4x10G
-!
 service routing protocols model multi-agent
 !
 hostname autovpn-rr1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -1,9 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
-transceiver qsfp default-mode 4x10G
-!
 service routing protocols model multi-agent
 !
 hostname autovpn-rr2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -1,7 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000
@@ -11,8 +9,6 @@ flow tracking hardware
          local interface Loopback0
          template interval 5000
    no shutdown
-!
-transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -1,7 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000
@@ -11,8 +9,6 @@ flow tracking hardware
          local interface Loopback0
          template interval 5000
    no shutdown
-!
-transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -1,7 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000
@@ -11,8 +9,6 @@ flow tracking hardware
          local interface Loopback0
          template interval 5000
    no shutdown
-!
-transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -1,7 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000
@@ -11,8 +9,6 @@ flow tracking hardware
          local interface Loopback0
          template interval 5000
    no shutdown
-!
-transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -1,7 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000
@@ -11,8 +9,6 @@ flow tracking hardware
          local interface Loopback0
          template interval 5000
    no shutdown
-!
-transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -1,7 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000
@@ -11,8 +9,6 @@ flow tracking hardware
          local interface Loopback0
          template interval 5000
    no shutdown
-!
-transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit.cfg
@@ -1,7 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-vlan internal order ascending range 1006 1199
-!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000
@@ -11,8 +9,6 @@ flow tracking hardware
          local interface Loopback0
          template interval 5000
    no shutdown
-!
-transceiver qsfp default-mode 4x10G
 !
 service routing protocols model multi-agent
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
@@ -90,11 +90,7 @@ router_bgp:
     - source_protocol: connected
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -94,11 +94,7 @@ router_bgp:
     - source_protocol: connected
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -82,11 +82,7 @@ router_bgp:
         - route-map RM-EVPN-EXPORT-VRF-DEFAULT
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -82,11 +82,7 @@ router_bgp:
         - route-map RM-EVPN-EXPORT-VRF-DEFAULT
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -120,11 +120,7 @@ router_bgp:
           any: true
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -101,11 +101,7 @@ router_bgp:
     - source_protocol: connected
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -126,11 +126,7 @@ router_bgp:
           any: true
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -88,11 +88,7 @@ router_bgp:
         - route-map RM-EVPN-EXPORT-VRF-DEFAULT
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -115,11 +115,7 @@ router_bgp:
         - route-map RM-EVPN-EXPORT-VRF-DEFAULT
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -115,11 +115,7 @@ router_bgp:
         - route-map RM-EVPN-EXPORT-VRF-DEFAULT
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit.yml
@@ -123,11 +123,7 @@ router_bgp:
     - source_protocol: connected
 service_routing_protocols_model: multi-agent
 ip_routing: true
-vlan_internal_order:
-  allocation: ascending
-  range:
-    beginning: 1006
-    ending: 1199
+transceiver_qsfp_default_mode_4x10: false
 spanning_tree:
   mode: none
 vrfs:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/base/avdstructuredconfig.py
@@ -304,10 +304,13 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
         return daemon_terminattr
 
     @cached_property
-    def vlan_internal_order(self) -> dict:
+    def vlan_internal_order(self) -> dict | None:
         """
         vlan_internal_order set based on internal_vlan_order data-model
         """
+        if self.shared_utils.wan_role:
+            return None
+
         DEFAULT_INTERNAL_VLAN_ORDER = {
             "allocation": "ascending",
             "range": {
@@ -316,6 +319,16 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
             },
         }
         return get(self._hostvars, "internal_vlan_order", default=DEFAULT_INTERNAL_VLAN_ORDER)
+
+    @cached_property
+    def transceiver_qsfp_default_mode_4x10(self) -> bool | None:
+        """
+        transceiver_qsfp_default_mode_4x10 is on by default in eos_cli_config_gen.
+
+        Set to false for WAN routers.
+        TODO: Add platform_setting to control this.
+        """
+        return False if self.shared_utils.wan_role else None
 
     @cached_property
     def event_monitor(self) -> dict | None:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove switch-focused config from WAN Routers

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Removing:

```eos
vlan internal order ascending range 1006 1199
!
transceiver qsfp default-mode 4x10G
!
```

from WAN routers.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
