### PR TITLE
Feat(eos_cli_config_gen): Add support for raw `eos_cli` under  `router_bgp`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-evpn.md
@@ -307,4 +307,11 @@ router bgp 65101
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.3
+   !
+   address-family evpn
+      evpn ethernet-segment domain all
+         identifier 0011:1111:1111:1111:1111
+         route-target import 00:01:00:01:00:01
+            !
+            layer-2 fec in-place update
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-evpn.cfg
@@ -159,5 +159,12 @@ router bgp 65101
       route-target import evpn 14:14
       route-target export evpn 14:14
       router-id 192.168.255.3
+   !
+   address-family evpn
+      evpn ethernet-segment domain all
+         identifier 0011:1111:1111:1111:1111
+         route-target import 00:01:00:01:00:01
+            !
+            layer-2 fec in-place update
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-evpn.yml
@@ -276,3 +276,10 @@ router_bgp:
           - address_family: evpn
             route_targets:
               - "14:14"
+  eos_cli: |-
+    address-family evpn
+       evpn ethernet-segment domain all
+          identifier 0011:1111:1111:1111:1111
+          route-target import 00:01:00:01:00:01
+             !
+             layer-2 fec in-place update

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -283,7 +283,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;import_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.import_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;export_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.export_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;next_hop_unchanged</samp>](## "router_bgp.address_family_evpn.next_hop_unchanged") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.address_family_evpn.eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.address_family_evpn.eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;address_family_rtc</samp>](## "router_bgp.address_family_rtc") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_rtc.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.address_family_rtc.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |
@@ -1246,7 +1246,7 @@
           export_ethernet_segment_ip_mass_withdraw: <bool>
         next_hop_unchanged: <bool>
 
-        # Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration
+        # Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.
         eos_cli: <str>
       address_family_rtc:
         peer_groups:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -283,6 +283,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;import_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.import_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;export_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.export_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;next_hop_unchanged</samp>](## "router_bgp.address_family_evpn.next_hop_unchanged") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.address_family_evpn.eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration           <br> |
     | [<samp>&nbsp;&nbsp;address_family_rtc</samp>](## "router_bgp.address_family_rtc") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_rtc.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.address_family_rtc.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |
@@ -1244,6 +1245,9 @@
           import_ethernet_segment_ip_mass_withdraw: <bool>
           export_ethernet_segment_ip_mass_withdraw: <bool>
         next_hop_unchanged: <bool>
+
+        # Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration
+        eos_cli: <str>
       address_family_rtc:
         peer_groups:
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -283,7 +283,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;import_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.import_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;export_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.export_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;next_hop_unchanged</samp>](## "router_bgp.address_family_evpn.next_hop_unchanged") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.address_family_evpn.eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.address_family_evpn.eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;address_family_rtc</samp>](## "router_bgp.address_family_rtc") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_rtc.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.address_family_rtc.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -732,6 +732,7 @@
     | [<samp>&nbsp;&nbsp;session_trackers</samp>](## "router_bgp.session_trackers") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.session_trackers.[].name") | String | Required, Unique |  |  | Name of session tracker |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_delay</samp>](## "router_bgp.session_trackers.[].recovery_delay") | Integer |  |  | Min: 1<br>Max: 3600 | Recovery delay in seconds |
+    | [<samp>&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP in the final EOS configuration. |
 
 === "YAML"
 
@@ -1980,4 +1981,7 @@
 
           # Recovery delay in seconds
           recovery_delay: <int; 1-3600>
+
+      # Multiline EOS CLI rendered directly on the Router BGP in the final EOS configuration.
+      eos_cli: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -283,7 +283,6 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;import_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.import_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;export_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.export_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;next_hop_unchanged</samp>](## "router_bgp.address_family_evpn.next_hop_unchanged") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.address_family_evpn.eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration. |
     | [<samp>&nbsp;&nbsp;address_family_rtc</samp>](## "router_bgp.address_family_rtc") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_rtc.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.address_family_rtc.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |
@@ -1246,9 +1245,6 @@
           import_ethernet_segment_ip_mass_withdraw: <bool>
           export_ethernet_segment_ip_mass_withdraw: <bool>
         next_hop_unchanged: <bool>
-
-        # Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.
-        eos_cli: <str>
       address_family_rtc:
         peer_groups:
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -283,7 +283,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;import_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.import_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;export_ethernet_segment_ip_mass_withdraw</samp>](## "router_bgp.address_family_evpn.route.export_ethernet_segment_ip_mass_withdraw") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;next_hop_unchanged</samp>](## "router_bgp.address_family_evpn.next_hop_unchanged") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.address_family_evpn.eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration           <br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_bgp.address_family_evpn.eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration<br> |
     | [<samp>&nbsp;&nbsp;address_family_rtc</samp>](## "router_bgp.address_family_rtc") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_rtc.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.address_family_rtc.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -20383,6 +20383,11 @@
             ]
           },
           "title": "Session Trackers"
+        },
+        "eos_cli": {
+          "type": "string",
+          "description": "Multiline EOS CLI rendered directly on the Router BGP in the final EOS configuration.",
+          "title": "EOS CLI"
         }
       },
       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17130,11 +17130,6 @@
             "next_hop_unchanged": {
               "type": "boolean",
               "title": "Next Hop Unchanged"
-            },
-            "eos_cli": {
-              "type": "string",
-              "description": "Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.",
-              "title": "EOS CLI"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17133,7 +17133,7 @@
             },
             "eos_cli": {
               "type": "string",
-              "description": "Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration\n",
+              "description": "Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.\n",
               "title": "EOS CLI"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17130,6 +17130,11 @@
             "next_hop_unchanged": {
               "type": "boolean",
               "title": "Next Hop Unchanged"
+            },
+            "eos_cli": {
+              "type": "string",
+              "description": "Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration           \n",
+              "title": "EOS CLI"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17133,7 +17133,7 @@
             },
             "eos_cli": {
               "type": "string",
-              "description": "Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.\n",
+              "description": "Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.",
               "title": "EOS CLI"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -17133,7 +17133,7 @@
             },
             "eos_cli": {
               "type": "string",
-              "description": "Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration           \n",
+              "description": "Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration\n",
               "title": "EOS CLI"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10238,8 +10238,10 @@ keys:
             type: bool
           eos_cli:
             type: str
-            description: "Multiline EOS CLI rendered directly on the Router BGP, Address
-              family EVPN in the final EOS configuration           \n"
+            description: 'Multiline EOS CLI rendered directly on the Router BGP, Address
+              family EVPN in the final EOS configuration
+
+              '
       address_family_rtc:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10236,6 +10236,10 @@ keys:
                 type: bool
           next_hop_unchanged:
             type: bool
+          eos_cli:
+            type: str
+            description: "Multiline EOS CLI rendered directly on the Router BGP, Address
+              family EVPN in the final EOS configuration           \n"
       address_family_rtc:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10238,10 +10238,8 @@ keys:
             type: bool
           eos_cli:
             type: str
-            description: 'Multiline EOS CLI rendered directly on the Router BGP, Address
+            description: Multiline EOS CLI rendered directly on the Router BGP, Address
               family EVPN in the final EOS configuration.
-
-              '
       address_family_rtc:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10236,10 +10236,6 @@ keys:
                 type: bool
           next_hop_unchanged:
             type: bool
-          eos_cli:
-            type: str
-            description: Multiline EOS CLI rendered directly on the Router BGP, Address
-              family EVPN in the final EOS configuration.
       address_family_rtc:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11920,6 +11920,10 @@ keys:
               - str
               min: 1
               max: 3600
+      eos_cli:
+        type: str
+        description: Multiline EOS CLI rendered directly on the Router BGP in the
+          final EOS configuration.
   router_general:
     type: dict
     display_name: Router General configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10239,7 +10239,7 @@ keys:
           eos_cli:
             type: str
             description: 'Multiline EOS CLI rendered directly on the Router BGP, Address
-              family EVPN in the final EOS configuration
+              family EVPN in the final EOS configuration.
 
               '
       address_family_rtc:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1032,7 +1032,7 @@ keys:
             type: bool
           eos_cli:
             type: str
-            description: |
+            description: |-
               Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.
       address_family_rtc:
         type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1030,6 +1030,10 @@ keys:
                 type: bool
           next_hop_unchanged:
             type: bool
+          eos_cli:
+            type: str
+            description: |
+              Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration           
       address_family_rtc:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1033,7 +1033,7 @@ keys:
           eos_cli:
             type: str
             description: |
-              Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration           
+              Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration
       address_family_rtc:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1033,7 +1033,7 @@ keys:
           eos_cli:
             type: str
             description: |
-              Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration
+              Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.
       address_family_rtc:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -1030,10 +1030,6 @@ keys:
                 type: bool
           next_hop_unchanged:
             type: bool
-          eos_cli:
-            type: str
-            description: |-
-              Multiline EOS CLI rendered directly on the Router BGP, Address family EVPN in the final EOS configuration.
       address_family_rtc:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -2681,3 +2681,7 @@ keys:
                 - str
               min: 1
               max: 3600
+      eos_cli:
+        type: str
+        description: |-
+          Multiline EOS CLI rendered directly on the Router BGP in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -1743,6 +1743,6 @@ router bgp {{ router_bgp.as }}
 {%     endfor %}
 {%     if router_bgp.eos_cli is arista.avd.defined %}
    !
-   {{ router_bgp.eos_cli | indent(6, false) }}
+   {{ router_bgp.eos_cli | indent(3, false) }}
 {%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -648,10 +648,6 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.address_family_evpn.route.export_ethernet_segment_ip_mass_withdraw is arista.avd.defined(true) %}
       route export ethernet-segment ip mass-withdraw
 {%         endif %}
-{%         if router_bgp.address_family_evpn.eos_cli is arista.avd.defined %}
-      !
-      {{ router_bgp.address_family_evpn.eos_cli | indent(6, false) }}
-{%         endif %}
 {%     endif %}
 {# address family flow-spec ipv4 activation #}
 {%     if router_bgp.address_family_flow_spec_ipv4 is arista.avd.defined %}
@@ -1745,4 +1741,8 @@ router bgp {{ router_bgp.as }}
       recovery delay {{ session_tracker.recovery_delay }} seconds
 {%         endif %}
 {%     endfor %}
+{%     if router_bgp.eos_cli is arista.avd.defined %}
+   !
+   {{ router_bgp.eos_cli | indent(6, false) }}
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -648,6 +648,10 @@ router bgp {{ router_bgp.as }}
 {%         if router_bgp.address_family_evpn.route.export_ethernet_segment_ip_mass_withdraw is arista.avd.defined(true) %}
       route export ethernet-segment ip mass-withdraw
 {%         endif %}
+{%         if router_bgp.address_family_evpn.eos_cli is arista.avd.defined %}
+      !
+      {{ router_bgp.address_family_evpn.eos_cli | indent(6, false) }}
+{%         endif %}
 {%     endif %}
 {# address family flow-spec ipv4 activation #}
 {%     if router_bgp.address_family_flow_spec_ipv4 is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Add support for raw cli under BGP address-family-evpn.
## Related Issue(s)

Fixes #3570

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added feature to add raw cli to address-family-evpn in router_bgp.

## How to test


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
