### PR TITLE
Refactor(eos_designs): WAN Preview - Prefix default zone name with region name

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -17,7 +17,7 @@ hostname cv-pathfinder-edge-custom-default-policy
 router adaptive-virtual-topology
    topology role edge
    region AVD_Land_West id 42
-   zone DEFAULT-ZONE id 1
+   zone AVD_Land_West-ZONE id 1
    site Site1 id 1
    !
    policy DEFAULT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -19,7 +19,7 @@ hostname cv-pathfinder-edge-no-common-path-group
 router adaptive-virtual-topology
    topology role edge
    region AVD_Land_East id 43
-   zone DEFAULT-ZONE id 1
+   zone AVD_Land_East-ZONE id 1
    site Site511 id 511
    !
    policy DEFAULT-AVT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -17,7 +17,7 @@ hostname cv-pathfinder-edge-no-default-policy
 router adaptive-virtual-topology
    topology role edge
    region AVD_Land_East id 43
-   zone DEFAULT-ZONE id 1
+   zone AVD_Land_East-ZONE id 1
    site Site511 id 511
    !
    policy DEFAULT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -19,7 +19,7 @@ hostname cv-pathfinder-edge
 router adaptive-virtual-topology
    topology role edge
    region AVD_Land_East id 43
-   zone DEFAULT-ZONE id 1
+   zone AVD_Land_East-ZONE id 1
    site Site511 id 511
    !
    policy DEFAULT-AVT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -19,7 +19,7 @@ hostname cv-pathfinder-edge2A
 router adaptive-virtual-topology
    topology role edge
    region AVD_Land_West id 42
-   zone DEFAULT-ZONE id 1
+   zone AVD_Land_West-ZONE id 1
    site Site423 id 423
    !
    policy DEFAULT-AVT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -19,7 +19,7 @@ hostname cv-pathfinder-edge2B
 router adaptive-virtual-topology
    topology role edge
    region AVD_Land_West id 42
-   zone DEFAULT-ZONE id 1
+   zone AVD_Land_West-ZONE id 1
    site Site423 id 423
    !
    policy DEFAULT-AVT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -19,7 +19,7 @@ hostname cv-pathfinder-transit1A
 router adaptive-virtual-topology
    topology role transit region
    region AVD_Land_West id 42
-   zone DEFAULT-ZONE id 1
+   zone AVD_Land_West-ZONE id 1
    site Site422 id 422
    !
    policy DEFAULT-AVT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -19,7 +19,7 @@ hostname cv-pathfinder-transit1B
 router adaptive-virtual-topology
    topology role transit region
    region AVD_Land_West id 42
-   zone DEFAULT-ZONE id 1
+   zone AVD_Land_West-ZONE id 1
    site Site422 id 422
    !
    policy DEFAULT-AVT-POLICY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -239,7 +239,7 @@ router_adaptive_virtual_topology:
     name: AVD_Land_West
     id: 42
   zone:
-    name: DEFAULT-ZONE
+    name: AVD_Land_West-ZONE
     id: 1
   site:
     name: Site1
@@ -402,7 +402,7 @@ metadata:
     - name: Region
       value: AVD_Land_West
     - name: Zone
-      value: DEFAULT-ZONE
+      value: AVD_Land_West-ZONE
     - name: Site
       value: Site1
     interface_tags:
@@ -434,7 +434,7 @@ metadata:
     role: edge
     vtep_ip: 192.168.255.1
     region: AVD_Land_West
-    zone: DEFAULT-ZONE
+    zone: AVD_Land_West-ZONE
     site: Site1
     interfaces:
     - name: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -346,7 +346,7 @@ router_adaptive_virtual_topology:
     name: AVD_Land_East
     id: 43
   zone:
-    name: DEFAULT-ZONE
+    name: AVD_Land_East-ZONE
     id: 1
   site:
     name: Site511
@@ -537,7 +537,7 @@ metadata:
     - name: Region
       value: AVD_Land_East
     - name: Zone
-      value: DEFAULT-ZONE
+      value: AVD_Land_East-ZONE
     - name: Site
       value: Site511
     interface_tags:
@@ -569,7 +569,7 @@ metadata:
     role: edge
     vtep_ip: 192.168.142.2
     region: AVD_Land_East
