### PR TITLE
Feat(eos_cli_config_gen): Adding 'ip igmp host-proxy' interface support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -347,6 +347,18 @@ interface Ethernet1
    ip verify unicast source reachable-via rx
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude 10.0.2.1
+   ip igmp host-proxy 239.0.0.3 include 10.0.3.1
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.3
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.4
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.1
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.2
+   ip igmp host-proxy access-list ACL1
+   ip igmp host-proxy access-list ACL2
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
    switchport port-security
    priority-flow-control on
    priority-flow-control priority 5 drop
@@ -355,14 +367,6 @@ interface Ethernet1
    Comment created from eos_cli under ethernet_interfaces.Ethernet1
    EOF
 
-   ip igmp host-proxy
-   ip igmp host-proxy 239.0.0.1
-   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
-   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
-   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
-   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
-   ip igmp host-proxy report-interval 2
-   ip igmp host-proxy version 2
 !
 interface Ethernet2
    description SRV-POD02_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -355,6 +355,14 @@ interface Ethernet1
    Comment created from eos_cli under ethernet_interfaces.Ethernet1
    EOF
 
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
+   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
+   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
+   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
 !
 interface Ethernet2
    description SRV-POD02_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -361,6 +361,18 @@ interface Port-Channel5
    switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude 10.0.2.1
+   ip igmp host-proxy 239.0.0.3 include 10.0.3.1
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.3
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.4
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.1
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.2
+   ip igmp host-proxy access-list ACL1
+   ip igmp host-proxy access-list ACL2
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
    l2 mtu 8000
    l2 mru 8000
    mlag 5
@@ -373,14 +385,6 @@ interface Port-Channel5
    Comment created from eos_cli under port_channel_interfaces.Port-Channel5
    EOF
 
-   ip igmp host-proxy
-   ip igmp host-proxy 239.0.0.1
-   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
-   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
-   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
-   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
-   ip igmp host-proxy report-interval 2
-   ip igmp host-proxy version 2
 !
 interface Port-Channel8
    description to Dev02 Port-channel 8

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -373,6 +373,14 @@ interface Port-Channel5
    Comment created from eos_cli under port_channel_interfaces.Port-Channel5
    EOF
 
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
+   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
+   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
+   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
 !
 interface Port-Channel8
    description to Dev02 Port-channel 8

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -218,6 +218,14 @@ interface Vlan41
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
+   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
+   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
+   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
    ip address virtual 10.10.41.1/24
 !
 interface Vlan42

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -220,10 +220,14 @@ interface Vlan41
    ip helper-address 10.10.96.151 source-interface Loopback0
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
-   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
-   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
-   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
-   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
+   ip igmp host-proxy 239.0.0.2 exclude 10.0.2.1
+   ip igmp host-proxy 239.0.0.3 include 10.0.3.1
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.3
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.4
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.1
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.2
+   ip igmp host-proxy access-list ACL1
+   ip igmp host-proxy access-list ACL2
    ip igmp host-proxy report-interval 2
    ip igmp host-proxy version 2
    ip address virtual 10.10.41.1/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -27,6 +27,14 @@ interface Ethernet1
    Comment created from eos_cli under ethernet_interfaces.Ethernet1
    EOF
 
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
+   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
+   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
+   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
 !
 interface Ethernet2
    description SRV-POD02_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -19,6 +19,18 @@ interface Ethernet1
    ip verify unicast source reachable-via rx
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude 10.0.2.1
+   ip igmp host-proxy 239.0.0.3 include 10.0.3.1
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.3
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.4
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.1
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.2
+   ip igmp host-proxy access-list ACL1
+   ip igmp host-proxy access-list ACL2
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
    switchport port-security
    priority-flow-control on
    priority-flow-control priority 5 drop
@@ -27,14 +39,6 @@ interface Ethernet1
    Comment created from eos_cli under ethernet_interfaces.Ethernet1
    EOF
 
-   ip igmp host-proxy
-   ip igmp host-proxy 239.0.0.1
-   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
-   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
-   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
-   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
-   ip igmp host-proxy report-interval 2
-   ip igmp host-proxy version 2
 !
 interface Ethernet2
    description SRV-POD02_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -23,6 +23,18 @@ interface Port-Channel5
    switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude 10.0.2.1
+   ip igmp host-proxy 239.0.0.3 include 10.0.3.1
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.3
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.4
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.1
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.2
+   ip igmp host-proxy access-list ACL1
+   ip igmp host-proxy access-list ACL2
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
    l2 mtu 8000
    l2 mru 8000
    mlag 5
@@ -35,14 +47,6 @@ interface Port-Channel5
    Comment created from eos_cli under port_channel_interfaces.Port-Channel5
    EOF
 
-   ip igmp host-proxy
-   ip igmp host-proxy 239.0.0.1
-   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
-   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
-   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
-   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
-   ip igmp host-proxy report-interval 2
-   ip igmp host-proxy version 2
 !
 interface Port-Channel8
    description to Dev02 Port-channel 8

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -35,6 +35,14 @@ interface Port-Channel5
    Comment created from eos_cli under port_channel_interfaces.Port-Channel5
    EOF
 
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
+   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
+   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
+   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
 !
 interface Port-Channel8
    description to Dev02 Port-channel 8

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -36,10 +36,14 @@ interface Vlan41
    ip helper-address 10.10.96.151 source-interface Loopback0
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
-   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
-   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
-   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
-   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
+   ip igmp host-proxy 239.0.0.2 exclude 10.0.2.1
+   ip igmp host-proxy 239.0.0.3 include 10.0.3.1
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.3
+   ip igmp host-proxy 239.0.0.4 include 10.0.4.4
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.1
+   ip igmp host-proxy 239.0.0.4 exclude 10.0.4.2
+   ip igmp host-proxy access-list ACL1
+   ip igmp host-proxy access-list ACL2
    ip igmp host-proxy report-interval 2
    ip igmp host-proxy version 2
    ip address virtual 10.10.41.1/24

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -34,6 +34,14 @@ interface Vlan41
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   ip igmp host-proxy
+   ip igmp host-proxy 239.0.0.1
+   ip igmp host-proxy 239.0.0.2 exclude [{'source': '10.0.2.1'}]
+   ip igmp host-proxy 239.0.0.3 include [{'source': '10.0.3.1'}]
+   ip igmp host-proxy 239.0.0.4 exclude [{'source': '10.0.4.1'}, {'source': '10.0.4.2'}]
+   ip igmp host-proxy 239.0.0.4 include [{'source': '10.0.4.3'}, {'source': '10.0.4.4'}]
+   ip igmp host-proxy report-interval 2
+   ip igmp host-proxy version 2
    ip address virtual 10.10.41.1/24
 !
 interface Vlan42

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -36,6 +36,28 @@ ethernet_interfaces:
       comment
       Comment created from eos_cli under ethernet_interfaces.Ethernet1
       EOF
+    ip_igmp_host_proxy:
+      enabled: true
+      groups:
+        - group: 239.0.0.1
+        - group: 239.0.0.2
+          exclude:
+            - source: 10.0.2.1
+        - group: 239.0.0.3
+          include:
+            - source: 10.0.3.1
+        - group: 239.0.0.4
+          exclude:
+            - source: 10.0.4.1
+            - source: 10.0.4.2
+          include:
+            - source: 10.0.4.3
+            - source: 10.0.4.4
+      report_interval: 2
+      access_lists:
+        - name: ACL1
+        - name: ACL2
+      version: 2
 
   - name: Ethernet2
     peer: SRV-POD03

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -28,7 +28,28 @@ port_channel_interfaces:
       comment
       Comment created from eos_cli under port_channel_interfaces.Port-Channel5
       EOF
-
+    ip_igmp_host_proxy:
+      enabled: true
+      groups:
+        - group: 239.0.0.1
+        - group: 239.0.0.2
+          exclude:
+            - source: 10.0.2.1
+        - group: 239.0.0.3
+          include:
+            - source: 10.0.3.1
+        - group: 239.0.0.4
+          exclude:
+            - source: 10.0.4.1
+            - source: 10.0.4.2
+          include:
+            - source: 10.0.4.3
+            - source: 10.0.4.4
+      report_interval: 2
+      access_lists:
+        - name: ACL1
+        - name: ACL2
+      version: 2
   - name: Port-Channel15
     description: DC1_L2LEAF3_Po1
     vlans: 110,201

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -126,6 +126,28 @@ vlan_interfaces:
         source_interface: Loopback0
       - ip_helper: 10.10.64.150
         source_interface: Loopback0
