### PR TITLE
Feat(eos_cli_config_gen): Add 1-step Boundary Clock support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -57,7 +57,7 @@ ptp ttl 12
 ptp domain 17
 ptp message-type general dscp 36 default
 ptp message-type event dscp 46 default
-ptp mode boundary
+ptp mode boundary one-step
 ptp forward-unicast
 ptp monitor threshold offset-from-master 11
 ptp monitor threshold mean-path-delay 12

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
@@ -12,7 +12,7 @@ ptp ttl 12
 ptp domain 17
 ptp message-type general dscp 36 default
 ptp message-type event dscp 46 default
-ptp mode boundary
+ptp mode boundary one-step
 ptp forward-unicast
 ptp monitor threshold offset-from-master 11
 ptp monitor threshold mean-path-delay 12

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
@@ -14,6 +14,7 @@ ptp:
     event:
       dscp: 46
   mode: boundary
+  boundary_one_step: true
   forward_unicast: true
   monitor:
     # enabled: true (default)

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ptp.yml
@@ -14,7 +14,7 @@ ptp:
     event:
       dscp: 46
   mode: boundary
-  boundary_one_step: true
+  mode_one_step: true
   forward_unicast: true
   monitor:
     # enabled: true (default)

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ptp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ptp.md
@@ -9,7 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>ptp</samp>](## "ptp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;mode</samp>](## "ptp.mode") | String |  |  | Valid Values:<br>- <code>boundary</code><br>- <code>transparent</code> |  |
-    | [<samp>&nbsp;&nbsp;boundary_one_step</samp>](## "ptp.boundary_one_step") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;mode_one_step</samp>](## "ptp.mode_one_step") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;forward_unicast</samp>](## "ptp.forward_unicast") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;clock_identity</samp>](## "ptp.clock_identity") | String |  |  |  | The clock-id in xx:xx:xx:xx:xx:xx format |
     | [<samp>&nbsp;&nbsp;source</samp>](## "ptp.source") | Dictionary |  |  |  |  |
@@ -48,7 +48,7 @@
     ```yaml
     ptp:
       mode: <str; "boundary" | "transparent">
-      boundary_one_step: <bool>
+      mode_one_step: <bool>
       forward_unicast: <bool>
 
       # The clock-id in xx:xx:xx:xx:xx:xx format

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ptp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ptp.md
@@ -9,6 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>ptp</samp>](## "ptp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;mode</samp>](## "ptp.mode") | String |  |  | Valid Values:<br>- <code>boundary</code><br>- <code>transparent</code> |  |
+    | [<samp>&nbsp;&nbsp;boundary_one_step</samp>](## "ptp.boundary_one_step") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;forward_unicast</samp>](## "ptp.forward_unicast") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;clock_identity</samp>](## "ptp.clock_identity") | String |  |  |  | The clock-id in xx:xx:xx:xx:xx:xx format |
     | [<samp>&nbsp;&nbsp;source</samp>](## "ptp.source") | Dictionary |  |  |  |  |
@@ -47,6 +48,7 @@
     ```yaml
     ptp:
       mode: <str; "boundary" | "transparent">
+      boundary_one_step: <bool>
       forward_unicast: <bool>
 
       # The clock-id in xx:xx:xx:xx:xx:xx format

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -13592,6 +13592,10 @@
           ],
           "title": "Mode"
         },
+        "boundary_one_step": {
+          "type": "boolean",
+          "title": "Boundary One Step"
+        },
         "forward_unicast": {
           "type": "boolean",
           "title": "Forward Unicast"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -13592,9 +13592,9 @@
           ],
           "title": "Mode"
         },
-        "boundary_one_step": {
+        "mode_one_step": {
           "type": "boolean",
-          "title": "Boundary One Step"
+          "title": "Mode One Step"
         },
         "forward_unicast": {
           "type": "boolean",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8000,6 +8000,8 @@ keys:
         valid_values:
         - boundary
         - transparent
+      boundary_one_step:
+        type: bool
       forward_unicast:
         type: bool
       clock_identity:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -8000,7 +8000,7 @@ keys:
         valid_values:
         - boundary
         - transparent
-      boundary_one_step:
+      mode_one_step:
         type: bool
       forward_unicast:
         type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
@@ -14,7 +14,7 @@ keys:
         valid_values:
         - boundary
         - transparent
-      boundary_one_step:
+      mode_one_step:
         type: bool
       forward_unicast:
         type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
@@ -14,6 +14,8 @@ keys:
         valid_values:
         - boundary
         - transparent
+      boundary_one_step:
+        type: bool
       forward_unicast:
         type: bool
       clock_identity:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -31,7 +31,11 @@ ptp message-type general dscp {{ ptp.message_type.general.dscp }} default
 ptp message-type event dscp {{ ptp.message_type.event.dscp }} default
 {%     endif %}
 {%     if ptp.mode is arista.avd.defined %}
+{%         if ptp.mode is arista.avd.defined('boundary') and ptp.boundary_one_step is arista.avd.defined(true) %}
+ptp mode boundary one-step
+{%         else %}
 ptp mode {{ ptp.mode }}
+{%         endif %}
 {%     endif %}
 {%     if ptp.forward_unicast is arista.avd.defined(true) %}
 ptp forward-unicast

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -31,8 +31,9 @@ ptp message-type general dscp {{ ptp.message_type.general.dscp }} default
 ptp message-type event dscp {{ ptp.message_type.event.dscp }} default
 {%     endif %}
 {%     if ptp.mode is arista.avd.defined %}
-{%         if ptp.mode is arista.avd.defined('boundary') and ptp.boundary_one_step is arista.avd.defined(true) %}
-ptp mode boundary one-step
+{# Update one-step support for "e2etransparent" mode as well, when it is available in valid_values of ptp.mode #}
+{%         if ptp.mode is arista.avd.defined('boundary') and ptp.mode_one_step is arista.avd.defined(true) %}
+ptp mode {{ ptp.mode }} one-step
 {%         else %}
 ptp mode {{ ptp.mode }}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Adding 1-step Boundary Clock support

## Related Issue(s)

Fixes #3480 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
```
 ptp:
     mode_one_step: <bool>
```

## How to test
Input-
```
ptp:
    mode: boundary
    mode_one_step: true
```
Should render config:

`ptp mode boundary one-step`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