-    zone: DEFAULT-ZONE
+    zone: AVD_Land_East-ZONE
     site: Site511
     interfaces:
     - name: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -256,7 +256,7 @@ router_adaptive_virtual_topology:
     name: AVD_Land_East
     id: 43
   zone:
-    name: DEFAULT-ZONE
+    name: AVD_Land_East-ZONE
     id: 1
   site:
     name: Site511
@@ -408,7 +408,7 @@ metadata:
     - name: Region
       value: AVD_Land_East
     - name: Zone
-      value: DEFAULT-ZONE
+      value: AVD_Land_East-ZONE
     - name: Site
       value: Site511
     interface_tags:
@@ -440,7 +440,7 @@ metadata:
     role: edge
     vtep_ip: 192.168.255.1
     region: AVD_Land_East
-    zone: DEFAULT-ZONE
+    zone: AVD_Land_East-ZONE
     site: Site511
     interfaces:
     - name: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -392,7 +392,7 @@ router_adaptive_virtual_topology:
     name: AVD_Land_East
     id: 43
   zone:
-    name: DEFAULT-ZONE
+    name: AVD_Land_East-ZONE
     id: 1
   site:
     name: Site511
@@ -651,7 +651,7 @@ metadata:
     - name: Region
       value: AVD_Land_East
     - name: Zone
-      value: DEFAULT-ZONE
+      value: AVD_Land_East-ZONE
     - name: Site
       value: Site511
     interface_tags:
@@ -699,7 +699,7 @@ metadata:
     role: edge
     vtep_ip: 192.168.142.1
     region: AVD_Land_East
-    zone: DEFAULT-ZONE
+    zone: AVD_Land_East-ZONE
     site: Site511
     interfaces:
     - name: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -461,7 +461,7 @@ router_adaptive_virtual_topology:
     name: AVD_Land_West
     id: 42
   zone:
-    name: DEFAULT-ZONE
+    name: AVD_Land_West-ZONE
     id: 1
   site:
     name: Site423
@@ -705,7 +705,7 @@ metadata:
     - name: Region
       value: AVD_Land_West
     - name: Zone
-      value: DEFAULT-ZONE
+      value: AVD_Land_West-ZONE
     - name: Site
       value: Site423
     interface_tags:
@@ -753,7 +753,7 @@ metadata:
     role: edge
     vtep_ip: 192.168.142.2
     region: AVD_Land_West
-    zone: DEFAULT-ZONE
+    zone: AVD_Land_West-ZONE
     site: Site423
     interfaces:
     - name: Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -460,7 +460,7 @@ router_adaptive_virtual_topology:
     name: AVD_Land_West
     id: 42
   zone:
-    name: DEFAULT-ZONE
+    name: AVD_Land_West-ZONE
     id: 1
   site:
     name: Site423
@@ -698,7 +698,7 @@ metadata:
     - name: Region
       value: AVD_Land_West
     - name: Zone
-      value: DEFAULT-ZONE
+      value: AVD_Land_West-ZONE
     - name: Site
       value: Site423
     interface_tags:
@@ -746,7 +746,7 @@ metadata:
     role: edge
     vtep_ip: 192.168.142.3
     region: AVD_Land_West
-    zone: DEFAULT-ZONE
+    zone: AVD_Land_West-ZONE
     site: Site423
     interfaces:
     - name: Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -538,7 +538,7 @@ metadata:
     - name: AVD_Land_West
       id: 42
       zones:
-      - name: DEFAULT-ZONE
+      - name: AVD_Land_West-ZONE
         id: 1
         sites:
         - name: Site422
@@ -552,7 +552,7 @@ metadata:
     - name: AVD_Land_East
       id: 43
       zones:
-      - name: DEFAULT-ZONE
+      - name: AVD_Land_East-ZONE
         id: 1
         sites:
         - name: Site511

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -526,7 +526,7 @@ metadata:
     - name: AVD_Land_West
       id: 42
       zones:
-      - name: DEFAULT-ZONE
+      - name: AVD_Land_West-ZONE
         id: 1
         sites:
         - name: Site422
@@ -540,7 +540,7 @@ metadata:
     - name: AVD_Land_East
       id: 43
       zones:
