### PR TITLE
Feat(eos_designs): Add flowtracking on WAN Router LAN uplinks

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -19,7 +19,7 @@ hostname uplink_lan_wan_router1
 router adaptive-virtual-topology
    topology role edge
    region region1 id 1
-   zone DEFAULT-ZONE id 1
+   zone region1-ZONE id 1
    site site1 id 1
    !
    policy DEFAULT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -1,8 +1,54 @@
 !RANCID-CONTENT-TYPE: arista
 !
+flow tracking hardware
+   tracker WAN-FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 5000
+      exporter DPI-EXPORTER
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 5000
+   no shutdown
+!
 service routing protocols model multi-agent
 !
+ip as-path access-list ASPATH-WAN permit 65100 any
+!
 hostname uplink_lan_wan_router1
+!
+router adaptive-virtual-topology
+   topology role edge
+   region region1 id 1
+   zone DEFAULT-ZONE id 1
+   site site1 id 1
+   !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-POLICY-CONTROL-PLANE
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-CONTROL-PLANE id 254
+   !
+   vrf VRF1
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
 !
 router path-selection
    tcp mss ceiling ipv4 ingress
@@ -10,22 +56,6 @@ router path-selection
    load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
-   !
-   policy DEFAULT-POLICY
-      default-match
-         load-balance LB-DEFAULT-POLICY-DEFAULT
-   !
-   policy DEFAULT-POLICY-WITH-CP
-      default-match
-         load-balance LB-DEFAULT-POLICY-DEFAULT
-      10 application-profile APP-PROFILE-CONTROL-PLANE
-         load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
-   !
-   vrf default
-      path-selection-policy DEFAULT-POLICY-WITH-CP
-   !
-   vrf VRF1
-      path-selection-policy DEFAULT-POLICY
 !
 spanning-tree mode none
 !
@@ -42,6 +72,8 @@ ip security
       local-id 192.168.2.1
    !
    sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
@@ -57,6 +89,7 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
+   flow tracker hardware WAN-FLOW-TRACKER
    ip address 192.168.2.1/32
 !
 interface Ethernet2
@@ -64,6 +97,7 @@ interface Ethernet2
    no shutdown
    mtu 9214
    no switchport
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf VRF1
    ip address 10.0.10.1/24
 !
@@ -71,6 +105,7 @@ interface Ethernet2.100
    description My vlan 100
    no shutdown
    encapsulation dot1q vlan 100
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf VRF1
    ip address 10.0.100.1/24
    ipv6 enable
@@ -104,14 +139,14 @@ no ip routing vrf MGMT
 ip routing vrf VRF1
 ipv6 unicast-routing vrf VRF1
 !
-ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.1.1:0
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.1.1:1
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.1.0/24 eq 32
 !
 route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
-   set extcommunity soo 192.168.1.1:0 additive
+   set extcommunity soo 192.168.1.1:1 additive
 !
 route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
    description Advertise local routes towards LAN
@@ -123,7 +158,7 @@ route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   set extcommunity soo 192.168.1.1:0 additive
+   set extcommunity soo 192.168.1.1:1 additive
 !
 route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
    match extcommunity ECL-EVPN-SOO
@@ -134,7 +169,7 @@ route-map RM-EVPN-SOO-IN deny 10
 route-map RM-EVPN-SOO-IN permit 20
 !
 route-map RM-EVPN-SOO-OUT permit 10
-   set extcommunity soo 192.168.1.1:0 additive
+   set extcommunity soo 192.168.1.1:1 additive
 !
 router bfd
    multihop interval 300 min-rx 300 multiplier 3
@@ -162,6 +197,13 @@ router bgp 65100
    address-family ipv4
       no neighbor WAN-OVERLAY-PEERS activate
    !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      path-selection
+   !
    address-family path-selection
       bgp additional-paths receive
       bgp additional-paths send any
@@ -179,6 +221,8 @@ router bgp 65100
       route-target export evpn 123:123
       router-id 192.168.1.1
       redistribute connected
