### PR TITLE
Refactor(eos_designs): Rename WAN CONTROL-PLANE objects

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
@@ -19,7 +19,7 @@ router path-selection
          name autovpn-rr3
          ipv4 address 10.7.7.7
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
       path-group INET
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
@@ -32,8 +32,8 @@ router path-selection
    policy DEFAULT-POLICY-WITH-CP
       default-match
          load-balance LB-DEFAULT-POLICY-DEFAULT
-      10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         load-balance LB-CONTROL-PLANE-PROFILE
+      10 application-profile APP-PROFILE-CONTROL-PLANE
+         load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
    !
    vrf default
       path-selection-policy DEFAULT-POLICY-WITH-CP
@@ -100,13 +100,13 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
       2.2.2.2/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
@@ -101,12 +101,12 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
+   field-set ipv4 prefix PFX-PATHFINDERS
       2.2.2.2/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -114,7 +114,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
@@ -125,7 +125,7 @@ application traffic recognition
    !
    application-profile VOICE
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
+   field-set ipv4 prefix PFX-PATHFINDERS
       192.168.131.1/32 192.168.131.2/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -23,7 +23,7 @@ router path-selection
          name autovpn-rr2
          ipv4 address 10.8.8.8
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
       path-group INET
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
@@ -39,8 +39,8 @@ router path-selection
       path-group INET
    !
    policy DEFAULT-AUTOVPN-POLICY-WITH-CP
-      10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         load-balance LB-CONTROL-PLANE-PROFILE
+      10 application-profile APP-PROFILE-CONTROL-PLANE
+         load-balance LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
       20 application-profile IT
          load-balance LB-DEFAULT-AUTOVPN-POLICY-IT
    !
@@ -113,11 +113,11 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile IT
    !
@@ -125,7 +125,7 @@ application traffic recognition
    !
    application-profile VOICE
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
       192.168.131.1/32 192.168.131.2/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -21,7 +21,7 @@ router path-selection
    !
    path-group MPLS id 100
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
       path-group INET
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
@@ -38,8 +38,8 @@ router path-selection
       path-group INET
    !
    policy DEFAULT-AUTOVPN-POLICY-WITH-CP
-      10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         load-balance LB-CONTROL-PLANE-PROFILE
+      10 application-profile APP-PROFILE-CONTROL-PLANE
+         load-balance LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
       20 application-profile IT
          load-balance LB-DEFAULT-AUTOVPN-POLICY-IT
    !
@@ -106,11 +106,11 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile IT
    !
@@ -118,7 +118,7 @@ application traffic recognition
    !
    application-profile VOICE
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
       192.168.131.1/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -107,7 +107,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
+      source prefix field-set PFX-LOCAL-VTEP-IP
    !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
@@ -118,7 +118,7 @@ application traffic recognition
    !
    application-profile VOICE
    !
-   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
+   field-set ipv4 prefix PFX-LOCAL-VTEP-IP
       192.168.131.1/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -21,7 +21,7 @@ router path-selection
    !
    path-group MPLS id 100
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
       path-group INET
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
@@ -38,8 +38,8 @@ router path-selection
       path-group INET
    !
    policy DEFAULT-AUTOVPN-POLICY-WITH-CP
-      10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         load-balance LB-CONTROL-PLANE-PROFILE
+      10 application-profile APP-PROFILE-CONTROL-PLANE
+         load-balance LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
       20 application-profile IT
          load-balance LB-DEFAULT-AUTOVPN-POLICY-IT
    !
@@ -105,11 +105,11 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile IT
    !
@@ -117,7 +117,7 @@ application traffic recognition
    !
    application-profile VOICE
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
       192.168.131.2/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -106,7 +106,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
+      source prefix field-set PFX-LOCAL-VTEP-IP
    !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
@@ -117,7 +117,7 @@ application traffic recognition
    !
    application-profile VOICE
    !
-   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
+   field-set ipv4 prefix PFX-LOCAL-VTEP-IP
       192.168.131.2/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -188,7 +188,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
@@ -197,7 +197,7 @@ application traffic recognition
       application CUSTOM-APPLICATION-1
       application skype
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
+   field-set ipv4 prefix PFX-PATHFINDERS
       192.168.144.1/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -30,8 +30,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-POLICY-VIDEO
@@ -39,8 +39,8 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile DEFAULT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   profile DEFAULT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
@@ -52,7 +52,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-POLICY-WITH-CP
       avt profile DEFAULT-POLICY-DEFAULT id 1
       avt profile DEFAULT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-POLICY-CONTROL-PLANE id 254
    !
    vrf PROD
       avt policy DEFAULT-POLICY
@@ -93,7 +93,7 @@ router path-selection
          name cv-pathfinder-pathfinder
          ipv4 address 172.16.0.1
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
       path-group INET
       path-group MPLS
    !
@@ -187,17 +187,17 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
       application skype
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
       192.168.144.1/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -32,8 +32,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-AVT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-AVT-POLICY-VIDEO
@@ -57,8 +57,8 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile PROD-AVT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   profile DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -86,7 +86,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-AVT-POLICY-WITH-CP
       avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
       avt profile DEFAULT-AVT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-AVT-POLICY
@@ -109,7 +109,7 @@ router path-selection
       !
       peer dynamic
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
       path-group Satellite
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -234,8 +234,8 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -249,8 +249,8 @@ application traffic recognition
       application CUSTOM-APPLICATION-2
       application microsoft-teams
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
@@ -260,7 +260,7 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -235,7 +235,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -260,13 +260,13 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
-   !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24
    !
    field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
       42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
    !
    field-set l4-port TCP-DEST-2
       666, 777

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -181,12 +181,12 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
+   field-set ipv4 prefix PFX-PATHFINDERS
       192.168.144.1/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -27,14 +27,14 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-POLICY-CONTROL-PLANE
       !
       match application-profile default
          avt profile DEFAULT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   profile DEFAULT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