-      - name: DEFAULT-ZONE
+      - name: AVD_Land_East-ZONE
         id: 1
         sites:
         - name: Site511

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -557,7 +557,7 @@ metadata:
     - name: AVD_Land_West
       id: 42
       zones:
-      - name: DEFAULT-ZONE
+      - name: AVD_Land_West-ZONE
         id: 1
         sites:
         - name: Site422
@@ -571,7 +571,7 @@ metadata:
     - name: AVD_Land_East
       id: 43
       zones:
-      - name: DEFAULT-ZONE
+      - name: AVD_Land_East-ZONE
         id: 1
         sites:
         - name: Site511

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -438,7 +438,7 @@ router_adaptive_virtual_topology:
     name: AVD_Land_West
     id: 42
   zone:
-    name: DEFAULT-ZONE
+    name: AVD_Land_West-ZONE
     id: 1
   site:
     name: Site422
@@ -736,7 +736,7 @@ metadata:
     - name: Region
       value: AVD_Land_West
     - name: Zone
-      value: DEFAULT-ZONE
+      value: AVD_Land_West-ZONE
     - name: Site
       value: Site422
     interface_tags:
@@ -782,7 +782,7 @@ metadata:
     role: transit region
     vtep_ip: 192.168.143.1
     region: AVD_Land_West
-    zone: DEFAULT-ZONE
+    zone: AVD_Land_West-ZONE
     site: Site422
     interfaces:
     - name: Ethernet1.42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -438,7 +438,7 @@ router_adaptive_virtual_topology:
     name: AVD_Land_West
     id: 42
   zone:
-    name: DEFAULT-ZONE
+    name: AVD_Land_West-ZONE
     id: 1
   site:
     name: Site422
@@ -736,7 +736,7 @@ metadata:
     - name: Region
       value: AVD_Land_West
     - name: Zone
-      value: DEFAULT-ZONE
+      value: AVD_Land_West-ZONE
     - name: Site
       value: Site422
     interface_tags:
@@ -782,7 +782,7 @@ metadata:
     role: transit region
     vtep_ip: 192.168.143.2
     region: AVD_Land_West
-    zone: DEFAULT-ZONE
+    zone: AVD_Land_West-ZONE
     site: Site422
     interfaces:
     - name: Ethernet1.42

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -267,10 +267,10 @@ class WanMixin:
         """
         WAN zone for Pathfinder
 
-        Currently, only default zone DEFAULT-ZONE with ID 1 is supported.
+        Currently, only one default zone with ID 1 is supported.
         """
-        # Injecting zone DEFAULT-ZONE with id 1.
-        return {"name": "DEFAULT-ZONE", "id": 1}
+        # Injecting default zone with id 1.
+        return {"name": f"{self.wan_region['name']}-ZONE", "id": 1}
 
     @cached_property
     def filtered_wan_route_servers(self: SharedUtils) -> dict:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-cv-pathfinder-regions.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-cv-pathfinder-regions.md
