### PR TITLE
Feat(eos_designs): Add 'dhcp_ip_address' under 'l3_interfaces' node settings

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-interfaces.yml
@@ -20,6 +20,7 @@ spine:
           peer: peer2
           name: Ethernet2/2
           ip_address: dhcp
+          dhcp_ip_address: 14.18.39.45/24
           dhcp_accept_default_route: true
         - # custom description
           peer: peer3

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-interfaces-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-interfaces-settings.md
@@ -14,6 +14,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].name") | String | Required, Unique |  | Pattern: Ethernet[\d/]+(.[\d]+)? | Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'<br>For a subinterface, the parent physical interface is automatically created. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].description") | String |  |  |  | Interface description.<br>If not set a default description will be configured with '[<peer>[ <peer_interface>]]' |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].ip_address") | String |  |  |  | Node IPv4 address/Mask or 'dhcp'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_ip_address</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].dhcp_ip_address") | String |  |  |  | When the `ip_address` is `dhcp`, this optional field allows to indicate the expected<br>IPv4 address/Mask to be allocated on the interface if known.<br>This is not rendered in the configuration but can be used in ACLs in certain scenarios. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].encapsulation_dot1q_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_accept_default_route</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].dhcp_accept_default_route") | Boolean |  | `False` |  | Accept a default route from DHCP if `ip_address` is set to `dhcp`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].enabled") | Boolean |  | `True` |  | Enable or Shutdown the interface. |
@@ -38,6 +39,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].name") | String | Required, Unique |  | Pattern: Ethernet[\d/]+(.[\d]+)? | Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'<br>For a subinterface, the parent physical interface is automatically created. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].description") | String |  |  |  | Interface description.<br>If not set a default description will be configured with '[<peer>[ <peer_interface>]]' |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].ip_address") | String |  |  |  | Node IPv4 address/Mask or 'dhcp'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_ip_address</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].dhcp_ip_address") | String |  |  |  | When the `ip_address` is `dhcp`, this optional field allows to indicate the expected<br>IPv4 address/Mask to be allocated on the interface if known.<br>This is not rendered in the configuration but can be used in ACLs in certain scenarios. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].encapsulation_dot1q_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_accept_default_route</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].dhcp_accept_default_route") | Boolean |  | `False` |  | Accept a default route from DHCP if `ip_address` is set to `dhcp`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].enabled") | Boolean |  | `True` |  | Enable or Shutdown the interface. |
@@ -58,6 +60,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].name") | String | Required, Unique |  | Pattern: Ethernet[\d/]+(.[\d]+)? | Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'<br>For a subinterface, the parent physical interface is automatically created. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].description") | String |  |  |  | Interface description.<br>If not set a default description will be configured with '[<peer>[ <peer_interface>]]' |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].ip_address") | String |  |  |  | Node IPv4 address/Mask or 'dhcp'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_ip_address</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].dhcp_ip_address") | String |  |  |  | When the `ip_address` is `dhcp`, this optional field allows to indicate the expected<br>IPv4 address/Mask to be allocated on the interface if known.<br>This is not rendered in the configuration but can be used in ACLs in certain scenarios. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].encapsulation_dot1q_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_accept_default_route</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].dhcp_accept_default_route") | Boolean |  | `False` |  | Accept a default route from DHCP if `ip_address` is set to `dhcp`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].enabled") | Boolean |  | `True` |  | Enable or Shutdown the interface. |
@@ -80,6 +83,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].name") | String | Required, Unique |  | Pattern: Ethernet[\d/]+(.[\d]+)? | Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'<br>For a subinterface, the parent physical interface is automatically created. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].description") | String |  |  |  | Interface description.<br>If not set a default description will be configured with '[<peer>[ <peer_interface>]]' |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].ip_address") | String |  |  |  | Node IPv4 address/Mask or 'dhcp'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_ip_address</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].dhcp_ip_address") | String |  |  |  | When the `ip_address` is `dhcp`, this optional field allows to indicate the expected<br>IPv4 address/Mask to be allocated on the interface if known.<br>This is not rendered in the configuration but can be used in ACLs in certain scenarios. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].encapsulation_dot1q_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dhcp_accept_default_route</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].dhcp_accept_default_route") | Boolean |  | `False` |  | Accept a default route from DHCP if `ip_address` is set to `dhcp`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].enabled") | Boolean |  | `True` |  | Enable or Shutdown the interface. |
@@ -100,6 +104,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "l3_interface_profiles.[].name") | String |  |  | Pattern: Ethernet[\d/]+(.[\d]+)? | Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'<br>For a subinterface, the parent physical interface is automatically created. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "l3_interface_profiles.[].description") | String |  |  |  | Interface description.<br>If not set a default description will be configured with '[<peer>[ <peer_interface>]]' |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "l3_interface_profiles.[].ip_address") | String |  |  |  | Node IPv4 address/Mask or 'dhcp'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_ip_address</samp>](## "l3_interface_profiles.[].dhcp_ip_address") | String |  |  |  | When the `ip_address` is `dhcp`, this optional field allows to indicate the expected<br>IPv4 address/Mask to be allocated on the interface if known.<br>This is not rendered in the configuration but can be used in ACLs in certain scenarios. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "l3_interface_profiles.[].encapsulation_dot1q_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_accept_default_route</samp>](## "l3_interface_profiles.[].dhcp_accept_default_route") | Boolean |  | `False` |  | Accept a default route from DHCP if `ip_address` is set to `dhcp`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "l3_interface_profiles.[].enabled") | Boolean |  | `True` |  | Enable or Shutdown the interface. |
@@ -142,6 +147,11 @@
 
             # Node IPv4 address/Mask or 'dhcp'.
             ip_address: <str>
