### PR TITLE
Feat(eos_designs): Add filter.allow_vrfs and filter.deny_vrfs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.vrfs.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.vrfs.cfg
@@ -14,10 +14,10 @@ no aaa root
 vrf instance MGMT
 !
 vrf instance VRF2
-   description This VRF will be configured because it is permitted by filter.vrfs
+   description This VRF is attracted by Loopback and will be configured because it is permitted by filter.allow_vrfs
 !
 vrf instance VRF5
-   description This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.vrfs
+   description This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.allow_vrfs
 !
 interface Loopback0
    description EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.vrfs.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.vrfs.cfg
@@ -1,0 +1,76 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname filter.vrfs
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+vrf instance VRF2
+   description This VRF will be configured because it is permitted by filter.vrfs
+!
+vrf instance VRF5
+   description This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.vrfs
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.0.0.1/32
+!
+interface Loopback2
+   no shutdown
+   vrf VRF2
+   ip address 192.168.1.1/32
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf VRF2
+ip routing vrf VRF5
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.0.0.0/24 eq 32
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 10.0.0.1
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.vrfs.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.vrfs.yml
@@ -1,0 +1,88 @@
+hostname: filter.vrfs
+is_deployed: true
+router_bgp:
+  as: '65001'
+  router_id: 10.0.0.1
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+- name: VRF2
+  tenant: TENANT1
+  ip_routing: true
+  description: This VRF will be configured because it is permitted by filter.vrfs
+- name: VRF5
+  tenant: TENANT2
+  ip_routing: true
+  description: This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.vrfs
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+loopback_interfaces:
+- name: Loopback0
+  description: EVPN_Overlay_Peering
+  shutdown: false
+  ip_address: 10.0.0.1/32
+- name: Loopback2
+  ip_address: 192.168.1.1/32
+  shutdown: false
+  vrf: VRF2
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 10.0.0.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+ip_igmp_snooping:
+  globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.vrfs.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.vrfs.yml
@@ -49,11 +49,11 @@ vrfs:
 - name: VRF2
   tenant: TENANT1
   ip_routing: true
-  description: This VRF will be configured because it is permitted by filter.vrfs
+  description: This VRF is attracted by Loopback and will be configured because it is permitted by filter.allow_vrfs
 - name: VRF5
   tenant: TENANT2
   ip_routing: true
-  description: This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.vrfs
+  description: This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.allow_vrfs
 management_api_http:
   enable_vrfs:
   - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.vrfs.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.vrfs.yml
@@ -8,6 +8,7 @@ l3leaf:
       bgp_as: 65001
       vtep: false
       filter:
+        # deny_vrfs takes precedence over allow_vrfs, so VRF1 & VRF4 will be denied even when listed under allow_vrfs.
         deny_vrfs: [VRF1, VRF4]
         allow_vrfs: [VRF1, VRF2, VRF4, VRF5]
         always_include_vrfs_in_tenants: [TENANT2]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.vrfs.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.vrfs.yml
@@ -8,26 +8,28 @@ l3leaf:
       bgp_as: 65001
       vtep: false
       filter:
-        not_vrfs: [VRF1, VRF4]
-        vrfs: [VRF1, VRF2, VRF4, VRF5]
+        deny_vrfs: [VRF1, VRF4]
+        allow_vrfs: [VRF1, VRF2, VRF4, VRF5]
         always_include_vrfs_in_tenants: [TENANT2]
 tenants:
   - name: TENANT1
     vrfs:
       - name: VRF1
-        description: This VRF would have been configured because it is attracted by Loopback0, but it is prevented by filter.not_vrfs
+        description: This VRF would have been configured because it is attracted by Loopback, but it is prevented by filter.deny_vrfs
         loopbacks:
           - loopback: 1
             node: filter.vrfs
             ip_address: 192.168.1.1/32
       - name: VRF2
-        description: This VRF will be configured because it is permitted by filter.vrfs
+        description: This VRF is attracted by Loopback and will be configured because it is permitted by filter.allow_vrfs
         loopbacks:
           - loopback: 2
             node: filter.vrfs
             ip_address: 192.168.1.1/32
       - name: VRF3
-        description: This VRF will not be configured because it is not permitted by filter.vrfs
+        description: >-
+          This VRF would have been configured because it is attracted by Loopback,
+          but it is prevented because it is not permitted by filter.allow_vrfs
         loopbacks:
           - loopback: 3
             node: filter.vrfs