@@ -42,7 +42,7 @@ router adaptive-virtual-topology
    vrf default
       avt policy DEFAULT-POLICY-WITH-CP
       avt profile DEFAULT-POLICY-DEFAULT id 1
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-POLICY
@@ -86,7 +86,7 @@ router path-selection
          name cv-pathfinder-pathfinder
          ipv4 address 172.16.0.1
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
       path-group INET
       path-group MPLS
    !
@@ -180,13 +180,13 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
       192.168.144.1/32
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -287,7 +287,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -312,14 +312,14 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
-      192.168.144.1/32
-   !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24
    !
    field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
       42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+      192.168.144.1/32
    !
    field-set l4-port TCP-DEST-2
       666, 777

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -32,8 +32,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-AVT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-AVT-POLICY-VIDEO
@@ -57,8 +57,8 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile PROD-AVT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   profile DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -86,7 +86,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-AVT-POLICY-WITH-CP
       avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
       avt profile DEFAULT-AVT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-AVT-POLICY
@@ -133,7 +133,7 @@ router path-selection
          name cv-pathfinder-pathfinder
          ipv4 address 172.16.0.1
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
       path-group INET
       path-group MPLS
    !
@@ -286,8 +286,8 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -301,8 +301,8 @@ application traffic recognition
       application CUSTOM-APPLICATION-2
       application microsoft-teams
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
@@ -312,7 +312,7 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
       192.168.144.1/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -302,7 +302,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -327,14 +327,14 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
-      192.168.144.1/32
-   !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24
    !
    field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
       42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+      192.168.144.1/32
    !
    field-set l4-port TCP-DEST-2
       666, 777

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -32,8 +32,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-AVT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-AVT-POLICY-VIDEO
@@ -57,8 +57,8 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile PROD-AVT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   profile DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -86,7 +86,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-AVT-POLICY-WITH-CP
       avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
       avt profile DEFAULT-AVT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-AVT-POLICY
@@ -128,7 +128,7 @@ router path-selection
          ipv4 address 172.17.0.9
          ipv4 address 172.17.0.11
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
       path-group INET
       path-group LAN_HA
    !
@@ -301,8 +301,8 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -316,8 +316,8 @@ application traffic recognition
       application CUSTOM-APPLICATION-2
       application microsoft-teams
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
@@ -327,7 +327,7 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
       192.168.144.1/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -32,8 +32,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-AVT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-AVT-POLICY-VIDEO
@@ -57,8 +57,8 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile PROD-AVT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
+   profile DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -86,7 +86,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-AVT-POLICY-WITH-CP
       avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
       avt profile DEFAULT-AVT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-AVT-POLICY
@@ -126,7 +126,7 @@ router path-selection
          name cv-pathfinder-pathfinder
          ipv4 address 172.16.0.1
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
       path-group LAN_HA
       path-group MPLS
    !
@@ -298,8 +298,8 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -313,8 +313,8 @@ application traffic recognition
       application CUSTOM-APPLICATION-2
       application microsoft-teams
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
@@ -324,7 +324,7 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
       192.168.144.1/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -299,7 +299,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -324,14 +324,14 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
-      192.168.144.1/32
-   !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24
    !
    field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
       42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+      192.168.144.1/32
    !
    field-set l4-port TCP-DEST-2
       666, 777

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -27,8 +27,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-AVT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-AVT-POLICY-VIDEO
@@ -60,11 +60,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
-   !
    profile CUSTOM-VOICE-PROFILE-NAME
       path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
+   !
+   profile DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -95,7 +95,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-AVT-POLICY-WITH-CP
       avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
       avt profile DEFAULT-AVT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-AVT-POLICY
@@ -137,15 +137,15 @@ router path-selection
    !
    path-group Satellite id 104
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-      path-group LAN_HA
-      path-group MPLS
-   !
    load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
       path-group LAN_HA
       path-group MPLS
       path-group INET priority 2
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group Equinix
@@ -253,8 +253,8 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -268,8 +268,8 @@ application traffic recognition
       application CUSTOM-APPLICATION-2
       application microsoft-teams
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
@@ -279,7 +279,7 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
       192.168.144.1/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -254,7 +254,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
+      source prefix field-set PFX-LOCAL-VTEP-IP
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -279,14 +279,14 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
-      192.168.144.1/32
-   !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24
    !
    field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
       42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-LOCAL-VTEP-IP
+      192.168.144.1/32
    !
    field-set l4-port TCP-DEST-2
       666, 777

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -242,7 +242,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
+      source prefix field-set PFX-LOCAL-VTEP-IP
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -267,14 +267,14 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
-      192.168.144.2/32
-   !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24
    !
    field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
       42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-LOCAL-VTEP-IP
+      192.168.144.2/32
    !
    field-set l4-port TCP-DEST-2
       666, 777

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -27,8 +27,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-AVT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-AVT-POLICY-VIDEO
@@ -60,11 +60,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
-   !
    profile CUSTOM-VOICE-PROFILE-NAME
       path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
+   !
+   profile DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -95,7 +95,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-AVT-POLICY-WITH-CP
       avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
       avt profile DEFAULT-AVT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-AVT-POLICY
