### PR TITLE
Fix(eos_cli_config_gen): Updating the valid values for PTP mode.

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ptp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ptp.md
@@ -8,7 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>ptp</samp>](## "ptp") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;mode</samp>](## "ptp.mode") | String |  |  | Valid Values:<br>- <code>boundary</code><br>- <code>transparent</code> |  |
+    | [<samp>&nbsp;&nbsp;mode</samp>](## "ptp.mode") | String |  |  | Valid Values:<br>- <code>boundary</code><br>- <code>disabled</code><br>- <code>e2etransparent</code><br>- <code>gptp</code><br>- <code>ordinarymaster</code><br>- <code>p2ptransparent</code> |  |
     | [<samp>&nbsp;&nbsp;mode_one_step</samp>](## "ptp.mode_one_step") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;forward_unicast</samp>](## "ptp.forward_unicast") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;clock_identity</samp>](## "ptp.clock_identity") | String |  |  |  | The clock-id in xx:xx:xx:xx:xx:xx format |
@@ -47,7 +47,7 @@
 
     ```yaml
     ptp:
-      mode: <str; "boundary" | "transparent">
+      mode: <str; "boundary" | "disabled" | "e2etransparent" | "gptp" | "ordinarymaster" | "p2ptransparent">
       mode_one_step: <bool>
       forward_unicast: <bool>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -13588,7 +13588,11 @@
           "type": "string",
           "enum": [
             "boundary",
-            "transparent"
+            "disabled",
+            "e2etransparent",
+            "gptp",
+            "ordinarymaster",
+            "p2ptransparent"
           ],
           "title": "Mode"
         },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7999,7 +7999,11 @@ keys:
         type: str
         valid_values:
         - boundary
-        - transparent
+        - disabled
+        - e2etransparent
+        - gptp
+        - ordinarymaster
+        - p2ptransparent
       mode_one_step:
         type: bool
       forward_unicast:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ptp.schema.yml
@@ -13,7 +13,11 @@ keys:
         type: str
         valid_values:
         - boundary
-        - transparent
+        - disabled
+        - e2etransparent
+        - gptp
+        - ordinarymaster
+        - p2ptransparent
       mode_one_step:
         type: bool
       forward_unicast:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -31,8 +31,7 @@ ptp message-type general dscp {{ ptp.message_type.general.dscp }} default
 ptp message-type event dscp {{ ptp.message_type.event.dscp }} default
 {%     endif %}
 {%     if ptp.mode is arista.avd.defined %}
-{# Update one-step support for "e2etransparent" mode as well, when it is available in valid_values of ptp.mode #}
-{%         if ptp.mode is arista.avd.defined('boundary') and ptp.mode_one_step is arista.avd.defined(true) %}
+{%         if (ptp.mode is arista.avd.defined('boundary') or ptp.mode is arista.avd.defined('e2etransparent')) and ptp.mode_one_step is arista.avd.defined(true) %}
 ptp mode {{ ptp.mode }} one-step
 {%         else %}
 ptp mode {{ ptp.mode }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ptp.j2
@@ -31,7 +31,7 @@ ptp message-type general dscp {{ ptp.message_type.general.dscp }} default
 ptp message-type event dscp {{ ptp.message_type.event.dscp }} default
 {%     endif %}
 {%     if ptp.mode is arista.avd.defined %}
-{%         if (ptp.mode is arista.avd.defined('boundary') or ptp.mode is arista.avd.defined('e2etransparent')) and ptp.mode_one_step is arista.avd.defined(true) %}
+{%         if ptp.mode_one_step is arista.avd.defined(true) and ptp.mode in ["boundary", "e2etransparent"] %}
 ptp mode {{ ptp.mode }} one-step
 {%         else %}
 ptp mode {{ ptp.mode }}


### PR DESCRIPTION
## Change Summary

Updating the valid values for PTP mode.

## Related Issue(s)

Fixes #3669 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```
ptp:
      mode: <str; "boundary" | "disabled" | "e2etransparent" | "gptp" | "ordinarymaster" | "p2ptransparent">
```

## How to test

Check PTP modes supported in EOS CLI.

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