+!
+router traffic-engineering
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -19,7 +19,7 @@ hostname uplink_lan_wan_router2
 router adaptive-virtual-topology
    topology role edge
    region region1 id 1
-   zone DEFAULT-ZONE id 1
+   zone region1-ZONE id 1
    site site2 id 2
    !
    policy DEFAULT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -1,8 +1,54 @@
 !RANCID-CONTENT-TYPE: arista
 !
+flow tracking hardware
+   tracker WAN-FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 5000
+      exporter DPI-EXPORTER
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 5000
+   no shutdown
+!
 service routing protocols model multi-agent
 !
+ip as-path access-list ASPATH-WAN permit 65100 any
+!
 hostname uplink_lan_wan_router2
+!
+router adaptive-virtual-topology
+   topology role edge
+   region region1 id 1
+   zone DEFAULT-ZONE id 1
+   site site2 id 2
+   !
+   policy DEFAULT-POLICY
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile DEFAULT-POLICY-CONTROL-PLANE
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-CONTROL-PLANE
+      path-selection load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-CONTROL-PLANE id 254
+   !
+   vrf VRF1
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
 !
 router path-selection
    tcp mss ceiling ipv4 ingress
@@ -10,22 +56,6 @@ router path-selection
    load-balance policy LB-DEFAULT-POLICY-CONTROL-PLANE
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
-   !
-   policy DEFAULT-POLICY
-      default-match
-         load-balance LB-DEFAULT-POLICY-DEFAULT
-   !
-   policy DEFAULT-POLICY-WITH-CP
-      default-match
-         load-balance LB-DEFAULT-POLICY-DEFAULT
-      10 application-profile APP-PROFILE-CONTROL-PLANE
-         load-balance LB-DEFAULT-POLICY-CONTROL-PLANE
-   !
-   vrf default
-      path-selection-policy DEFAULT-POLICY-WITH-CP
-   !
-   vrf VRF1
-      path-selection-policy DEFAULT-POLICY
 !
 spanning-tree mode none
 !
@@ -42,6 +72,8 @@ ip security
       local-id 192.168.2.2
    !
    sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
@@ -57,6 +89,7 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
+   flow tracker hardware WAN-FLOW-TRACKER
    ip address 192.168.2.2/32
 !
 interface Ethernet2
@@ -70,6 +103,7 @@ interface Ethernet2.10
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 10
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf VRF1
    ip address 10.0.10.1/24
 !
@@ -77,6 +111,7 @@ interface Ethernet2.100
    description My vlan 100
    no shutdown
    encapsulation dot1q vlan 100
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf VRF1
    ip address 10.0.100.1/24
    ipv6 enable
@@ -110,14 +145,14 @@ no ip routing vrf MGMT
 ip routing vrf VRF1
 ipv6 unicast-routing vrf VRF1
 !
-ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.1.2:0
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.1.2:2
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.1.0/24 eq 32
 !
 route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
-   set extcommunity soo 192.168.1.2:0 additive
+   set extcommunity soo 192.168.1.2:2 additive
 !
 route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
    description Advertise local routes towards LAN
@@ -129,7 +164,7 @@ route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   set extcommunity soo 192.168.1.2:0 additive
+   set extcommunity soo 192.168.1.2:2 additive
 !
 route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
    match extcommunity ECL-EVPN-SOO
@@ -140,7 +175,7 @@ route-map RM-EVPN-SOO-IN deny 10
 route-map RM-EVPN-SOO-IN permit 20
 !
 route-map RM-EVPN-SOO-OUT permit 10
-   set extcommunity soo 192.168.1.2:0 additive
+   set extcommunity soo 192.168.1.2:2 additive
 !
 router bfd
    multihop interval 300 min-rx 300 multiplier 3
@@ -168,6 +203,13 @@ router bgp 65100
    address-family ipv4
       no neighbor WAN-OVERLAY-PEERS activate
    !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      path-selection
+   !
    address-family path-selection
       bgp additional-paths receive
       bgp additional-paths send any