@@ -141,14 +141,14 @@ router path-selection
    !
    path-group Satellite id 104
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-      path-group LAN_HA
-   !
    load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
       path-group LAN_HA
       path-group MPLS
       path-group INET priority 2
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-group INET
+      path-group LAN_HA
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group Equinix
@@ -241,8 +241,8 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -256,8 +256,8 @@ application traffic recognition
       application CUSTOM-APPLICATION-2
       application microsoft-teams
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
@@ -267,7 +267,7 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
       192.168.144.2/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -257,7 +257,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
+      source prefix field-set PFX-LOCAL-VTEP-IP
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -282,14 +282,14 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
-      192.168.144.3/32
-   !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24
    !
    field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
       42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-LOCAL-VTEP-IP
+      192.168.144.3/32
    !
    field-set l4-port TCP-DEST-2
       666, 777

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -27,8 +27,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-AVT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-AVT-POLICY-VIDEO
@@ -60,11 +60,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
-   !
    profile CUSTOM-VOICE-PROFILE-NAME
       path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
+   !
+   profile DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -95,7 +95,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-AVT-POLICY-WITH-CP
       avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
       avt profile DEFAULT-AVT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-AVT-POLICY
@@ -147,15 +147,15 @@ router path-selection
    !
    path-group Satellite id 104
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-      path-group LAN_HA
-      path-group MPLS
-   !
    load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
       path-group LAN_HA
       path-group MPLS
       path-group INET priority 2
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group Equinix
@@ -256,8 +256,8 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      source prefix field-set CONTROL-PLANE-APP-SRC-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      source prefix field-set APP-SRC-PFX-CONTROL-PLANE
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -271,8 +271,8 @@ application traffic recognition
       application CUSTOM-APPLICATION-2
       application microsoft-teams
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
@@ -282,7 +282,7 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-SRC-PREFIXES
+   field-set ipv4 prefix APP-SRC-PFX-CONTROL-PLANE
       192.168.144.3/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -32,8 +32,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-AVT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-AVT-POLICY-VIDEO
@@ -65,11 +65,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
-   !
    profile CUSTOM-VOICE-PROFILE-NAME
       path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
+   !
+   profile DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -100,7 +100,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-AVT-POLICY-WITH-CP
       avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
       avt profile DEFAULT-AVT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-AVT-POLICY
@@ -154,15 +154,15 @@ router path-selection
          name cv-pathfinder-pathfinder
          ipv4 address 172.16.0.1
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-      path-group LAN_HA
-      path-group MPLS
-   !
    load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
       path-group LAN_HA
       path-group MPLS
       path-group INET priority 2
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group INET
@@ -332,8 +332,8 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -347,8 +347,8 @@ application traffic recognition
       application CUSTOM-APPLICATION-2
       application microsoft-teams
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
@@ -358,7 +358,7 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
       192.168.144.1/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -333,7 +333,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -358,14 +358,14 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
-      192.168.144.1/32
-   !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24
    !
    field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
       42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+      192.168.144.1/32
    !
    field-set l4-port TCP-DEST-2
       666, 777

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -32,8 +32,8 @@ router adaptive-virtual-topology
    !
    policy DEFAULT-AVT-POLICY-WITH-CP
       !
-      match application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         avt profile CONTROL-PLANE-PROFILE
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE
       !
       match application-profile VIDEO
          avt profile DEFAULT-AVT-POLICY-VIDEO
@@ -65,11 +65,11 @@ router adaptive-virtual-topology
       match application-profile default
          avt profile TRANSIT-AVT-POLICY-DEFAULT
    !
-   profile CONTROL-PLANE-PROFILE
-      path-selection load-balance LB-CONTROL-PLANE-PROFILE
-   !
    profile CUSTOM-VOICE-PROFILE-NAME
       path-selection load-balance LB-CUSTOM-VOICE-PROFILE-NAME
+   !
+   profile DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
    !
    profile DEFAULT-AVT-POLICY-DEFAULT
       path-selection load-balance LB-DEFAULT-AVT-POLICY-DEFAULT
@@ -100,7 +100,7 @@ router adaptive-virtual-topology
       avt policy DEFAULT-AVT-POLICY-WITH-CP
       avt profile DEFAULT-AVT-POLICY-DEFAULT id 1
       avt profile DEFAULT-AVT-POLICY-VIDEO id 3
-      avt profile CONTROL-PLANE-PROFILE id 254
+      avt profile DEFAULT-AVT-POLICY-CONTROL-PLANE id 254
    !
    vrf IT
       avt policy DEFAULT-AVT-POLICY
@@ -154,15 +154,15 @@ router path-selection
          name cv-pathfinder-pathfinder
          ipv4 address 172.16.0.1
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
-      path-group INET
-      path-group LAN_HA
-      path-group MPLS
-   !
    load-balance policy LB-CUSTOM-VOICE-PROFILE-NAME
       path-group LAN_HA
       path-group MPLS
       path-group INET priority 2
+   !
+   load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
       path-group INET
@@ -332,8 +332,8 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -347,8 +347,8 @@ application traffic recognition
       application CUSTOM-APPLICATION-2
       application microsoft-teams
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
    application-profile VIDEO
       application CUSTOM-APPLICATION-1
@@ -358,7 +358,7 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
       192.168.144.1/32
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -333,7 +333,7 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application ipv4 CUSTOM-APPLICATION-1
       source prefix field-set CUSTOM-SRC-PREFIX-1
@@ -358,14 +358,14 @@ application traffic recognition
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
-      192.168.144.1/32
-   !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24
    !
    field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
       42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+      192.168.144.1/32
    !
    field-set l4-port TCP-DEST-2
       666, 777

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -7,7 +7,7 @@ hostname uplink_lan_wan_router1
 router path-selection
    tcp mss ceiling ipv4 ingress
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
    !