+
+            # When the `ip_address` is `dhcp`, this optional field allows to indicate the expected
+            # IPv4 address/Mask to be allocated on the interface if known.
+            # This is not rendered in the configuration but can be used in ACLs in certain scenarios.
+            dhcp_ip_address: <str>
 
             # For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
             encapsulation_dot1q_vlan: <int; 1-4094>
@@ -222,6 +232,11 @@
                   # Node IPv4 address/Mask or 'dhcp'.
                   ip_address: <str>
 
+                  # When the `ip_address` is `dhcp`, this optional field allows to indicate the expected
+                  # IPv4 address/Mask to be allocated on the interface if known.
+                  # This is not rendered in the configuration but can be used in ACLs in certain scenarios.
+                  dhcp_ip_address: <str>
+
                   # For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
                   encapsulation_dot1q_vlan: <int; 1-4094>
 
@@ -287,6 +302,11 @@
 
               # Node IPv4 address/Mask or 'dhcp'.
               ip_address: <str>
+
+              # When the `ip_address` is `dhcp`, this optional field allows to indicate the expected
+              # IPv4 address/Mask to be allocated on the interface if known.
+              # This is not rendered in the configuration but can be used in ACLs in certain scenarios.
+              dhcp_ip_address: <str>
 
               # For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
               encapsulation_dot1q_vlan: <int; 1-4094>
@@ -360,6 +380,11 @@
               # Node IPv4 address/Mask or 'dhcp'.
               ip_address: <str>
 
+              # When the `ip_address` is `dhcp`, this optional field allows to indicate the expected
+              # IPv4 address/Mask to be allocated on the interface if known.
+              # This is not rendered in the configuration but can be used in ACLs in certain scenarios.
+              dhcp_ip_address: <str>
+
               # For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
               encapsulation_dot1q_vlan: <int; 1-4094>
 
@@ -426,6 +451,11 @@
 
         # Node IPv4 address/Mask or 'dhcp'.
         ip_address: <str>
+
+        # When the `ip_address` is `dhcp`, this optional field allows to indicate the expected
+        # IPv4 address/Mask to be allocated on the interface if known.
+        # This is not rendered in the configuration but can be used in ACLs in certain scenarios.
+        dhcp_ip_address: <str>
 
         # For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
         encapsulation_dot1q_vlan: <int; 1-4094>

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5930,6 +5930,11 @@
             "description": "Node IPv4 address/Mask or 'dhcp'.",
             "title": "IP Address"
           },
+          "dhcp_ip_address": {
+            "type": "string",
+            "description": "When the `ip_address` is `dhcp`, this optional field allows to indicate the expected\nIPv4 address/Mask to be allocated on the interface if known.\nThis is not rendered in the configuration but can be used in ACLs in certain scenarios.",
+            "title": "DHCP IP Address"
+          },
           "encapsulation_dot1q_vlan": {
             "description": "For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified.",
             "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -7867,6 +7867,15 @@ $defs:
         ip_address:
           type: str
           description: Node IPv4 address/Mask or 'dhcp'.
+        dhcp_ip_address:
+          type: str
+          description: 'When the `ip_address` is `dhcp`, this optional field allows
+            to indicate the expected
+
+            IPv4 address/Mask to be allocated on the interface if known.
+
+            This is not rendered in the configuration but can be used in ACLs in certain
+            scenarios.'
         encapsulation_dot1q_vlan:
           description: For subinterfaces the dot1q vlan is derived from the interface
             name by default, but can also be specified.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type_l3_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_node_type_l3_interfaces.schema.yml
@@ -26,6 +26,12 @@ $defs:
         ip_address:
           type: str
           description: Node IPv4 address/Mask or 'dhcp'.
+        dhcp_ip_address:
+          type: str
+          description: |-
+            When the `ip_address` is `dhcp`, this optional field allows to indicate the expected
+            IPv4 address/Mask to be allocated on the interface if known.
+            This is not rendered in the configuration but can be used in ACLs in certain scenarios.
         encapsulation_dot1q_vlan:
           description: For subinterfaces the dot1q vlan is derived from the interface name by default, but can also be specified.
           type: int


### PR DESCRIPTION
## Change Summary

Add a key to store the dhcp allocated IPv4/ Mask in scenarii when it is known beforehands.

The key does not do anything now but the goal is to leverage this in ACLs later.

Note that this would fail miserably if the allocated IP address is not static

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
cf summary

## How to test
molecule -> no change to config but no error when adding it

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