+    ip_igmp_host_proxy:
+      enabled: true
+      groups:
+        - group: 239.0.0.1
+        - group: 239.0.0.2
+          exclude:
+            - source: 10.0.2.1
+        - group: 239.0.0.3
+          include:
+            - source: 10.0.3.1
+        - group: 239.0.0.4
+          exclude:
+            - source: 10.0.4.1
+            - source: 10.0.4.2
+          include:
+            - source: 10.0.4.3
+            - source: 10.0.4.4
+      report_interval: 2
+      access_lists:
+        - name: ACL1
+        - name: ACL2
+      version: 2
 
   - name: Vlan42
     description: SVI Description

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -323,16 +323,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;session_tracker</samp>](## "ethernet_interfaces.[].bgp.session_tracker") | String |  |  |  | Name of session tracker |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_host_proxy</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  | Group Address. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  | Multicast Address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  | `1` | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  |  | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.access_lists.[].name") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.version") | Integer |  | `3` | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.version") | Integer |  |  | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "ethernet_interfaces.[].peer") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "ethernet_interfaces.[].peer_interface") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "ethernet_interfaces.[].peer_type") | String |  |  |  | Key only used for documentation or validation purposes |
@@ -956,9 +956,9 @@
           session_tracker: <str>
         ip_igmp_host_proxy:
           enabled: <bool>
-
-          # Group Address.
           groups:
+
+              # Multicast Address.
             - group: <str; required; unique>
               exclude:
                 - source: <str; required; unique>
@@ -966,14 +966,14 @@
                 - source: <str; required; unique>
 
           # Time interval between unsolicited reports.
-          report_interval: <int; 1-31744; default=1>
+          report_interval: <int; 1-31744>
 
           # Non-standard Access List name.
           access_lists:
             - name: <str; required; unique>
 
           # IGMP version on IGMP host-proxy interface.
-          version: <int; 1-3; default=3>
+          version: <int; 1-3>
 
         # Key only used for documentation or validation purposes
         peer: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -321,6 +321,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;output</samp>](## "ethernet_interfaces.[].traffic_policy.output") | String |  |  |  | Egress traffic policy |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "ethernet_interfaces.[].bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;session_tracker</samp>](## "ethernet_interfaces.[].bgp.session_tracker") | String |  |  |  | Name of session tracker |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_host_proxy</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  | Group Address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  | `1` | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.access_lists.[].name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.version") | Integer |  | `3` | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "ethernet_interfaces.[].peer") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "ethernet_interfaces.[].peer_interface") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "ethernet_interfaces.[].peer_type") | String |  |  |  | Key only used for documentation or validation purposes |
@@ -389,18 +401,6 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;range</samp>](## "ethernet_interfaces.[].switchport.port_security.vlans.[].range") | String | Required, Unique |  |  | VLAN ID or range(s) of VLAN IDs, <1-4094>.<br>Example:<br>  - 3<br>  - 1,3<br>  - 1-10<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address_maximum</samp>](## "ethernet_interfaces.[].switchport.port_security.vlans.[].mac_address_maximum") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_host_proxy</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  | Group Address. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  | `1` | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.access_lists.[].name") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.version") | Integer |  | `3` | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
 
 === "YAML"
 
@@ -954,6 +954,26 @@
 
           # Name of session tracker
           session_tracker: <str>
+        ip_igmp_host_proxy:
+          enabled: <bool>
+
+          # Group Address.
+          groups:
+            - group: <str; required; unique>
+              exclude:
+                - source: <str; required; unique>
+              include:
+                - source: <str; required; unique>
+
+          # Time interval between unsolicited reports.
+          report_interval: <int; 1-31744; default=1>
+
+          # Non-standard Access List name.
+          access_lists:
+            - name: <str; required; unique>
+
+          # IGMP version on IGMP host-proxy interface.
+          version: <int; 1-3; default=3>
 
         # Key only used for documentation or validation purposes
         peer: <str>
@@ -1108,24 +1128,4 @@
 
         # Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration
         eos_cli: <str>
-        ip_igmp_host_proxy:
-          enabled: <bool>
-
-          # Group Address.
-          groups:
-            - group: <str; required; unique>
-              exclude:
-                - source: <str; required; unique>
-              include:
-                - source: <str; required; unique>
-
-          # Time interval between unsolicited reports.
-          report_interval: <int; 1-31744; default=1>
-
-          # Non-standard Access List name.
-          access_lists:
-            - name: <str; required; unique>
-
-          # IGMP version on IGMP host-proxy interface.
-          version: <int; 1-3; default=3>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -325,9 +325,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  | Multicast Address. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  | The same source must not be present both in `exclude` and `include` list. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  | The same source must not be present both in `exclude` and `include` list. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  |  | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
@@ -960,8 +960,12 @@
 
               # Multicast Address.
             - group: <str; required; unique>
+
+              # The same source must not be present both in `exclude` and `include` list.
               exclude:
                 - source: <str; required; unique>
+
+              # The same source must not be present both in `exclude` and `include` list.
               include:
                 - source: <str; required; unique>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -389,6 +389,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;range</samp>](## "ethernet_interfaces.[].switchport.port_security.vlans.[].range") | String | Required, Unique |  |  | VLAN ID or range(s) of VLAN IDs, <1-4094>.<br>Example:<br>  - 3<br>  - 1,3<br>  - 1-10<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mac_address_maximum</samp>](## "ethernet_interfaces.[].switchport.port_security.vlans.[].mac_address_maximum") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_host_proxy</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  | Group Address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  | `1` | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.access_lists.[].name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "ethernet_interfaces.[].ip_igmp_host_proxy.version") | Integer |  | `3` | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
 
 === "YAML"
 
@@ -1096,4 +1108,24 @@
 
         # Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration
         eos_cli: <str>
+        ip_igmp_host_proxy:
+          enabled: <bool>
+
+          # Group Address.
+          groups:
+            - group: <str; required; unique>
+              exclude:
+                - source: <str; required; unique>
+              include:
+                - source: <str; required; unique>
+
+          # Time interval between unsolicited reports.
+          report_interval: <int; 1-31744; default=1>
+
+          # Non-standard Access List name.
+          access_lists:
+            - name: <str; required; unique>
+
+          # IGMP version on IGMP host-proxy interface.
+          version: <int; 1-3; default=3>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -227,9 +227,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  | Multicast Address. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  | The same source must not be present both in `exclude` and `include` list. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  | The same source must not be present both in `exclude` and `include` list. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  |  | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
@@ -662,8 +662,12 @@
 
               # Multicast Address.
             - group: <str; required; unique>
+
+              # The same source must not be present both in `exclude` and `include` list.
               exclude:
                 - source: <str; required; unique>
+
+              # The same source must not be present both in `exclude` and `include` list.
               include:
                 - source: <str; required; unique>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -233,6 +233,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmodified_enable</samp>](## "port_channel_interfaces.[].sflow.egress.unmodified_enable") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;validate_state</samp>](## "port_channel_interfaces.[].validate_state") | Boolean |  |  |  | Set to false to disable interface validation by the `eos_validate_state` role |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "port_channel_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_host_proxy</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  | Group Address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  | `1` | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.access_lists.[].name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.version") | Integer |  | `3` | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
 
 === "YAML"
 
@@ -664,4 +676,24 @@
 
         # Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration
         eos_cli: <str>
+        ip_igmp_host_proxy:
+          enabled: <bool>
+
+          # Group Address.
+          groups:
+            - group: <str; required; unique>
+              exclude:
+                - source: <str; required; unique>
+              include:
+                - source: <str; required; unique>
+
+          # Time interval between unsolicited reports.
+          report_interval: <int; 1-31744; default=1>
+
+          # Non-standard Access List name.
+          access_lists:
+            - name: <str; required; unique>
+
+          # IGMP version on IGMP host-proxy interface.
+          version: <int; 1-3; default=3>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -225,16 +225,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;session_tracker</samp>](## "port_channel_interfaces.[].bgp.session_tracker") | String |  |  |  | Name of session tracker |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_host_proxy</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  | Group Address. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  | Multicast Address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  | `1` | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  |  | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.access_lists.[].name") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.version") | Integer |  | `3` | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.version") | Integer |  |  | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "port_channel_interfaces.[].peer") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "port_channel_interfaces.[].peer_interface") | String |  |  |  | Key only used for documentation or validation purposes |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "port_channel_interfaces.[].peer_type") | String |  |  |  | Key only used for documentation or validation purposes |
@@ -658,9 +658,9 @@
           session_tracker: <str>
         ip_igmp_host_proxy:
           enabled: <bool>
-
-          # Group Address.
           groups:
+
+              # Multicast Address.
             - group: <str; required; unique>
               exclude:
                 - source: <str; required; unique>
@@ -668,14 +668,14 @@
                 - source: <str; required; unique>
 
           # Time interval between unsolicited reports.
-          report_interval: <int; 1-31744; default=1>
+          report_interval: <int; 1-31744>
 
           # Non-standard Access List name.
           access_lists:
             - name: <str; required; unique>
 
           # IGMP version on IGMP host-proxy interface.
-          version: <int; 1-3; default=3>
+          version: <int; 1-3>
 
         # Key only used for documentation or validation purposes
         peer: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -223,16 +223,6 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hardware</samp>](## "port_channel_interfaces.[].flow_tracker.hardware") | String |  |  |  | Hardware flow tracker name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "port_channel_interfaces.[].bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;session_tracker</samp>](## "port_channel_interfaces.[].bgp.session_tracker") | String |  |  |  | Name of session tracker |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "port_channel_interfaces.[].peer") | String |  |  |  | Key only used for documentation or validation purposes |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "port_channel_interfaces.[].peer_interface") | String |  |  |  | Key only used for documentation or validation purposes |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "port_channel_interfaces.[].peer_type") | String |  |  |  | Key only used for documentation or validation purposes |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sflow</samp>](## "port_channel_interfaces.[].sflow") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "port_channel_interfaces.[].sflow.enable") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;egress</samp>](## "port_channel_interfaces.[].sflow.egress") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "port_channel_interfaces.[].sflow.egress.enable") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmodified_enable</samp>](## "port_channel_interfaces.[].sflow.egress.unmodified_enable") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;validate_state</samp>](## "port_channel_interfaces.[].validate_state") | Boolean |  |  |  | Set to false to disable interface validation by the `eos_validate_state` role |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "port_channel_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_host_proxy</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  | Group Address. |
@@ -245,6 +235,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.access_lists.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "port_channel_interfaces.[].ip_igmp_host_proxy.version") | Integer |  | `3` | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "port_channel_interfaces.[].peer") | String |  |  |  | Key only used for documentation or validation purposes |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "port_channel_interfaces.[].peer_interface") | String |  |  |  | Key only used for documentation or validation purposes |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_type</samp>](## "port_channel_interfaces.[].peer_type") | String |  |  |  | Key only used for documentation or validation purposes |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sflow</samp>](## "port_channel_interfaces.[].sflow") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "port_channel_interfaces.[].sflow.enable") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;egress</samp>](## "port_channel_interfaces.[].sflow.egress") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "port_channel_interfaces.[].sflow.egress.enable") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmodified_enable</samp>](## "port_channel_interfaces.[].sflow.egress.unmodified_enable") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;validate_state</samp>](## "port_channel_interfaces.[].validate_state") | Boolean |  |  |  | Set to false to disable interface validation by the `eos_validate_state` role |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "port_channel_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration |
 
 === "YAML"
 
@@ -656,26 +656,6 @@
 
           # Name of session tracker
           session_tracker: <str>
-
-        # Key only used for documentation or validation purposes
-        peer: <str>
-
-        # Key only used for documentation or validation purposes
-        peer_interface: <str>
-
-        # Key only used for documentation or validation purposes
-        peer_type: <str>
-        sflow:
-          enable: <bool>
-          egress:
-            enable: <bool>
-            unmodified_enable: <bool>
-
-        # Set to false to disable interface validation by the `eos_validate_state` role
-        validate_state: <bool>
-
-        # Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration
-        eos_cli: <str>
         ip_igmp_host_proxy:
           enabled: <bool>
 
@@ -696,4 +676,24 @@
 
           # IGMP version on IGMP host-proxy interface.
           version: <int; 1-3; default=3>
+
+        # Key only used for documentation or validation purposes
+        peer: <str>
+
+        # Key only used for documentation or validation purposes
+        peer_interface: <str>
+
+        # Key only used for documentation or validation purposes
+        peer_type: <str>
+        sflow:
+          enable: <bool>
+          egress:
+            enable: <bool>
+            unmodified_enable: <bool>
+
+        # Set to false to disable interface validation by the `eos_validate_state` role
+        validate_state: <bool>
+
+        # Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration
+        eos_cli: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -32,6 +32,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify_unicast_source_reachable_via</samp>](## "vlan_interfaces.[].ip_verify_unicast_source_reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp</samp>](## "vlan_interfaces.[].ip_igmp") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_version</samp>](## "vlan_interfaces.[].ip_igmp_version") | Integer |  |  | Min: 1<br>Max: 3 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_host_proxy</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  | Group Address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  | `1` | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.access_lists.[].name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.version") | Integer |  | `3` | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "vlan_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  | List of DHCP servers |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "vlan_interfaces.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IP address or hostname of DHCP server |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vlan_interfaces.[].ip_helpers.[].source_interface") | String |  |  |  | Interface used as source for forwarded DHCP packets |
@@ -235,6 +247,26 @@
         ip_verify_unicast_source_reachable_via: <str; "any" | "rx">
         ip_igmp: <bool>
         ip_igmp_version: <int; 1-3>
+        ip_igmp_host_proxy:
+          enabled: <bool>
+
+          # Group Address.
+          groups:
+            - group: <str; required; unique>
+              exclude:
+                - source: <str; required; unique>
+              include:
+                - source: <str; required; unique>
+
+          # Time interval between unsolicited reports.
+          report_interval: <int; 1-31744; default=1>
+
+          # Non-standard Access List name.
+          access_lists:
+            - name: <str; required; unique>
+
+          # IGMP version on IGMP host-proxy interface.
+          version: <int; 1-3; default=3>
 
         # List of DHCP servers
         ip_helpers:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -34,16 +34,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_version</samp>](## "vlan_interfaces.[].ip_igmp_version") | Integer |  |  | Min: 1<br>Max: 3 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_igmp_host_proxy</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  | Group Address. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  | Multicast Address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  | `1` | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  |  | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.access_lists.[].name") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.version") | Integer |  | `3` | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.version") | Integer |  |  | Min: 1<br>Max: 3 | IGMP version on IGMP host-proxy interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "vlan_interfaces.[].ip_helpers") | List, items: Dictionary |  |  |  | List of DHCP servers |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "vlan_interfaces.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IP address or hostname of DHCP server |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vlan_interfaces.[].ip_helpers.[].source_interface") | String |  |  |  | Interface used as source for forwarded DHCP packets |
@@ -249,9 +249,9 @@
         ip_igmp_version: <int; 1-3>
         ip_igmp_host_proxy:
           enabled: <bool>
-
-          # Group Address.
           groups:
+
+              # Multicast Address.
             - group: <str; required; unique>
               exclude:
                 - source: <str; required; unique>
@@ -259,14 +259,14 @@
                 - source: <str; required; unique>
 
           # Time interval between unsolicited reports.
-          report_interval: <int; 1-31744; default=1>
+          report_interval: <int; 1-31744>
 
           # Non-standard Access List name.
           access_lists:
             - name: <str; required; unique>
 
           # IGMP version on IGMP host-proxy interface.
-          version: <int; 1-3; default=3>
+          version: <int; 1-3>
 
         # List of DHCP servers
         ip_helpers:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -36,9 +36,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;group</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].group") | String | Required, Unique |  |  | Multicast Address. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exclude</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].exclude") | List, items: Dictionary |  |  |  | The same source must not be present both in `exclude` and `include` list. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].exclude.[].source") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].include") | List, items: Dictionary |  |  |  | The same source must not be present both in `exclude` and `include` list. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.groups.[].include.[].source") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;report_interval</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.report_interval") | Integer |  |  | Min: 1<br>Max: 31744 | Time interval between unsolicited reports. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "vlan_interfaces.[].ip_igmp_host_proxy.access_lists") | List, items: Dictionary |  |  |  | Non-standard Access List name. |
@@ -253,8 +253,12 @@
 
               # Multicast Address.
             - group: <str; required; unique>
