### PR TITLE
Feat(eos_designs): Add default_preference and excluded for wan_path_groups

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/invalid-wan-role-overlay-routing-protocol.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/invalid-wan-role-overlay-routing-protocol.yml
@@ -13,6 +13,18 @@ wan_router:
   nodes:
     - name: invalid-wan-role-overlay-routing-protocol
       id: 1
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: TEST
+          ip_address: dhcp
+
+wan_carriers:
+  - name: TEST
+    path_group: TEST
+
+wan_path_groups:
+  - name: TEST
+    id: 42
 
 expected_error_message: >-
   Only 'ibgp' is supported as 'overlay_routing_protocol' for WAN nodes.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-data-plane_cpu-allocation-max.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-data-plane_cpu-allocation-max.yml
@@ -7,5 +7,17 @@ wan_rr:
   nodes:
     - name: missing-data-plane_cpu-allocation-max
       id: 1
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: TEST
+          ip_address: 42.42.42.42/24
+
+wan_carriers:
+  - name: TEST
+    path_group: TEST
+
+wan_path_groups:
+  - name: TEST
+    id: 42
 
 expected_error_message: "For AutoVPN RRs and Pathfinders, 'data_plane_cpu_allocation_max' must be set"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -24,7 +24,7 @@ router path-selection
          ipv4 address 10.8.8.8
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
-      path-group INET
+      path-group INET priority 42
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
       path-group INET priority 2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -23,6 +23,8 @@ router path-selection
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
       path-group INET
+      path-group LTE
+      path-group MPLS
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
       path-group MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -22,9 +22,8 @@ router path-selection
    path-group MPLS id 100
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
-      path-group INET
-      path-group LTE
       path-group MPLS
+      path-group INET priority 42
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
       path-group MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -23,6 +23,8 @@ router path-selection
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
       path-group INET
+      path-group LTE
+      path-group MPLS
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
       path-group MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -22,9 +22,8 @@ router path-selection
    path-group MPLS id 100
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
-      path-group INET
-      path-group LTE
       path-group MPLS
+      path-group INET priority 42
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
       path-group MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -102,6 +102,13 @@ router adaptive-virtual-topology
 router path-selection
    tcp mss ceiling ipv4 ingress
    !
+   path-group AWS id 105
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet2
+      !
+      peer dynamic
+   !
    path-group Satellite id 104
       ipsec profile CP-PROFILE
       !
@@ -110,14 +117,15 @@ router path-selection
       peer dynamic
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
-      path-group Satellite
+      path-group Satellite priority 2
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
-      path-group Satellite
+      path-group AWS
+      path-group Satellite priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT
    !
@@ -180,6 +188,14 @@ interface Dps1
 !
 interface Ethernet1
    description Inmrasat_S511
+   no shutdown
+   no switchport
+   flow tracker hardware WAN-FLOW-TRACKER
+   ip address dhcp
+   dhcp client accept default-route
+!
+interface Ethernet2
+   description AWS-1_212
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -139,7 +139,7 @@ router path-selection
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group INET
-      path-group MPLS priority 42
+      path-group MPLS priority 4223
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
       path-group INET
@@ -147,7 +147,6 @@ router path-selection
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
       path-group INET
-      path-group LTE
       path-group MPLS
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -132,7 +132,7 @@ router path-selection
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group LAN_HA
-      path-group MPLS priority 42
+      path-group MPLS priority 4223
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
       path-group LAN_HA

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -117,6 +117,8 @@ router path-selection
    peer dynamic source stun
    tcp mss ceiling ipv4 ingress
    !
+   path-group AWS id 105
+   !
    path-group Equinix id 103
    !
    path-group INET id 101
@@ -143,25 +145,32 @@ router path-selection
       path-group INET priority 2
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-group AWS
       path-group INET
       path-group LAN_HA
       path-group MPLS
+      path-group Equinix priority 2
+      path-group Satellite priority 2
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group Equinix
       path-group INET
       path-group LAN_HA
-      path-group MPLS priority 42
+      path-group Equinix priority 2
+      path-group MPLS priority 4223
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group Equinix
       path-group INET
       path-group LAN_HA
       path-group MPLS
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group AWS
       path-group INET
       path-group LAN_HA
       path-group MPLS
+      path-group Equinix priority 2
+      path-group Satellite priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT
       path-group INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -117,6 +117,8 @@ router path-selection
    peer dynamic source stun
    tcp mss ceiling ipv4 ingress
    !
+   path-group AWS id 105
+   !
    path-group Equinix id 103
    !
    path-group INET id 101
@@ -147,23 +149,32 @@ router path-selection
       path-group INET priority 2
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-group AWS
       path-group INET
       path-group LAN_HA
+      path-group MPLS
+      path-group Equinix priority 2
+      path-group Satellite priority 2
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group Equinix
       path-group INET
       path-group LAN_HA
-      path-group MPLS priority 42
+      path-group Equinix priority 2
+      path-group MPLS priority 4223
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group Equinix
       path-group INET
       path-group LAN_HA
       path-group MPLS
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group AWS
       path-group INET
       path-group LAN_HA
+      path-group MPLS
+      path-group Equinix priority 2
+      path-group Satellite priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT
       path-group INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -117,6 +117,8 @@ router path-selection
    peer dynamic source stun
    tcp mss ceiling ipv4 ingress
    !
+   path-group AWS id 105
+   !
    path-group Equinix id 103
    !
    path-group INET id 101
@@ -153,25 +155,32 @@ router path-selection
       path-group INET priority 2
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-group AWS
       path-group INET
       path-group LAN_HA
       path-group MPLS
+      path-group Equinix priority 2
+      path-group Satellite priority 2
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group Equinix
       path-group INET
       path-group LAN_HA
-      path-group MPLS priority 42
+      path-group Equinix priority 2
+      path-group MPLS priority 4223
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
+      path-group Equinix
       path-group INET
       path-group LAN_HA
       path-group MPLS
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group AWS
       path-group INET
       path-group LAN_HA
       path-group MPLS
+      path-group Equinix priority 2
+      path-group Satellite priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT
       path-group INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -167,7 +167,7 @@ router path-selection
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group INET
       path-group LAN_HA
-      path-group MPLS priority 42
+      path-group MPLS priority 4223
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
       path-group INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -167,7 +167,7 @@ router path-selection
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group INET
       path-group LAN_HA
-      path-group MPLS priority 42
+      path-group MPLS priority 4223
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
       path-group INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -7,9 +7,17 @@ hostname uplink_lan_wan_router1
 router path-selection
    tcp mss ceiling ipv4 ingress
    !
+   path-group INET id 100
+      !
+      local interface Ethernet1
+      !
+      peer dynamic
+   !
    load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
+      path-group INET
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
    !
    policy DEFAULT-POLICY
       default-match
@@ -58,6 +66,12 @@ interface Dps1
    description DPS Interface
    mtu 9214
    ip address 192.168.2.1/32
+!
+interface Ethernet1
+   description Comcast_999
+   no shutdown
+   no switchport
+   ip address 10.9.9.9/31
 !
 interface Ethernet2
    description UPLINK_LAN_L2LEAF_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -7,9 +7,17 @@ hostname uplink_lan_wan_router2
 router path-selection
    tcp mss ceiling ipv4 ingress
    !
+   path-group INET id 100
+      !
+      local interface Ethernet1
+      !
+      peer dynamic
+   !
    load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
+      path-group INET
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
    !
    policy DEFAULT-POLICY
       default-match
@@ -58,6 +66,12 @@ interface Dps1
    description DPS Interface
    mtu 9214
    ip address 192.168.2.2/32
+!
+interface Ethernet1
+   description Comcast_999
+   no shutdown
+   no switchport
+   ip address 10.9.9.1/31
 !
 interface Ethernet2
    description UPLINK_LAN_L2LEAF_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -204,6 +204,7 @@ router_path_selection:
   - name: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     path_groups:
     - name: INET
+      priority: 42
   - name: LB-DEFAULT-AUTOVPN-POLICY-IT
     path_groups:
     - name: INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -185,7 +185,9 @@ router_path_selection:
   load_balance_policies:
   - name: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     path_groups:
+    - name: MPLS
     - name: INET
+    - name: LTE
   - name: LB-DEFAULT-AUTOVPN-POLICY-IT
     path_groups:
     - name: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -187,7 +187,7 @@ router_path_selection:
     path_groups:
     - name: MPLS
     - name: INET
-    - name: LTE
+      priority: 42
   - name: LB-DEFAULT-AUTOVPN-POLICY-IT
     path_groups:
     - name: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -189,7 +189,7 @@ router_path_selection:
     path_groups:
     - name: MPLS
     - name: INET
-    - name: LTE
+      priority: 42
   - name: LB-DEFAULT-AUTOVPN-POLICY-IT
     path_groups:
     - name: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -187,7 +187,9 @@ router_path_selection:
   load_balance_policies:
   - name: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     path_groups:
+    - name: MPLS
     - name: INET
+    - name: LTE
   - name: LB-DEFAULT-AUTOVPN-POLICY-IT
     path_groups:
     - name: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -323,8 +323,8 @@ router_path_selection:
   load_balance_policies:
   - name: LB-DEFAULT-POLICY-CONTROL-PLANE
     path_groups:
-    - name: INET
     - name: MPLS
+    - name: INET
   - name: LB-DEFAULT-POLICY-VIDEO
     path_groups:
     - name: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -212,6 +212,15 @@ ethernet_interfaces:
   dhcp_client_accept_default_route: true
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
+- name: Ethernet2
+  peer_type: l3_interface
+  ip_address: dhcp
+  shutdown: false
+  type: routed
+  description: AWS-1_212
+  dhcp_client_accept_default_route: true
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -430,10 +439,18 @@ router_path_selection:
     dynamic_peers:
       enabled: true
     ipsec_profile: CP-PROFILE