@@ -18,8 +18,8 @@ router path-selection
    policy DEFAULT-POLICY-WITH-CP
       default-match
          load-balance LB-DEFAULT-POLICY-DEFAULT
-      10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         load-balance LB-CONTROL-PLANE-PROFILE
+      10 application-profile APP-PROFILE-CONTROL-PLANE
+         load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
    !
    vrf default
       path-selection-policy DEFAULT-POLICY-WITH-CP
@@ -91,13 +91,13 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -92,12 +92,12 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
+   field-set ipv4 prefix PFX-PATHFINDERS
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -7,7 +7,7 @@ hostname uplink_lan_wan_router2
 router path-selection
    tcp mss ceiling ipv4 ingress
    !
-   load-balance policy LB-CONTROL-PLANE-PROFILE
+   load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
    !
@@ -18,8 +18,8 @@ router path-selection
    policy DEFAULT-POLICY-WITH-CP
       default-match
          load-balance LB-DEFAULT-POLICY-DEFAULT
-      10 application-profile CONTROL-PLANE-APPLICATION-PROFILE
-         load-balance LB-CONTROL-PLANE-PROFILE
+      10 application-profile APP-PROFILE-CONTROL-PLANE
+         load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
    !
    vrf default
       path-selection-policy DEFAULT-POLICY-WITH-CP
@@ -97,13 +97,13 @@ interface Vxlan1
 !
 application traffic recognition
    !
-   application ipv4 CONTROL-PLANE-APPLICATION
-      destination prefix field-set CONTROL-PLANE-APP-DEST-PREFIXES
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
    !
-   application-profile CONTROL-PLANE-APPLICATION-PROFILE
-      application CONTROL-PLANE-APPLICATION
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
    !
-   field-set ipv4 prefix CONTROL-PLANE-APP-DEST-PREFIXES
+   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -98,12 +98,12 @@ interface Vxlan1
 application traffic recognition
    !
    application ipv4 APP-CONTROL-PLANE
-      destination prefix field-set APP-DEST-PFX-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
    !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
-   field-set ipv4 prefix APP-DEST-PFX-CONTROL-PLANE
+   field-set ipv4 prefix PFX-PATHFINDERS
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
@@ -209,7 +209,7 @@ router_path_selection:
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
     - name: INET
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-POLICY-CONTROL-PLANE
     path_groups:
     - name: INET
   policies:
@@ -219,8 +219,8 @@ router_path_selection:
   - name: DEFAULT-POLICY-WITH-CP
     rules:
     - id: 10
-      application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      load_balance: LB-CONTROL-PLANE-PROFILE
+      application_profile: APP-PROFILE-CONTROL-PLANE
+      load_balance: LB-DEFAULT-POLICY-CONTROL-PLANE
     default_match:
       load_balance: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
@@ -237,16 +237,16 @@ stun:
       ip_address: 10.7.7.7
 application_traffic_recognition:
   application_profiles:
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   applications:
     ipv4_applications:
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
       prefix_values:
       - 2.2.2.2/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
@@ -243,10 +243,10 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     ipv4_prefixes:
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
       prefix_values:
       - 2.2.2.2/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -201,7 +201,7 @@ router_path_selection:
       - 10.8.8.8
     ipsec_profile: AUTOVPN
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     path_groups:
     - name: INET
   - name: LB-DEFAULT-AUTOVPN-POLICY-IT
@@ -221,8 +221,8 @@ router_path_selection:
   - name: DEFAULT-AUTOVPN-POLICY-WITH-CP
     rules:
     - id: 10
-      application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      load_balance: LB-CONTROL-PLANE-PROFILE
+      application_profile: APP-PROFILE-CONTROL-PLANE
+      load_balance: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     - id: 20
       application_profile: IT
       load_balance: LB-DEFAULT-AUTOVPN-POLICY-IT
@@ -253,16 +253,16 @@ application_traffic_recognition:
   - name: IT
   - name: VOICE
   - name: VIDEO
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   applications:
     ipv4_applications:
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.131.1/32
       - 192.168.131.2/32

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -259,10 +259,10 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     ipv4_prefixes:
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
       prefix_values:
       - 192.168.131.1/32
       - 192.168.131.2/32

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -183,7 +183,7 @@ router_path_selection:
     id: 102
   peer_dynamic_source: stun
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     path_groups:
     - name: INET
   - name: LB-DEFAULT-AUTOVPN-POLICY-IT
@@ -204,8 +204,8 @@ router_path_selection:
   - name: DEFAULT-AUTOVPN-POLICY-WITH-CP
     rules:
     - id: 10
-      application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      load_balance: LB-CONTROL-PLANE-PROFILE
+      application_profile: APP-PROFILE-CONTROL-PLANE
+      load_balance: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     - id: 20
       application_profile: IT
       load_balance: LB-DEFAULT-AUTOVPN-POLICY-IT
@@ -233,16 +233,16 @@ application_traffic_recognition:
   - name: IT
   - name: VOICE
   - name: VIDEO
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   applications:
     ipv4_applications:
-    - name: CONTROL-PLANE-APPLICATION
-      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-CONTROL-PLANE
+      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-SRC-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.131.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -239,10 +239,10 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: APP-CONTROL-PLANE
-      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
+      src_prefix_set_name: PFX-LOCAL-VTEP-IP
   field_sets:
     ipv4_prefixes:
-    - name: APP-SRC-PFX-CONTROL-PLANE
+    - name: PFX-LOCAL-VTEP-IP
       prefix_values:
       - 192.168.131.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -241,10 +241,10 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: APP-CONTROL-PLANE
