### PR TITLE
Fix(deploy_to_cv): Do not add Pathfinders to Routers section of metadata studio

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
@@ -239,7 +239,6 @@ async def deploy_cv_pathfinder_metadata_to_cv(cv_pathfinder_metadata: list[CVPat
                 device_metadata.device.serial_number,
                 device_role,
             )
-            edges.append(device_metadata)
             pathfinders.append(device_metadata)
         else:
             LOGGER.info(


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Do not add Pathfinders to Routers section of metadata studio

## Component(s) name

`arista.avd.deploy_to_cv`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Testing manually for now.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