+  - name: AWS
+    id: 105
+    local_interfaces:
+    - name: Ethernet2
+    dynamic_peers:
+      enabled: true
+    ipsec_profile: CP-PROFILE
   load_balance_policies:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: Satellite
+      priority: 2
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: LB-DEFAULT-AVT-POLICY-DEFAULT
   - name: LB-PROD-AVT-POLICY-VOICE
@@ -445,6 +462,8 @@ router_path_selection:
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: Satellite
+      priority: 2
+    - name: AWS
 router_traffic_engineering:
   enabled: true
 application_traffic_recognition:
@@ -555,6 +574,14 @@ metadata:
         value: Inmrasat
       - name: Circuit
         value: S511
+    - interface: Ethernet2
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: AWS-1
+      - name: Circuit
+        value: '212'
   cv_pathfinder:
     role: edge
     vtep_ip: 192.168.142.2
@@ -566,3 +593,7 @@ metadata:
       carrier: Inmrasat
       circuit_id: S511
       pathgroup: Satellite
+    - name: Ethernet2
+      carrier: AWS-1
+      circuit_id: '212'
+      pathgroup: AWS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -335,13 +335,13 @@ router_path_selection:
   load_balance_policies:
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
-    - name: INET
     - name: MPLS
+    - name: INET
     - name: LTE
   - name: LB-DEFAULT-POLICY-CONTROL-PLANE
     path_groups:
-    - name: INET
     - name: MPLS
+    - name: INET
 router_traffic_engineering:
   enabled: true
 stun:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -510,8 +510,8 @@ router_path_selection:
   load_balance_policies:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
-    - name: INET
     - name: MPLS
+    - name: INET
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
     path_groups:
     - name: MPLS
@@ -520,7 +520,7 @@ router_path_selection:
     path_groups:
     - name: INET
     - name: MPLS
-      priority: 42
+      priority: 4223
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: MPLS
@@ -542,9 +542,8 @@ router_path_selection:
       priority: 2
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
-    - name: INET
     - name: MPLS
-    - name: LTE
+    - name: INET
 router_traffic_engineering:
   enabled: true
 stun:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -577,7 +577,7 @@ router_path_selection:
     path_groups:
     - name: LAN_HA
     - name: MPLS
-      priority: 42
+      priority: 4223
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -314,6 +314,8 @@ router_path_selection:
     id: 103
   - name: Satellite
     id: 104
+  - name: AWS
+    id: 105
   - name: LAN_HA
     id: 65535
     flow_assignment: lan
@@ -322,20 +324,27 @@ router_path_selection:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
-    - name: INET
     - name: MPLS
+    - name: INET
+    - name: Equinix
+      priority: 2
+    - name: Satellite
+      priority: 2
+    - name: AWS
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
     path_groups:
     - name: LAN_HA
     - name: MPLS
     - name: INET
+    - name: Equinix
   - name: LB-DEFAULT-AVT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
     - name: INET
     - name: Equinix
+      priority: 2
     - name: MPLS
-      priority: 42
+      priority: 4223
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -373,8 +382,13 @@ router_path_selection:
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
-    - name: INET
     - name: MPLS
+    - name: INET
+    - name: Equinix
+      priority: 2
+    - name: Satellite
+      priority: 2
+    - name: AWS
 router_traffic_engineering:
   enabled: true
 stun:
@@ -522,6 +536,9 @@ metadata:
     - name: Satellite
       carriers:
       - name: Inmrasat
+    - name: AWS
+      carriers:
+      - name: AWS-1
     regions:
     - name: AVD_Land_West
       id: 42
@@ -554,9 +571,15 @@ metadata:
         pathgroups:
         - name: LAN_HA
           preference: preferred
+        - name: MPLS
+          preference: preferred
         - name: INET
           preference: preferred
-        - name: MPLS
+        - name: Equinix
+          preference: alternate
+        - name: Satellite
+          preference: alternate
+        - name: AWS
           preference: preferred
       - id: 3
         name: DEFAULT-AVT-POLICY-VIDEO
@@ -567,6 +590,8 @@ metadata:
           preference: preferred
         - name: INET
           preference: preferred
+        - name: Equinix
+          preference: preferred
       - id: 1
         name: DEFAULT-AVT-POLICY-DEFAULT
         pathgroups:
@@ -575,7 +600,7 @@ metadata:
         - name: INET
           preference: preferred
         - name: Equinix
-          preference: preferred
+          preference: alternate
         - name: MPLS
           preference: alternate
     - name: PROD
@@ -624,6 +649,8 @@ metadata:
           preference: preferred
         - name: INET
           preference: preferred
+        - name: Equinix
+          preference: preferred
       - id: 1
         name: DEFAULT-AVT-POLICY-DEFAULT
         pathgroups:
@@ -632,7 +659,7 @@ metadata:
         - name: INET
           preference: preferred
         - name: Equinix
-          preference: preferred
+          preference: alternate
         - name: MPLS
           preference: alternate
     - name: TRANSIT
@@ -664,7 +691,13 @@ metadata:
         pathgroups:
         - name: LAN_HA
           preference: preferred
+        - name: MPLS
+          preference: preferred
         - name: INET
           preference: preferred
-        - name: MPLS
+        - name: Equinix
+          preference: alternate
+        - name: Satellite
+          preference: alternate
+        - name: AWS
           preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -332,6 +332,8 @@ router_path_selection:
     id: 103
   - name: Satellite
     id: 104
+  - name: AWS
+    id: 105
   - name: LAN_HA
     id: 65535
     flow_assignment: lan
@@ -340,19 +342,27 @@ router_path_selection:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
+    - name: MPLS
     - name: INET
+    - name: Equinix
+      priority: 2
+    - name: Satellite
+      priority: 2
+    - name: AWS
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
     path_groups:
     - name: LAN_HA
     - name: MPLS
     - name: INET
+    - name: Equinix
   - name: LB-DEFAULT-AVT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
     - name: INET
     - name: Equinix
+      priority: 2
     - name: MPLS
-      priority: 42
+      priority: 4223
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -390,7 +400,13 @@ router_path_selection:
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
+    - name: MPLS
     - name: INET
+    - name: Equinix
+      priority: 2
+    - name: Satellite
+      priority: 2
+    - name: AWS
 router_traffic_engineering:
   enabled: true
 stun:
@@ -510,6 +526,9 @@ metadata:
     - name: Satellite
       carriers:
       - name: Inmrasat
+    - name: AWS
+      carriers:
+      - name: AWS-1
     regions:
     - name: AVD_Land_West
       id: 42
@@ -542,7 +561,15 @@ metadata:
         pathgroups:
         - name: LAN_HA
           preference: preferred
+        - name: MPLS
+          preference: preferred
         - name: INET
+          preference: preferred
+        - name: Equinix
+          preference: alternate
+        - name: Satellite
+          preference: alternate
+        - name: AWS
           preference: preferred
       - id: 3
         name: DEFAULT-AVT-POLICY-VIDEO
@@ -553,6 +580,8 @@ metadata:
           preference: preferred
         - name: INET
           preference: preferred
+        - name: Equinix
+          preference: preferred
       - id: 1
         name: DEFAULT-AVT-POLICY-DEFAULT
         pathgroups:
@@ -561,7 +590,7 @@ metadata:
         - name: INET
           preference: preferred
         - name: Equinix
-          preference: preferred
+          preference: alternate
         - name: MPLS
           preference: alternate
     - name: PROD
@@ -610,6 +639,8 @@ metadata:
           preference: preferred
         - name: INET
           preference: preferred
+        - name: Equinix
+          preference: preferred
       - id: 1
         name: DEFAULT-AVT-POLICY-DEFAULT
         pathgroups:
@@ -618,7 +649,7 @@ metadata:
         - name: INET
           preference: preferred
         - name: Equinix
-          preference: preferred
+          preference: alternate
         - name: MPLS
           preference: alternate
     - name: TRANSIT
@@ -650,5 +681,13 @@ metadata:
         pathgroups:
         - name: LAN_HA
           preference: preferred
+        - name: MPLS
+          preference: preferred
         - name: INET
+          preference: preferred
+        - name: Equinix
+          preference: alternate
+        - name: Satellite
+          preference: alternate
+        - name: AWS
           preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -347,6 +347,8 @@ router_path_selection:
     id: 103
   - name: Satellite
     id: 104
+  - name: AWS
+    id: 105
   - name: LAN_HA
     id: 65535
     flow_assignment: lan
@@ -355,20 +357,27 @@ router_path_selection:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
-    - name: INET
     - name: MPLS
+    - name: INET
+    - name: Equinix
+      priority: 2
+    - name: Satellite
+      priority: 2
+    - name: AWS
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
     path_groups:
     - name: LAN_HA
     - name: MPLS
     - name: INET
+    - name: Equinix
   - name: LB-DEFAULT-AVT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
     - name: INET
     - name: Equinix
+      priority: 2
     - name: MPLS
-      priority: 42
+      priority: 4223
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -406,8 +415,13 @@ router_path_selection:
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
-    - name: INET
     - name: MPLS
+    - name: INET
+    - name: Equinix
+      priority: 2
+    - name: Satellite
+      priority: 2
+    - name: AWS
 router_traffic_engineering:
   enabled: true
 stun:
@@ -541,6 +555,9 @@ metadata:
     - name: Satellite
       carriers:
       - name: Inmrasat