@@ -10,9 +10,9 @@
     | [<samp>cv_pathfinder_regions</samp>](## "cv_pathfinder_regions") | List, items: Dictionary |  |  |  | PREVIEW: This key is currently not supported<br>Define the SDWAN hierarchy for the device. |
     | [<samp>&nbsp;&nbsp;-&nbsp;description</samp>](## "cv_pathfinder_regions.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "cv_pathfinder_regions.[].id") | Integer | Required |  | Min: 1<br>Max: 255 | The region ID must be unique for the whole WAN deployment. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sites</samp>](## "cv_pathfinder_regions.[].sites") | List, items: Dictionary |  |  |  | All sites are placed in a default zone called DEFAULT-ZONE with ID 1. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sites</samp>](## "cv_pathfinder_regions.[].sites") | List, items: Dictionary |  |  |  | All sites are placed in a default zone "<region_name>-ZONE" with ID 1. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;description</samp>](## "cv_pathfinder_regions.[].sites.[].description") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "cv_pathfinder_regions.[].sites.[].id") | Integer | Required |  | Min: 1<br>Max: 10000 | The site ID must be unique within a zone.<br>Given that all the sites are placed in the DEFAULT-ZONE, the site ID must be unique within a region. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "cv_pathfinder_regions.[].sites.[].id") | Integer | Required |  | Min: 1<br>Max: 10000 | The Site ID must be unique within a zone.<br>Given that all the Sites are placed in a Zone named after the Region, the Site ID must be unique within a Region. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;location</samp>](## "cv_pathfinder_regions.[].sites.[].location") | String |  |  |  | Will be interpreted |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;site_contact</samp>](## "cv_pathfinder_regions.[].sites.[].site_contact") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;site_after_hours_contact</samp>](## "cv_pathfinder_regions.[].sites.[].site_after_hours_contact") | String |  |  |  |  |
@@ -30,12 +30,12 @@
         # The region ID must be unique for the whole WAN deployment.
         id: <int; 1-255; required>
 
-        # All sites are placed in a default zone called DEFAULT-ZONE with ID 1.
+        # All sites are placed in a default zone "<region_name>-ZONE" with ID 1.
         sites:
           - description: <str>
 
-            # The site ID must be unique within a zone.
-            # Given that all the sites are placed in the DEFAULT-ZONE, the site ID must be unique within a region.
+            # The Site ID must be unique within a zone.
+            # Given that all the Sites are placed in a Zone named after the Region, the Site ID must be unique within a Region.
             id: <int; 1-10000; required>
 
             # Will be interpreted

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -109,7 +109,7 @@ The HA tunnel will come up properly today but route redistribution will be missi
 
 ## Known limitations
 
-- Zones are not configurable for CV Pathfinder. All sites are being configured in a default zone `DEFAULT-ZONE` with ID `1`.
+- Zones are not configurable for CV Pathfinder. All sites are being configured in a default zone `<region_name>-ZONE` with ID `1`.
 - Because of the previous point, in `eos_designs`, the `transit` node type is always configured as `transit region`.
 - For `cv-pathfinder` mode, the following flow-tracking configuration is applied
     without any customization possible:
@@ -245,7 +245,7 @@ The tags will only be generated when `wan_mode` is set to `cv-pathfinder`.
 | Tag Name        | Source of information                                      |
 | --------------- | ---------------------------------------------------------- |
 | `Region`        | `cv_pathfinder_region` for `wan_router`                    |
-| `Zone`          | `DEFAULT-ZONE` for `wan_router`                            |
+| `Zone`          | `<region_name>-ZONE` for `wan_router`                            |
 | `Site`          | `cv_pathfinder_site` for `wan_router`                      |
 | `PathfinderSet` | name of `node_group` or default `PATHFINDERS` for `wan_rr` |
 | `Role`          | `pathfinder`, `edge`, `transit region` or `transit zone`   |

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -20,7 +20,7 @@ title: Ansible Collection Role eos_designs - WAN preview
 
 ## Overview
 
-The intention is to support both a single [AutoVPN design](https://www.arista.com/en/cg-veos-router/veos-router-auto-vpn) and [CV Pathfinder](https://www.arista.com/en/solutions/enterprise-wan/pathfinder).
+The intention is to support both a single AutoVPN design and [CV Pathfinder](https://www.arista.com/en/solutions/enterprise-wan/pathfinder).
 
 ### Design points
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/avdstructuredconfig.py
@@ -28,7 +28,7 @@ class AvdStructuredConfigMetadata(AvdFacts, CvTagsMixin, CvPathfinderMixin):
                     {"name": "<custom_tag_name>", "value": "custom tag value"},
                     {"name": "<custom_tag_name>", "value": "<value extracted from structured_config>"},
                     {"name": "Region", "value": <value copied from cv_pathfinder_region for pathfinder clients>},
-                    {"name": "Zone", "value": <always "DEFAULT-ZONE" for pathfinder clients>},
+                    {"name": "Zone", "value": <"<region-name>-ZONE" for pathfinder clients>},
                     {"name": "Site", "value": <value copied from cv_pathfinder_site for pathfinder clients>},
                     {"name": "PathfinderSet", "value": <value copied from node group or default "PATHFINDERS" for pathfinder servers>},
                     {"name": "Role", "value": <'pathfinder', 'edge', 'transit region' or 'transit zone'>}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
@@ -97,8 +97,8 @@ class CvPathfinderMixin:
                 "zones": [
                     {
                         # TODO: Once we give configurable zones this should be updated
-                        "name": self.shared_utils.wan_zone["name"],
-                        "id": self.shared_utils.wan_zone["id"],
+                        "name": f"{region['name']}-ZONE",
+                        "id": 1,
                         "sites": [
                             {
                                 "name": site["name"],

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_tags.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_tags.py
@@ -93,7 +93,7 @@ class CvTagsMixin:
         Return list of device_tags for cv_pathfinder solution
         Example: [
             {"name": "Region", "value": <value copied from cv_pathfinder_region for pathfinder clients>},
-            {"name": "Zone", "value": <always "DEFAULT-ZONE" for pathfinder clients>},
+            {"name": "Zone", "value": <"<region-name>-ZONE" for pathfinder clients>},
             {"name": "Site", "value": <value copied from cv_pathfinder_site for pathfinder clients>},
             {"name": "PathfinderSet", "value": <value copied from node group or default "PATHFINDERS" for pathfinder servers>},
             {"name": "Role", "value": <'pathfinder', 'edge', 'transit region' or 'transit zone'>}
@@ -111,7 +111,7 @@ class CvTagsMixin:
             device_tags.extend(
                 [
                     self._tag_dict("Region", self.shared_utils.wan_region["name"]),
-                    self._tag_dict("Zone", "DEFAULT-ZONE"),
+                    self._tag_dict("Zone", self.shared_utils.wan_zone["name"]),
                     self._tag_dict("Site", self.shared_utils.wan_site["name"]),
                 ]
             )

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4400,7 +4400,7 @@
           },
           "sites": {
             "type": "array",
-            "description": "All sites are placed in a default zone called DEFAULT-ZONE with ID 1.",
+            "description": "All sites are placed in a default zone \"<region_name>-ZONE\" with ID 1.",
             "items": {
               "type": "object",
               "properties": {
@@ -4410,7 +4410,7 @@
                 },
                 "id": {
                   "type": "integer",
-                  "description": "The site ID must be unique within a zone.\nGiven that all the sites are placed in the DEFAULT-ZONE, the site ID must be unique within a region.",
+                  "description": "The Site ID must be unique within a zone.\nGiven that all the Sites are placed in a Zone named after the Region, the Site ID must be unique within a Region.",
                   "minimum": 1,
                   "maximum": 10000,
                   "title": "ID"

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -621,7 +621,7 @@ keys:
           description: The region ID must be unique for the whole WAN deployment.
         sites:
           type: list
-          description: All sites are placed in a default zone called DEFAULT-ZONE
+          description: All sites are placed in a default zone "<region_name>-ZONE"
             with ID 1.
           primary_key: name
           items:
@@ -632,10 +632,10 @@ keys:
                 type: str
               id:
                 type: int
-                description: 'The site ID must be unique within a zone.
+                description: 'The Site ID must be unique within a zone.
 
-                  Given that all the sites are placed in the DEFAULT-ZONE, the site
-                  ID must be unique within a region.'
+                  Given that all the Sites are placed in a Zone named after the Region,
+                  the Site ID must be unique within a Region.'
               location:
                 type: str
                 description: Will be interpreted

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/cv_pathfinder_regions.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/cv_pathfinder_regions.schema.yml
@@ -27,7 +27,7 @@ keys:
         sites:
           type: list
           description: |-
-            All sites are placed in a default zone called DEFAULT-ZONE with ID 1.
+            All sites are placed in a default zone "<region_name>-ZONE" with ID 1.
           primary_key: name
           items:
             type: dict
@@ -38,8 +38,8 @@ keys:
               id:
                 type: int
                 description: |-
-                  The site ID must be unique within a zone.
-                  Given that all the sites are placed in the DEFAULT-ZONE, the site ID must be unique within a region.
+                  The Site ID must be unique within a zone.
+                  Given that all the Sites are placed in a Zone named after the Region, the Site ID must be unique within a Region.
               location:
                 type: str
                 description: Will be interpreted


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
WAN Preview - Prefix default zone name with region name

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

We need to ensure the region names are unique for the CV Visualization, so here we include the region name in the zone name.
When we make the regions configurable later, we have to enforce uniqueness in names.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing molecule scenarios reflect the change.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