@@ -185,6 +227,8 @@ router bgp 65100
       route-target export evpn 123:123
       router-id 192.168.1.2
       redistribute connected
+!
+router traffic-engineering
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -36,6 +36,17 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: false
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    path_selection:
+      roles:
+        producer: true
   address_family_path_selection:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
@@ -99,6 +110,8 @@ ethernet_interfaces:
   vrf: VRF1
   ip_address: 10.0.10.1/24
   mtu: 9214
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet2.100
   peer: uplink_lan_l2leaf
   peer_interface: Ethernet1 VLAN 100
@@ -112,12 +125,20 @@ ethernet_interfaces:
   ipv6_address: cafe::cafe/64
   ipv6_enable: true
   eos_cli: comment yo
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
   _custom_key: custom_value
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
   shutdown: false
   ip_address: 192.168.1.1/32
+as_path:
+  access_lists:
+  - name: ASPATH-WAN
+    entries:
+    - type: permit
+      match: '65100'
 prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
@@ -131,14 +152,14 @@ route_maps:
     match:
     - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
     set:
-    - extcommunity soo 192.168.1.1:0 additive
+    - extcommunity soo 192.168.1.1:1 additive
 - name: RM-BGP-UNDERLAY-PEERS-IN
   sequence_numbers:
   - sequence: 40
     type: permit
     description: Mark prefixes originated from the LAN
     set:
-    - extcommunity soo 192.168.1.1:0 additive
+    - extcommunity soo 192.168.1.1:1 additive
 - name: RM-BGP-UNDERLAY-PEERS-OUT
   sequence_numbers:
   - sequence: 10
@@ -164,24 +185,41 @@ route_maps:
   - sequence: 10
     type: permit
     set:
-    - extcommunity soo 192.168.1.1:0 additive
+    - extcommunity soo 192.168.1.1:1 additive
 - name: RM-EVPN-EXPORT-VRF-DEFAULT
   sequence_numbers:
   - sequence: 10
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+flow_tracking:
+  hardware:
+    trackers:
+    - name: WAN-FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 5000
+      exporters:
+      - name: DPI-EXPORTER
+        collector:
+          host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 5000
+    shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:
   - type: permit
-    extcommunities: soo 192.168.1.1:0
+    extcommunities: soo 192.168.1.1:1
 ip_security:
   ike_policies:
   - name: CP-IKE-POLICY
     local_id: 192.168.2.1
   sa_policies:
   - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
   profiles:
   - name: CP-PROFILE
     ike_policy: CP-IKE-POLICY
@@ -205,6 +243,46 @@ management_security:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
     tls_versions: '1.2'
+router_adaptive_virtual_topology:
+  topology_role: edge
+  region:
+    name: region1
+    id: 1
+  zone:
+    name: DEFAULT-ZONE
+    id: 1
+  site:
+    name: site1
+    id: 1
+  profiles:
+  - name: DEFAULT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-POLICY-CONTROL-PLANE
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: VRF1
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: DEFAULT-POLICY-CONTROL-PLANE
+      id: 254
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  policies:
+  - name: DEFAULT-POLICY
+    matches:
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-POLICY-CONTROL-PLANE
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -216,22 +294,8 @@ router_path_selection:
   load_balance_policies:
   - name: LB-DEFAULT-POLICY-DEFAULT
   - name: LB-DEFAULT-POLICY-CONTROL-PLANE
-  policies:
-  - name: DEFAULT-POLICY
-    default_match:
-      load_balance: LB-DEFAULT-POLICY-DEFAULT
-  - name: DEFAULT-POLICY-WITH-CP
-    rules:
-    - id: 10
-      application_profile: APP-PROFILE-CONTROL-PLANE
-      load_balance: LB-DEFAULT-POLICY-CONTROL-PLANE
-    default_match:
-      load_balance: LB-DEFAULT-POLICY-DEFAULT
-  vrfs:
-  - name: VRF1
-    path_selection_policy: DEFAULT-POLICY
-  - name: default
-    path_selection_policy: DEFAULT-POLICY-WITH-CP
+router_traffic_engineering:
+  enabled: true
 application_traffic_recognition:
   application_profiles:
   - name: APP-PROFILE-CONTROL-PLANE
