### PR TITLE
Refactor(eos_designs): Set cv-pathfinder interface tags for subinterfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -535,6 +535,18 @@ metadata:
       tags:
       - name: Type
         value: lan
+    - interface: Ethernet52.1000
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.142
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.666
+      tags:
+      - name: Type
+        value: lan
     - interface: Ethernet1
       tags:
       - name: Type

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -646,6 +646,18 @@ metadata:
       tags:
       - name: Type
         value: lan
+    - interface: Ethernet52.1000
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.142
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.666
+      tags:
+      - name: Type
+        value: lan
     - interface: Ethernet1
       tags:
       - name: Type

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -701,7 +701,31 @@ metadata:
       tags:
       - name: Type
         value: lan
+    - interface: Ethernet52.1000
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.142
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.666
+      tags:
+      - name: Type
+        value: lan
     - interface: Ethernet53
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet53.1000
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet53.142
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet53.666
       tags:
       - name: Type
         value: lan

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -695,7 +695,31 @@ metadata:
       tags:
       - name: Type
         value: lan
+    - interface: Ethernet52.1000
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.142
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.666
+      tags:
+      - name: Type
+        value: lan
     - interface: Ethernet53
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet53.1000
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet53.142
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet53.666
       tags:
       - name: Type
         value: lan

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -731,6 +731,32 @@ metadata:
       tags:
       - name: Type
         value: lan
+    - interface: Ethernet52.1000
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.142
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.666
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet1.42
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Comcast
+    - interface: Ethernet2.42
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Colt
+      - name: Circuit
+        value: '10666'
     - interface: Ethernet1
       tags:
       - name: Type

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -731,6 +731,32 @@ metadata:
       tags:
       - name: Type
         value: lan
+    - interface: Ethernet52.1000
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.142
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet52.666
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet1.42
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Comcast
+    - interface: Ethernet2.42
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Colt
+      - name: Circuit
+        value: '10666'
     - interface: Ethernet1
       tags:
       - name: Type

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -75,7 +75,7 @@ class WanMixin:
     @cached_property
     def wan_interfaces(self: SharedUtils) -> list:
         """
-        As a first approach, only interfaces under l3edge.l3_interfaces can be considered
+        As a first approach, only interfaces under node config l3_interfaces can be considered
         as WAN interfaces.
         This may need to be made wider.
         This also may require a different format for the dictionaries inside the list.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_tags.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_tags.py
@@ -182,7 +182,8 @@ class CvTagsMixin:
                 if value:
                     tags.append(self._tag_dict(generate_tag["name"], value))
 
-            tags.extend(self._get_cv_pathfinder_interface_tags(ethernet_interface))
+            if self.shared_utils.is_cv_pathfinder_router:
+                tags.extend(self._get_cv_pathfinder_interface_tags(ethernet_interface))
 
             if tags:
                 interface_tags.append({"interface": ethernet_interface["name"], "tags": tags})
@@ -198,10 +199,6 @@ class CvTagsMixin:
             {"name": "Circuit", <value copied from wan_circuit_id if this is a wan interface>}
         ]
         """
-        # Skip if not cv_pathfinder_role or if this is a subinterface.
-        if not self.shared_utils.is_cv_pathfinder_router or "." in ethernet_interface["name"]:
-            return []
-
         if ethernet_interface["name"] in self._wan_interface_names:
             wan_interface = get_item(self.shared_utils.wan_interfaces, "name", ethernet_interface["name"], required=True)
             return strip_empties_from_list(


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Set cv-pathfinder interface tags for subinterfaces

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing molecule scenarios already cover this.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