@@ -36,8 +38,8 @@ tenants:
   - name: TENANT2
     vrfs:
       - name: VRF4
-        description: This VRF would have been configured because of always_include_vrfs_in_tenants, but it is prevented by filter.not_vrfs
+        description: This VRF would have been configured because of always_include_vrfs_in_tenants, but it is prevented by filter.deny_vrfs
       - name: VRF5
-        description: This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.vrfs
+        description: This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.allow_vrfs
       - name: VRF6
-        description: This VRF will not be configured because it is not permitted by filter.vrfs
+        description: This VRF will not be configured because it is not permitted by filter.allow_vrfs

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.vrfs.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/filter.vrfs.yml
@@ -1,0 +1,43 @@
+type: l3leaf
+
+l3leaf:
+  nodes:
+    - name: filter.vrfs
+      id: 1
+      loopback_ipv4_pool: 10.0.0.0/24
+      bgp_as: 65001
+      vtep: false
+      filter:
+        not_vrfs: [VRF1, VRF4]
+        vrfs: [VRF1, VRF2, VRF4, VRF5]
+        always_include_vrfs_in_tenants: [TENANT2]
+tenants:
+  - name: TENANT1
+    vrfs:
+      - name: VRF1
+        description: This VRF would have been configured because it is attracted by Loopback0, but it is prevented by filter.not_vrfs
+        loopbacks:
+          - loopback: 1
+            node: filter.vrfs
+            ip_address: 192.168.1.1/32
+      - name: VRF2
+        description: This VRF will be configured because it is permitted by filter.vrfs
+        loopbacks:
+          - loopback: 2
+            node: filter.vrfs
+            ip_address: 192.168.1.1/32
+      - name: VRF3
+        description: This VRF will not be configured because it is not permitted by filter.vrfs
+        loopbacks:
+          - loopback: 3
+            node: filter.vrfs
+            ip_address: 192.168.1.1/32
+
+  - name: TENANT2
+    vrfs:
+      - name: VRF4
+        description: This VRF would have been configured because of always_include_vrfs_in_tenants, but it is prevented by filter.not_vrfs
+      - name: VRF5
+        description: This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.vrfs
+      - name: VRF6
+        description: This VRF will not be configured because it is not permitted by filter.vrfs

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -14,6 +14,7 @@ all:
             evpn-vtep-with-default-vrf-not-evpn:
             duplicate-vrfs:
             filter.only_vlans_in_use:
+            filter.vrfs:
             generate-cv-tags-1:
             generate-cv-tags-2:
             ignore-custom-keys-in-data-models:

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
@@ -161,13 +161,15 @@ class FilteredTenantsMixin:
         """
         Returns True if
 
-        - filter.vrfs == ["all"] OR VRF is included in filter.vrfs.
+        - filter.allow_vrfs == ["all"] OR VRF is included in filter.allow_vrfs.
 
         AND
 
-        - filter.not_vrfs == [] OR VRF is NOT in filter.not_vrfs
+        - filter.not_vrfs == [] OR VRF is NOT in filter.deny_vrfs
         """
-        return ("all" in self.filter_vrfs or vrf["name"] in self.filter_vrfs) and (not self.filter_not_vrfs or vrf["name"] not in self.filter_not_vrfs)
+        return ("all" in self.filter_allow_vrfs or vrf["name"] in self.filter_allow_vrfs) and (
+            not self.filter_deny_vrfs or vrf["name"] not in self.filter_deny_vrfs
+        )
 
     def filtered_vrfs(self: SharedUtils, tenant: dict) -> list[dict]:
         """

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
@@ -165,7 +165,7 @@ class FilteredTenantsMixin:
 
         AND
 
-        - filter.not_vrfs == [] OR (filter.not_vrfs != ["all"] AND VRF is NOT in filter.not_vrfs)
+        - filter.not_vrfs == [] OR VRF is NOT in filter.not_vrfs
         """
         return ("all" in self.filter_vrfs or vrf["name"] in self.filter_vrfs) and (not self.filter_not_vrfs or vrf["name"] not in self.filter_not_vrfs)
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/filtered_tenants.py
@@ -157,6 +157,18 @@ class FilteredTenantsMixin:
 
         return accepted_vlans
 
