### PR TITLE
Feat(eos_designs): Add wan_carrier and circuit_id to l3 interface description

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
@@ -79,6 +79,7 @@ interface Dps1
    ip address 192.168.255.1/32
 !
 interface Ethernet1
+   description Comcast_666
    no shutdown
    no switchport
    ip address dhcp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -93,6 +93,7 @@ interface Dps1
    ip address 192.168.130.1/32
 !
 interface Ethernet1
+   description Comcast_666
    no shutdown
    no switchport
    ip address dhcp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -87,6 +87,7 @@ interface Dps1
    ip address 192.168.131.1/32
 !
 interface Ethernet1
+   description ATT_777
    no shutdown
    no switchport
    ip address dhcp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -87,6 +87,7 @@ interface Dps1
    ip address 192.168.131.2/32
 !
 interface Ethernet1
+   description ATT_888
    no shutdown
    no switchport
    ip address 10.8.8.8/31

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -152,6 +152,7 @@ interface Dps1
    ip address 192.168.255.1/32
 !
 interface Ethernet1
+   description ATT_666
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER
@@ -159,12 +160,14 @@ interface Ethernet1
    dhcp client accept default-route
 !
 interface Ethernet2
+   description Colt_10555
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.15.5.5/31
 !
 interface Ethernet3
+   description Comcast-5G_AF830
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -179,6 +179,7 @@ interface Dps1
    ip address 192.168.142.2/32
 !
 interface Ethernet1
+   description Inmrasat_S511
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -144,6 +144,7 @@ interface Dps1
    ip address 192.168.255.1/32
 !
 interface Ethernet1
+   description ATT_666
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER
@@ -151,12 +152,14 @@ interface Ethernet1
    dhcp client accept default-route
 !
 interface Ethernet2
+   description Colt_10555
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.15.5.5/31
 !
 interface Ethernet3
+   description Comcast-5G_AF830
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -217,6 +217,7 @@ interface Dps1
    ip address 192.168.142.1/32
 !
 interface Ethernet1
+   description ATT_666_peer3_Ethernet42
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER
@@ -224,12 +225,14 @@ interface Ethernet1
    dhcp client accept default-route
 !
 interface Ethernet2
+   description Colt_10555
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.15.5.5/31
 !
 interface Ethernet3
+   description Comcast-5G_AF830
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -214,6 +214,7 @@ interface Dps1
    ip address 192.168.142.2/32
 !
 interface Ethernet1
+   description ATT_423-01
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -212,6 +212,7 @@ interface Dps1
    ip address 192.168.142.3/32
 !
 interface Ethernet2
+   description Colt_10423
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -220,18 +220,21 @@ interface Dps1
    ip address 192.168.144.1/32
 !
 interface Ethernet1
+   description Bouygues_Telecom_777
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 10.7.7.7/31
 !
 interface Ethernet2
+   description Colt_10000
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 172.16.0.1/31
 !
 interface Ethernet3
+   description Another-ISP_999
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -222,6 +222,7 @@ interface Dps1
    ip address 192.168.144.2/32
 !
 interface Ethernet1
+   description Orange_888
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -230,12 +230,14 @@ interface Dps1
    ip address 192.168.144.3/32
 !
 interface Ethernet1
+   description SFR_999
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER
    ip address 10.9.9.9/31
 !
 interface Ethernet2
+   description ATT-MPLS_10999
    no shutdown
    no switchport
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -265,6 +265,7 @@ interface Ethernet1
    no switchport
 !
 interface Ethernet1.42
+   description Comcast
    no shutdown
    encapsulation dot1q vlan 42
    flow tracker hardware WAN-FLOW-TRACKER
@@ -276,6 +277,7 @@ interface Ethernet2
    no switchport
 !
 interface Ethernet2.42
+   description Colt_10666
    no shutdown
    encapsulation dot1q vlan 666
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -265,6 +265,7 @@ interface Ethernet1
    no switchport
 !
 interface Ethernet1.42
+   description Comcast
    no shutdown
    encapsulation dot1q vlan 42
    flow tracker hardware WAN-FLOW-TRACKER
@@ -276,6 +277,7 @@ interface Ethernet2
    no switchport
 !
 interface Ethernet2.42
+   description Colt_10666
    no shutdown
    encapsulation dot1q vlan 666
    flow tracker hardware WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
@@ -116,6 +116,7 @@ ethernet_interfaces:
   ip_address: dhcp
   shutdown: false
   type: routed
+  description: Comcast_666
   dhcp_client_accept_default_route: true
 loopback_interfaces:
 - name: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -106,6 +106,7 @@ ethernet_interfaces:
   ip_address: dhcp
   shutdown: false
   type: routed