@@ -249,6 +313,8 @@ dps_interfaces:
   description: DPS Interface
   mtu: 9214
   ip_address: 192.168.2.1/32
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: uplink_lan_wan_router1_VTEP
@@ -260,3 +326,29 @@ vxlan_interface:
         vni: 123
       - name: default
         vni: 1
+metadata:
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: edge
+    - name: Region
+      value: region1
+    - name: Zone
+      value: DEFAULT-ZONE
+    - name: Site
+      value: site1
+    interface_tags:
+    - interface: Ethernet2
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet2.100
+      tags:
+      - name: Type
+        value: lan
+  cv_pathfinder:
+    role: edge
+    vtep_ip: 192.168.2.1
+    region: region1
+    zone: DEFAULT-ZONE
+    site: site1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -249,7 +249,7 @@ router_adaptive_virtual_topology:
     name: region1
     id: 1
   zone:
-    name: DEFAULT-ZONE
+    name: region1-ZONE
     id: 1
   site:
     name: site1
@@ -334,7 +334,7 @@ metadata:
     - name: Region
       value: region1
     - name: Zone
-      value: DEFAULT-ZONE
+      value: region1-ZONE
     - name: Site
       value: site1
     interface_tags:
@@ -350,5 +350,5 @@ metadata:
     role: edge
     vtep_ip: 192.168.2.1
     region: region1
-    zone: DEFAULT-ZONE
+    zone: region1-ZONE
     site: site1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -36,6 +36,17 @@ router_bgp:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
       activate: false
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    path_selection:
+      roles:
+        producer: true
   address_family_path_selection:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
@@ -108,6 +119,8 @@ ethernet_interfaces:
   vrf: VRF1
   ip_address: 10.0.10.1/24
   mtu: 9214
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet2.100
   peer: uplink_lan_l2leaf
   peer_interface: Ethernet2 VLAN 100
@@ -121,12 +134,20 @@ ethernet_interfaces:
   ipv6_address: cafe::cafe/64
   ipv6_enable: true
   eos_cli: comment yo
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
   _custom_key: custom_value
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
   shutdown: false
   ip_address: 192.168.1.2/32
+as_path:
+  access_lists:
+  - name: ASPATH-WAN
+    entries:
+    - type: permit
+      match: '65100'
 prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
@@ -140,14 +161,14 @@ route_maps:
     match:
     - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
     set:
-    - extcommunity soo 192.168.1.2:0 additive
+    - extcommunity soo 192.168.1.2:2 additive
 - name: RM-BGP-UNDERLAY-PEERS-IN
   sequence_numbers:
   - sequence: 40
     type: permit
     description: Mark prefixes originated from the LAN
     set:
-    - extcommunity soo 192.168.1.2:0 additive
+    - extcommunity soo 192.168.1.2:2 additive
 - name: RM-BGP-UNDERLAY-PEERS-OUT
   sequence_numbers:
   - sequence: 10
@@ -173,24 +194,41 @@ route_maps:
   - sequence: 10
     type: permit
     set:
-    - extcommunity soo 192.168.1.2:0 additive
+    - extcommunity soo 192.168.1.2:2 additive
 - name: RM-EVPN-EXPORT-VRF-DEFAULT
   sequence_numbers:
   - sequence: 10
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+flow_tracking:
+  hardware:
+    trackers:
+    - name: WAN-FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 5000
+      exporters:
+      - name: DPI-EXPORTER
+        collector:
+          host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 5000
+    shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:
   - type: permit
-    extcommunities: soo 192.168.1.2:0
+    extcommunities: soo 192.168.1.2:2
 ip_security:
   ike_policies:
   - name: CP-IKE-POLICY
     local_id: 192.168.2.2
   sa_policies:
   - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
   profiles:
   - name: CP-PROFILE
     ike_policy: CP-IKE-POLICY