+    def is_accepted_vrf(self: SharedUtils, vrf: dict) -> bool:
+        """
+        Returns True if
+
+        - filter.vrfs == ["all"] OR VRF is included in filter.vrfs.
+
+        AND
+
+        - filter.not_vrfs == [] OR (filter.not_vrfs != ["all"] AND VRF is NOT in filter.not_vrfs)
+        """
+        return ("all" in self.filter_vrfs or vrf["name"] in self.filter_vrfs) and (not self.filter_not_vrfs or vrf["name"] not in self.filter_not_vrfs)
+
     def filtered_vrfs(self: SharedUtils, tenant: dict) -> list[dict]:
         """
         Return sorted and filtered vrf list from given tenant.
@@ -169,6 +181,9 @@ class FilteredTenantsMixin:
 
         vrfs: list[dict] = natural_sort(convert_dicts(tenant.get("vrfs", []), "name"), "name")
         for original_vrf in vrfs:
+            if not self.is_accepted_vrf(original_vrf):
+                continue
+
             # Copying original_vrf and setting "tenant" for use by child objects like SVIs
             vrf = {**original_vrf, "tenant": tenant["name"]}
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
@@ -68,6 +68,14 @@ class MiscMixin:
         return filter_tags
 
     @cached_property
+    def filter_vrfs(self: SharedUtils) -> list:
+        return get(self.switch_data_combined, "filter.vrfs", default=["all"])
+
+    @cached_property
+    def filter_not_vrfs(self: SharedUtils) -> list:
+        return get(self.switch_data_combined, "filter.not_vrfs", default=[])
+
+    @cached_property
     def filter_tenants(self: SharedUtils) -> list:
         return get(self.switch_data_combined, "filter.tenants", default=["all"])
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/misc.py
@@ -68,12 +68,12 @@ class MiscMixin:
         return filter_tags
 
     @cached_property
-    def filter_vrfs(self: SharedUtils) -> list:
-        return get(self.switch_data_combined, "filter.vrfs", default=["all"])
+    def filter_allow_vrfs(self: SharedUtils) -> list:
+        return get(self.switch_data_combined, "filter.allow_vrfs", default=["all"])
 
     @cached_property
-    def filter_not_vrfs(self: SharedUtils) -> list:
-        return get(self.switch_data_combined, "filter.not_vrfs", default=[])
+    def filter_deny_vrfs(self: SharedUtils) -> list:
+        return get(self.switch_data_combined, "filter.deny_vrfs", default=[])
 
     @cached_property
     def filter_tenants(self: SharedUtils) -> list:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-services-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-services-configuration.md
@@ -15,10 +15,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.defaults.filter.tags") | List, items: String |  | `['all']` |  | Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.tags.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "<node_type_keys.key>.defaults.filter.vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.vrfs.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;not_vrfs</samp>](## "<node_type_keys.key>.defaults.filter.not_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.not_vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allow_vrfs</samp>](## "<node_type_keys.key>.defaults.filter.allow_vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.allow_vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;deny_vrfs</samp>](## "<node_type_keys.key>.defaults.filter.deny_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.deny_vrfs.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_include_vrfs_in_tenants</samp>](## "<node_type_keys.key>.defaults.filter.always_include_vrfs_in_tenants") | List, items: String |  |  |  | List of tenants where VRFs will be configured even if VLANs are not included in tags.<br>Useful for L3 "border" leaf.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.always_include_vrfs_in_tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;only_vlans_in_use</samp>](## "<node_type_keys.key>.defaults.filter.only_vlans_in_use") | Boolean |  | `False` |  | Only configure VLANs, SVIs, VRFs in use by connected endpoints or downstream L2 switches.<br>Note! This feature only considers configuration managed by eos_designs.<br>This excludes structured_config, custom_structured_configuration_, raw_eos_cli, eos_cli, custom templates, configlets etc.<br> |
@@ -33,10 +33,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.tags") | List, items: String |  | `['all']` |  | Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.tags.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.vrfs.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;not_vrfs</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.not_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.not_vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allow_vrfs</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.allow_vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.allow_vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;deny_vrfs</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.deny_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.deny_vrfs.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_include_vrfs_in_tenants</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.always_include_vrfs_in_tenants") | List, items: String |  |  |  | List of tenants where VRFs will be configured even if VLANs are not included in tags.<br>Useful for L3 "border" leaf.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.always_include_vrfs_in_tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;only_vlans_in_use</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.only_vlans_in_use") | Boolean |  | `False` |  | Only configure VLANs, SVIs, VRFs in use by connected endpoints or downstream L2 switches.<br>Note! This feature only considers configuration managed by eos_designs.<br>This excludes structured_config, custom_structured_configuration_, raw_eos_cli, eos_cli, custom templates, configlets etc.<br> |
@@ -47,10 +47,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.node_groups.[].filter.tags") | List, items: String |  | `['all']` |  | Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.tags.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "<node_type_keys.key>.node_groups.[].filter.vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.vrfs.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;not_vrfs</samp>](## "<node_type_keys.key>.node_groups.[].filter.not_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.not_vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allow_vrfs</samp>](## "<node_type_keys.key>.node_groups.[].filter.allow_vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.allow_vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;deny_vrfs</samp>](## "<node_type_keys.key>.node_groups.[].filter.deny_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.deny_vrfs.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_include_vrfs_in_tenants</samp>](## "<node_type_keys.key>.node_groups.[].filter.always_include_vrfs_in_tenants") | List, items: String |  |  |  | List of tenants where VRFs will be configured even if VLANs are not included in tags.<br>Useful for L3 "border" leaf.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.always_include_vrfs_in_tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;only_vlans_in_use</samp>](## "<node_type_keys.key>.node_groups.[].filter.only_vlans_in_use") | Boolean |  | `False` |  | Only configure VLANs, SVIs, VRFs in use by connected endpoints or downstream L2 switches.<br>Note! This feature only considers configuration managed by eos_designs.<br>This excludes structured_config, custom_structured_configuration_, raw_eos_cli, eos_cli, custom templates, configlets etc.<br> |
@@ -63,10 +63,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.nodes.[].filter.tags") | List, items: String |  | `['all']` |  | Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.tags.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "<node_type_keys.key>.nodes.[].filter.vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.vrfs.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;not_vrfs</samp>](## "<node_type_keys.key>.nodes.[].filter.not_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.not_vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allow_vrfs</samp>](## "<node_type_keys.key>.nodes.[].filter.allow_vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.allow_vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;deny_vrfs</samp>](## "<node_type_keys.key>.nodes.[].filter.deny_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.deny_vrfs.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_include_vrfs_in_tenants</samp>](## "<node_type_keys.key>.nodes.[].filter.always_include_vrfs_in_tenants") | List, items: String |  |  |  | List of tenants where VRFs will be configured even if VLANs are not included in tags.<br>Useful for L3 "border" leaf.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.always_include_vrfs_in_tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;only_vlans_in_use</samp>](## "<node_type_keys.key>.nodes.[].filter.only_vlans_in_use") | Boolean |  | `False` |  | Only configure VLANs, SVIs, VRFs in use by connected endpoints or downstream L2 switches.<br>Note! This feature only considers configuration managed by eos_designs.<br>This excludes structured_config, custom_structured_configuration_, raw_eos_cli, eos_cli, custom templates, configlets etc.<br> |
@@ -100,12 +100,12 @@
 
           # Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
           # This list also limits VRFs included by `always_include_vrfs_in_tenants`.
-          vrfs: # default=['all']
+          allow_vrfs: # default=['all']
             - <str>
 
           # Prevent configuration of Network Services defined under these VRFs.
           # This list prevents the given VRFs to be included by any other filtering mechanism.
-          not_vrfs: # default=['all']
+          deny_vrfs: # default=['all']
             - <str>
 
           # List of tenants where VRFs will be configured even if VLANs are not included in tags.
@@ -154,12 +154,12 @@
 
                 # Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
                 # This list also limits VRFs included by `always_include_vrfs_in_tenants`.
-                vrfs: # default=['all']
+                allow_vrfs: # default=['all']
                   - <str>
 
                 # Prevent configuration of Network Services defined under these VRFs.
                 # This list prevents the given VRFs to be included by any other filtering mechanism.
-                not_vrfs: # default=['all']
+                deny_vrfs: # default=['all']
                   - <str>
 
                 # List of tenants where VRFs will be configured even if VLANs are not included in tags.
@@ -195,12 +195,12 @@
 
             # Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
             # This list also limits VRFs included by `always_include_vrfs_in_tenants`.
-            vrfs: # default=['all']
+            allow_vrfs: # default=['all']
               - <str>
 
             # Prevent configuration of Network Services defined under these VRFs.
             # This list prevents the given VRFs to be included by any other filtering mechanism.
-            not_vrfs: # default=['all']
+            deny_vrfs: # default=['all']
               - <str>
 
             # List of tenants where VRFs will be configured even if VLANs are not included in tags.
@@ -242,12 +242,12 @@
 
             # Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
             # This list also limits VRFs included by `always_include_vrfs_in_tenants`.
-            vrfs: # default=['all']
+            allow_vrfs: # default=['all']
               - <str>
 
             # Prevent configuration of Network Services defined under these VRFs.
             # This list prevents the given VRFs to be included by any other filtering mechanism.
-            not_vrfs: # default=['all']
+            deny_vrfs: # default=['all']
               - <str>
 
             # List of tenants where VRFs will be configured even if VLANs are not included in tags.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-services-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-evpn-services-configuration.md
@@ -11,10 +11,14 @@
     | [<samp>&nbsp;&nbsp;defaults</samp>](## "<node_type_keys.key>.defaults") | Dictionary |  |  |  | Define variables for all nodes of this type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_services_l2_only</samp>](## "<node_type_keys.key>.defaults.evpn_services_l2_only") | Boolean |  | `False` |  | Possibility to prevent configuration of Tenant VRFs and SVIs.<br>Override node definition "network_services_l3" from node_type_keys.<br>This allows support for centralized routing.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;filter</samp>](## "<node_type_keys.key>.defaults.filter") | Dictionary |  |  |  | Filter L3 and L2 network services based on tenant and tags (and operation filter).<br>If filter is not defined it will default to all.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenants</samp>](## "<node_type_keys.key>.defaults.filter.tenants") | List, items: String |  | `['all']` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenants</samp>](## "<node_type_keys.key>.defaults.filter.tenants") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).<br>This list also limits Tenants included by `always_include_vrfs_in_tenants`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.tenants.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.defaults.filter.tags") | List, items: String |  | `['all']` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.defaults.filter.tags") | List, items: String |  | `['all']` |  | Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.tags.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "<node_type_keys.key>.defaults.filter.vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;not_vrfs</samp>](## "<node_type_keys.key>.defaults.filter.not_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.not_vrfs.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_include_vrfs_in_tenants</samp>](## "<node_type_keys.key>.defaults.filter.always_include_vrfs_in_tenants") | List, items: String |  |  |  | List of tenants where VRFs will be configured even if VLANs are not included in tags.<br>Useful for L3 "border" leaf.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.defaults.filter.always_include_vrfs_in_tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;only_vlans_in_use</samp>](## "<node_type_keys.key>.defaults.filter.only_vlans_in_use") | Boolean |  | `False` |  | Only configure VLANs, SVIs, VRFs in use by connected endpoints or downstream L2 switches.<br>Note! This feature only considers configuration managed by eos_designs.<br>This excludes structured_config, custom_structured_configuration_, raw_eos_cli, eos_cli, custom templates, configlets etc.<br> |
@@ -25,20 +29,28 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_services_l2_only</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].evpn_services_l2_only") | Boolean |  | `False` |  | Possibility to prevent configuration of Tenant VRFs and SVIs.<br>Override node definition "network_services_l3" from node_type_keys.<br>This allows support for centralized routing.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;filter</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter") | Dictionary |  |  |  | Filter L3 and L2 network services based on tenant and tags (and operation filter).<br>If filter is not defined it will default to all.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenants</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.tenants") | List, items: String |  | `['all']` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenants</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.tenants") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).<br>This list also limits Tenants included by `always_include_vrfs_in_tenants`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.tenants.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.tags") | List, items: String |  | `['all']` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.tags") | List, items: String |  | `['all']` |  | Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.tags.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;not_vrfs</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.not_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.not_vrfs.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_include_vrfs_in_tenants</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.always_include_vrfs_in_tenants") | List, items: String |  |  |  | List of tenants where VRFs will be configured even if VLANs are not included in tags.<br>Useful for L3 "border" leaf.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.always_include_vrfs_in_tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;only_vlans_in_use</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].filter.only_vlans_in_use") | Boolean |  | `False` |  | Only configure VLANs, SVIs, VRFs in use by connected endpoints or downstream L2 switches.<br>Note! This feature only considers configuration managed by eos_designs.<br>This excludes structured_config, custom_structured_configuration_, raw_eos_cli, eos_cli, custom templates, configlets etc.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;igmp_snooping_enabled</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].igmp_snooping_enabled") | Boolean |  | `True` |  | Activate or deactivate IGMP snooping on device level. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_services_l2_only</samp>](## "<node_type_keys.key>.node_groups.[].evpn_services_l2_only") | Boolean |  | `False` |  | Possibility to prevent configuration of Tenant VRFs and SVIs.<br>Override node definition "network_services_l3" from node_type_keys.<br>This allows support for centralized routing.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;filter</samp>](## "<node_type_keys.key>.node_groups.[].filter") | Dictionary |  |  |  | Filter L3 and L2 network services based on tenant and tags (and operation filter).<br>If filter is not defined it will default to all.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenants</samp>](## "<node_type_keys.key>.node_groups.[].filter.tenants") | List, items: String |  | `['all']` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenants</samp>](## "<node_type_keys.key>.node_groups.[].filter.tenants") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).<br>This list also limits Tenants included by `always_include_vrfs_in_tenants`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.tenants.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.node_groups.[].filter.tags") | List, items: String |  | `['all']` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.node_groups.[].filter.tags") | List, items: String |  | `['all']` |  | Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.tags.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "<node_type_keys.key>.node_groups.[].filter.vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;not_vrfs</samp>](## "<node_type_keys.key>.node_groups.[].filter.not_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.not_vrfs.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_include_vrfs_in_tenants</samp>](## "<node_type_keys.key>.node_groups.[].filter.always_include_vrfs_in_tenants") | List, items: String |  |  |  | List of tenants where VRFs will be configured even if VLANs are not included in tags.<br>Useful for L3 "border" leaf.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.node_groups.[].filter.always_include_vrfs_in_tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;only_vlans_in_use</samp>](## "<node_type_keys.key>.node_groups.[].filter.only_vlans_in_use") | Boolean |  | `False` |  | Only configure VLANs, SVIs, VRFs in use by connected endpoints or downstream L2 switches.<br>Note! This feature only considers configuration managed by eos_designs.<br>This excludes structured_config, custom_structured_configuration_, raw_eos_cli, eos_cli, custom templates, configlets etc.<br> |
@@ -47,10 +59,14 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "<node_type_keys.key>.nodes.[].name") | String | Required, Unique |  |  | The Node Name is used as "hostname". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_services_l2_only</samp>](## "<node_type_keys.key>.nodes.[].evpn_services_l2_only") | Boolean |  | `False` |  | Possibility to prevent configuration of Tenant VRFs and SVIs.<br>Override node definition "network_services_l3" from node_type_keys.<br>This allows support for centralized routing.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;filter</samp>](## "<node_type_keys.key>.nodes.[].filter") | Dictionary |  |  |  | Filter L3 and L2 network services based on tenant and tags (and operation filter).<br>If filter is not defined it will default to all.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenants</samp>](## "<node_type_keys.key>.nodes.[].filter.tenants") | List, items: String |  | `['all']` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenants</samp>](## "<node_type_keys.key>.nodes.[].filter.tenants") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).<br>This list also limits Tenants included by `always_include_vrfs_in_tenants`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.tenants.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.nodes.[].filter.tags") | List, items: String |  | `['all']` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tags</samp>](## "<node_type_keys.key>.nodes.[].filter.tags") | List, items: String |  | `['all']` |  | Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.tags.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrfs</samp>](## "<node_type_keys.key>.nodes.[].filter.vrfs") | List, items: String |  | `['all']` |  | Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).<br>This list also limits VRFs included by `always_include_vrfs_in_tenants`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.vrfs.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;not_vrfs</samp>](## "<node_type_keys.key>.nodes.[].filter.not_vrfs") | List, items: String |  | `['all']` |  | Prevent configuration of Network Services defined under these VRFs.<br>This list prevents the given VRFs to be included by any other filtering mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.not_vrfs.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always_include_vrfs_in_tenants</samp>](## "<node_type_keys.key>.nodes.[].filter.always_include_vrfs_in_tenants") | List, items: String |  |  |  | List of tenants where VRFs will be configured even if VLANs are not included in tags.<br>Useful for L3 "border" leaf.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<node_type_keys.key>.nodes.[].filter.always_include_vrfs_in_tenants.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;only_vlans_in_use</samp>](## "<node_type_keys.key>.nodes.[].filter.only_vlans_in_use") | Boolean |  | `False` |  | Only configure VLANs, SVIs, VRFs in use by connected endpoints or downstream L2 switches.<br>Note! This feature only considers configuration managed by eos_designs.<br>This excludes structured_config, custom_structured_configuration_, raw_eos_cli, eos_cli, custom templates, configlets etc.<br> |
@@ -72,9 +88,24 @@
         # Filter L3 and L2 network services based on tenant and tags (and operation filter).
         # If filter is not defined it will default to all.
         filter:
+
+          # Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).
+          # This list also limits Tenants included by `always_include_vrfs_in_tenants`.
           tenants: # default=['all']
             - <str>
+
+          # Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default).
           tags: # default=['all']
+            - <str>
+
+          # Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
+          # This list also limits VRFs included by `always_include_vrfs_in_tenants`.
+          vrfs: # default=['all']
+            - <str>
+
+          # Prevent configuration of Network Services defined under these VRFs.
+          # This list prevents the given VRFs to be included by any other filtering mechanism.
+          not_vrfs: # default=['all']
             - <str>
 
           # List of tenants where VRFs will be configured even if VLANs are not included in tags.
@@ -111,9 +142,24 @@
               # Filter L3 and L2 network services based on tenant and tags (and operation filter).
               # If filter is not defined it will default to all.
               filter:
+
+                # Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).
+                # This list also limits Tenants included by `always_include_vrfs_in_tenants`.
                 tenants: # default=['all']
                   - <str>
+
+                # Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default).
                 tags: # default=['all']
+                  - <str>
+
+                # Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
+                # This list also limits VRFs included by `always_include_vrfs_in_tenants`.
+                vrfs: # default=['all']
+                  - <str>
+
+                # Prevent configuration of Network Services defined under these VRFs.
+                # This list prevents the given VRFs to be included by any other filtering mechanism.
+                not_vrfs: # default=['all']
                   - <str>
 
                 # List of tenants where VRFs will be configured even if VLANs are not included in tags.
@@ -137,9 +183,24 @@
           # Filter L3 and L2 network services based on tenant and tags (and operation filter).
           # If filter is not defined it will default to all.
           filter:
+
+            # Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).
+            # This list also limits Tenants included by `always_include_vrfs_in_tenants`.
             tenants: # default=['all']
               - <str>
+
+            # Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default).
             tags: # default=['all']
+              - <str>
+
+            # Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
+            # This list also limits VRFs included by `always_include_vrfs_in_tenants`.
+            vrfs: # default=['all']
+              - <str>
+
+            # Prevent configuration of Network Services defined under these VRFs.
+            # This list prevents the given VRFs to be included by any other filtering mechanism.
+            not_vrfs: # default=['all']
               - <str>
 
             # List of tenants where VRFs will be configured even if VLANs are not included in tags.
@@ -169,9 +230,24 @@
           # Filter L3 and L2 network services based on tenant and tags (and operation filter).
           # If filter is not defined it will default to all.
           filter:
+
+            # Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).
+            # This list also limits Tenants included by `always_include_vrfs_in_tenants`.
             tenants: # default=['all']
               - <str>
+
+            # Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default).
             tags: # default=['all']
+              - <str>
+
+            # Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
+            # This list also limits VRFs included by `always_include_vrfs_in_tenants`.
+            vrfs: # default=['all']
+              - <str>
+
+            # Prevent configuration of Network Services defined under these VRFs.
+            # This list prevents the given VRFs to be included by any other filtering mechanism.
+            not_vrfs: # default=['all']
               - <str>
 
             # List of tenants where VRFs will be configured even if VLANs are not included in tags.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -6777,7 +6777,7 @@ $defs:
                   type: str
                 default:
                 - all
-              vrfs:
+              allow_vrfs:
                 type: list
                 description: 'Limit configured Network Services to those defined under
                   these VRFs. Set to [''all''] for all VRFs (default).
@@ -6789,7 +6789,7 @@ $defs:
                   - int
                 default:
                 - all
-              not_vrfs:
+              deny_vrfs:
                 type: list
                 description: 'Prevent configuration of Network Services defined under
                   these VRFs.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -6721,14 +6721,45 @@ $defs:
             keys:
               tenants:
                 type: list
+                description: 'Limit configured Network Services to those defined under
+                  these Tenants. Set to [''all''] for all Tenants (default).
+
+                  This list also limits Tenants included by `always_include_vrfs_in_tenants`.'
                 items:
                   type: str
                 default:
                 - all
               tags:
                 type: list
+                description: Limit configured VLANs to those matching the given tags.
+                  Set to ['all'] for all VLANs (default).
                 items:
                   type: str
+                default:
+                - all
+              vrfs:
+                type: list
+                description: 'Limit configured Network Services to those defined under
+                  these VRFs. Set to [''all''] for all VRFs (default).
+
+                  This list also limits VRFs included by `always_include_vrfs_in_tenants`.'
+                items:
+                  type: str
+                  convert_types:
+                  - int
+                default:
+                - all
+              not_vrfs:
+                type: list
+                description: 'Prevent configuration of Network Services defined under
+                  these VRFs.
+
+                  This list prevents the given VRFs to be included by any other filtering
+                  mechanism.'
+                items:
+                  type: str
+                  convert_types:
+                  - int
                 default:
                 - all
               always_include_vrfs_in_tenants:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
@@ -507,14 +507,40 @@ $defs:
             keys:
               tenants:
                 type: list
+                description: |-
+                  Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).
+                  This list also limits Tenants included by `always_include_vrfs_in_tenants`.
                 items:
                   type: str
                 default:
                   - all
               tags:
                 type: list
+                description: Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default).
                 items:
                   type: str
+                default:
+                  - all
+              vrfs:
+                type: list
+                description: |-
+                  Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
+                  This list also limits VRFs included by `always_include_vrfs_in_tenants`.
+                items:
+                  type: str
+                  convert_types:
+                    - int
+                default:
+                  - all
+              not_vrfs:
+                type: list
+                description: |-
+                  Prevent configuration of Network Services defined under these VRFs.
+                  This list prevents the given VRFs to be included by any other filtering mechanism.
+                items:
+                  type: str
+                  convert_types:
+                    - int
                 default:
                   - all
               always_include_vrfs_in_tenants:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type.schema.yml
@@ -521,7 +521,7 @@ $defs:
                   type: str
                 default:
                   - all
-              vrfs:
+              allow_vrfs:
                 type: list
                 description: |-
                   Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
@@ -532,7 +532,7 @@ $defs:
                     - int
                 default:
                   - all
-              not_vrfs:
+              deny_vrfs:
                 type: list
                 description: |-
                   Prevent configuration of Network Services defined under these VRFs.


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add filter.vrfs and filter.not_vrfs

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```
          # Filter L3 and L2 network services based on tenant and tags (and operation filter).
          # If filter is not defined it will default to all.
          filter:

            # Limit configured Network Services to those defined under these Tenants. Set to ['all'] for all Tenants (default).
            # This list also limits Tenants included by `always_include_vrfs_in_tenants`.
            tenants: # default=['all']
              - <str>

            # Limit configured VLANs to those matching the given tags. Set to ['all'] for all VLANs (default).
            tags: # default=['all']
              - <str>

            # Limit configured Network Services to those defined under these VRFs. Set to ['all'] for all VRFs (default).
            # This list also limits VRFs included by `always_include_vrfs_in_tenants`.
            allow_vrfs: # default=['all']
              - <str>

            # Prevent configuration of Network Services defined under these VRFs.
            # This list prevents the given VRFs to be included by any other filtering mechanism.
            deny_vrfs: # default=['all']
              - <str>

            # List of tenants where VRFs will be configured even if VLANs are not included in tags.
            # Useful for L3 "border" leaf.
            always_include_vrfs_in_tenants:
              - <str>
            # Only configure VLANs, SVIs, VRFs in use by connected endpoints or downstream L2 switches.
            # Note! This feature only considers configuration managed by eos_designs.
            # This excludes structured_config, custom_structured_configuration_, raw_eos_cli, eos_cli, custom templates, configlets etc.
            only_vlans_in
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Molecule case with all combinations.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
