### PR TITLE
Feat(eos_designs): Enable KERNELFIB_PROGRAM_ALL_ECMP for all wan routers

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge-no-default-policy.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 service routing protocols model multi-agent
 !
 hostname autovpn-edge-no-default-policy

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 service routing protocols model multi-agent
 !
 hostname autovpn-edge

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 service routing protocols model multi-agent
 !
 hostname autovpn-rr1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 service routing protocols model multi-agent
 !
 hostname autovpn-rr2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 flow tracking hardware
    tracker WAN-FLOW-TRACKER
       record export on inactive timeout 70000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 service routing protocols model multi-agent
 !
 hostname uplink_lan_wan_router1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -1,5 +1,7 @@
 !RANCID-CONTENT-TYPE: arista
 !
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
 service routing protocols model multi-agent
 !
 hostname uplink_lan_wan_router2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge-no-default-policy.yml
@@ -157,6 +157,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -147,6 +147,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -136,6 +136,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -138,6 +138,11 @@ route_maps:
 static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.8.8.9
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -169,6 +169,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -276,6 +276,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -186,6 +186,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -322,6 +322,11 @@ static_routes:
 - destination_address_prefix: 66.66.66.0/24
   gateway: 172.17.0.0
   vrf: default
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -388,6 +388,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -387,6 +387,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -158,6 +158,11 @@ route_maps:
 static_routes:
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.7.7.6
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -170,6 +170,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -178,6 +178,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -365,6 +365,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -365,6 +365,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 flow_tracking:
   hardware:
     trackers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -171,6 +171,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -180,6 +180,11 @@ route_maps:
     type: permit
     match:
     - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
   entries:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/agents.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/agents.py
@@ -1,0 +1,30 @@
+# Copyright (c) 2024-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from functools import cached_property
+
+from .utils import UtilsMixin
+
+
+class AgentsMixin(UtilsMixin):
+    """
+    Mixin Class used to generate structured config for one key.
+    Class should only be used as Mixin to a AvdStructuredConfig class
+    """
+
+    @cached_property
+    def agents(self) -> dict | None:
+        """
+        Return structured config for agents
+        """
+
+        if not self.shared_utils.is_wan_router:
+            return None
+
+        agents = [
+            {"name": "KernelFib", "environment_variables": [{"name": "KERNELFIB_PROGRAM_ALL_ECMP", "value": "1"}]},
+        ]
+
+        return agents

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/agents.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/agents.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2024-2024 Arista Networks, Inc.
+# Copyright (c) 2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 from __future__ import annotations

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/avdstructuredconfig.py
@@ -3,6 +3,7 @@
 # that can be found in the LICENSE file.
 from ansible_collections.arista.avd.plugins.plugin_utils.avdfacts import AvdFacts
 
+from .agents import AgentsMixin
 from .as_path import AsPathMixin
 from .ethernet_interfaces import EthernetInterfacesMixin
 from .loopback_interfaces import LoopbackInterfacesMixin
@@ -37,6 +38,7 @@ class AvdStructuredConfigUnderlay(
     StandardAccessListsMixin,
     StaticRoutesMixin,
     MplsMixin,
+    AgentsMixin,
 ):
     """
     The AvdStructuredConfig Class is imported used "get_structured_config" to render parts of the structured config.


### PR DESCRIPTION
## Change Summary
Enable KERNELFIB_PROGRAM_ALL_ECMP for all wan routers by setting environment variable for KernelFib.

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Add file agents.py in underlay python_modules to generate agent structured config for KernelFib
```
 {
     "name": "KernelFib", 
     "environment_variables": [
                {"name": "KERNELFIB_PROGRAM_ALL_ECMP", "value": "1"}
      ]
},
 ```

## How to test
`molecule`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