+  description: Comcast_666
   dhcp_client_accept_default_route: true
 loopback_interfaces:
 - name: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -109,6 +109,7 @@ ethernet_interfaces:
   ip_address: dhcp
   shutdown: false
   type: routed
+  description: ATT_777
   dhcp_client_accept_default_route: true
 loopback_interfaces:
 - name: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -109,6 +109,7 @@ ethernet_interfaces:
   ip_address: 10.8.8.8/31
   shutdown: false
   type: routed
+  description: ATT_888
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -110,6 +110,7 @@ ethernet_interfaces:
   ip_address: dhcp
   shutdown: false
   type: routed
+  description: ATT_666
   dhcp_client_accept_default_route: true
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
@@ -118,6 +119,7 @@ ethernet_interfaces:
   ip_address: 172.15.5.5/31
   shutdown: false
   type: routed
+  description: Colt_10555
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 - name: Ethernet3
@@ -125,6 +127,7 @@ ethernet_interfaces:
   ip_address: 172.20.20.20/31
   shutdown: false
   type: routed
+  description: Comcast-5G_AF830
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -208,6 +208,7 @@ ethernet_interfaces:
   ip_address: dhcp
   shutdown: false
   type: routed
+  description: Inmrasat_S511
   dhcp_client_accept_default_route: true
   flow_tracker:
     hardware: WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -127,6 +127,7 @@ ethernet_interfaces:
   ip_address: dhcp
   shutdown: false
   type: routed
+  description: ATT_666
   dhcp_client_accept_default_route: true
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
@@ -135,6 +136,7 @@ ethernet_interfaces:
   ip_address: 172.15.5.5/31
   shutdown: false
   type: routed
+  description: Colt_10555
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 - name: Ethernet3
@@ -142,6 +144,7 @@ ethernet_interfaces:
   ip_address: 172.20.20.20/31
   shutdown: false
   type: routed
+  description: Comcast-5G_AF830
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -215,9 +215,12 @@ ethernet_interfaces:
   ip_address: 172.17.0.1/31
 - name: Ethernet1
   peer_type: l3_interface
+  peer: peer3
+  peer_interface: Ethernet42
   ip_address: dhcp
   shutdown: false
   type: routed
+  description: ATT_666_peer3_Ethernet42
   dhcp_client_accept_default_route: true
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
@@ -226,6 +229,7 @@ ethernet_interfaces:
   ip_address: 172.15.5.5/31
   shutdown: false
   type: routed
+  description: Colt_10555
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 - name: Ethernet3
@@ -233,6 +237,7 @@ ethernet_interfaces:
   ip_address: 172.20.20.20/31
   shutdown: false
   type: routed
+  description: Comcast-5G_AF830
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -280,6 +280,7 @@ ethernet_interfaces:
   ip_address: dhcp
   shutdown: false
   type: routed
+  description: ATT_423-01
   dhcp_client_accept_default_route: true
   flow_tracker:
     hardware: WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -280,6 +280,7 @@ ethernet_interfaces:
   ip_address: 172.15.6.6/31
   shutdown: false
   type: routed
+  description: Colt_10423
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -111,6 +111,7 @@ ethernet_interfaces:
   ip_address: 10.7.7.7/31
   shutdown: false
   type: routed
+  description: Bouygues_Telecom_777
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 - name: Ethernet2
@@ -118,6 +119,7 @@ ethernet_interfaces:
   ip_address: 172.16.0.1/31
   shutdown: false
   type: routed
+  description: Colt_10000
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 - name: Ethernet3
@@ -125,6 +127,7 @@ ethernet_interfaces:
   ip_address: 10.9.9.9/31
   shutdown: false
   type: routed
+  description: Another-ISP_999
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -142,6 +142,7 @@ ethernet_interfaces:
   ip_address: 10.8.8.8/31
   shutdown: false
   type: routed
+  description: Orange_888
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -142,6 +142,7 @@ ethernet_interfaces:
   ip_address: 10.9.9.9/31
   shutdown: false
   type: routed
+  description: SFR_999
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 - name: Ethernet2
@@ -149,6 +150,7 @@ ethernet_interfaces:
   ip_address: 172.19.9.9/31
   shutdown: false
   type: routed
+  description: ATT-MPLS_10999
   flow_tracker:
     hardware: WAN-FLOW-TRACKER
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -243,6 +243,7 @@ ethernet_interfaces:
   ip_address: dhcp
   shutdown: false
   type: l3dot1q
+  description: Comcast
   encapsulation_dot1q_vlan: 42
   dhcp_client_accept_default_route: true
   flow_tracker:
@@ -252,6 +253,7 @@ ethernet_interfaces:
   ip_address: 172.16.6.6/31
   shutdown: false
   type: l3dot1q