+
+              # The same source must not be present both in `exclude` and `include` list.
               exclude:
                 - source: <str; required; unique>
+
+              # The same source must not be present both in `exclude` and `include` list.
               include:
                 - source: <str; required; unique>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4606,12 +4606,12 @@
               },
               "groups": {
                 "type": "array",
-                "description": "Group Address.",
                 "items": {
                   "type": "object",
                   "properties": {
                     "group": {
                       "type": "string",
+                      "description": "Multicast Address.",
                       "title": "Group"
                     },
                     "exclude": {
@@ -4669,7 +4669,6 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 31744,
-                "default": 1,
                 "description": "Time interval between unsolicited reports.",
                 "title": "Report Interval"
               },
@@ -4698,7 +4697,6 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 3,
-                "default": 3,
                 "description": "IGMP version on IGMP host-proxy interface.",
                 "title": "Version"
               }
@@ -13850,12 +13848,12 @@
               },
               "groups": {
                 "type": "array",
-                "description": "Group Address.",
                 "items": {
                   "type": "object",
                   "properties": {
                     "group": {
                       "type": "string",
+                      "description": "Multicast Address.",
                       "title": "Group"
                     },
                     "exclude": {
@@ -13913,7 +13911,6 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 31744,
-                "default": 1,
                 "description": "Time interval between unsolicited reports.",
                 "title": "Report Interval"
               },
@@ -13942,7 +13939,6 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 3,
-                "default": 3,
                 "description": "IGMP version on IGMP host-proxy interface.",
                 "title": "Version"
               }
@@ -26362,12 +26358,12 @@
               },
               "groups": {
                 "type": "array",
-                "description": "Group Address.",
                 "items": {
                   "type": "object",
                   "properties": {
                     "group": {
                       "type": "string",
+                      "description": "Multicast Address.",
                       "title": "Group"
                     },
                     "exclude": {
@@ -26425,7 +26421,6 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 31744,
-                "default": 1,
                 "description": "Time interval between unsolicited reports.",
                 "title": "Report Interval"
               },
@@ -26454,7 +26449,6 @@
                 "type": "integer",
                 "minimum": 1,
                 "maximum": 3,
-                "default": 3,
                 "description": "IGMP version on IGMP host-proxy interface.",
                 "title": "Version"
               }

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4616,6 +4616,7 @@
                     },
                     "exclude": {
                       "type": "array",
+                      "description": "The same source must not be present both in `exclude` and `include` list.",
                       "items": {
                         "type": "object",
                         "properties": {
@@ -4636,6 +4637,7 @@
                     },
                     "include": {
                       "type": "array",
+                      "description": "The same source must not be present both in `exclude` and `include` list.",
                       "items": {
                         "type": "object",
                         "properties": {
@@ -13858,6 +13860,7 @@
                     },
                     "exclude": {
                       "type": "array",
+                      "description": "The same source must not be present both in `exclude` and `include` list.",
                       "items": {
                         "type": "object",
                         "properties": {
@@ -13878,6 +13881,7 @@
                     },
                     "include": {
                       "type": "array",
+                      "description": "The same source must not be present both in `exclude` and `include` list.",
                       "items": {
                         "type": "object",
                         "properties": {
@@ -26368,6 +26372,7 @@
                     },
                     "exclude": {
                       "type": "array",
+                      "description": "The same source must not be present both in `exclude` and `include` list.",
                       "items": {
                         "type": "object",
                         "properties": {
@@ -26388,6 +26393,7 @@
                     },
                     "include": {
                       "type": "array",
+                      "description": "The same source must not be present both in `exclude` and `include` list.",
                       "items": {
                         "type": "object",
                         "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -4597,6 +4597,118 @@
             },
             "title": "BGP"
           },
+          "ip_igmp_host_proxy": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled"
+              },
+              "groups": {
+                "type": "array",
+                "description": "Group Address.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "type": "string",
+                      "title": "Group"
+                    },
+                    "exclude": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "title": "Source"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "required": [
+                          "source"
+                        ]
+                      },
+                      "title": "Exclude"
+                    },
+                    "include": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "title": "Source"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "required": [
+                          "source"
+                        ]
+                      },
+                      "title": "Include"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "group"
+                  ]
+                },
+                "title": "Groups"
+              },
+              "report_interval": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 31744,
+                "default": 1,
+                "description": "Time interval between unsolicited reports.",
+                "title": "Report Interval"
+              },
+              "access_lists": {
+                "type": "array",
+                "description": "Non-standard Access List name.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "title": "Name"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "name"
+                  ]
+                },
+                "title": "Access Lists"
+              },
+              "version": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 3,
+                "default": 3,
+                "description": "IGMP version on IGMP host-proxy interface.",
+                "title": "Version"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "IP IGMP Host Proxy"
+          },
           "peer": {
             "type": "string",
             "description": "Key only used for documentation or validation purposes",
@@ -5156,118 +5268,6 @@
             "type": "string",
             "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
             "title": "EOS CLI"
-          },
-          "ip_igmp_host_proxy": {
-            "type": "object",
-            "properties": {
-              "enabled": {
-                "type": "boolean",
-                "title": "Enabled"
-              },
-              "groups": {
-                "type": "array",
-                "description": "Group Address.",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "group": {
-                      "type": "string",
-                      "title": "Group"
-                    },
-                    "exclude": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "source": {
-                            "type": "string",
-                            "title": "Source"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "patternProperties": {
-                          "^_.+$": {}
-                        },
-                        "required": [
-                          "source"
-                        ]
-                      },
-                      "title": "Exclude"
-                    },
-                    "include": {
-                      "type": "array",
-                      "items": {
-                        "type": "object",
-                        "properties": {
-                          "source": {
-                            "type": "string",
-                            "title": "Source"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "patternProperties": {
-                          "^_.+$": {}
-                        },
-                        "required": [
-                          "source"
-                        ]
-                      },
-                      "title": "Include"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {
-                    "^_.+$": {}
-                  },
-                  "required": [
-                    "group"
-                  ]
-                },
-                "title": "Groups"
-              },
-              "report_interval": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 31744,
-                "default": 1,
-                "description": "Time interval between unsolicited reports.",
-                "title": "Report Interval"
-              },
-              "access_lists": {
-                "type": "array",
-                "description": "Non-standard Access List name.",
-                "items": {
-                  "type": "object",
-                  "properties": {
-                    "name": {
-                      "type": "string",
-                      "title": "Name"
-                    }
-                  },
-                  "additionalProperties": false,
-                  "patternProperties": {
-                    "^_.+$": {}
-                  },
-                  "required": [
-                    "name"
-                  ]
-                },
-                "title": "Access Lists"
-              },
-              "version": {
-                "type": "integer",
-                "minimum": 1,
-                "maximum": 3,
-                "default": 3,
-                "description": "IGMP version on IGMP host-proxy interface.",
-                "title": "Version"
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {
-              "^_.+$": {}
-            },
-            "title": "IP IGMP Host Proxy"
           }
         },
         "additionalProperties": false,
@@ -13841,63 +13841,6 @@
             },
             "title": "BGP"
           },
-          "peer": {
-            "type": "string",
-            "description": "Key only used for documentation or validation purposes",
-            "title": "Peer"
-          },
-          "peer_interface": {
-            "type": "string",
-            "description": "Key only used for documentation or validation purposes",
-            "title": "Peer Interface"
-          },
-          "peer_type": {
-            "type": "string",
-            "description": "Key only used for documentation or validation purposes",
-            "title": "Peer Type"
-          },
-          "sflow": {
-            "type": "object",
-            "properties": {
-              "enable": {
-                "type": "boolean",
-                "title": "Enable"
-              },
-              "egress": {
-                "type": "object",
-                "properties": {
-                  "enable": {
-                    "type": "boolean",
-                    "title": "Enable"
-                  },
-                  "unmodified_enable": {
-                    "type": "boolean",
-                    "title": "Unmodified Enable"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "Egress"
-              }
-            },
-            "additionalProperties": false,
-            "patternProperties": {
-              "^_.+$": {}
-            },
-            "title": "Sflow"
-          },
-          "validate_state": {
-            "type": "boolean",
-            "description": "Set to false to disable interface validation by the `eos_validate_state` role",
-            "title": "Validate State"
-          },
-          "eos_cli": {
-            "type": "string",
-            "description": "Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration",
-            "title": "EOS CLI"
-          },
           "ip_igmp_host_proxy": {
             "type": "object",
             "properties": {
@@ -14009,6 +13952,63 @@
               "^_.+$": {}
             },
             "title": "IP IGMP Host Proxy"
+          },
+          "peer": {
+            "type": "string",
+            "description": "Key only used for documentation or validation purposes",
+            "title": "Peer"
+          },
+          "peer_interface": {
+            "type": "string",
+            "description": "Key only used for documentation or validation purposes",
+            "title": "Peer Interface"
+          },
+          "peer_type": {
+            "type": "string",
+            "description": "Key only used for documentation or validation purposes",
+            "title": "Peer Type"
+          },
+          "sflow": {
+            "type": "object",
+            "properties": {
+              "enable": {
+                "type": "boolean",
+                "title": "Enable"
+              },
+              "egress": {
+                "type": "object",
+                "properties": {
+                  "enable": {
+                    "type": "boolean",
+                    "title": "Enable"
+                  },
+                  "unmodified_enable": {
+                    "type": "boolean",
+                    "title": "Unmodified Enable"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Egress"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Sflow"
+          },
+          "validate_state": {
+            "type": "boolean",
+            "description": "Set to false to disable interface validation by the `eos_validate_state` role",
+            "title": "Validate State"
+          },
+          "eos_cli": {
+            "type": "string",
+            "description": "Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration",
+            "title": "EOS CLI"
           }
         },
         "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5156,6 +5156,118 @@
             "type": "string",
             "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
             "title": "EOS CLI"
+          },
+          "ip_igmp_host_proxy": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled"
+              },
+              "groups": {
+                "type": "array",
+                "description": "Group Address.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "type": "string",
+                      "title": "Group"
+                    },
+                    "exclude": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "title": "Source"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "required": [
+                          "source"
+                        ]
+                      },
+                      "title": "Exclude"
+                    },
+                    "include": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "title": "Source"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "required": [
+                          "source"
+                        ]
+                      },
+                      "title": "Include"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "group"
+                  ]
+                },
+                "title": "Groups"
+              },
+              "report_interval": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 31744,
+                "default": 1,
+                "description": "Time interval between unsolicited reports.",
+                "title": "Report Interval"
+              },
+              "access_lists": {
+                "type": "array",
+                "description": "Non-standard Access List name.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "title": "Name"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "name"
+                  ]
+                },
+                "title": "Access Lists"
+              },
+              "version": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 3,
+                "default": 3,
+                "description": "IGMP version on IGMP host-proxy interface.",
+                "title": "Version"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "IP IGMP Host Proxy"
           }
         },
         "additionalProperties": false,
@@ -13785,6 +13897,118 @@
             "type": "string",
             "description": "Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration",
             "title": "EOS CLI"
+          },
+          "ip_igmp_host_proxy": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled"
+              },
+              "groups": {
+                "type": "array",
+                "description": "Group Address.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "type": "string",
+                      "title": "Group"
+                    },
+                    "exclude": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "title": "Source"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "required": [
+                          "source"
+                        ]
+                      },
+                      "title": "Exclude"
+                    },
+                    "include": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "title": "Source"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "required": [
+                          "source"
+                        ]
+                      },
+                      "title": "Include"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "group"
+                  ]
+                },
+                "title": "Groups"
+              },
+              "report_interval": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 31744,
+                "default": 1,
+                "description": "Time interval between unsolicited reports.",
+                "title": "Report Interval"
+              },
+              "access_lists": {
+                "type": "array",
+                "description": "Non-standard Access List name.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "title": "Name"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "name"
+                  ]
+                },
+                "title": "Access Lists"
+              },
+              "version": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 3,
+                "default": 3,
+                "description": "IGMP version on IGMP host-proxy interface.",
+                "title": "Version"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "IP IGMP Host Proxy"
           }
         },
         "additionalProperties": false,
@@ -26128,6 +26352,118 @@
             "minimum": 1,
             "maximum": 3,
             "title": "IP IGMP Version"