+    - name: AWS
+      carriers:
+      - name: AWS-1
     regions:
     - name: AVD_Land_West
       id: 42
@@ -573,9 +590,15 @@ metadata:
         pathgroups:
         - name: LAN_HA
           preference: preferred
+        - name: MPLS
+          preference: preferred
         - name: INET
           preference: preferred
-        - name: MPLS
+        - name: Equinix
+          preference: alternate
+        - name: Satellite
+          preference: alternate
+        - name: AWS
           preference: preferred
       - id: 3
         name: DEFAULT-AVT-POLICY-VIDEO
@@ -586,6 +609,8 @@ metadata:
           preference: preferred
         - name: INET
           preference: preferred
+        - name: Equinix
+          preference: preferred
       - id: 1
         name: DEFAULT-AVT-POLICY-DEFAULT
         pathgroups:
@@ -594,7 +619,7 @@ metadata:
         - name: INET
           preference: preferred
         - name: Equinix
-          preference: preferred
+          preference: alternate
         - name: MPLS
           preference: alternate
     - name: PROD
@@ -643,6 +668,8 @@ metadata:
           preference: preferred
         - name: INET
           preference: preferred
+        - name: Equinix
+          preference: preferred
       - id: 1
         name: DEFAULT-AVT-POLICY-DEFAULT
         pathgroups:
@@ -651,7 +678,7 @@ metadata:
         - name: INET
           preference: preferred
         - name: Equinix
-          preference: preferred
+          preference: alternate
         - name: MPLS
           preference: alternate
     - name: TRANSIT
@@ -683,7 +710,13 @@ metadata:
         pathgroups:
         - name: LAN_HA
           preference: preferred
+        - name: MPLS
+          preference: preferred
         - name: INET
           preference: preferred
-        - name: MPLS
+        - name: Equinix
+          preference: alternate
+        - name: Satellite
+          preference: alternate
+        - name: AWS
           preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -577,8 +577,8 @@ router_path_selection:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
-    - name: INET
     - name: MPLS
+    - name: INET
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
     path_groups:
     - name: LAN_HA
@@ -589,7 +589,7 @@ router_path_selection:
     - name: LAN_HA
     - name: INET
     - name: MPLS
-      priority: 42
+      priority: 4223
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -626,8 +626,8 @@ router_path_selection:
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
-    - name: INET
     - name: MPLS
+    - name: INET
 router_traffic_engineering:
   enabled: true
 stun:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -577,8 +577,8 @@ router_path_selection:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
-    - name: INET
     - name: MPLS
+    - name: INET
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
     path_groups:
     - name: LAN_HA
@@ -589,7 +589,7 @@ router_path_selection:
     - name: LAN_HA
     - name: INET
     - name: MPLS
-      priority: 42
+      priority: 4223
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
     - name: LAN_HA
@@ -626,8 +626,8 @@ router_path_selection:
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: LAN_HA
-    - name: INET
     - name: MPLS
+    - name: INET
 router_traffic_engineering:
   enabled: true
 stun:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -113,6 +113,12 @@ ethernet_interfaces:
   ipv6_enable: true
   eos_cli: comment yo
   _custom_key: custom_value
+- name: Ethernet1
+  peer_type: l3_interface
+  ip_address: 10.9.9.9/31
+  shutdown: false
+  type: routed
+  description: Comcast_999
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -203,9 +209,20 @@ router_bfd:
 router_path_selection:
   tcp_mss_ceiling:
     ipv4_segment_size: auto
+  path_groups:
+  - name: INET
+    id: 100
+    local_interfaces:
+    - name: Ethernet1
+    dynamic_peers:
+      enabled: true
   load_balance_policies:
   - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
   - name: LB-DEFAULT-POLICY-CONTROL-PLANE
+    path_groups:
+    - name: INET
   policies:
   - name: DEFAULT-POLICY
     default_match:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -122,6 +122,12 @@ ethernet_interfaces:
   ipv6_enable: true
   eos_cli: comment yo
   _custom_key: custom_value
+- name: Ethernet1
+  peer_type: l3_interface
+  ip_address: 10.9.9.1/31
+  shutdown: false
+  type: routed
+  description: Comcast_999
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -212,9 +218,20 @@ router_bfd:
 router_path_selection:
   tcp_mss_ceiling:
     ipv4_segment_size: auto
+  path_groups:
+  - name: INET
+    id: 100
+    local_interfaces:
+    - name: Ethernet1
+    dynamic_peers:
+      enabled: true
   load_balance_policies:
   - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
   - name: LB-DEFAULT-POLICY-CONTROL-PLANE
+    path_groups:
+    - name: INET
   policies:
   - name: DEFAULT-POLICY
     default_match:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
@@ -87,8 +87,11 @@ wan_path_groups:
     id: 100
   - name: INET
     id: 101
+    default_preference: 42
   - name: LTE
     id: 102
+    # Testing this knob for AutoVPN
+    excluded_from_default_policy: true
 
 wan_carriers:
   - name: Comcast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -93,7 +93,7 @@ wan_router:
               wan_carrier: Comcast-5G
               wan_circuit_id: AF830
               ip_address: 172.20.20.20/31
-              connected_to_pathfinder: False
+              connected_to_pathfinder: false
         - name: cv-pathfinder-edge-no-common-path-group
           id: 2
           uplink_switch_interfaces: [Ethernet2]
@@ -108,7 +108,7 @@ wan_router:
               wan_circuit_id: 212
               dhcp_accept_default_route: true
               ip_address: dhcp
-              connected_to_pathfinder: False
+              connected_to_pathfinder: false
     # SITE_HA_ENABLED
     - group: Site423
       cv_pathfinder_region: AVD_Land_West
@@ -255,7 +255,7 @@ wan_path_groups:
   - name: LTE
     id: 102
     # The expectation here is that LTE shouldn't be present in the default lb policy.
-    default_preference: excluded
+    excluded_from_default_policy: true
   - name: Equinix
     id: 103
     default_preference: alternate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -101,6 +101,12 @@ wan_router:
               wan_circuit_id: S511
               dhcp_accept_default_route: true
               ip_address: dhcp
+            - name: Ethernet2
+              wan_carrier: AWS-1
+              wan_circuit_id: 212
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+              connected_to_pathfinder: False
     # SITE_HA_ENABLED
     - group: Site423
       cv_pathfinder_region: AVD_Land_West
@@ -241,16 +247,21 @@ wan_rr:
 wan_path_groups:
   - name: MPLS
     ipsec: false
-    # TODO remove one once auto-id is implemented - for now required in schema
     id: 100
   - name: INET
     id: 101
   - name: LTE
     id: 102
+    # The expectation here is that LTE shouldn't be present in the default lb policy.
+    default_preference: excluded
   - name: Equinix
     id: 103
+    default_preference: alternate
   - name: Satellite
     id: 104
+    default_preference: alternate
+  - name: AWS
+    id: 105
 
 wan_carriers:
   - name: Comcast
@@ -273,6 +284,8 @@ wan_carriers:
     path_group: LTE
   - name: Inmrasat
     path_group: Satellite
+  - name: AWS-1
+    path_group: AWS
 
 tenants:
   - name: TenantA
@@ -373,11 +386,13 @@ wan_virtual_topologies:
           # No prefence to check the default.
           - names: [INET, Equinix]
           - names: [MPLS]
-            preference: 42
+            preference: 4223
       application_virtual_topologies:
         - application_profile: VIDEO
           path_groups:
-            - names: [MPLS, INET]
+            # The expectation here is that Equinix will be configured with priority 1/preferred,
+            # since we are overriding the default_preference value (2/alternate).
+            - names: [MPLS, INET, Equinix]
               preference: preferred
           id: 3
     - name: TRANSIT-AVT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_LAN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_LAN_TESTS.yml
@@ -26,9 +26,19 @@ wan_router: # dynamic_key: node_type
       id: 1
       uplink_switch_interfaces: [Ethernet1]
       uplink_native_vlan: 10
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: Comcast
+          wan_circuit_id: 999
+          ip_address: 10.9.9.9/31
     - name: uplink_lan_wan_router2
       uplink_switch_interfaces: [Ethernet2]
       id: 2
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: Comcast
+          wan_circuit_id: 999
+          ip_address: 10.9.9.1/31
 
 tenants: # dynamic_key: network_services
   - name: TEST
@@ -74,8 +84,14 @@ wan_ipsec_profiles:
 wan_mode: autovpn
 
 wan_route_servers: []
-wan_path_groups: []
-wan_carriers: []
+wan_path_groups:
+  - name: INET
+    ipsec: false
+    # TODO remove one once auto-id is implemented - for now required in schema
+    id: 100
+wan_carriers:
+  - name: Comcast
+    path_group: INET
 bgp_peer_groups:
   wan_overlay_peers:
     listen_range_prefixes: [0.0.0.0/0]

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -135,42 +135,15 @@ class WanMixin:
 
         return list(local_carriers_dict.values())
 
-    def path_group_preference_to_eos_priority(self, path_group_preference: int | str, context_path: str) -> int | None:
-        """
-        Convert "preferred" to 1 and "alternate" to 2 and "excluded" to None. Everything else is returned as is.
-
-        Arguments:
-        ----------
-        path_group_preference (str|int): The value of the preference key to be converted. It must be either "preferred", "alternate" or an integer.
-        context_path (str): Input path context for the error message.
-        """
-        if path_group_preference == "preferred":
-            return 1
-        if path_group_preference == "alternate":
-            return 2
-        if path_group_preference == "excluded":
-            return None
-
-        failedConversion = False
-        try:
-            priority = int(path_group_preference)
-        except ValueError:
-            failedConversion = True
-
-        if failedConversion or not (1 <= priority <= 65535):
-            raise AristaAvdError(
-                f"Invalid value '{path_group_preference}' for Path-Group preference - should be either 'preferred', "
-                f"'alternate' or an integer[1-65535] for {context_path}."
-            )
-
-        return priority
-
     @cached_property
     def wan_path_groups(self: SharedUtils) -> list:
+        """
+        List of path-groups defined in the top level key `wan_path_groups`
+        Updating default preference for each path-group to 'preferred' if not set.
+        """
         path_groups = get(self.hostvars, "wan_path_groups", required=True)
         for path_group in path_groups:
-            default_preference = get(path_group, "default_preference", default=1)
-            path_group["default_priority"] = self.path_group_preference_to_eos_priority(default_preference, f"wan_path_groups[{path_group['name']}]")
+            path_group["default_preference"] = get(path_group, "default_preference", default="preferred")
         return path_groups
 
     @cached_property

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -135,9 +135,9 @@ class WanMixin:
 
         return list(local_carriers_dict.values())
 
-    def path_group_preference_to_eos_priority(self, path_group_preference: int | str, context_path: str) -> int:
+    def path_group_preference_to_eos_priority(self, path_group_preference: int | str, context_path: str) -> int | None:
         """
-        Convert "preferred" to 1 and "alternate" to 2. Everything else is returned as is.
+        Convert "preferred" to 1 and "alternate" to 2 and "excluded" to None. Everything else is returned as is.
 
         Arguments:
         ----------
@@ -148,6 +148,8 @@ class WanMixin:
             return 1
         if path_group_preference == "alternate":
             return 2
+        if path_group_preference == "excluded":
+            return None
 
         failedConversion = False
         try:
@@ -168,10 +170,7 @@ class WanMixin:
         path_groups = get(self.hostvars, "wan_path_groups", required=True)
         for path_group in path_groups:
             default_preference = get(path_group, "default_preference", default=1)
-            priority = 0
-            if default_preference != "excluded":
-                priority = self.path_group_preference_to_eos_priority(default_preference, f"wan_path_groups[{path_group['name']}]")
-            path_group["default_priority"] = priority
+            path_group["default_priority"] = self.path_group_preference_to_eos_priority(default_preference, f"wan_path_groups[{path_group['name']}]")
         return path_groups
 
     @cached_property

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-path-groups.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-path-groups.md
@@ -15,7 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;import_path_groups</samp>](## "wan_path_groups.[].import_path_groups") | List, items: Dictionary |  |  |  | List of path-groups to import in this path-group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;remote</samp>](## "wan_path_groups.[].import_path_groups.[].remote") | String |  |  |  | Remote path-group to import. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "wan_path_groups.[].import_path_groups.[].local") | String |  |  |  | Optional, if not set, the path-group `name` is used as local. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_preference</samp>](## "wan_path_groups.[].default_preference") | String |  | `preferred` |  | Preference to be used in auto-generated load balance policies and policies in which preference is not given for the path group.<br><br>Valid values are 1-65535 | "preferred" | "alternate" | "excluded".<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2.<br>excluded means that the path-group is not considered for generating policies. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_preference</samp>](## "wan_path_groups.[].default_preference") | String |  | `preferred` |  | Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when<br>the path-group is used in an auto generated policy.<br><br>Valid values are 1-65535 | "preferred" | "alternate" | "excluded".<br><br>`preferred` is converted to priority 1.<br>`alternate` is converted to priority 2.<br>`excluded` is used to ignore the path-group when generating policies. |
 
 === "YAML"
 
@@ -49,12 +49,13 @@
             # Optional, if not set, the path-group `name` is used as local.
             local: <str>
 
-        # Preference to be used in auto-generated load balance policies and policies in which preference is not given for the path group.
+        # Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when
+        # the path-group is used in an auto generated policy.
         #
         # Valid values are 1-65535 | "preferred" | "alternate" | "excluded".
         #
-        # preferred is converted to priority 1.
-        # alternate is converted to priority 2.
-        # excluded means that the path-group is not considered for generating policies.
+        # `preferred` is converted to priority 1.
+        # `alternate` is converted to priority 2.
+        # `excluded` is used to ignore the path-group when generating policies.
         default_preference: <str; default="preferred">
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-path-groups.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-path-groups.md
@@ -15,7 +15,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;import_path_groups</samp>](## "wan_path_groups.[].import_path_groups") | List, items: Dictionary |  |  |  | List of path-groups to import in this path-group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;remote</samp>](## "wan_path_groups.[].import_path_groups.[].remote") | String |  |  |  | Remote path-group to import. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "wan_path_groups.[].import_path_groups.[].local") | String |  |  |  | Optional, if not set, the path-group `name` is used as local. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_preference</samp>](## "wan_path_groups.[].default_preference") | String |  | `preferred` |  | Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when<br>the path-group is used in an auto generated policy.<br><br>Valid values are 1-65535 | "preferred" | "alternate" | "excluded".<br><br>`preferred` is converted to priority 1.<br>`alternate` is converted to priority 2.<br>`excluded` is used to ignore the path-group when generating policies. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_preference</samp>](## "wan_path_groups.[].default_preference") | String |  | `preferred` |  | Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when<br>the path-group is used in an auto generated policy except if `excluded_from_default_policy` is set to `true.<br><br>Valid values are 1-65535 | "preferred" | "alternate".<br><br>`preferred` is converted to priority 1.<br>`alternate` is converted to priority 2. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;excluded_from_default_policy</samp>](## "wan_path_groups.[].excluded_from_default_policy") | Boolean |  | `False` |  | When set to `true`, the path-group is excluded from AVD auto generated policies. |
 
 === "YAML"
 
@@ -50,12 +51,14 @@
             local: <str>
 
         # Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when
-        # the path-group is used in an auto generated policy.
+        # the path-group is used in an auto generated policy except if `excluded_from_default_policy` is set to `true.
         #
-        # Valid values are 1-65535 | "preferred" | "alternate" | "excluded".
+        # Valid values are 1-65535 | "preferred" | "alternate".
         #
         # `preferred` is converted to priority 1.
         # `alternate` is converted to priority 2.
-        # `excluded` is used to ignore the path-group when generating policies.
         default_preference: <str; default="preferred">
+
+        # When set to `true`, the path-group is excluded from AVD auto generated policies.
+        excluded_from_default_policy: <bool; default=False>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-path-groups.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-path-groups.md
@@ -12,9 +12,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "wan_path_groups.[].id") | Integer | Required |  |  | Path-group id.<br><br>TODO: Required until an auto ID algorithm is implemented. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "wan_path_groups.[].description") | String |  |  |  | Additional information about the path-group for documentation purposes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipsec</samp>](## "wan_path_groups.[].ipsec") | Boolean |  | `True` |  | Flag to configure IPsec at the path-group level.<br><br>When set to `true`, IPsec is enabled for both the static and dynamic peers. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;import_path_groups</samp>](## "wan_path_groups.[].import_path_groups") | List, items: Dictionary |  |  |  | List of [ath-groups to import in this path-group. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;import_path_groups</samp>](## "wan_path_groups.[].import_path_groups") | List, items: Dictionary |  |  |  | List of path-groups to import in this path-group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;remote</samp>](## "wan_path_groups.[].import_path_groups.[].remote") | String |  |  |  | Remote path-group to import. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "wan_path_groups.[].import_path_groups.[].local") | String |  |  |  | Optional, if not set, the path-group `name` is used as local. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;default_preference</samp>](## "wan_path_groups.[].default_preference") | String |  | `preferred` |  | Preference to be used in auto-generated load balance policies and policies in which preference is not given for the path group.<br><br>Valid values are 1-65535 | "preferred" | "alternate" | "excluded".<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2.<br>excluded means that the path-group is not considered for generating policies. |
 
 === "YAML"
 
@@ -39,7 +40,7 @@
         # When set to `true`, IPsec is enabled for both the static and dynamic peers.
         ipsec: <bool; default=True>
 
-        # List of [ath-groups to import in this path-group.
+        # List of path-groups to import in this path-group.
         import_path_groups:
 
             # Remote path-group to import.
@@ -47,4 +48,13 @@
 
             # Optional, if not set, the path-group `name` is used as local.
             local: <str>
+
+        # Preference to be used in auto-generated load balance policies and policies in which preference is not given for the path group.
+        #
+        # Valid values are 1-65535 | "preferred" | "alternate" | "excluded".
+        #
+        # preferred is converted to priority 1.
+        # alternate is converted to priority 2.
+        # excluded means that the path-group is not considered for generating policies.
+        default_preference: <str; default="preferred">
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
@@ -24,7 +24,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].preference") | String |  | `preferred` |  | Valid values are 1-255 | preferred | alternate.<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].preference") | String |  | `preferred` |  | Valid values are 1-65535 | preferred | alternate.<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2. |
     | [<samp>&nbsp;&nbsp;policies</samp>](## "wan_virtual_topologies.policies") | List, items: Dictionary |  |  |  | List of virtual toplogies policies.<br><br>For AutoVPN, each item in the list creates:<br>  * one policy with:<br>      * one `match` entry per `application_virtual_topologies` item<br>        they are indexed using `10 * <list_index>` where `list_index` starts at `1`.<br>      * one `default-match`<br>  * one load-balance policy per `application_virtual_topologies` and one for the `default_virtual_topology`.<br>  * if the policy is associated with the default VRF, a special control-plane rule is injected<br>    in the policy with index `1` referring to a control-plane load-balance policy as defined under<br>    `control_plane_virtual_topology`.<br><br>For CV Pathfinder, each item in the list creates:<br>  * one policy with:<br>      * one `match` entry per `application_virtual_topologies` item ordered as in the model.<br>      * one last match entry for the `default` application-profile using `default_virtual_topology` information.<br>  * one profile per `application_virtual_topologies` item.<br>  * one profile for the `default_virtual_topology`..<br>  * one load-balance policy per `application_virtual_topologies`.<br>  * one load_balance policy for the `default_virtual_topology`.<br>  * if the policy is associated with the default VRF, a special control-plane profile is configured<br>    and injected first in the policy assigned to the `default` VRF. This profile points to a<br>    control-plane load-balance policy as defined under `control_plane_virtual_topology`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "wan_virtual_topologies.policies.[].name") | String | Required, Unique |  |  | Name of the AVT policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;application_virtual_topologies</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies") | List, items: Dictionary |  |  |  | List of application specific virtual topologies. |
@@ -41,7 +41,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].preference") | String |  | `preferred` |  | Valid values are 1-255 | preferred | alternate.<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].preference") | String |  | `preferred` |  | Valid values are 1-65535 | preferred | alternate.<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_virtual_topology</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology") | Dictionary | Required |  |  | Default match for the policy.<br>If no default match should be configured, set `drop_unmatched` to `true`.<br>Otherwise, in CV Pathfinder mode, a default AVT profile will be configured with ID 1. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.name") | String |  |  |  | Optional name, if not set `<policy_name>-DEFAULT` is used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;drop_unmatched</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.drop_unmatched") | Boolean |  | `False` |  | When set, no `catch-all` match is configured for the policy and unmatched traffic is dropped. |
@@ -55,7 +55,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].preference") | String |  | `preferred` |  | Valid values are 1-255 | preferred | alternate.<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].preference") | String |  | `preferred` |  | Valid values are 1-65535 | preferred | alternate.<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2. |
 
 === "YAML"
 
@@ -124,7 +124,7 @@
           - names: # >=1 items; required
               - <str>
 
-            # Valid values are 1-255 | preferred | alternate.
+            # Valid values are 1-65535 | preferred | alternate.
             #
             # preferred is converted to priority 1.
             # alternate is converted to priority 2.
@@ -198,7 +198,7 @@
                 - names: # >=1 items; required
                     - <str>
 
-                  # Valid values are 1-255 | preferred | alternate.
+                  # Valid values are 1-65535 | preferred | alternate.
                   #
                   # preferred is converted to priority 1.
                   # alternate is converted to priority 2.
@@ -241,7 +241,7 @@
               - names: # >=1 items; required
                   - <str>
 
-                # Valid values are 1-255 | preferred | alternate.
+                # Valid values are 1-65535 | preferred | alternate.
                 #
                 # preferred is converted to priority 1.
                 # alternate is converted to priority 2.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
@@ -24,7 +24,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].preference") | String |  | `preferred` |  | Valid values are 1-65535 | preferred | alternate.<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].preference") | String |  |  |  | Valid values are 1-65535 | "preferred" | "alternate".<br><br>"preferred" is converted to priority 1.<br>"alternate" is converted to priority 2.<br><br>If not set, each path-group in `names` will be attributed its `default_preference`.<br>In that casem the `default_preference` cannot be "excluded". |
     | [<samp>&nbsp;&nbsp;policies</samp>](## "wan_virtual_topologies.policies") | List, items: Dictionary |  |  |  | List of virtual toplogies policies.<br><br>For AutoVPN, each item in the list creates:<br>  * one policy with:<br>      * one `match` entry per `application_virtual_topologies` item<br>        they are indexed using `10 * <list_index>` where `list_index` starts at `1`.<br>      * one `default-match`<br>  * one load-balance policy per `application_virtual_topologies` and one for the `default_virtual_topology`.<br>  * if the policy is associated with the default VRF, a special control-plane rule is injected<br>    in the policy with index `1` referring to a control-plane load-balance policy as defined under<br>    `control_plane_virtual_topology`.<br><br>For CV Pathfinder, each item in the list creates:<br>  * one policy with:<br>      * one `match` entry per `application_virtual_topologies` item ordered as in the model.<br>      * one last match entry for the `default` application-profile using `default_virtual_topology` information.<br>  * one profile per `application_virtual_topologies` item.<br>  * one profile for the `default_virtual_topology`..<br>  * one load-balance policy per `application_virtual_topologies`.<br>  * one load_balance policy for the `default_virtual_topology`.<br>  * if the policy is associated with the default VRF, a special control-plane profile is configured<br>    and injected first in the policy assigned to the `default` VRF. This profile points to a<br>    control-plane load-balance policy as defined under `control_plane_virtual_topology`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "wan_virtual_topologies.policies.[].name") | String | Required, Unique |  |  | Name of the AVT policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;application_virtual_topologies</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies") | List, items: Dictionary |  |  |  | List of application specific virtual topologies. |
@@ -41,7 +41,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].preference") | String |  | `preferred` |  | Valid values are 1-65535 | preferred | alternate.<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].preference") | String |  |  |  | Valid values are 1-65535 | "preferred" | "alternate".<br><br>"preferred" is converted to priority 1.<br>"alternate" is converted to priority 2.<br><br>If not set, each path-group in `names` will be attributed its `default_preference`.<br>In that casem the `default_preference` cannot be "excluded". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_virtual_topology</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology") | Dictionary | Required |  |  | Default match for the policy.<br>If no default match should be configured, set `drop_unmatched` to `true`.<br>Otherwise, in CV Pathfinder mode, a default AVT profile will be configured with ID 1. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.name") | String |  |  |  | Optional name, if not set `<policy_name>-DEFAULT` is used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;drop_unmatched</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.drop_unmatched") | Boolean |  | `False` |  | When set, no `catch-all` match is configured for the policy and unmatched traffic is dropped. |
@@ -55,7 +55,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].preference") | String |  | `preferred` |  | Valid values are 1-65535 | preferred | alternate.<br><br>preferred is converted to priority 1.<br>alternate is converted to priority 2. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].preference") | String |  |  |  | Valid values are 1-65535 | "preferred" | "alternate".<br><br>"preferred" is converted to priority 1.<br>"alternate" is converted to priority 2.<br><br>If not set, each path-group in `names` will be attributed its `default_preference`.<br>In that casem the `default_preference` cannot be "excluded". |
 
 === "YAML"
 
@@ -124,11 +124,14 @@
           - names: # >=1 items; required
               - <str>
 
-            # Valid values are 1-65535 | preferred | alternate.
+            # Valid values are 1-65535 | "preferred" | "alternate".
             #
-            # preferred is converted to priority 1.
-            # alternate is converted to priority 2.
-            preference: <str; default="preferred">
+            # "preferred" is converted to priority 1.
+            # "alternate" is converted to priority 2.
+            #
+            # If not set, each path-group in `names` will be attributed its `default_preference`.
+            # In that casem the `default_preference` cannot be "excluded".
+            preference: <str>
 
       # List of virtual toplogies policies.
       #
@@ -198,11 +201,14 @@
                 - names: # >=1 items; required
                     - <str>
 
-                  # Valid values are 1-65535 | preferred | alternate.
+                  # Valid values are 1-65535 | "preferred" | "alternate".
                   #
-                  # preferred is converted to priority 1.
-                  # alternate is converted to priority 2.
-                  preference: <str; default="preferred">
+                  # "preferred" is converted to priority 1.
+                  # "alternate" is converted to priority 2.
+                  #
+                  # If not set, each path-group in `names` will be attributed its `default_preference`.
+                  # In that casem the `default_preference` cannot be "excluded".
+                  preference: <str>
 
           # Default match for the policy.
           # If no default match should be configured, set `drop_unmatched` to `true`.
@@ -241,9 +247,12 @@
               - names: # >=1 items; required
                   - <str>
 
-                # Valid values are 1-65535 | preferred | alternate.
+                # Valid values are 1-65535 | "preferred" | "alternate".
                 #
-                # preferred is converted to priority 1.
-                # alternate is converted to priority 2.
-                preference: <str; default="preferred">
+                # "preferred" is converted to priority 1.
+                # "alternate" is converted to priority 2.
+                #
+                # If not set, each path-group in `names` will be attributed its `default_preference`.
+                # In that casem the `default_preference` cannot be "excluded".
+                preference: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
@@ -24,7 +24,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].preference") | String |  |  |  | Valid values are 1-65535 | "preferred" | "alternate".<br><br>"preferred" is converted to priority 1.<br>"alternate" is converted to priority 2.<br><br>If not set, each path-group in `names` will be attributed its `default_preference`.<br>In that casem the `default_preference` cannot be "excluded". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.path_groups.[].preference") | String |  |  |  | Valid values are 1-65535 | "preferred" | "alternate".<br><br>"preferred" is converted to priority 1.<br>"alternate" is converted to priority 2.<br><br>If not set, each path-group in `names` will be attributed its `default_preference`. |
     | [<samp>&nbsp;&nbsp;policies</samp>](## "wan_virtual_topologies.policies") | List, items: Dictionary |  |  |  | List of virtual toplogies policies.<br><br>For AutoVPN, each item in the list creates:<br>  * one policy with:<br>      * one `match` entry per `application_virtual_topologies` item<br>        they are indexed using `10 * <list_index>` where `list_index` starts at `1`.<br>      * one `default-match`<br>  * one load-balance policy per `application_virtual_topologies` and one for the `default_virtual_topology`.<br>  * if the policy is associated with the default VRF, a special control-plane rule is injected<br>    in the policy with index `1` referring to a control-plane load-balance policy as defined under<br>    `control_plane_virtual_topology`.<br><br>For CV Pathfinder, each item in the list creates:<br>  * one policy with:<br>      * one `match` entry per `application_virtual_topologies` item ordered as in the model.<br>      * one last match entry for the `default` application-profile using `default_virtual_topology` information.<br>  * one profile per `application_virtual_topologies` item.<br>  * one profile for the `default_virtual_topology`..<br>  * one load-balance policy per `application_virtual_topologies`.<br>  * one load_balance policy for the `default_virtual_topology`.<br>  * if the policy is associated with the default VRF, a special control-plane profile is configured<br>    and injected first in the policy assigned to the `default` VRF. This profile points to a<br>    control-plane load-balance policy as defined under `control_plane_virtual_topology`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "wan_virtual_topologies.policies.[].name") | String | Required, Unique |  |  | Name of the AVT policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;application_virtual_topologies</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies") | List, items: Dictionary |  |  |  | List of application specific virtual topologies. |
@@ -41,7 +41,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].names.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].preference") | String |  |  |  | Valid values are 1-65535 | "preferred" | "alternate".<br><br>"preferred" is converted to priority 1.<br>"alternate" is converted to priority 2.<br><br>If not set, each path-group in `names` will be attributed its `default_preference`.<br>In that casem the `default_preference` cannot be "excluded". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].path_groups.[].preference") | String |  |  |  | Valid values are 1-65535 | "preferred" | "alternate".<br><br>"preferred" is converted to priority 1.<br>"alternate" is converted to priority 2.<br><br>If not set, each path-group in `names` will be attributed its `default_preference`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_virtual_topology</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology") | Dictionary | Required |  |  | Default match for the policy.<br>If no default match should be configured, set `drop_unmatched` to `true`.<br>Otherwise, in CV Pathfinder mode, a default AVT profile will be configured with ID 1. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.name") | String |  |  |  | Optional name, if not set `<policy_name>-DEFAULT` is used. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;drop_unmatched</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.drop_unmatched") | Boolean |  | `False` |  | When set, no `catch-all` match is configured for the policy and unmatched traffic is dropped. |
@@ -55,7 +55,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;path_groups</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups") | List, items: Dictionary |  |  | Min Length: 1 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;names</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names") | List, items: String | Required |  | Min Length: 1 | List of path-group names. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].names.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].preference") | String |  |  |  | Valid values are 1-65535 | "preferred" | "alternate".<br><br>"preferred" is converted to priority 1.<br>"alternate" is converted to priority 2.<br><br>If not set, each path-group in `names` will be attributed its `default_preference`.<br>In that casem the `default_preference` cannot be "excluded". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;preference</samp>](## "wan_virtual_topologies.policies.[].default_virtual_topology.path_groups.[].preference") | String |  |  |  | Valid values are 1-65535 | "preferred" | "alternate".<br><br>"preferred" is converted to priority 1.<br>"alternate" is converted to priority 2.<br><br>If not set, each path-group in `names` will be attributed its `default_preference`. |
 
 === "YAML"
 
@@ -130,7 +130,6 @@
             # "alternate" is converted to priority 2.
             #
             # If not set, each path-group in `names` will be attributed its `default_preference`.
-            # In that casem the `default_preference` cannot be "excluded".
             preference: <str>
 
       # List of virtual toplogies policies.
@@ -207,7 +206,6 @@
                   # "alternate" is converted to priority 2.
                   #
                   # If not set, each path-group in `names` will be attributed its `default_preference`.
-                  # In that casem the `default_preference` cannot be "excluded".
                   preference: <str>
 
           # Default match for the policy.
@@ -253,6 +251,5 @@
                 # "alternate" is converted to priority 2.
                 #
                 # If not set, each path-group in `names` will be attributed its `default_preference`.
-                # In that casem the `default_preference` cannot be "excluded".
                 preference: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
@@ -141,7 +141,11 @@ class CvPathfinderMixin:
         if self.shared_utils.is_wan_server:
             # On pathfinders, verify that the Load Balance policies have at least one priority one except for the HA path-group
             for lb_policy in load_balance_policies:
-                if not any(path_group.get("priority", 1) == 1 for path_group in lb_policy["path_groups"] if path_group["name"] != self.shared_utils.wan_ha_path_group_name):
+                if not any(
+                    path_group.get("priority", 1) == 1
+                    for path_group in lb_policy["path_groups"]
+                    if path_group["name"] != self.shared_utils.wan_ha_path_group_name
+                ):
                     raise AristaAvdError(
                         "At least one path-group must be configured with preference '1' or 'preferred' for "
                         f"load-balance policy {lb_policy['name']}' to use CloudVision integration. "

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
@@ -158,7 +158,6 @@ class RouterPathSelectionMixin(UtilsMixin):
             for path_group_name in policy_entry.get("names"):
                 if (priority := policy_entry_priority) is None:
                     # No preference defined at the policy level, need to retrieve the default preference
-                    # TODO error message
                     wan_path_group = get_item(
                         self.shared_utils.wan_path_groups,
                         "name",

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_path_selection.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 
 from functools import cached_property
 
+from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_empties_from_dict
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import append_if_not_duplicate, get, get_item
 
 from .utils import UtilsMixin
 
@@ -27,7 +28,7 @@ class RouterPathSelectionMixin(UtilsMixin):
             return None
 
         router_path_selection = {
-            "load_balance_policies": self._wan_load_balance_policies,
+            "load_balance_policies": self._wan_load_balance_policies(),
         }
 
         # When running CV Pathfinder, only load balance policies are configured
@@ -37,14 +38,180 @@ class RouterPathSelectionMixin(UtilsMixin):
 
             router_path_selection.update(
                 {
-                    "policies": self._autovpn_policies,
+                    "policies": self._autovpn_policies(),
                     "vrfs": vrfs,
                 }
             )
 
         return strip_empties_from_dict(router_path_selection)
 
-    @cached_property
+    def _wan_load_balance_policies(self) -> list:
+        """
+        Return a list of WAN router path-selection load-balance policies based on the local path-groups.
+        """
+        if not self.shared_utils.is_wan_router:
+            return []
+
+        wan_load_balance_policies = []
+
+        for policy in self._filtered_wan_policies:
+            if get(policy, "is_default", default=False):
+                # for the default policy, need to render the control_plane_virtual_topology
+                # Control plane Load Balancing policy - if not configured, render the default one.
+                control_plane_virtual_topology = get(
+                    self._hostvars,
+                    "wan_virtual_topologies.control_plane_virtual_topology",
+                    default=self._default_control_plane_virtual_topology,
+                )
+
+                wan_load_balance_policies.append(
+                    self._generate_wan_load_balance_policy(
+                        self.shared_utils.generate_lb_policy_name(self._wan_control_plane_profile),
+                        control_plane_virtual_topology,
+                        policy["name"],
+                    )
+                )
+
+            for application_virtual_topology in get(policy, "application_virtual_topologies", []):
+                # TODO add internet exit once supported
+                name = get(
+                    application_virtual_topology,
+                    "name",
+                    default=self._default_profile_name(policy["profile_prefix"], application_virtual_topology["application_profile"]),
+                )
+                context_path = (
+                    f"wan_virtual_topologies.policies[{policy['profile_prefix']}]."
+                    f"application_virtual_topologies[{application_virtual_topology['application_profile']}]"
+                )
+                append_if_not_duplicate(
+                    list_of_dicts=wan_load_balance_policies,
+                    primary_key="name",
+                    new_dict=self._generate_wan_load_balance_policy(
+                        self.shared_utils.generate_lb_policy_name(name), application_virtual_topology, context_path
+                    ),
+                    context="Router Path-Selection Load-Balance policies.",
+                    context_keys=["name"],
+                )
+
+            default_virtual_topology = get(
+                policy,
+                "default_virtual_topology",
+                required=True,
+                org_key=f"wan_virtual_topologies.policies[{policy['profile_prefix']}].default_virtual_toplogy",
+            )
+            if not get(default_virtual_topology, "drop_unmatched", default=False):
+                name = get(default_virtual_topology, "name", default=self._default_profile_name(policy["profile_prefix"], "DEFAULT"))
+                context_path = f"wan_virtual_topologies.policies[{policy['profile_prefix']}].default_virtual_topology"
+
+                # Verify that path_groups are set or raise
+                get(
+                    default_virtual_topology,
+                    "path_groups",
+                    required=True,
+                    org_key=f"Either 'drop_unmatched' or 'path_groups' must be set under '{context_path}'.",
+                )
+
+                append_if_not_duplicate(
+                    list_of_dicts=wan_load_balance_policies,
+                    primary_key="name",
+                    new_dict=self._generate_wan_load_balance_policy(self.shared_utils.generate_lb_policy_name(name), default_virtual_topology, context_path),
+                    context="Router Path-Selection Load-Balance policies.",
+                    context_keys=["name"],
+                )
+
+        return wan_load_balance_policies
+
+    def _generate_wan_load_balance_policy(self, name: str, input_dict: dict, context_path: str) -> dict:
+        """
+        Generate and return a router path-selection load-balance policy.
+        If HA is enabled, inject the HA path-group with priority 1.
+
+        Attrs:
+        ------
+        name (str): The name of the load balance policy
+        input_dict (dict): The dictionary containing the list of path-groups and their preference.
+        context_path (str): Key used for context for error messages.
+        """
+        wan_load_balance_policy = {
+            "name": name,
+            "path_groups": [],
+            **get(input_dict, "constraints", default={}),
+        }
+
+        local_path_groups_names = [path_group["name"] for path_group in self.shared_utils.wan_local_path_groups]
+
+        if self.shared_utils.wan_mode == "cv-pathfinder":
+            wan_load_balance_policy["lowest_hop_count"] = get(input_dict, "lowest_hop_count")
+
+        if self.shared_utils.wan_ha or self.shared_utils.is_cv_pathfinder_server:
+            # Adding HA path-group with priority 1 - it does not count as an entry with priority 1
+            wan_load_balance_policy["path_groups"].append({"name": self.shared_utils.wan_ha_path_group_name})
+
+        # An entry is composed of a list of path-groups in `names` and a `priority`
+        policy_entries = get(input_dict, "path_groups", [])
+
+        for policy_entry in policy_entries:
+            policy_entry_priority = None
+            if preference := get(policy_entry, "preference"):
+                policy_entry_priority = self._path_group_preference_to_eos_priority(preference, f"{context_path}[{policy_entry.get('names')}]")
+
+            for path_group_name in policy_entry.get("names"):
+                if (priority := policy_entry_priority) is None:
+                    # No preference defined at the policy level, need to retrieve the default preference
+                    # TODO error message
+                    wan_path_group = get_item(
+                        self.shared_utils.wan_path_groups,
+                        "name",
+                        path_group_name,
+                        required=True,
+                        custom_error_msg=(
+                            f"Failed to retrieve path-group {path_group_name} from `wan_path_groups` when generating load balance policy {name}. "
+                            f"Verify the path-groups defined under {context_path}."
+                        ),
+                    )
+                    priority = self._path_group_preference_to_eos_priority(wan_path_group["default_preference"], f"wan_path_groups[{wan_path_group['name']}]")
+
+                # Skip path-group on this device if not present on the router except for pathfinders
+                if self.shared_utils.is_wan_client and path_group_name not in local_path_groups_names:
+                    continue
+
+                path_group = {
+                    "name": path_group_name,
+                    "priority": priority if priority != 1 else None,
+                }
+
+                wan_load_balance_policy["path_groups"].append(path_group)
+
+        return wan_load_balance_policy
+
+    def _path_group_preference_to_eos_priority(self, path_group_preference: int | str, context_path: str) -> int:
+        """
+        Convert "preferred" to 1 and "alternate" to 2. Everything else is returned as is.
+
+        Arguments:
+        ----------
+        path_group_preference (str|int): The value of the preference key to be converted. It must be either "preferred", "alternate" or an integer.
+        context_path (str): Input path context for the error message.
+        """
+        if path_group_preference == "preferred":
+            return 1
+        if path_group_preference == "alternate":
+            return 2
+
+        failed_conversion = False
+        try:
+            priority = int(path_group_preference)
+        except ValueError:
+            failed_conversion = True
+
+        if failed_conversion or not (1 <= priority <= 65535):
+            raise AristaAvdError(
+                f"Invalid value '{path_group_preference}' for Path-Group preference - should be either 'preferred', "
+                f"'alternate' or an integer[1-65535] for {context_path}."
+            )
+
+        return priority
+
     def _autovpn_policies(self) -> list:
         """
         Return a list of AutoVPN Policies.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -289,7 +289,7 @@ class UtilsMixin:
         control_plane_virtual_topology = get(
             self._hostvars,
             "wan_virtual_topologies.control_plane_virtual_topology",
-            default={"path_groups": [{"names": [path_group['name'] for path_group in self.shared_utils.wan_path_groups]}]},
+            default={"path_groups": [{"names": [path_group["name"] for path_group in self.shared_utils.wan_path_groups]}]},
         )
 
         wan_load_balance_policies = []