@@ -214,6 +252,46 @@ management_security:
       certificates:
       - aristaDeviceCertProvisionerDefaultRootCA.crt
     tls_versions: '1.2'
+router_adaptive_virtual_topology:
+  topology_role: edge
+  region:
+    name: region1
+    id: 1
+  zone:
+    name: DEFAULT-ZONE
+    id: 1
+  site:
+    name: site2
+    id: 2
+  profiles:
+  - name: DEFAULT-POLICY-CONTROL-PLANE
+    load_balance_policy: LB-DEFAULT-POLICY-CONTROL-PLANE
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: VRF1
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: DEFAULT-POLICY-CONTROL-PLANE
+      id: 254
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  policies:
+  - name: DEFAULT-POLICY
+    matches:
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: DEFAULT-POLICY-CONTROL-PLANE
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300
@@ -225,22 +303,8 @@ router_path_selection:
   load_balance_policies:
   - name: LB-DEFAULT-POLICY-DEFAULT
   - name: LB-DEFAULT-POLICY-CONTROL-PLANE
-  policies:
-  - name: DEFAULT-POLICY
-    default_match:
-      load_balance: LB-DEFAULT-POLICY-DEFAULT
-  - name: DEFAULT-POLICY-WITH-CP
-    rules:
-    - id: 10
-      application_profile: APP-PROFILE-CONTROL-PLANE
-      load_balance: LB-DEFAULT-POLICY-CONTROL-PLANE
-    default_match:
-      load_balance: LB-DEFAULT-POLICY-DEFAULT
-  vrfs:
-  - name: VRF1
-    path_selection_policy: DEFAULT-POLICY
-  - name: default
-    path_selection_policy: DEFAULT-POLICY-WITH-CP
+router_traffic_engineering:
+  enabled: true
 application_traffic_recognition:
   application_profiles:
   - name: APP-PROFILE-CONTROL-PLANE
@@ -258,6 +322,8 @@ dps_interfaces:
   description: DPS Interface
   mtu: 9214
   ip_address: 192.168.2.2/32
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: uplink_lan_wan_router2_VTEP
@@ -269,3 +335,33 @@ vxlan_interface:
         vni: 123
       - name: default
         vni: 1
+metadata:
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: edge
+    - name: Region
+      value: region1
+    - name: Zone
+      value: DEFAULT-ZONE
+    - name: Site
+      value: site2
+    interface_tags:
+    - interface: Ethernet2
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet2.10
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet2.100
+      tags:
+      - name: Type
+        value: lan
+  cv_pathfinder:
+    role: edge
+    vtep_ip: 192.168.2.2
+    region: region1
+    zone: DEFAULT-ZONE
+    site: site2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -258,7 +258,7 @@ router_adaptive_virtual_topology:
     name: region1
     id: 1
   zone:
-    name: DEFAULT-ZONE
+    name: region1-ZONE
     id: 1
   site:
     name: site2
@@ -343,7 +343,7 @@ metadata:
     - name: Region
       value: region1
     - name: Zone
-      value: DEFAULT-ZONE
+      value: region1-ZONE
     - name: Site
       value: site2
     interface_tags:
@@ -363,5 +363,5 @@ metadata:
     role: edge
     vtep_ip: 192.168.2.2
     region: region1
-    zone: DEFAULT-ZONE
+    zone: region1-ZONE
     site: site2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_LAN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UPLINK_LAN_TESTS.yml
@@ -26,9 +26,13 @@ wan_router: # dynamic_key: node_type
       id: 1
       uplink_switch_interfaces: [Ethernet1]
       uplink_native_vlan: 10
+      cv_pathfinder_region: region1
+      cv_pathfinder_site: site1
     - name: uplink_lan_wan_router2
       uplink_switch_interfaces: [Ethernet2]
       id: 2
+      cv_pathfinder_region: region1
+      cv_pathfinder_site: site2
 
 tenants: # dynamic_key: network_services
   - name: TEST