+          },
+          "ip_igmp_host_proxy": {
+            "type": "object",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "title": "Enabled"
+              },
+              "groups": {
+                "type": "array",
+                "description": "Group Address.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "group": {
+                      "type": "string",
+                      "title": "Group"
+                    },
+                    "exclude": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "title": "Source"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "required": [
+                          "source"
+                        ]
+                      },
+                      "title": "Exclude"
+                    },
+                    "include": {
+                      "type": "array",
+                      "items": {
+                        "type": "object",
+                        "properties": {
+                          "source": {
+                            "type": "string",
+                            "title": "Source"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "required": [
+                          "source"
+                        ]
+                      },
+                      "title": "Include"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "group"
+                  ]
+                },
+                "title": "Groups"
+              },
+              "report_interval": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 31744,
+                "default": 1,
+                "description": "Time interval between unsolicited reports.",
+                "title": "Report Interval"
+              },
+              "access_lists": {
+                "type": "array",
+                "description": "Non-standard Access List name.",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string",
+                      "title": "Name"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "required": [
+                    "name"
+                  ]
+                },
+                "title": "Access Lists"
+              },
+              "version": {
+                "type": "integer",
+                "minimum": 1,
+                "maximum": 3,
+                "default": 3,
+                "description": "IGMP version on IGMP host-proxy interface.",
+                "title": "Version"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "IP IGMP Host Proxy"
           },
           "ip_helpers": {
             "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2847,12 +2847,12 @@ keys:
             groups:
               type: list
               primary_key: group
-              description: Group Address.
               items:
                 type: dict
                 keys:
                   group:
                     type: str
+                    description: Multicast Address.
                   exclude:
                     type: list
                     primary_key: source
@@ -2875,7 +2875,6 @@ keys:
               - str
               min: 1
               max: 31744
-              default: 1
               description: Time interval between unsolicited reports.
             access_lists:
               type: list
@@ -2892,7 +2891,6 @@ keys:
               - str
               min: 1
               max: 3
-              default: 3
               description: IGMP version on IGMP host-proxy interface.
         peer:
           type: str
@@ -8101,12 +8099,12 @@ keys:
             groups:
               type: list
               primary_key: group
-              description: Group Address.
               items:
                 type: dict
                 keys:
                   group:
                     type: str
+                    description: Multicast Address.
                   exclude:
                     type: list
                     primary_key: source
@@ -8129,7 +8127,6 @@ keys:
               - str
               min: 1
               max: 31744
-              default: 1
               description: Time interval between unsolicited reports.
             access_lists:
               type: list
@@ -8146,7 +8143,6 @@ keys:
               - str
               min: 1
               max: 3
-              default: 3
               description: IGMP version on IGMP host-proxy interface.
         peer:
           type: str
@@ -15230,12 +15226,12 @@ keys:
             groups:
               type: list
               primary_key: group
-              description: Group Address.
               items:
                 type: dict
                 keys:
                   group:
                     type: str
+                    description: Multicast Address.
                   exclude:
                     type: list
                     primary_key: source
@@ -15258,7 +15254,6 @@ keys:
               - str
               min: 1
               max: 31744
-              default: 1
               description: Time interval between unsolicited reports.
             access_lists:
               type: list
@@ -15275,7 +15270,6 @@ keys:
               - str
               min: 1
               max: 3
-              default: 3
               description: IGMP version on IGMP host-proxy interface.
         ip_helpers:
           type: list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2856,6 +2856,8 @@ keys:
                   exclude:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude`
+                      and `include` list.
                     items:
                       type: dict
                       keys:
@@ -2864,6 +2866,8 @@ keys:
                   include:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude`
+                      and `include` list.
                     items:
                       type: dict
                       keys:
@@ -8108,6 +8112,8 @@ keys:
                   exclude:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude`
+                      and `include` list.
                     items:
                       type: dict
                       keys:
@@ -8116,6 +8122,8 @@ keys:
                   include:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude`
+                      and `include` list.
                     items:
                       type: dict
                       keys:
@@ -15235,6 +15243,8 @@ keys:
                   exclude:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude`
+                      and `include` list.
                     items:
                       type: dict
                       keys:
@@ -15243,6 +15253,8 @@ keys:
                   include:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude`
+                      and `include` list.
                     items:
                       type: dict
                       keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2839,6 +2839,61 @@ keys:
             session_tracker:
               type: str
               description: Name of session tracker
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.
         peer:
           type: str
           description: Key only used for documentation or validation purposes
@@ -3173,69 +3228,6 @@ keys:
           type: str
           description: Multiline EOS CLI rendered directly on the ethernet interface
             in the final EOS configuration
-        ip_igmp_host_proxy:
-          type: dict
-          keys:
-            enabled:
-              type: bool
-            groups:
-              type: list
-              primary_key: group
-              convert_types:
-              - dict
-              description: Group Address.
-              items:
-                type: dict
-                keys:
-                  group:
-                    type: str
-                  exclude:
-                    type: list
-                    primary_key: source
-                    convert_types:
-                    - dict
-                    items:
-                      type: dict
-                      keys:
-                        source:
-                          type: str
-                  include:
-                    type: list
-                    primary_key: source
-                    convert_types:
-                    - dict
-                    items:
-                      type: dict
-                      keys:
-                        source:
-                          type: str
-            report_interval:
-              type: int
-              convert_types:
-              - str
-              min: 1
-              max: 31744
-              default: 1
-              description: Time interval between unsolicited reports.
-            access_lists:
-              type: list
-              primary_key: name
-              convert_types:
-              - dict
-              description: Non-standard Access List name.
-              items:
-                type: dict
-                keys:
-                  name:
-                    type: str
-            version:
-              type: int
-              convert_types:
-              - str
-              min: 1
-              max: 3
-              default: 3
-              description: IGMP version on IGMP host-proxy interface.
   event_handlers:
     type: list
     description: 'Gives the ability to monitor and react to Syslog messages.
@@ -8101,6 +8093,61 @@ keys:
             session_tracker:
               type: str
               description: Name of session tracker
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.
         peer:
           type: str
           description: Key only used for documentation or validation purposes
@@ -8130,69 +8177,6 @@ keys:
           type: str
           description: Multiline EOS CLI rendered directly on the port-channel interface
             in the final EOS configuration
-        ip_igmp_host_proxy:
-          type: dict
-          keys:
-            enabled:
-              type: bool
-            groups:
-              type: list
-              primary_key: group
-              convert_types:
-              - dict
-              description: Group Address.
-              items:
-                type: dict
-                keys:
-                  group:
-                    type: str
-                  exclude:
-                    type: list
-                    primary_key: source
-                    convert_types:
-                    - dict
-                    items:
-                      type: dict
-                      keys:
-                        source:
-                          type: str
-                  include:
-                    type: list
-                    primary_key: source
-                    convert_types:
-                    - dict
-                    items:
-                      type: dict
-                      keys:
-                        source:
-                          type: str
-            report_interval:
-              type: int
-              convert_types:
-              - str
-              min: 1
-              max: 31744
-              default: 1
-              description: Time interval between unsolicited reports.
-            access_lists:
-              type: list
-              primary_key: name
-              convert_types:
-              - dict
-              description: Non-standard Access List name.
-              items:
-                type: dict
-                keys:
-                  name:
-                    type: str
-            version:
-              type: int
-              convert_types:
-              - str
-              min: 1
-              max: 3
-              default: 3
-              description: IGMP version on IGMP host-proxy interface.
   prefix_lists:
     type: list
     primary_key: name
@@ -15246,8 +15230,6 @@ keys:
             groups:
               type: list
               primary_key: group
-              convert_types:
-              - dict
               description: Group Address.
               items:
                 type: dict
@@ -15257,8 +15239,6 @@ keys:
                   exclude:
                     type: list
                     primary_key: source
-                    convert_types:
-                    - dict
                     items:
                       type: dict
                       keys:
@@ -15267,8 +15247,6 @@ keys:
                   include:
                     type: list
                     primary_key: source
-                    convert_types:
-                    - dict
                     items:
                       type: dict
                       keys:
@@ -15285,8 +15263,6 @@ keys:
             access_lists:
               type: list
               primary_key: name
-              convert_types:
-              - dict
               description: Non-standard Access List name.
               items:
                 type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3173,6 +3173,69 @@ keys:
           type: str
           description: Multiline EOS CLI rendered directly on the ethernet interface
             in the final EOS configuration
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              convert_types:
+              - dict
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                    - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                    - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              convert_types:
+              - dict
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.
   event_handlers:
     type: list
     description: 'Gives the ability to monitor and react to Syslog messages.
@@ -8067,6 +8130,69 @@ keys:
           type: str
           description: Multiline EOS CLI rendered directly on the port-channel interface
             in the final EOS configuration
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              convert_types:
+              - dict
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                    - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                    - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              convert_types:
+              - dict
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.
   prefix_lists:
     type: list
     primary_key: name
@@ -15112,6 +15238,69 @@ keys:
           - str
           min: 1
           max: 3
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              convert_types:
+              - dict
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                    - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                    - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              convert_types:
+              - dict
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+              - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.
         ip_helpers:
           type: list
           description: List of DHCP servers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -1024,12 +1024,12 @@ keys:
             groups:
               type: list
               primary_key: group
-              description: Group Address.
               items:
                 type: dict
                 keys:
                   group:
                     type: str
+                    description: Multicast Address.
                   exclude:
                     type: list
                     primary_key: source
@@ -1052,7 +1052,6 @@ keys:
                 - str
               min: 1
               max: 31744
-              default: 1
               description: Time interval between unsolicited reports.
             access_lists:
               type: list
@@ -1069,7 +1068,6 @@ keys:
                 - str
               min: 1
               max: 3
-              default: 3
               description: IGMP version on IGMP host-proxy interface.
         peer:
           type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -1016,6 +1016,61 @@ keys:
             session_tracker:
               type: str
               description: Name of session tracker
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.
         peer:
           type: str
           description: Key only used for documentation or validation purposes
@@ -1336,66 +1391,3 @@ keys:
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration
-        ip_igmp_host_proxy:
-          type: dict
-          keys:
-            enabled:
-              type: bool
-            groups:
-              type: list
-              primary_key: group
-              convert_types:
-                - dict
-              description: Group Address.
-              items:
-                type: dict
-                keys:
-                  group:
-                    type: str
-                  exclude:
-                    type: list
-                    primary_key: source
-                    convert_types:
-                      - dict
-                    items:
-                      type: dict
-                      keys:
-                        source:
-                          type: str
-                  include:
-                    type: list
-                    primary_key: source
-                    convert_types:
-                      - dict
-                    items:
-                      type: dict
-                      keys:
-                        source:
-                          type: str
-            report_interval:
-              type: int
-              convert_types:
-                - str
-              min: 1
-              max: 31744
-              default: 1
-              description: Time interval between unsolicited reports.
-            access_lists:
-              type: list
-              primary_key: name
-              convert_types:
-                - dict
-              description: Non-standard Access List name.
-              items:
-                type: dict
-                keys:
-                  name:
-                    type: str
-            version:
-              type: int
-              convert_types:
-                - str
-              min: 1
-              max: 3
-              default: 3
-              description: IGMP version on IGMP host-proxy interface.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -1033,6 +1033,7 @@ keys:
                   exclude:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude` and `include` list.
                     items:
                       type: dict
                       keys:
@@ -1041,6 +1042,7 @@ keys:
                   include:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude` and `include` list.
                     items:
                       type: dict
                       keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -1336,3 +1336,66 @@ keys:
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              convert_types:
+                - dict
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                      - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                      - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              convert_types:
+                - dict
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -779,3 +779,66 @@ keys:
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              convert_types:
+                - dict
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                      - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                      - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              convert_types:
+                - dict
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -752,6 +752,69 @@ keys:
             session_tracker:
               type: str
               description: Name of session tracker
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              # convert_types:
+              #   - dict
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    # convert_types:
+                    #   - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    # convert_types:
+                    #   - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              # convert_types:
+              #   - dict
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.
         peer:
           type: str
           description: Key only used for documentation or validation purposes
@@ -779,66 +842,3 @@ keys:
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration
-        ip_igmp_host_proxy:
-          type: dict
-          keys:
-            enabled:
-              type: bool
-            groups:
-              type: list
-              primary_key: group
-              convert_types:
-                - dict
-              description: Group Address.
-              items:
-                type: dict
-                keys:
-                  group:
-                    type: str
-                  exclude:
-                    type: list
-                    primary_key: source
-                    convert_types:
-                      - dict
-                    items:
-                      type: dict
-                      keys:
-                        source:
-                          type: str
-                  include:
-                    type: list
-                    primary_key: source
-                    convert_types:
-                      - dict
-                    items:
-                      type: dict
-                      keys:
-                        source:
-                          type: str
-            report_interval:
-              type: int
-              convert_types:
-                - str
-              min: 1
-              max: 31744
-              default: 1
-              description: Time interval between unsolicited reports.
-            access_lists:
-              type: list
-              primary_key: name
-              convert_types:
-                - dict
-              description: Non-standard Access List name.
-              items:
-                type: dict
-                keys:
-                  name:
-                    type: str
-            version:
-              type: int
-              convert_types:
-                - str
-              min: 1
-              max: 3
-              default: 3
-              description: IGMP version on IGMP host-proxy interface.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -769,6 +769,7 @@ keys:
                   exclude:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude` and `include` list.
                     items:
                       type: dict
                       keys:
@@ -777,6 +778,7 @@ keys:
                   include:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude` and `include` list.
                     items:
                       type: dict
                       keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/port_channel_interfaces.schema.yml
@@ -760,19 +760,15 @@ keys:
             groups:
               type: list
               primary_key: group
-              # convert_types:
-              #   - dict
-              description: Group Address.
               items:
                 type: dict
                 keys:
                   group:
                     type: str
+                    description: Multicast Address.
                   exclude:
                     type: list
                     primary_key: source
-                    # convert_types:
-                    #   - dict
                     items:
                       type: dict
                       keys:
@@ -781,8 +777,6 @@ keys:
                   include:
                     type: list
                     primary_key: source
-                    # convert_types:
-                    #   - dict
                     items:
                       type: dict
                       keys:
@@ -794,13 +788,10 @@ keys:
                 - str
               min: 1
               max: 31744
-              default: 1
               description: Time interval between unsolicited reports.
             access_lists:
               type: list
               primary_key: name
-              # convert_types:
-              #   - dict
               description: Non-standard Access List name.
               items:
                 type: dict
@@ -813,7 +804,6 @@ keys:
                 - str
               min: 1
               max: 3
-              default: 3
               description: IGMP version on IGMP host-proxy interface.
         peer:
           type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -106,6 +106,7 @@ keys:
                   exclude:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude` and `include` list.
                     items:
                       type: dict
                       keys:
@@ -114,6 +115,7 @@ keys:
                   include:
                     type: list
                     primary_key: source
+                    description: The same source must not be present both in `exclude` and `include` list.
                     items:
                       type: dict
                       keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -89,6 +89,69 @@ keys:
             - str
           min: 1
           max: 3
+        ip_igmp_host_proxy:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+            groups:
+              type: list
+              primary_key: group
+              convert_types:
+                - dict
+              description: Group Address.
+              items:
+                type: dict
+                keys:
+                  group:
+                    type: str
+                  exclude:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                      - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+                  include:
+                    type: list
+                    primary_key: source
+                    convert_types:
+                      - dict
+                    items:
+                      type: dict
+                      keys:
+                        source:
+                          type: str
+            report_interval:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 31744
+              default: 1
+              description: Time interval between unsolicited reports.
+            access_lists:
+              type: list
+              primary_key: name
+              convert_types:
+                - dict
+              description: Non-standard Access List name.
+              items:
+                type: dict
+                keys:
+                  name:
+                    type: str
+            version:
+              type: int
+              convert_types:
+                - str
+              min: 1
+              max: 3
+              default: 3
+              description: IGMP version on IGMP host-proxy interface.
         ip_helpers:
           type: list
           description: List of DHCP servers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -97,8 +97,6 @@ keys:
             groups:
               type: list
               primary_key: group
-              convert_types:
-                - dict
               description: Group Address.
               items:
                 type: dict
@@ -108,8 +106,6 @@ keys:
                   exclude:
                     type: list
                     primary_key: source
-                    convert_types:
-                      - dict
                     items:
                       type: dict
                       keys:
@@ -118,8 +114,6 @@ keys:
                   include:
                     type: list
                     primary_key: source
-                    convert_types:
-                      - dict
                     items:
                       type: dict
                       keys:
@@ -136,8 +130,6 @@ keys:
             access_lists:
               type: list
               primary_key: name
-              convert_types:
-                - dict
               description: Non-standard Access List name.
               items:
                 type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -97,12 +97,12 @@ keys:
             groups:
               type: list
               primary_key: group
-              description: Group Address.
               items:
                 type: dict
                 keys:
                   group:
                     type: str
+                    description: Multicast Address.
                   exclude:
                     type: list
                     primary_key: source
@@ -125,7 +125,6 @@ keys:
                 - str
               min: 1
               max: 31744
-              default: 1
               description: Time interval between unsolicited reports.
             access_lists:
               type: list
@@ -142,7 +141,6 @@ keys:
                 - str
               min: 1
               max: 3
-              default: 3
               description: IGMP version on IGMP host-proxy interface.
         ip_helpers:
           type: list

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -811,4 +811,28 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.eos_cli is arista.avd.defined %}
    {{ ethernet_interface.eos_cli | indent(3, false) }}
 {%     endif %}
+{%     if ethernet_interface.ip_igmp_host_proxy.enabled is arista.avd.defined(true) %}
+{%         set host_proxy_cli =  "ip igmp host-proxy" %}
+   {{ host_proxy_cli }}
+{%         if ethernet_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
+{%             for proxy_group in ethernet_interface.ip_igmp_host_proxy.groups %}
+{%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
+{%                     if proxy_group.exclude is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} exclude {{ proxy_group.exclude }}
+{%                     endif %}
+{%                     if proxy_group.include is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} include {{ proxy_group.include }}
+{%                     endif %}
+{%                 elif proxy_group.group is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if ethernet_interface.ip_igmp_host_proxy.report_interval is arista.avd.defined %}
+   {{ host_proxy_cli }} report-interval {{ ethernet_interface.ip_igmp_host_proxy.report_interval }}
+{%         endif %}
+{%         if ethernet_interface.ip_igmp_host_proxy.version is arista.avd.defined %}
+   {{ host_proxy_cli }} version {{ ethernet_interface.ip_igmp_host_proxy.version }}
+{%         endif %}
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -360,6 +360,39 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.dhcp_server_ipv6 is arista.avd.defined(true) %}
    dhcp server ipv6
 {%     endif %}
+{%     if ethernet_interface.ip_igmp_host_proxy.enabled is arista.avd.defined(true) %}
+{%         set host_proxy_cli =  "ip igmp host-proxy" %}
+   {{ host_proxy_cli }}
+{%         if ethernet_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
+{%             for proxy_group in ethernet_interface.ip_igmp_host_proxy.groups %}
+{%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
+{%                     if proxy_group.include is arista.avd.defined %}
+{%                         for include_source in proxy_group.include %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} include {{ include_source.source }}
+{%                         endfor %}
+{%                     endif %}
+{%                     if proxy_group.exclude is arista.avd.defined %}
+{%                         for exclude_source in proxy_group.exclude %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} exclude {{ exclude_source.source }}
+{%                         endfor %}
+{%                     endif %}
+{%                 elif proxy_group.group is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if ethernet_interface.ip_igmp_host_proxy.access_lists is arista.avd.defined %}
+{%             for access_list in ethernet_interface.ip_igmp_host_proxy.access_lists %}
+   {{ host_proxy_cli }} access-list {{ access_list.name }}
+{%             endfor %}
+{%         endif %}
+{%         if ethernet_interface.ip_igmp_host_proxy.report_interval is arista.avd.defined %}
+   {{ host_proxy_cli }} report-interval {{ ethernet_interface.ip_igmp_host_proxy.report_interval }}
+{%         endif %}
+{%         if ethernet_interface.ip_igmp_host_proxy.version is arista.avd.defined %}
+   {{ host_proxy_cli }} version {{ ethernet_interface.ip_igmp_host_proxy.version }}
+{%         endif %}
+{%     endif %}
 {%     if ethernet_interface.ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%     endif %}
@@ -810,29 +843,5 @@ interface {{ ethernet_interface.name }}
 {%     endif %}
 {%     if ethernet_interface.eos_cli is arista.avd.defined %}
    {{ ethernet_interface.eos_cli | indent(3, false) }}
-{%     endif %}
-{%     if ethernet_interface.ip_igmp_host_proxy.enabled is arista.avd.defined(true) %}
-{%         set host_proxy_cli =  "ip igmp host-proxy" %}
-   {{ host_proxy_cli }}
-{%         if ethernet_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
-{%             for proxy_group in ethernet_interface.ip_igmp_host_proxy.groups %}
-{%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
-{%                     if proxy_group.exclude is arista.avd.defined %}
-   {{ host_proxy_cli }} {{ proxy_group.group }} exclude {{ proxy_group.exclude }}
-{%                     endif %}
-{%                     if proxy_group.include is arista.avd.defined %}
-   {{ host_proxy_cli }} {{ proxy_group.group }} include {{ proxy_group.include }}
-{%                     endif %}
-{%                 elif proxy_group.group is arista.avd.defined %}
-   {{ host_proxy_cli }} {{ proxy_group.group }}
-{%                 endif %}
-{%             endfor %}
-{%         endif %}
-{%         if ethernet_interface.ip_igmp_host_proxy.report_interval is arista.avd.defined %}
-   {{ host_proxy_cli }} report-interval {{ ethernet_interface.ip_igmp_host_proxy.report_interval }}
-{%         endif %}
-{%         if ethernet_interface.ip_igmp_host_proxy.version is arista.avd.defined %}
-   {{ host_proxy_cli }} version {{ ethernet_interface.ip_igmp_host_proxy.version }}
-{%         endif %}
 {%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -466,4 +466,28 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.eos_cli is arista.avd.defined %}
    {{ port_channel_interface.eos_cli | indent(3, false) }}
 {%     endif %}
+{%     if port_channel_interface.ip_igmp_host_proxy.enabled is arista.avd.defined(true) %}
+{%         set host_proxy_cli =  "ip igmp host-proxy" %}
+   {{ host_proxy_cli }}
+{%         if port_channel_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
+{%             for proxy_group in port_channel_interface.ip_igmp_host_proxy.groups %}
+{%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
+{%                     if proxy_group.exclude is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} exclude {{ proxy_group.exclude }}
+{%                     endif %}
+{%                     if proxy_group.include is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} include {{ proxy_group.include }}
+{%                     endif %}
+{%                 elif proxy_group.group is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if port_channel_interface.ip_igmp_host_proxy.report_interval is arista.avd.defined %}
+   {{ host_proxy_cli }} report-interval {{ port_channel_interface.ip_igmp_host_proxy.report_interval }}
+{%         endif %}
+{%         if port_channel_interface.ip_igmp_host_proxy.version is arista.avd.defined %}
+   {{ host_proxy_cli }} version {{ port_channel_interface.ip_igmp_host_proxy.version }}
+{%         endif %}
+{%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -166,6 +166,39 @@ interface {{ port_channel_interface.name }}
 {%     elif port_channel_interface.snmp_trap_link_change is arista.avd.defined(true) %}
    snmp trap link-change
 {%     endif %}
+{%     if port_channel_interface.ip_igmp_host_proxy.enabled is arista.avd.defined(true) %}
+{%         set host_proxy_cli =  "ip igmp host-proxy" %}
+   {{ host_proxy_cli }}
+{%         if port_channel_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
+{%             for proxy_group in port_channel_interface.ip_igmp_host_proxy.groups %}
+{%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
+{%                     if proxy_group.include is arista.avd.defined %}
+{%                         for include_source in proxy_group.include %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} include {{ include_source.source }}
+{%                         endfor %}
+{%                     endif %}
+{%                     if proxy_group.exclude is arista.avd.defined %}
+{%                         for exclude_source in proxy_group.exclude %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} exclude {{ exclude_source.source }}
+{%                         endfor %}
+{%                     endif %}
+{%                 elif proxy_group.group is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if port_channel_interface.ip_igmp_host_proxy.access_lists is arista.avd.defined %}
+{%             for access_list in port_channel_interface.ip_igmp_host_proxy.access_lists %}
+   {{ host_proxy_cli }} access-list {{ access_list.name }}
+{%             endfor %}
+{%         endif %}
+{%         if port_channel_interface.ip_igmp_host_proxy.report_interval is arista.avd.defined %}
+   {{ host_proxy_cli }} report-interval {{ port_channel_interface.ip_igmp_host_proxy.report_interval }}
+{%         endif %}
+{%         if port_channel_interface.ip_igmp_host_proxy.version is arista.avd.defined %}
+   {{ host_proxy_cli }} version {{ port_channel_interface.ip_igmp_host_proxy.version }}
+{%         endif %}
+{%     endif %}
 {%     if port_channel_interface.l2_mtu is arista.avd.defined %}
    l2 mtu {{ port_channel_interface.l2_mtu }}
 {%     endif %}
@@ -465,29 +498,5 @@ interface {{ port_channel_interface.name }}
 {%     endif %}
 {%     if port_channel_interface.eos_cli is arista.avd.defined %}
    {{ port_channel_interface.eos_cli | indent(3, false) }}
-{%     endif %}
-{%     if port_channel_interface.ip_igmp_host_proxy.enabled is arista.avd.defined(true) %}
-{%         set host_proxy_cli =  "ip igmp host-proxy" %}
-   {{ host_proxy_cli }}
-{%         if port_channel_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
-{%             for proxy_group in port_channel_interface.ip_igmp_host_proxy.groups %}
-{%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
-{%                     if proxy_group.exclude is arista.avd.defined %}
-   {{ host_proxy_cli }} {{ proxy_group.group }} exclude {{ proxy_group.exclude }}
-{%                     endif %}
-{%                     if proxy_group.include is arista.avd.defined %}
-   {{ host_proxy_cli }} {{ proxy_group.group }} include {{ proxy_group.include }}
-{%                     endif %}
-{%                 elif proxy_group.group is arista.avd.defined %}
-   {{ host_proxy_cli }} {{ proxy_group.group }}
-{%                 endif %}
-{%             endfor %}
-{%         endif %}
-{%         if port_channel_interface.ip_igmp_host_proxy.report_interval is arista.avd.defined %}
-   {{ host_proxy_cli }} report-interval {{ port_channel_interface.ip_igmp_host_proxy.report_interval }}
-{%         endif %}
-{%         if port_channel_interface.ip_igmp_host_proxy.version is arista.avd.defined %}
-   {{ host_proxy_cli }} version {{ port_channel_interface.ip_igmp_host_proxy.version }}
-{%         endif %}
 {%     endif %}
 {% endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -105,15 +105,24 @@ interface {{ vlan_interface.name }}
 {%         if vlan_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
 {%             for proxy_group in vlan_interface.ip_igmp_host_proxy.groups %}
 {%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
-{%                     if proxy_group.exclude is arista.avd.defined %}
-   {{ host_proxy_cli }} {{ proxy_group.group }} exclude {{ proxy_group.exclude }}
-{%                     endif %}
 {%                     if proxy_group.include is arista.avd.defined %}
-   {{ host_proxy_cli }} {{ proxy_group.group }} include {{ proxy_group.include }}
+{%                         for include_source in proxy_group.include %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} include {{ include_source.source }}
+{%                         endfor %}
+{%                     endif %}
+{%                     if proxy_group.exclude is arista.avd.defined %}
+{%                         for exclude_source in proxy_group.exclude %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} exclude {{ exclude_source.source }}
+{%                         endfor %}
 {%                     endif %}
 {%                 elif proxy_group.group is arista.avd.defined %}
    {{ host_proxy_cli }} {{ proxy_group.group }}
 {%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if vlan_interface.ip_igmp_host_proxy.access_lists is arista.avd.defined %}
+{%             for access_list in vlan_interface.ip_igmp_host_proxy.access_lists %}
+   {{ host_proxy_cli }} access-list {{ access_list.name }}
 {%             endfor %}
 {%         endif %}
 {%         if vlan_interface.ip_igmp_host_proxy.report_interval is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -99,6 +99,30 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.ip_igmp_version is arista.avd.defined %}
    ip igmp version {{ vlan_interface.ip_igmp_version }}
 {%     endif %}
+{%     if vlan_interface.ip_igmp_host_proxy.enabled is arista.avd.defined(true) %}
+{%         set host_proxy_cli =  "ip igmp host-proxy" %}
+   {{ host_proxy_cli }}
+{%         if vlan_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
+{%             for proxy_group in vlan_interface.ip_igmp_host_proxy.groups %}
+{%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
+{%                     if proxy_group.exclude is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} exclude {{ proxy_group.exclude }}
+{%                     endif %}
+{%                     if proxy_group.include is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }} include {{ proxy_group.include }}
+{%                     endif %}
+{%                 elif proxy_group.group is arista.avd.defined %}
+   {{ host_proxy_cli }} {{ proxy_group.group }}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if vlan_interface.ip_igmp_host_proxy.report_interval is arista.avd.defined %}
+   {{ host_proxy_cli }} report-interval {{ vlan_interface.ip_igmp_host_proxy.report_interval }}
+{%         endif %}
+{%         if vlan_interface.ip_igmp_host_proxy.version is arista.avd.defined %}
+   {{ host_proxy_cli }} version {{ vlan_interface.ip_igmp_host_proxy.version }}
+{%         endif %}
+{%     endif %}
 {%     if vlan_interface.ipv6_enable is arista.avd.defined(true) %}
    ipv6 enable
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -8518,12 +8518,12 @@
                   },
                   "groups": {
                     "type": "array",
-                    "description": "Group Address.",
                     "items": {
                       "type": "object",
                       "properties": {
                         "group": {
                           "type": "string",
+                          "description": "Multicast Address.",
                           "title": "Group"
                         },
                         "exclude": {
@@ -8581,7 +8581,6 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 31744,
-                    "default": 1,
                     "description": "Time interval between unsolicited reports.",
                     "title": "Report Interval"
                   },
@@ -8610,7 +8609,6 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 3,
-                    "default": 3,
                     "description": "IGMP version on IGMP host-proxy interface.",
                     "title": "Version"
                   }
@@ -11872,12 +11870,12 @@
                       },
                       "groups": {
                         "type": "array",
-                        "description": "Group Address.",
                         "items": {
                           "type": "object",
                           "properties": {
                             "group": {
                               "type": "string",
+                              "description": "Multicast Address.",
                               "title": "Group"
                             },
                             "exclude": {
@@ -11935,7 +11933,6 @@
                         "type": "integer",
                         "minimum": 1,
                         "maximum": 31744,
-                        "default": 1,
                         "description": "Time interval between unsolicited reports.",
                         "title": "Report Interval"
                       },
@@ -11964,7 +11961,6 @@
                         "type": "integer",
                         "minimum": 1,
                         "maximum": 3,
-                        "default": 3,
                         "description": "IGMP version on IGMP host-proxy interface.",
                         "title": "Version"
                       }
@@ -14230,12 +14226,12 @@
                   },
                   "groups": {
                     "type": "array",
-                    "description": "Group Address.",
                     "items": {
                       "type": "object",
                       "properties": {
                         "group": {
                           "type": "string",
+                          "description": "Multicast Address.",
                           "title": "Group"
                         },
                         "exclude": {
@@ -14293,7 +14289,6 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 31744,
-                    "default": 1,
                     "description": "Time interval between unsolicited reports.",
                     "title": "Report Interval"
                   },
@@ -14322,7 +14317,6 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 3,
-                    "default": 3,
                     "description": "IGMP version on IGMP host-proxy interface.",
                     "title": "Version"
                   }
@@ -18405,12 +18399,12 @@
                       },
                       "groups": {
                         "type": "array",
-                        "description": "Group Address.",
                         "items": {
                           "type": "object",
                           "properties": {
                             "group": {
                               "type": "string",
+                              "description": "Multicast Address.",
                               "title": "Group"
                             },
                             "exclude": {
@@ -18468,7 +18462,6 @@
                         "type": "integer",
                         "minimum": 1,
                         "maximum": 31744,
-                        "default": 1,
                         "description": "Time interval between unsolicited reports.",
                         "title": "Report Interval"
                       },
@@ -18497,7 +18490,6 @@
                         "type": "integer",
                         "minimum": 1,
                         "maximum": 3,
-                        "default": 3,
                         "description": "IGMP version on IGMP host-proxy interface.",
                         "title": "Version"
                       }
@@ -20763,12 +20755,12 @@
                   },
                   "groups": {
                     "type": "array",
-                    "description": "Group Address.",
                     "items": {
                       "type": "object",
                       "properties": {
                         "group": {
                           "type": "string",
+                          "description": "Multicast Address.",
                           "title": "Group"
                         },
                         "exclude": {
@@ -20826,7 +20818,6 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 31744,
-                    "default": 1,
                     "description": "Time interval between unsolicited reports.",
                     "title": "Report Interval"
                   },
@@ -20855,7 +20846,6 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 3,
-                    "default": 3,
                     "description": "IGMP version on IGMP host-proxy interface.",
                     "title": "Version"
                   }
@@ -23004,12 +22994,12 @@
                         },
                         "groups": {
                           "type": "array",
-                          "description": "Group Address.",
                           "items": {
                             "type": "object",
                             "properties": {
                               "group": {
                                 "type": "string",
+                                "description": "Multicast Address.",
                                 "title": "Group"
                               },
                               "exclude": {
@@ -23067,7 +23057,6 @@
                           "type": "integer",
                           "minimum": 1,
                           "maximum": 31744,
-                          "default": 1,
                           "description": "Time interval between unsolicited reports.",
                           "title": "Report Interval"
                         },
@@ -23096,7 +23085,6 @@
                           "type": "integer",
                           "minimum": 1,
                           "maximum": 3,
-                          "default": 3,
                           "description": "IGMP version on IGMP host-proxy interface.",
                           "title": "Version"
                         }
@@ -24852,12 +24840,12 @@
                   },
                   "groups": {
                     "type": "array",
-                    "description": "Group Address.",
                     "items": {
                       "type": "object",
                       "properties": {
                         "group": {
                           "type": "string",
+                          "description": "Multicast Address.",
                           "title": "Group"
                         },
                         "exclude": {
@@ -24915,7 +24903,6 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 31744,
-                    "default": 1,
                     "description": "Time interval between unsolicited reports.",
                     "title": "Report Interval"
                   },
@@ -24944,7 +24931,6 @@
                     "type": "integer",
                     "minimum": 1,
                     "maximum": 3,
-                    "default": 3,
                     "description": "IGMP version on IGMP host-proxy interface.",
                     "title": "Version"
                   }

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9068,6 +9068,118 @@
                 "type": "string",
                 "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
                 "title": "EOS CLI"
+              },
+              "ip_igmp_host_proxy": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                  },
+                  "groups": {
+                    "type": "array",
+                    "description": "Group Address.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "group": {
+                          "type": "string",
+                          "title": "Group"
+                        },
+                        "exclude": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Exclude"
+                        },
+                        "include": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Include"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "group"
+                      ]
+                    },
+                    "title": "Groups"
+                  },
+                  "report_interval": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 31744,
+                    "default": 1,
+                    "description": "Time interval between unsolicited reports.",
+                    "title": "Report Interval"
+                  },
+                  "access_lists": {
+                    "type": "array",
+                    "description": "Non-standard Access List name.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Access Lists"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "default": 3,
+                    "description": "IGMP version on IGMP host-proxy interface.",
+                    "title": "Version"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP IGMP Host Proxy"
               }
             },
             "additionalProperties": false,
@@ -11807,6 +11919,118 @@
                     "type": "string",
                     "description": "Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration",
                     "title": "EOS CLI"
+                  },
+                  "ip_igmp_host_proxy": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "title": "Enabled"
+                      },
+                      "groups": {
+                        "type": "array",
+                        "description": "Group Address.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "group": {
+                              "type": "string",
+                              "title": "Group"
+                            },
+                            "exclude": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "source": {
+                                    "type": "string",
+                                    "title": "Source"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "required": [
+                                  "source"
+                                ]
+                              },
+                              "title": "Exclude"
+                            },
+                            "include": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "source": {
+                                    "type": "string",
+                                    "title": "Source"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "required": [
+                                  "source"
+                                ]
+                              },
+                              "title": "Include"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "required": [
+                            "group"
+                          ]
+                        },
+                        "title": "Groups"
+                      },
+                      "report_interval": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 31744,
+                        "default": 1,
+                        "description": "Time interval between unsolicited reports.",
+                        "title": "Report Interval"
+                      },
+                      "access_lists": {
+                        "type": "array",
+                        "description": "Non-standard Access List name.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "title": "Name"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        },
+                        "title": "Access Lists"
+                      },
+                      "version": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 3,
+                        "default": 3,
+                        "description": "IGMP version on IGMP host-proxy interface.",
+                        "title": "Version"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "IP IGMP Host Proxy"
                   }
                 },
                 "additionalProperties": false,
@@ -14556,6 +14780,118 @@
                 "type": "string",
                 "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
                 "title": "EOS CLI"
+              },
+              "ip_igmp_host_proxy": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                  },
+                  "groups": {
+                    "type": "array",
+                    "description": "Group Address.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "group": {
+                          "type": "string",
+                          "title": "Group"
+                        },
+                        "exclude": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Exclude"
+                        },
+                        "include": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Include"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "group"
+                      ]
+                    },
+                    "title": "Groups"
+                  },
+                  "report_interval": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 31744,
+                    "default": 1,
+                    "description": "Time interval between unsolicited reports.",
+                    "title": "Report Interval"
+                  },
+                  "access_lists": {
+                    "type": "array",
+                    "description": "Non-standard Access List name.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Access Lists"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "default": 3,
+                    "description": "IGMP version on IGMP host-proxy interface.",
+                    "title": "Version"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP IGMP Host Proxy"
               }
             },
             "additionalProperties": false,
@@ -18116,6 +18452,118 @@
                     "type": "string",
                     "description": "Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration",
                     "title": "EOS CLI"
+                  },
+                  "ip_igmp_host_proxy": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "title": "Enabled"
+                      },
+                      "groups": {
+                        "type": "array",
+                        "description": "Group Address.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "group": {
+                              "type": "string",
+                              "title": "Group"
+                            },
+                            "exclude": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "source": {
+                                    "type": "string",
+                                    "title": "Source"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "required": [
+                                  "source"
+                                ]
+                              },
+                              "title": "Exclude"
+                            },
+                            "include": {
+                              "type": "array",
+                              "items": {
+                                "type": "object",
+                                "properties": {
+                                  "source": {
+                                    "type": "string",
+                                    "title": "Source"
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "required": [
+                                  "source"
+                                ]
+                              },
+                              "title": "Include"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "required": [
+                            "group"
+                          ]
+                        },
+                        "title": "Groups"
+                      },
+                      "report_interval": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 31744,
+                        "default": 1,
+                        "description": "Time interval between unsolicited reports.",
+                        "title": "Report Interval"
+                      },
+                      "access_lists": {
+                        "type": "array",
+                        "description": "Non-standard Access List name.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "title": "Name"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        },
+                        "title": "Access Lists"
+                      },
+                      "version": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 3,
+                        "default": 3,
+                        "description": "IGMP version on IGMP host-proxy interface.",
+                        "title": "Version"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "IP IGMP Host Proxy"
                   }
                 },
                 "additionalProperties": false,
@@ -20865,6 +21313,118 @@
                 "type": "string",
                 "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
                 "title": "EOS CLI"
+              },
+              "ip_igmp_host_proxy": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                  },
+                  "groups": {
+                    "type": "array",
+                    "description": "Group Address.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "group": {
+                          "type": "string",
+                          "title": "Group"
+                        },
+                        "exclude": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Exclude"
+                        },
+                        "include": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Include"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "group"
+                      ]
+                    },
+                    "title": "Groups"
+                  },
+                  "report_interval": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 31744,
+                    "default": 1,
+                    "description": "Time interval between unsolicited reports.",
+                    "title": "Report Interval"
+                  },
+                  "access_lists": {
+                    "type": "array",
+                    "description": "Non-standard Access List name.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Access Lists"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "default": 3,
+                    "description": "IGMP version on IGMP host-proxy interface.",
+                    "title": "Version"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP IGMP Host Proxy"
               }
             },
             "additionalProperties": false,
@@ -22434,6 +22994,118 @@
                       "minimum": 1,
                       "maximum": 3,
                       "title": "IP IGMP Version"
+                    },
+                    "ip_igmp_host_proxy": {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "type": "boolean",
+                          "title": "Enabled"
+                        },
+                        "groups": {
+                          "type": "array",
+                          "description": "Group Address.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "group": {
+                                "type": "string",
+                                "title": "Group"
+                              },
+                              "exclude": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "source": {
+                                      "type": "string",
+                                      "title": "Source"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "required": [
+                                    "source"
+                                  ]
+                                },
+                                "title": "Exclude"
+                              },
+                              "include": {
+                                "type": "array",
+                                "items": {
+                                  "type": "object",
+                                  "properties": {
+                                    "source": {
+                                      "type": "string",
+                                      "title": "Source"
+                                    }
+                                  },
+                                  "additionalProperties": false,
+                                  "patternProperties": {
+                                    "^_.+$": {}
+                                  },
+                                  "required": [
+                                    "source"
+                                  ]
+                                },
+                                "title": "Include"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "group"
+                            ]
+                          },
+                          "title": "Groups"
+                        },
+                        "report_interval": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 31744,
+                          "default": 1,
+                          "description": "Time interval between unsolicited reports.",
+                          "title": "Report Interval"
+                        },
+                        "access_lists": {
+                          "type": "array",
+                          "description": "Non-standard Access List name.",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "name": {
+                                "type": "string",
+                                "title": "Name"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "name"
+                            ]
+                          },
+                          "title": "Access Lists"
+                        },
+                        "version": {
+                          "type": "integer",
+                          "minimum": 1,
+                          "maximum": 3,
+                          "default": 3,
+                          "description": "IGMP version on IGMP host-proxy interface.",
+                          "title": "Version"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "IP IGMP Host Proxy"
                     },
                     "ip_helpers": {
                       "type": "array",
@@ -24170,6 +24842,118 @@
                 "minimum": 1,
                 "maximum": 3,
                 "title": "IP IGMP Version"
+              },
+              "ip_igmp_host_proxy": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                  },
+                  "groups": {
+                    "type": "array",
+                    "description": "Group Address.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "group": {
+                          "type": "string",
+                          "title": "Group"
+                        },
+                        "exclude": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Exclude"
+                        },
+                        "include": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Include"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "group"
+                      ]
+                    },
+                    "title": "Groups"
+                  },
+                  "report_interval": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 31744,
+                    "default": 1,
+                    "description": "Time interval between unsolicited reports.",
+                    "title": "Report Interval"
+                  },
+                  "access_lists": {
+                    "type": "array",
+                    "description": "Non-standard Access List name.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Access Lists"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "default": 3,
+                    "description": "IGMP version on IGMP host-proxy interface.",
+                    "title": "Version"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP IGMP Host Proxy"
               },
               "ip_helpers": {
                 "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -8509,6 +8509,118 @@
                 },
                 "title": "BGP"
               },
+              "ip_igmp_host_proxy": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                  },
+                  "groups": {
+                    "type": "array",
+                    "description": "Group Address.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "group": {
+                          "type": "string",
+                          "title": "Group"
+                        },
+                        "exclude": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Exclude"
+                        },
+                        "include": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Include"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "group"
+                      ]
+                    },
+                    "title": "Groups"
+                  },
+                  "report_interval": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 31744,
+                    "default": 1,
+                    "description": "Time interval between unsolicited reports.",
+                    "title": "Report Interval"
+                  },
+                  "access_lists": {
+                    "type": "array",
+                    "description": "Non-standard Access List name.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Access Lists"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "default": 3,
+                    "description": "IGMP version on IGMP host-proxy interface.",
+                    "title": "Version"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP IGMP Host Proxy"
+              },
               "peer": {
                 "type": "string",
                 "description": "Key only used for documentation or validation purposes",
@@ -9068,118 +9180,6 @@
                 "type": "string",
                 "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
                 "title": "EOS CLI"
-              },
-              "ip_igmp_host_proxy": {
-                "type": "object",
-                "properties": {
-                  "enabled": {
-                    "type": "boolean",
-                    "title": "Enabled"
-                  },
-                  "groups": {
-                    "type": "array",
-                    "description": "Group Address.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "group": {
-                          "type": "string",
-                          "title": "Group"
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "source": {
-                                "type": "string",
-                                "title": "Source"
-                              }
-                            },
-                            "additionalProperties": false,
-                            "patternProperties": {
-                              "^_.+$": {}
-                            },
-                            "required": [
-                              "source"
-                            ]
-                          },
-                          "title": "Exclude"
-                        },
-                        "include": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "source": {
-                                "type": "string",
-                                "title": "Source"
-                              }
-                            },
-                            "additionalProperties": false,
-                            "patternProperties": {
-                              "^_.+$": {}
-                            },
-                            "required": [
-                              "source"
-                            ]
-                          },
-                          "title": "Include"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {
-                        "^_.+$": {}
-                      },
-                      "required": [
-                        "group"
-                      ]
-                    },
-                    "title": "Groups"
-                  },
-                  "report_interval": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 31744,
-                    "default": 1,
-                    "description": "Time interval between unsolicited reports.",
-                    "title": "Report Interval"
-                  },
-                  "access_lists": {
-                    "type": "array",
-                    "description": "Non-standard Access List name.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "title": "Name"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {
-                        "^_.+$": {}
-                      },
-                      "required": [
-                        "name"
-                      ]
-                    },
-                    "title": "Access Lists"
-                  },
-                  "version": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 3,
-                    "default": 3,
-                    "description": "IGMP version on IGMP host-proxy interface.",
-                    "title": "Version"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "IP IGMP Host Proxy"
               }
             },
             "additionalProperties": false,
@@ -11863,63 +11863,6 @@
                     },
                     "title": "BGP"
                   },
-                  "peer": {
-                    "type": "string",
-                    "description": "Key only used for documentation or validation purposes",
-                    "title": "Peer"
-                  },
-                  "peer_interface": {
-                    "type": "string",
-                    "description": "Key only used for documentation or validation purposes",
-                    "title": "Peer Interface"
-                  },
-                  "peer_type": {
-                    "type": "string",
-                    "description": "Key only used for documentation or validation purposes",
-                    "title": "Peer Type"
-                  },
-                  "sflow": {
-                    "type": "object",
-                    "properties": {
-                      "enable": {
-                        "type": "boolean",
-                        "title": "Enable"
-                      },
-                      "egress": {
-                        "type": "object",
-                        "properties": {
-                          "enable": {
-                            "type": "boolean",
-                            "title": "Enable"
-                          },
-                          "unmodified_enable": {
-                            "type": "boolean",
-                            "title": "Unmodified Enable"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "patternProperties": {
-                          "^_.+$": {}
-                        },
-                        "title": "Egress"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^_.+$": {}
-                    },
-                    "title": "Sflow"
-                  },
-                  "validate_state": {
-                    "type": "boolean",
-                    "description": "Set to false to disable interface validation by the `eos_validate_state` role",
-                    "title": "Validate State"
-                  },
-                  "eos_cli": {
-                    "type": "string",
-                    "description": "Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration",
-                    "title": "EOS CLI"
-                  },
                   "ip_igmp_host_proxy": {
                     "type": "object",
                     "properties": {
@@ -12031,6 +11974,63 @@
                       "^_.+$": {}
                     },
                     "title": "IP IGMP Host Proxy"
+                  },
+                  "peer": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer"
+                  },
+                  "peer_interface": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Interface"
+                  },
+                  "peer_type": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Type"
+                  },
+                  "sflow": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "egress": {
+                        "type": "object",
+                        "properties": {
+                          "enable": {
+                            "type": "boolean",
+                            "title": "Enable"
+                          },
+                          "unmodified_enable": {
+                            "type": "boolean",
+                            "title": "Unmodified Enable"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Egress"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Sflow"
+                  },
+                  "validate_state": {
+                    "type": "boolean",
+                    "description": "Set to false to disable interface validation by the `eos_validate_state` role",
+                    "title": "Validate State"
+                  },
+                  "eos_cli": {
+                    "type": "string",
+                    "description": "Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration",
+                    "title": "EOS CLI"
                   }
                 },
                 "additionalProperties": false,
@@ -14221,6 +14221,118 @@
                 },
                 "title": "BGP"
               },
+              "ip_igmp_host_proxy": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                  },
+                  "groups": {
+                    "type": "array",
+                    "description": "Group Address.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "group": {
+                          "type": "string",
+                          "title": "Group"
+                        },
+                        "exclude": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Exclude"
+                        },
+                        "include": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Include"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "group"
+                      ]
+                    },
+                    "title": "Groups"
+                  },
+                  "report_interval": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 31744,
+                    "default": 1,
+                    "description": "Time interval between unsolicited reports.",
+                    "title": "Report Interval"
+                  },
+                  "access_lists": {
+                    "type": "array",
+                    "description": "Non-standard Access List name.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Access Lists"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "default": 3,
+                    "description": "IGMP version on IGMP host-proxy interface.",
+                    "title": "Version"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP IGMP Host Proxy"
+              },
               "peer": {
                 "type": "string",
                 "description": "Key only used for documentation or validation purposes",
@@ -14780,118 +14892,6 @@
                 "type": "string",
                 "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
                 "title": "EOS CLI"
-              },
-              "ip_igmp_host_proxy": {
-                "type": "object",
-                "properties": {
-                  "enabled": {
-                    "type": "boolean",
-                    "title": "Enabled"
-                  },
-                  "groups": {
-                    "type": "array",
-                    "description": "Group Address.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "group": {
-                          "type": "string",
-                          "title": "Group"
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "source": {
-                                "type": "string",
-                                "title": "Source"
-                              }
-                            },
-                            "additionalProperties": false,
-                            "patternProperties": {
-                              "^_.+$": {}
-                            },
-                            "required": [
-                              "source"
-                            ]
-                          },
-                          "title": "Exclude"
-                        },
-                        "include": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "source": {
-                                "type": "string",
-                                "title": "Source"
-                              }
-                            },
-                            "additionalProperties": false,
-                            "patternProperties": {
-                              "^_.+$": {}
-                            },
-                            "required": [
-                              "source"
-                            ]
-                          },
-                          "title": "Include"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {
-                        "^_.+$": {}
-                      },
-                      "required": [
-                        "group"
-                      ]
-                    },
-                    "title": "Groups"
-                  },
-                  "report_interval": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 31744,
-                    "default": 1,
-                    "description": "Time interval between unsolicited reports.",
-                    "title": "Report Interval"
-                  },
-                  "access_lists": {
-                    "type": "array",
-                    "description": "Non-standard Access List name.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "title": "Name"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {
-                        "^_.+$": {}
-                      },
-                      "required": [
-                        "name"
-                      ]
-                    },
-                    "title": "Access Lists"
-                  },
-                  "version": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 3,
-                    "default": 3,
-                    "description": "IGMP version on IGMP host-proxy interface.",
-                    "title": "Version"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "IP IGMP Host Proxy"
               }
             },
             "additionalProperties": false,
@@ -18396,63 +18396,6 @@
                     },
                     "title": "BGP"
                   },
-                  "peer": {
-                    "type": "string",
-                    "description": "Key only used for documentation or validation purposes",
-                    "title": "Peer"
-                  },
-                  "peer_interface": {
-                    "type": "string",
-                    "description": "Key only used for documentation or validation purposes",
-                    "title": "Peer Interface"
-                  },
-                  "peer_type": {
-                    "type": "string",
-                    "description": "Key only used for documentation or validation purposes",
-                    "title": "Peer Type"
-                  },
-                  "sflow": {
-                    "type": "object",
-                    "properties": {
-                      "enable": {
-                        "type": "boolean",
-                        "title": "Enable"
-                      },
-                      "egress": {
-                        "type": "object",
-                        "properties": {
-                          "enable": {
-                            "type": "boolean",
-                            "title": "Enable"
-                          },
-                          "unmodified_enable": {
-                            "type": "boolean",
-                            "title": "Unmodified Enable"
-                          }
-                        },
-                        "additionalProperties": false,
-                        "patternProperties": {
-                          "^_.+$": {}
-                        },
-                        "title": "Egress"
-                      }
-                    },
-                    "additionalProperties": false,
-                    "patternProperties": {
-                      "^_.+$": {}
-                    },
-                    "title": "Sflow"
-                  },
-                  "validate_state": {
-                    "type": "boolean",
-                    "description": "Set to false to disable interface validation by the `eos_validate_state` role",
-                    "title": "Validate State"
-                  },
-                  "eos_cli": {
-                    "type": "string",
-                    "description": "Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration",
-                    "title": "EOS CLI"
-                  },
                   "ip_igmp_host_proxy": {
                     "type": "object",
                     "properties": {
@@ -18564,6 +18507,63 @@
                       "^_.+$": {}
                     },
                     "title": "IP IGMP Host Proxy"
+                  },
+                  "peer": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer"
+                  },
+                  "peer_interface": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Interface"
+                  },
+                  "peer_type": {
+                    "type": "string",
+                    "description": "Key only used for documentation or validation purposes",
+                    "title": "Peer Type"
+                  },
+                  "sflow": {
+                    "type": "object",
+                    "properties": {
+                      "enable": {
+                        "type": "boolean",
+                        "title": "Enable"
+                      },
+                      "egress": {
+                        "type": "object",
+                        "properties": {
+                          "enable": {
+                            "type": "boolean",
+                            "title": "Enable"
+                          },
+                          "unmodified_enable": {
+                            "type": "boolean",
+                            "title": "Unmodified Enable"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Egress"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Sflow"
+                  },
+                  "validate_state": {
+                    "type": "boolean",
+                    "description": "Set to false to disable interface validation by the `eos_validate_state` role",
+                    "title": "Validate State"
+                  },
+                  "eos_cli": {
+                    "type": "string",
+                    "description": "Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration",
+                    "title": "EOS CLI"
                   }
                 },
                 "additionalProperties": false,
@@ -20754,6 +20754,118 @@
                 },
                 "title": "BGP"
               },
+              "ip_igmp_host_proxy": {
+                "type": "object",
+                "properties": {
+                  "enabled": {
+                    "type": "boolean",
+                    "title": "Enabled"
+                  },
+                  "groups": {
+                    "type": "array",
+                    "description": "Group Address.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "group": {
+                          "type": "string",
+                          "title": "Group"
+                        },
+                        "exclude": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Exclude"
+                        },
+                        "include": {
+                          "type": "array",
+                          "items": {
+                            "type": "object",
+                            "properties": {
+                              "source": {
+                                "type": "string",
+                                "title": "Source"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "required": [
+                              "source"
+                            ]
+                          },
+                          "title": "Include"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "group"
+                      ]
+                    },
+                    "title": "Groups"
+                  },
+                  "report_interval": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 31744,
+                    "default": 1,
+                    "description": "Time interval between unsolicited reports.",
+                    "title": "Report Interval"
+                  },
+                  "access_lists": {
+                    "type": "array",
+                    "description": "Non-standard Access List name.",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "name": {
+                          "type": "string",
+                          "title": "Name"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "required": [
+                        "name"
+                      ]
+                    },
+                    "title": "Access Lists"
+                  },
+                  "version": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 3,
+                    "default": 3,
+                    "description": "IGMP version on IGMP host-proxy interface.",
+                    "title": "Version"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IP IGMP Host Proxy"
+              },
               "peer": {
                 "type": "string",
                 "description": "Key only used for documentation or validation purposes",
@@ -21313,118 +21425,6 @@
                 "type": "string",
                 "description": "Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration",
                 "title": "EOS CLI"
-              },
-              "ip_igmp_host_proxy": {
-                "type": "object",
-                "properties": {
-                  "enabled": {
-                    "type": "boolean",
-                    "title": "Enabled"
-                  },
-                  "groups": {
-                    "type": "array",
-                    "description": "Group Address.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "group": {
-                          "type": "string",
-                          "title": "Group"
-                        },
-                        "exclude": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "source": {
-                                "type": "string",
-                                "title": "Source"
-                              }
-                            },
-                            "additionalProperties": false,
-                            "patternProperties": {
-                              "^_.+$": {}
-                            },
-                            "required": [
-                              "source"
-                            ]
-                          },
-                          "title": "Exclude"
-                        },
-                        "include": {
-                          "type": "array",
-                          "items": {
-                            "type": "object",
-                            "properties": {
-                              "source": {
-                                "type": "string",
-                                "title": "Source"
-                              }
-                            },
-                            "additionalProperties": false,
-                            "patternProperties": {
-                              "^_.+$": {}
-                            },
-                            "required": [
-                              "source"
-                            ]
-                          },
-                          "title": "Include"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {
-                        "^_.+$": {}
-                      },
-                      "required": [
-                        "group"
-                      ]
-                    },
-                    "title": "Groups"
-                  },
-                  "report_interval": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 31744,
-                    "default": 1,
-                    "description": "Time interval between unsolicited reports.",
-                    "title": "Report Interval"
-                  },
-                  "access_lists": {
-                    "type": "array",
-                    "description": "Non-standard Access List name.",
-                    "items": {
-                      "type": "object",
-                      "properties": {
-                        "name": {
-                          "type": "string",
-                          "title": "Name"
-                        }
-                      },
-                      "additionalProperties": false,
-                      "patternProperties": {
-                        "^_.+$": {}
-                      },
-                      "required": [
-                        "name"
-                      ]
-                    },
-                    "title": "Access Lists"
-                  },
-                  "version": {
-                    "type": "integer",
-                    "minimum": 1,
-                    "maximum": 3,
-                    "default": 3,
-                    "description": "IGMP version on IGMP host-proxy interface.",
-                    "title": "Version"
-                  }
-                },
-                "additionalProperties": false,
-                "patternProperties": {
-                  "^_.+$": {}
-                },
-                "title": "IP IGMP Host Proxy"
               }
             },
             "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -8528,6 +8528,7 @@
                         },
                         "exclude": {
                           "type": "array",
+                          "description": "The same source must not be present both in `exclude` and `include` list.",
                           "items": {
                             "type": "object",
                             "properties": {
@@ -8548,6 +8549,7 @@
                         },
                         "include": {
                           "type": "array",
+                          "description": "The same source must not be present both in `exclude` and `include` list.",
                           "items": {
                             "type": "object",
                             "properties": {
@@ -11880,6 +11882,7 @@
                             },
                             "exclude": {
                               "type": "array",
+                              "description": "The same source must not be present both in `exclude` and `include` list.",
                               "items": {
                                 "type": "object",
                                 "properties": {
@@ -11900,6 +11903,7 @@
                             },
                             "include": {
                               "type": "array",
+                              "description": "The same source must not be present both in `exclude` and `include` list.",
                               "items": {
                                 "type": "object",
                                 "properties": {
@@ -14236,6 +14240,7 @@
                         },
                         "exclude": {
                           "type": "array",
+                          "description": "The same source must not be present both in `exclude` and `include` list.",
                           "items": {
                             "type": "object",
                             "properties": {
@@ -14256,6 +14261,7 @@
                         },
                         "include": {
                           "type": "array",
+                          "description": "The same source must not be present both in `exclude` and `include` list.",
                           "items": {
                             "type": "object",
                             "properties": {
@@ -18409,6 +18415,7 @@
                             },
                             "exclude": {
                               "type": "array",
+                              "description": "The same source must not be present both in `exclude` and `include` list.",
                               "items": {
                                 "type": "object",
                                 "properties": {
@@ -18429,6 +18436,7 @@
                             },
                             "include": {
                               "type": "array",
+                              "description": "The same source must not be present both in `exclude` and `include` list.",
                               "items": {
                                 "type": "object",
                                 "properties": {
@@ -20765,6 +20773,7 @@
                         },
                         "exclude": {
                           "type": "array",
+                          "description": "The same source must not be present both in `exclude` and `include` list.",
                           "items": {
                             "type": "object",
                             "properties": {
@@ -20785,6 +20794,7 @@
                         },
                         "include": {
                           "type": "array",
+                          "description": "The same source must not be present both in `exclude` and `include` list.",
                           "items": {
                             "type": "object",
                             "properties": {
@@ -23004,6 +23014,7 @@
                               },
                               "exclude": {
                                 "type": "array",
+                                "description": "The same source must not be present both in `exclude` and `include` list.",
                                 "items": {
                                   "type": "object",
                                   "properties": {
@@ -23024,6 +23035,7 @@
                               },
                               "include": {
                                 "type": "array",
+                                "description": "The same source must not be present both in `exclude` and `include` list.",
                                 "items": {
                                   "type": "object",
                                   "properties": {
@@ -24850,6 +24862,7 @@
                         },
                         "exclude": {
                           "type": "array",
+                          "description": "The same source must not be present both in `exclude` and `include` list.",
                           "items": {
                             "type": "object",
                             "properties": {
@@ -24870,6 +24883,7 @@
                         },
                         "include": {
                           "type": "array",
+                          "description": "The same source must not be present both in `exclude` and `include` list.",
                           "items": {
                             "type": "object",
                             "properties": {


### PR DESCRIPTION
## Change Summary

Adding 'ip igmp host-proxy' interface support

## Related Issue(s)

Fixes #3633  , #3566 

## Component(s) name

`arista.avd.eos_cli_config_gen`

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