@@ -446,7 +446,10 @@ class UtilsMixin:
 
         # Returning policy containing all path groups, _generate_wan_load_balance_policy will take
         # care of filtering it based on only local path groups
-        return {"name": "DEFAULT-POLICY", "default_virtual_topology": {"path_groups": [{"names": [path_group['name'] for path_group in self.shared_utils.wan_path_groups]}]}}
+        return {
+            "name": "DEFAULT-POLICY",
+            "default_virtual_topology": {"path_groups": [{"names": [path_group["name"] for path_group in self.shared_utils.wan_path_groups]}]},
+        }
 
     def _default_profile_name(self, profile_name: str, application_profile: str) -> str:
         """

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24757,7 +24757,7 @@
           },
           "import_path_groups": {
             "type": "array",
-            "description": "List of [ath-groups to import in this path-group.",
+            "description": "List of path-groups to import in this path-group.",
             "items": {
               "type": "object",
               "properties": {
@@ -24778,6 +24778,12 @@
               }
             },
             "title": "Import Path Groups"
+          },
+          "default_preference": {
+            "type": "string",
+            "description": "Preference to be used in auto-generated load balance policies and policies in which preference is not given for the path group.\n\nValid values are 1-65535 | \"preferred\" | \"alternate\" | \"excluded\".\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.\nexcluded means that the path-group is not considered for generating policies.",
+            "default": "preferred",
+            "title": "Default Preference"
           }
         },
         "required": [
@@ -24984,7 +24990,7 @@
                   },
                   "preference": {
                     "type": "string",
-                    "description": "Valid values are 1-255 | preferred | alternate.\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.",
+                    "description": "Valid values are 1-65535 | preferred | alternate.\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.",
                     "default": "preferred",
                     "title": "Preference"
                   }
@@ -25107,7 +25113,7 @@
                           },
                           "preference": {
                             "type": "string",
-                            "description": "Valid values are 1-255 | preferred | alternate.\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.",
+                            "description": "Valid values are 1-65535 | preferred | alternate.\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.",
                             "default": "preferred",
                             "title": "Preference"
                           }
@@ -25215,7 +25221,7 @@
                         },
                         "preference": {
                           "type": "string",
-                          "description": "Valid values are 1-255 | preferred | alternate.\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.",
+                          "description": "Valid values are 1-65535 | preferred | alternate.\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.",
                           "default": "preferred",
                           "title": "Preference"
                         }

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24781,7 +24781,7 @@
           },
           "default_preference": {
             "type": "string",
-            "description": "Preference to be used in auto-generated load balance policies and policies in which preference is not given for the path group.\n\nValid values are 1-65535 | \"preferred\" | \"alternate\" | \"excluded\".\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.\nexcluded means that the path-group is not considered for generating policies.",
+            "description": "Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when\nthe path-group is used in an auto generated policy.\n\nValid values are 1-65535 | \"preferred\" | \"alternate\" | \"excluded\".\n\n`preferred` is converted to priority 1.\n`alternate` is converted to priority 2.\n`excluded` is used to ignore the path-group when generating policies.",
             "default": "preferred",
             "title": "Default Preference"
           }

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -25270,7 +25270,7 @@
                   },
                   "preference": {
                     "type": "string",
-                    "description": "Valid values are 1-65535 | \"preferred\" | \"alternate\".\n\n\"preferred\" is converted to priority 1.\n\"alternate\" is converted to priority 2.\n\nIf not set, each path-group in `names` will be attributed its `default_preference`.\nIn that casem the `default_preference` cannot be \"excluded\".",
+                    "description": "Valid values are 1-65535 | \"preferred\" | \"alternate\".\n\n\"preferred\" is converted to priority 1.\n\"alternate\" is converted to priority 2.\n\nIf not set, each path-group in `names` will be attributed its `default_preference`.",
                     "title": "Preference"
                   }
                 },
@@ -25392,7 +25392,7 @@
                           },
                           "preference": {
                             "type": "string",
-                            "description": "Valid values are 1-65535 | \"preferred\" | \"alternate\".\n\n\"preferred\" is converted to priority 1.\n\"alternate\" is converted to priority 2.\n\nIf not set, each path-group in `names` will be attributed its `default_preference`.\nIn that casem the `default_preference` cannot be \"excluded\".",
+                            "description": "Valid values are 1-65535 | \"preferred\" | \"alternate\".\n\n\"preferred\" is converted to priority 1.\n\"alternate\" is converted to priority 2.\n\nIf not set, each path-group in `names` will be attributed its `default_preference`.",
                             "title": "Preference"
                           }
                         },
@@ -25499,7 +25499,7 @@
                         },
                         "preference": {
                           "type": "string",
-                          "description": "Valid values are 1-65535 | \"preferred\" | \"alternate\".\n\n\"preferred\" is converted to priority 1.\n\"alternate\" is converted to priority 2.\n\nIf not set, each path-group in `names` will be attributed its `default_preference`.\nIn that casem the `default_preference` cannot be \"excluded\".",
+                          "description": "Valid values are 1-65535 | \"preferred\" | \"alternate\".\n\n\"preferred\" is converted to priority 1.\n\"alternate\" is converted to priority 2.\n\nIf not set, each path-group in `names` will be attributed its `default_preference`.",
                           "title": "Preference"
                         }
                       },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -25003,9 +25003,15 @@
           },
           "default_preference": {
             "type": "string",
-            "description": "Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when\nthe path-group is used in an auto generated policy.\n\nValid values are 1-65535 | \"preferred\" | \"alternate\" | \"excluded\".\n\n`preferred` is converted to priority 1.\n`alternate` is converted to priority 2.\n`excluded` is used to ignore the path-group when generating policies.",
+            "description": "Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when\nthe path-group is used in an auto generated policy except if `excluded_from_default_policy` is set to `true.\n\nValid values are 1-65535 | \"preferred\" | \"alternate\".\n\n`preferred` is converted to priority 1.\n`alternate` is converted to priority 2.",
             "default": "preferred",
             "title": "Default Preference"
+          },
+          "excluded_from_default_policy": {
+            "type": "boolean",
+            "default": false,
+            "description": "When set to `true`, the path-group is excluded from AVD auto generated policies.",
+            "title": "Excluded From Default Policy"
           }
         },
         "required": [
@@ -25224,8 +25230,7 @@
                   },
                   "preference": {
                     "type": "string",
-                    "description": "Valid values are 1-65535 | preferred | alternate.\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.",
-                    "default": "preferred",
+                    "description": "Valid values are 1-65535 | \"preferred\" | \"alternate\".\n\n\"preferred\" is converted to priority 1.\n\"alternate\" is converted to priority 2.\n\nIf not set, each path-group in `names` will be attributed its `default_preference`.\nIn that casem the `default_preference` cannot be \"excluded\".",
                     "title": "Preference"
                   }
                 },
@@ -25347,8 +25352,7 @@
                           },
                           "preference": {
                             "type": "string",
-                            "description": "Valid values are 1-65535 | preferred | alternate.\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.",
-                            "default": "preferred",
+                            "description": "Valid values are 1-65535 | \"preferred\" | \"alternate\".\n\n\"preferred\" is converted to priority 1.\n\"alternate\" is converted to priority 2.\n\nIf not set, each path-group in `names` will be attributed its `default_preference`.\nIn that casem the `default_preference` cannot be \"excluded\".",
                             "title": "Preference"
                           }
                         },
@@ -25455,8 +25459,7 @@
                         },
                         "preference": {
                           "type": "string",
-                          "description": "Valid values are 1-65535 | preferred | alternate.\n\npreferred is converted to priority 1.\nalternate is converted to priority 2.",
-                          "default": "preferred",
+                          "description": "Valid values are 1-65535 | \"preferred\" | \"alternate\".\n\n\"preferred\" is converted to priority 1.\n\"alternate\" is converted to priority 2.\n\nIf not set, each path-group in `names` will be attributed its `default_preference`.\nIn that casem the `default_preference` cannot be \"excluded\".",
                           "title": "Preference"
                         }
                       },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3626,7 +3626,7 @@ keys:
           default: true
         import_path_groups:
           type: list
-          description: List of [ath-groups to import in this path-group.
+          description: List of path-groups to import in this path-group.
           items:
             type: dict
             keys:
@@ -3637,6 +3637,23 @@ keys:
                 type: str
                 description: Optional, if not set, the path-group `name` is used as
                   local.
+        default_preference:
+          type: str
+          convert_types:
+          - int
+          description: 'Preference to be used in auto-generated load balance policies
+            and policies in which preference is not given for the path group.
+
+
+            Valid values are 1-65535 | "preferred" | "alternate" | "excluded".
+
+
+            preferred is converted to priority 1.
+
+            alternate is converted to priority 2.
+
+            excluded means that the path-group is not considered for generating policies.'
+          default: preferred
   wan_route_servers:
     documentation_options:
       table: wan-settings
@@ -8491,7 +8508,7 @@ $defs:
               type: str
               convert_types:
               - int
-              description: 'Valid values are 1-255 | preferred | alternate.
+              description: 'Valid values are 1-65535 | preferred | alternate.
 
 
                 preferred is converted to priority 1.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3644,18 +3644,22 @@ keys:
           description: 'Preference value used when a preference is not given for a
             path-group in the `wan_virtual_topologies.policies` input or when
 
-            the path-group is used in an auto generated policy.
+            the path-group is used in an auto generated policy except if `excluded_from_default_policy`
+            is set to `true.
 
 
-            Valid values are 1-65535 | "preferred" | "alternate" | "excluded".
+            Valid values are 1-65535 | "preferred" | "alternate".
 
 
             `preferred` is converted to priority 1.
 
-            `alternate` is converted to priority 2.
-
-            `excluded` is used to ignore the path-group when generating policies.'
+            `alternate` is converted to priority 2.'
           default: preferred
+        excluded_from_default_policy:
+          type: bool
+          default: false
+          description: When set to `true`, the path-group is excluded from AVD auto
+            generated policies.
   wan_route_servers:
     documentation_options:
       table: wan-settings
@@ -8552,10 +8556,14 @@ $defs:
               type: str
               convert_types:
               - int
-              description: 'Valid values are 1-65535 | preferred | alternate.
+              description: 'Valid values are 1-65535 | "preferred" | "alternate".
 
 
-                preferred is converted to priority 1.
+                "preferred" is converted to priority 1.
 
-                alternate is converted to priority 2.'
-              default: preferred
+                "alternate" is converted to priority 2.
+
+
+                If not set, each path-group in `names` will be attributed its `default_preference`.
+
+                In that casem the `default_preference` cannot be "excluded".'

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3641,18 +3641,20 @@ keys:
           type: str
           convert_types:
           - int
-          description: 'Preference to be used in auto-generated load balance policies
-            and policies in which preference is not given for the path group.
+          description: 'Preference value used when a preference is not given for a
+            path-group in the `wan_virtual_topologies.policies` input or when
+
+            the path-group is used in an auto generated policy.
 
 
             Valid values are 1-65535 | "preferred" | "alternate" | "excluded".
 
 
-            preferred is converted to priority 1.
+            `preferred` is converted to priority 1.
 
-            alternate is converted to priority 2.
+            `alternate` is converted to priority 2.
 
-            excluded means that the path-group is not considered for generating policies.'
+            `excluded` is used to ignore the path-group when generating policies.'
           default: preferred
   wan_route_servers:
     documentation_options:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -8608,6 +8608,4 @@ $defs:
                 "alternate" is converted to priority 2.
 
 
-                If not set, each path-group in `names` will be attributed its `default_preference`.
-
-                In that casem the `default_preference` cannot be "excluded".'
+                If not set, each path-group in `names` will be attributed its `default_preference`.'

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_virtual_topology.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_virtual_topology.schema.yml
@@ -61,4 +61,3 @@ $defs:
                 "alternate" is converted to priority 2.
 
                 If not set, each path-group in `names` will be attributed its `default_preference`.
-                In that casem the `default_preference` cannot be "excluded".

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_virtual_topology.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_virtual_topology.schema.yml
@@ -55,8 +55,10 @@ $defs:
               convert_types:
                 - int
               description: |-
-                Valid values are 1-65535 | preferred | alternate.
+                Valid values are 1-65535 | "preferred" | "alternate".
 
-                preferred is converted to priority 1.
-                alternate is converted to priority 2.
-              default: "preferred"
+                "preferred" is converted to priority 1.
+                "alternate" is converted to priority 2.
+
+                If not set, each path-group in `names` will be attributed its `default_preference`.
+                In that casem the `default_preference` cannot be "excluded".

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_virtual_topology.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_virtual_topology.schema.yml
@@ -55,7 +55,7 @@ $defs:
               convert_types:
                 - int
               description: |-
-                Valid values are 1-255 | preferred | alternate.
+                Valid values are 1-65535 | preferred | alternate.
 
                 preferred is converted to priority 1.
                 alternate is converted to priority 2.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_path_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_path_groups.schema.yml
@@ -54,11 +54,12 @@ keys:
           convert_types:
             - int
           description: |-
-            Preference to be used in auto-generated load balance policies and policies in which preference is not given for the path group.
+            Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when
+            the path-group is used in an auto generated policy.
 
             Valid values are 1-65535 | "preferred" | "alternate" | "excluded".
 
-            preferred is converted to priority 1.
-            alternate is converted to priority 2.
-            excluded means that the path-group is not considered for generating policies.
+            `preferred` is converted to priority 1.
+            `alternate` is converted to priority 2.
+            `excluded` is used to ignore the path-group when generating policies.
           default: "preferred"

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_path_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_path_groups.schema.yml
@@ -39,7 +39,7 @@ keys:
           default: true
         import_path_groups:
           type: list
-          description: List of [ath-groups to import in this path-group.
+          description: List of path-groups to import in this path-group.
           items:
             type: dict
             keys:
@@ -49,3 +49,16 @@ keys:
               local:
                 type: str
                 description: Optional, if not set, the path-group `name` is used as local.
+        default_preference:
+          type: str
+          convert_types:
+            - int
+          description: |-
+            Preference to be used in auto-generated load balance policies and policies in which preference is not given for the path group.
+
+            Valid values are 1-65535 | "preferred" | "alternate" | "excluded".
+
+            preferred is converted to priority 1.
+            alternate is converted to priority 2.
+            excluded means that the path-group is not considered for generating policies.
+          default: "preferred"

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_path_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_path_groups.schema.yml
@@ -55,11 +55,15 @@ keys:
             - int
           description: |-
             Preference value used when a preference is not given for a path-group in the `wan_virtual_topologies.policies` input or when
-            the path-group is used in an auto generated policy.
+            the path-group is used in an auto generated policy except if `excluded_from_default_policy` is set to `true.
 
-            Valid values are 1-65535 | "preferred" | "alternate" | "excluded".
+            Valid values are 1-65535 | "preferred" | "alternate".
 
             `preferred` is converted to priority 1.
             `alternate` is converted to priority 2.
-            `excluded` is used to ignore the path-group when generating policies.
           default: "preferred"
+        excluded_from_default_policy:
+          type: bool
+          default: false
+          description: |-
+            When set to `true`, the path-group is excluded from AVD auto generated policies.


### PR DESCRIPTION
## Change Summary

Whenever AVD automatically generates a policy including a path group (e.g. for Control Plane), currently we use preference 1. Give an option to user in wan_path_gorups to specify default_preference which will be used instead of 1.

Also provide an exclude_from_auto_lb_policies parameter so user can exclude this path group from auto generated load balance policies if need be

## Related Issue(s)

Fixes #
## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Add a knob to define default preference used when no preference is defined under `wan_virtual_topologies.polices` or when AVD is auto-generating a policy.

`excluded` means that the path-group is not inserted.

```
wan_path_groups
  - name: <str>
    default_preference : str < preferred | alternate | excluded | priority as integer>
```

## How to test
molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