+  description: Colt_10666
   encapsulation_dot1q_vlan: 666
   flow_tracker:
     hardware: WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -243,6 +243,7 @@ ethernet_interfaces:
   ip_address: dhcp
   shutdown: false
   type: l3dot1q
+  description: Comcast
   encapsulation_dot1q_vlan: 42
   dhcp_client_accept_default_route: true
   flow_tracker:
@@ -252,6 +253,7 @@ ethernet_interfaces:
   ip_address: 172.16.6.6/31
   shutdown: false
   type: l3dot1q
+  description: Colt_10666
   encapsulation_dot1q_vlan: 666
   flow_tracker:
     hardware: WAN-FLOW-TRACKER

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -74,6 +74,8 @@ wan_router:
           uplink_switch_interfaces: [Ethernet1]
           l3_interfaces:
             - name: Ethernet1
+              peer: peer3
+              peer_interface: Ethernet42
               wan_carrier: ATT
               wan_circuit_id: 666
               dhcp_accept_default_route: true

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/avdinterfacedescriptions.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/avdinterfacedescriptions.py
@@ -43,8 +43,19 @@ class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
             - overlay_routing_protocol
             - type
             - vrf
+            - wan_carrier
+            - wan_circuit_id
         """
-        desc = self.underlay_ethernet_interfaces(link_type=data.link_type, link_peer=data.peer, link_peer_interface=data.peer_interface)
+        desc = self.underlay_ethernet_interfaces(
+            link_type=data.link_type,
+            link_peer=data.peer,
+            link_peer_interface=data.peer_interface,
+        )
+
+        if not desc:
+            elems = [data.wan_carrier, data.wan_circuit_id, data.peer, data.peer_interface]
+            desc = "_".join([elem for elem in elems if elem])
+
         return f"{desc}_vrf_{data.vrf}" if data.vrf is not None else desc
 
     def underlay_ethernet_interfaces(self, link_type: str, link_peer: str, link_peer_interface: str) -> str:
@@ -59,7 +70,8 @@ class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
                 },
             )
 
-        link_peer = str(link_peer).upper()
+        if link_peer:
+            link_peer = str(link_peer).upper()
         if link_type == "underlay_p2p":
             return f"P2P_LINK_TO_{link_peer}_{link_peer_interface}"
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/models.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/interface_descriptions/models.py
@@ -41,6 +41,10 @@ class InterfaceDescriptionData:
     """Set description for port-channel"""
     vrf: str | None
     """Interface VRF"""
+    wan_carrier: str | None
+    """The WAN Carrier this interface is connected to"""
+    wan_circuit_id: str | None
+    """The WAN Circuit ID for this interface."""
 
     def __init__(
         self,
@@ -53,6 +57,8 @@ class InterfaceDescriptionData:
         peer_channel_group_id: int | None = None,
         port_channel_description: str | None = None,
         vrf: str | None = None,
+        wan_carrier: str | None = None,
+        wan_circuit_id: str | None = None,
     ):
         self._shared_utils = shared_utils
         self.description = description
@@ -63,6 +69,8 @@ class InterfaceDescriptionData:
         self.peer_channel_group_id = peer_channel_group_id
         self.port_channel_description = port_channel_description
         self.vrf = vrf
+        self.wan_carrier = wan_carrier
+        self.wan_circuit_id = wan_circuit_id
 
     @cached_property
     def mpls_overlay_role(self) -> str:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -10,6 +10,8 @@ from ansible_collections.arista.avd.plugins.plugin_utils.eos_designs_shared_util
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_empties_from_dict
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
 
+from ..interface_descriptions import InterfaceDescriptionData
+
 
 class UtilsMixin:
     """
@@ -144,12 +146,18 @@ class UtilsMixin:
         else:
             iface_type = "routed"
 
-        # TODO move this to description module?
-        interface_description = (
-            l3_interface.get("description")
-            or "_".join([elem for elem in [l3_interface.get("peer"), l3_interface.get("peer_interface")] if elem is not None])
-            or None
-        )
+        interface_description = l3_interface.get("description")
+        if not interface_description:
+            interface_description = self.shared_utils.interface_descriptions.underlay_ethernet_interface(
+                InterfaceDescriptionData(
+                    shared_utils=self.shared_utils,
+                    interface=interface_name,
+                    peer=l3_interface.get("peer"),
+                    peer_interface=l3_interface.get("peer_interface"),
+                    wan_carrier=l3_interface.get("wan_carrier"),
+                    wan_circuit_id=l3_interface.get("wan_circuit_id"),
+                )
+            )
 
         # TODO catch if ip_address is not valid or not dhcp
         ip_address = get(


### PR DESCRIPTION
## Change Summary

Add wan_carrier and circuit_id to l3 interface description

## Related Issue(s)

Fixes #3527

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
.

## How to test
molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