-      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
+      src_prefix_set_name: PFX-LOCAL-VTEP-IP
   field_sets:
     ipv4_prefixes:
-    - name: APP-SRC-PFX-CONTROL-PLANE
+    - name: PFX-LOCAL-VTEP-IP
       prefix_values:
       - 192.168.131.2/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -185,7 +185,7 @@ router_path_selection:
     id: 102
   peer_dynamic_source: stun
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     path_groups:
     - name: INET
   - name: LB-DEFAULT-AUTOVPN-POLICY-IT
@@ -206,8 +206,8 @@ router_path_selection:
   - name: DEFAULT-AUTOVPN-POLICY-WITH-CP
     rules:
     - id: 10
-      application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      load_balance: LB-CONTROL-PLANE-PROFILE
+      application_profile: APP-PROFILE-CONTROL-PLANE
+      load_balance: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     - id: 20
       application_profile: IT
       load_balance: LB-DEFAULT-AUTOVPN-POLICY-IT
@@ -235,16 +235,16 @@ application_traffic_recognition:
   - name: IT
   - name: VOICE
   - name: VIDEO
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   applications:
     ipv4_applications:
-    - name: CONTROL-PLANE-APPLICATION
-      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-CONTROL-PLANE
+      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-SRC-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.131.2/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -357,10 +357,10 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     ipv4_prefixes:
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -235,8 +235,8 @@ router_adaptive_virtual_topology:
     name: Site1
     id: 1
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-POLICY-CONTROL-PLANE
   - name: DEFAULT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-POLICY-VIDEO
   - name: DEFAULT-POLICY-DEFAULT
@@ -245,7 +245,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-POLICY-VIDEO
       id: 3
@@ -261,8 +261,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-POLICY-VIDEO
     - application_profile: default
@@ -321,7 +321,7 @@ router_path_selection:
       enabled: true
     ipsec_profile: CP-PROFILE
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-POLICY-CONTROL-PLANE
     path_groups:
     - name: INET
     - name: MPLS
@@ -351,16 +351,16 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   applications:
     ipv4_applications:
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -479,7 +479,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -496,7 +496,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -342,8 +342,8 @@ router_adaptive_virtual_topology:
     name: Site511
     id: 511
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
   - name: DEFAULT-AVT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
@@ -360,7 +360,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-AVT-POLICY-VIDEO
       id: 3
@@ -390,8 +390,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-AVT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
@@ -431,7 +431,7 @@ router_path_selection:
       enabled: true
     ipsec_profile: CP-PROFILE
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: Satellite
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
@@ -458,9 +458,9 @@ application_traffic_recognition:
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   categories:
   - name: VIDEO1
     applications:
@@ -478,8 +478,8 @@ application_traffic_recognition:
       - tcp
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -496,7 +496,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -252,8 +252,8 @@ router_adaptive_virtual_topology:
     name: Site511
     id: 511
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-POLICY-CONTROL-PLANE
   - name: DEFAULT-POLICY-DEFAULT
     load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
@@ -270,7 +270,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-POLICY-DEFAULT
       id: 1
@@ -281,8 +281,8 @@ router_adaptive_virtual_topology:
       avt_profile: DEFAULT-POLICY-DEFAULT
   - name: DEFAULT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-POLICY-CONTROL-PLANE
     - application_profile: default
       avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
@@ -338,7 +338,7 @@ router_path_selection:
     - name: INET
     - name: MPLS
     - name: LTE
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-POLICY-CONTROL-PLANE
     path_groups:
     - name: INET
     - name: MPLS
@@ -355,16 +355,16 @@ stun:
       ip_address: 172.16.0.1
 application_traffic_recognition:
   application_profiles:
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   applications:
     ipv4_applications:
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -361,10 +361,10 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     ipv4_prefixes:
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -388,8 +388,8 @@ router_adaptive_virtual_topology:
     name: Site511
     id: 511
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
   - name: DEFAULT-AVT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
@@ -406,7 +406,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-AVT-POLICY-VIDEO
       id: 3
@@ -436,8 +436,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-AVT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
@@ -508,7 +508,7 @@ router_path_selection:
       enabled: true
     ipsec_profile: CP-PROFILE
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: INET
     - name: MPLS
@@ -567,9 +567,9 @@ application_traffic_recognition:
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   categories:
   - name: VIDEO1
     applications:
@@ -587,8 +587,8 @@ application_traffic_recognition:
       - tcp
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -605,7 +605,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -588,7 +588,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -605,7 +605,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -457,8 +457,8 @@ router_adaptive_virtual_topology:
     name: Site423
     id: 423
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
   - name: DEFAULT-AVT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
@@ -475,7 +475,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-AVT-POLICY-VIDEO
       id: 3
@@ -505,8 +505,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-AVT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
@@ -569,7 +569,7 @@ router_path_selection:
       - 172.17.0.11
     ipsec_profile: DP-PROFILE
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
     - name: INET
@@ -622,9 +622,9 @@ application_traffic_recognition:
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   categories:
   - name: VIDEO1
     applications:
@@ -642,8 +642,8 @@ application_traffic_recognition:
       - tcp
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -660,7 +660,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -643,7 +643,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -660,7 +660,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -456,8 +456,8 @@ router_adaptive_virtual_topology:
     name: Site423
     id: 423
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
   - name: DEFAULT-AVT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
@@ -474,7 +474,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-AVT-POLICY-VIDEO
       id: 3
@@ -504,8 +504,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-AVT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
@@ -565,7 +565,7 @@ router_path_selection:
       - 172.17.0.7
     ipsec_profile: DP-PROFILE
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
     - name: MPLS