@@ -67,11 +71,12 @@ tenants: # dynamic_key: network_services
             ip_address: 10.0.102.1/24
             enabled: true
             tags: [l2leaf]
+
 wan_ipsec_profiles:
   control_plane:
     shared_key: test
 
-wan_mode: autovpn
+wan_mode: cv-pathfinder
 
 wan_route_servers: []
 wan_path_groups: []
@@ -84,3 +89,12 @@ wan_virtual_topologies:
   vrfs:
     - name: VRF1
       wan_vni: 123
+
+cv_pathfinder_regions:
+  - name: region1
+    id: 1
+    sites:
+      - name: site1
+        id: 1
+      - name: site2
+        id: 2

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -222,7 +222,7 @@ class UtilsMixin:
             "path_groups": [],
             **get(input_dict, "constraints", default={}),
         }
-        if self.shared_utils.wan_mode == "cv-pathfinder":
+        if self.shared_utils.is_cv_pathfinder_router:
             wan_load_balance_policy["lowest_hop_count"] = get(input_dict, "lowest_hop_count")
 
         if self.shared_utils.wan_ha or self.shared_utils.is_cv_pathfinder_server:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
@@ -110,7 +110,7 @@ class EthernetInterfacesMixin(UtilsMixin):
                     ethernet_interface["pim"] = {"ipv4": {"sparse_mode": True}}
 
                 # Configuring flow tracking on LAN interfaces
-                if self.shared_utils.wan_mode == "cv-pathfinder" and self.shared_utils.wan_role == "client":
+                if self.shared_utils.is_cv_pathfinder_client:
                     ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                 # Structured Config
@@ -193,7 +193,7 @@ class EthernetInterfacesMixin(UtilsMixin):
                         ethernet_subinterface.update({"ip_address": f"{subinterface['ip_address']}/{subinterface['prefix_length']}"}),
 
                     # Configuring flow tracking on LAN interfaces
-                    if self.shared_utils.wan_mode == "cv-pathfinder" and self.shared_utils.wan_role == "client":
+                    if self.shared_utils.is_cv_pathfinder_client:
                         ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                     ethernet_subinterface = {key: value for key, value in ethernet_subinterface.items() if value is not None}
@@ -246,7 +246,7 @@ class EthernetInterfacesMixin(UtilsMixin):
                 }
 
                 # Configuring flow tracking on LAN interfaces
-                if self.shared_utils.wan_mode == "cv-pathfinder" and self.shared_utils.wan_role == "client":
+                if self.shared_utils.is_cv_pathfinder_client:
                     ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                 append_if_not_duplicate(

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/router_bgp.py
@@ -43,7 +43,7 @@ class RouterBgpMixin(UtilsMixin):
             "struct_cfg": self.shared_utils.bgp_peer_groups["ipv4_underlay_peers"]["structured_config"],
         }
 
-        if self.shared_utils.overlay_routing_protocol == "ibgp" and self.shared_utils.wan_mode == "cv-pathfinder" and self.shared_utils.wan_role is not None:
+        if self.shared_utils.overlay_routing_protocol == "ibgp" and self.shared_utils.is_cv_pathfinder_router:
             peer_group["route_map_in"] = "RM-BGP-UNDERLAY-PEERS-IN"
             peer_group["route_map_out"] = "RM-BGP-UNDERLAY-PEERS-OUT"
             if self.shared_utils.wan_ha:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -274,4 +274,8 @@ class UtilsMixin:
         # Adding IP helpers and OSPF via a common function also used for SVIs on L3 switches.
         self.shared_utils.get_additional_svi_config(subinterface, svi, vrf)
 
+        # Configuring flow tracking on LAN interfaces of WAN routers
+        if self.shared_utils.is_cv_pathfinder_client:
+            subinterface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
+
         return strip_empties_from_dict(subinterface)


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add flowtracking on WAN Router LAN uplinks

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Updated existing lan uplink test to use cv-pathfinder

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