@@ -616,9 +616,9 @@ application_traffic_recognition:
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   categories:
   - name: VIDEO1
     applications:
@@ -636,8 +636,8 @@ application_traffic_recognition:
       - tcp
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -654,7 +654,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -637,7 +637,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -654,7 +654,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -200,8 +200,8 @@ ip_security:
 router_adaptive_virtual_topology:
   topology_role: pathfinder
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
   - name: DEFAULT-AVT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
@@ -222,7 +222,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-AVT-POLICY-VIDEO
       id: 3
@@ -259,8 +259,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-AVT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
@@ -319,7 +319,7 @@ router_path_selection:
     flow_assignment: lan
   peer_dynamic_source: stun
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
     - name: INET
@@ -394,9 +394,9 @@ application_traffic_recognition:
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   categories:
   - name: VIDEO1
     applications:
@@ -414,8 +414,8 @@ application_traffic_recognition:
       - tcp
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
-    - name: CONTROL-PLANE-APPLICATION
-      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-CONTROL-PLANE
+      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -432,7 +432,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-SRC-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:
@@ -550,7 +550,7 @@ metadata:
       vni: 1
       avts:
       - id: 254
-        name: CONTROL-PLANE-PROFILE
+        name: DEFAULT-AVT-POLICY-CONTROL-PLANE
         pathgroups:
         - name: LAN_HA
           preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -415,7 +415,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: APP-CONTROL-PLANE
-      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
+      src_prefix_set_name: PFX-LOCAL-VTEP-IP
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -432,7 +432,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: APP-SRC-PFX-CONTROL-PLANE
+    - name: PFX-LOCAL-VTEP-IP
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -212,8 +212,8 @@ ip_security:
 router_adaptive_virtual_topology:
   topology_role: pathfinder
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
   - name: DEFAULT-AVT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
@@ -234,7 +234,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-AVT-POLICY-VIDEO
       id: 3
@@ -271,8 +271,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-AVT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
@@ -337,7 +337,7 @@ router_path_selection:
     flow_assignment: lan
   peer_dynamic_source: stun
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
     - name: INET
@@ -408,9 +408,9 @@ application_traffic_recognition:
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   categories:
   - name: VIDEO1
     applications:
@@ -428,8 +428,8 @@ application_traffic_recognition:
       - tcp
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
-    - name: CONTROL-PLANE-APPLICATION
-      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-CONTROL-PLANE
+      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -446,7 +446,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-SRC-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.2/32
 dps_interfaces:
@@ -538,7 +538,7 @@ metadata:
       vni: 1
       avts:
       - id: 254
-        name: CONTROL-PLANE-PROFILE
+        name: DEFAULT-AVT-POLICY-CONTROL-PLANE
         pathgroups:
         - name: LAN_HA
           preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -429,7 +429,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: APP-CONTROL-PLANE
-      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
+      src_prefix_set_name: PFX-LOCAL-VTEP-IP
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -446,7 +446,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: APP-SRC-PFX-CONTROL-PLANE
+    - name: PFX-LOCAL-VTEP-IP
       prefix_values:
       - 192.168.144.2/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -447,7 +447,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: APP-CONTROL-PLANE
-      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
+      src_prefix_set_name: PFX-LOCAL-VTEP-IP
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -464,7 +464,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: APP-SRC-PFX-CONTROL-PLANE
+    - name: PFX-LOCAL-VTEP-IP
       prefix_values:
       - 192.168.144.3/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -220,8 +220,8 @@ ip_security:
 router_adaptive_virtual_topology:
   topology_role: pathfinder
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
   - name: DEFAULT-AVT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
@@ -242,7 +242,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-AVT-POLICY-VIDEO
       id: 3
@@ -279,8 +279,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-AVT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
@@ -352,7 +352,7 @@ router_path_selection:
     flow_assignment: lan
   peer_dynamic_source: stun
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
     - name: INET
@@ -426,9 +426,9 @@ application_traffic_recognition:
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   categories:
   - name: VIDEO1
     applications:
@@ -446,8 +446,8 @@ application_traffic_recognition:
       - tcp
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
-    - name: CONTROL-PLANE-APPLICATION
-      src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-CONTROL-PLANE
+      src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -464,7 +464,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-SRC-PREFIXES
+    - name: APP-SRC-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.3/32
 dps_interfaces:
@@ -569,7 +569,7 @@ metadata:
       vni: 1
       avts:
       - id: 254
-        name: CONTROL-PLANE-PROFILE
+        name: DEFAULT-AVT-POLICY-CONTROL-PLANE
         pathgroups:
         - name: LAN_HA
           preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -434,8 +434,8 @@ router_adaptive_virtual_topology:
     name: Site422
     id: 422
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
   - name: DEFAULT-AVT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
@@ -456,7 +456,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-AVT-POLICY-VIDEO
       id: 3
@@ -493,8 +493,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-AVT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
@@ -574,7 +574,7 @@ router_path_selection:
       ipv4_addresses:
       - 172.17.0.3
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
     - name: INET
@@ -650,9 +650,9 @@ application_traffic_recognition:
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   categories:
   - name: VIDEO1
     applications:
@@ -670,8 +670,8 @@ application_traffic_recognition:
       - tcp
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -688,7 +688,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -671,7 +671,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -688,7 +688,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -671,7 +671,7 @@ application_traffic_recognition:
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -688,7 +688,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -434,8 +434,8 @@ router_adaptive_virtual_topology:
     name: Site422
     id: 422
   profiles:
-  - name: CONTROL-PLANE-PROFILE
-    load_balance_policy: LB-CONTROL-PLANE-PROFILE
+  - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
   - name: DEFAULT-AVT-POLICY-VIDEO
     load_balance_policy: LB-DEFAULT-AVT-POLICY-VIDEO
   - name: DEFAULT-AVT-POLICY-DEFAULT
@@ -456,7 +456,7 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: CONTROL-PLANE-PROFILE
+    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
       id: 254
     - name: DEFAULT-AVT-POLICY-VIDEO
       id: 3
@@ -493,8 +493,8 @@ router_adaptive_virtual_topology:
   policies:
   - name: DEFAULT-AVT-POLICY-WITH-CP
     matches:
-    - application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      avt_profile: CONTROL-PLANE-PROFILE
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-AVT-POLICY-CONTROL-PLANE
     - application_profile: VIDEO
       avt_profile: DEFAULT-AVT-POLICY-VIDEO
     - application_profile: default
@@ -574,7 +574,7 @@ router_path_selection:
       ipv4_addresses:
       - 172.17.0.1
   load_balance_policies:
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
     - name: LAN_HA
     - name: INET
@@ -650,9 +650,9 @@ application_traffic_recognition:
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   categories:
   - name: VIDEO1
     applications:
@@ -670,8 +670,8 @@ application_traffic_recognition:
       - tcp
       tcp_src_port_set_name: TCP-SRC-2
       tcp_dest_port_set_name: TCP-DEST-2
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -688,7 +688,7 @@ application_traffic_recognition:
     - name: CUSTOM-DEST-PREFIX-1
       prefix_values:
       - 6.6.6.0/24
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
       prefix_values:
       - 192.168.144.1/32
 dps_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -230,10 +230,10 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     ipv4_prefixes:
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -205,7 +205,7 @@ router_path_selection:
     ipv4_segment_size: auto
   load_balance_policies:
   - name: LB-DEFAULT-POLICY-DEFAULT
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-POLICY-CONTROL-PLANE
   policies:
   - name: DEFAULT-POLICY
     default_match:
@@ -213,8 +213,8 @@ router_path_selection:
   - name: DEFAULT-POLICY-WITH-CP
     rules:
     - id: 10
-      application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      load_balance: LB-CONTROL-PLANE-PROFILE
+      application_profile: APP-PROFILE-CONTROL-PLANE
+      load_balance: LB-DEFAULT-POLICY-CONTROL-PLANE
     default_match:
       load_balance: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
@@ -224,16 +224,16 @@ router_path_selection:
     path_selection_policy: DEFAULT-POLICY-WITH-CP
 application_traffic_recognition:
   application_profiles:
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   applications:
     ipv4_applications:
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -239,10 +239,10 @@ application_traffic_recognition:
   applications:
     ipv4_applications:
     - name: APP-CONTROL-PLANE
-      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
   field_sets:
     ipv4_prefixes:
-    - name: APP-DEST-PFX-CONTROL-PLANE
+    - name: PFX-PATHFINDERS
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -214,7 +214,7 @@ router_path_selection:
     ipv4_segment_size: auto
   load_balance_policies:
   - name: LB-DEFAULT-POLICY-DEFAULT
-  - name: LB-CONTROL-PLANE-PROFILE
+  - name: LB-DEFAULT-POLICY-CONTROL-PLANE
   policies:
   - name: DEFAULT-POLICY
     default_match:
@@ -222,8 +222,8 @@ router_path_selection:
   - name: DEFAULT-POLICY-WITH-CP
     rules:
     - id: 10
-      application_profile: CONTROL-PLANE-APPLICATION-PROFILE
-      load_balance: LB-CONTROL-PLANE-PROFILE
+      application_profile: APP-PROFILE-CONTROL-PLANE
+      load_balance: LB-DEFAULT-POLICY-CONTROL-PLANE
     default_match:
       load_balance: LB-DEFAULT-POLICY-DEFAULT
   vrfs:
@@ -233,16 +233,16 @@ router_path_selection:
     path_selection_policy: DEFAULT-POLICY-WITH-CP
 application_traffic_recognition:
   application_profiles:
-  - name: CONTROL-PLANE-APPLICATION-PROFILE
+  - name: APP-PROFILE-CONTROL-PLANE
     applications:
-    - name: CONTROL-PLANE-APPLICATION
+    - name: APP-CONTROL-PLANE
   applications:
     ipv4_applications:
-    - name: CONTROL-PLANE-APPLICATION
-      dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
   field_sets:
     ipv4_prefixes:
-    - name: CONTROL-PLANE-APP-DEST-PREFIXES
+    - name: APP-DEST-PFX-CONTROL-PLANE
 dps_interfaces:
 - name: Dps1
   description: DPS Interface

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -37,7 +37,7 @@ The intention is to support both a single [AutoVPN design](https://www.arista.co
   - The `default_virtual_topology` is used as the default match in the policy.  To prevent configuring it, the `drop_unmatched` boolean must be set to `true` otherwise, at least one `path-group` must be configured or AVD will raise an error.
   - Policies are assigned to VRFs using the list `wan_virtual_topologies.vrfs`. A policy can be reused in multiple VRFs.
   - If no policy is assigned for the `default` VRF policy, AVD auto generates one with one `default_virtual_topology` entry configured to use all available local path-groups.
-  - For the policy defined for VRF `default` (or the auto-generared one), an extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `CONTROL-PLANE-APPLICATION-PROFILE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
+  - For the policy defined for VRF `default` (or the auto-generared one), an extra match statement is injected in the policy to match the traffic towards the Pathfinders or AutoVPN RRs, the name of the application-profile is hardcoded as `APP-PROFILE-CONTROL-PLANE`. A special policy is created by appending `-WITH-CP` at the end of the targetted policy name.
   - For HA, the considered interfaces are only the `uplink_interfaces` in VRF default. It is possible to disable HA under node settings.
 
 #### LAN Designs

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
@@ -38,11 +38,11 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
 
     @cached_property
     def _wan_cp_app_dst_prefix(self) -> str:
-        return "APP-DEST-PFX-CONTROL-PLANE"
+        return "PFX-PATHFINDERS"
 
     @cached_property
     def _wan_cp_app_src_prefix(self) -> str:
-        return "APP-SRC-PFX-CONTROL-PLANE"
+        return "PFX-LOCAL-VTEP-IP"
 
     def _generate_control_plane_application_profile(self, app_dict: dict) -> None:
         """
@@ -62,10 +62,10 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
               applications:
                 ipv4_applications:
                   - name: APP-CONTROL-PLANE
-                    dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
+                    dest_prefix_set_name: PFX-PATHFINDERS
               field_sets:
                 ipv4_prefixes:
-                  - name: APP-DEST-PFX-CONTROL-PLANE
+                  - name: PFX-PATHFINDERS
                     prefix_values: [Pathfinder to which the router is connected vtep_ips]
 
         Pathfinder:
@@ -78,10 +78,10 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
               applications:
                 ipv4_applications:
                   - name: APP-CONTROL-PLANE
-                    src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
+                    src_prefix_set_name: PFX-LOCAL-VTEP-IP
               field_sets:
                 ipv4_prefixes:
-                  - name: APP-SRC-PFX-CONTROL-PLANE
+                  - name: PFX-LOCAL-VTEP-IP
                     prefix_values: [Pathfinder vtep_ip]
         """
         # Adding the application-profile

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
@@ -34,15 +34,15 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
     #  self._wan_control_plane_application_profile is defined in utils.py
     @cached_property
     def _wan_control_plane_application(self) -> str:
-        return "CONTROL-PLANE-APPLICATION"
+        return "APP-CONTROL-PLANE"
 
     @cached_property
     def _wan_cp_app_dst_prefix(self) -> str:
-        return "CONTROL-PLANE-APP-DEST-PREFIXES"
+        return "APP-DEST-PFX-CONTROL-PLANE"
 
     @cached_property
     def _wan_cp_app_src_prefix(self) -> str:
-        return "CONTROL-PLANE-APP-SRC-PREFIXES"
+        return "APP-SRC-PFX-CONTROL-PLANE"
 
     def _generate_control_plane_application_profile(self, app_dict: dict) -> None:
         """
@@ -56,32 +56,32 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
 
             application_traffic_recognition:
               application_profiles:
-                - name: CONTROL-PLANE-APPLICATION-PROFILE
+                - name: APP-PROFILE-CONTROL-PLANE
                   applications:
-                    - name: CONTROL-PLANE-APPLICATION
+                    - name: APP-CONTROL-PLANE
               applications:
                 ipv4_applications:
-                  - name: CONTROL-PLANE-APPLICATION
-                    dest_prefix_set_name: CONTROL-PLANE-APP-DEST-PREFIXES
+                  - name: APP-CONTROL-PLANE
+                    dest_prefix_set_name: APP-DEST-PFX-CONTROL-PLANE
               field_sets:
                 ipv4_prefixes:
-                  - name: CONTROL-PLANE-APP-DEST-PREFIXES
+                  - name: APP-DEST-PFX-CONTROL-PLANE
                     prefix_values: [Pathfinder to which the router is connected vtep_ips]
 
         Pathfinder:
 
             application_traffic_recognition:
               application_profiles:
-                - name: CONTROL-PLANE-APPLICATION-PROFILE
+                - name: APP-PROFILE-CONTROL-PLANE
                   applications:
-                    - name: CONTROL-PLANE-APPLICATION
+                    - name: APP-CONTROL-PLANE
               applications:
                 ipv4_applications:
-                  - name: CONTROL-PLANE-APPLICATION
-                    src_prefix_set_name: CONTROL-PLANE-APP-SRC-PREFIXES
+                  - name: APP-CONTROL-PLANE
+                    src_prefix_set_name: APP-SRC-PFX-CONTROL-PLANE
               field_sets:
                 ipv4_prefixes:
-                  - name: CONTROL-PLANE-APP-SRC-PREFIXES
+                  - name: APP-SRC-PFX-CONTROL-PLANE
                     prefix_values: [Pathfinder vtep_ip]
         """
         # Adding the application-profile

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -194,7 +194,8 @@ class UtilsMixin:
         Control plane profile name
         """
         control_plane_virtual_topology = get(self._hostvars, "wan_virtual_topologies.control_plane_virtual_topology", default={})
-        return get(control_plane_virtual_topology, "name", default="CONTROL-PLANE-PROFILE")
+        vrf_default_policy_name = get(get_item(self._filtered_wan_vrfs, "name", "default"), "original_policy")
+        return get(control_plane_virtual_topology, "name", default=f"{vrf_default_policy_name}-CONTROL-PLANE")
 
     @cached_property
     def _wan_control_plane_application_profile(self) -> str:
@@ -203,7 +204,7 @@ class UtilsMixin:
 
         TODO: make this configurable
         """
-        return "CONTROL-PLANE-APPLICATION-PROFILE"
+        return "APP-PROFILE-CONTROL-PLANE"
 
     def _generate_wan_load_balance_policy(self, name: str, input_dict: dict, context_path: str) -> dict:
         """


### PR DESCRIPTION
## Change Summary

cf title

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Following some discussions renaming objects for consistency

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
