### PR TITLE
Feat(eos_designs): Add ability to override wan control plane policy

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
@@ -1,0 +1,335 @@
+!RANCID-CONTENT-TYPE: arista
+!
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
+flow tracking hardware
+   tracker FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 300000
+      exporter CV-TELEMETRY
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 3600000
+   no shutdown
+!
+service routing protocols model multi-agent
+!
+ip as-path access-list ASPATH-WAN permit 65000 any
+!
+hostname cv-pathfinder-custom-control-plane-policy-edge-1
+!
+router adaptive-virtual-topology
+   topology role edge
+   region AVD_Land_East id 43
+   zone AVD_Land_East-ZONE id 1
+   site Site511 id 511
+   !
+   policy DEFAULT-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile CUSTOM-CP-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile CUSTOM-CP-POLICY
+      path-selection load-balance LB-CUSTOM-CP-POLICY
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-VIDEO
+      path-selection load-balance LB-DEFAULT-POLICY-VIDEO
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+      avt profile CUSTOM-CP-POLICY id 254
+   !
+   vrf IT
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+   !
+   vrf PROD
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+!
+router path-selection
+   tcp mss ceiling ipv4 ingress
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+         stun server-profile INET-cv-pathfinder-pathfinder-Ethernet1 INET-cv-pathfinder-pathfinder-Ethernet3
+      !
+      peer dynamic
+      !
+      peer static router-ip 192.168.144.1
+         name cv-pathfinder-pathfinder
+         ipv4 address 10.7.7.7
+         ipv4 address 10.9.9.9
+   !
+   load-balance policy LB-CUSTOM-CP-POLICY
+      hop count lowest
+      jitter 5
+      path-group INET
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
+   !
+   load-balance policy LB-DEFAULT-POLICY-VIDEO
+      path-group INET
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance IT
+!
+vrf instance MGMT
+!
+vrf instance PROD
+!
+ip security
+   !
+   ike policy CP-IKE-POLICY
+      local-id 192.168.142.1
+   !
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
+      dpd 10 50 clear
+      mode transport
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   key controller
+      profile DP-PROFILE
+!
+interface Dps1
+   description DPS Interface
+   mtu 9214
+   flow tracker hardware FLOW-TRACKER
+   ip address 192.168.142.1/32
+!
+interface Ethernet1
+   description ATT_666_peer3_Ethernet42
+   no shutdown
+   no switchport
+   flow tracker hardware FLOW-TRACKER
+   ip address dhcp
+   dhcp client accept default-route
+!
+interface Loopback0
+   description Router_ID
+   no shutdown
+   ip address 192.168.42.1/32
+!
+interface Vxlan1
+   description cv-pathfinder-custom-control-plane-policy-edge-1_VTEP
+   vxlan source-interface Dps1
+   vxlan udp-port 4789
+   vxlan vrf default vni 1
+   vxlan vrf IT vni 14
+   vxlan vrf PROD vni 42
+!
+application traffic recognition
+   !
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
+   !
+   application ipv4 CUSTOM-APPLICATION-1
+      source prefix field-set CUSTOM-SRC-PREFIX-1
+      destination prefix field-set CUSTOM-DEST-PREFIX-1
+      protocol tcp
+   !
+   application ipv4 CUSTOM-APPLICATION-2
+      protocol tcp source port field-set TCP-SRC-2 destination port field-set TCP-DEST-2
+   !
+   category VIDEO1
+      application CUSTOM-APPLICATION-2
+      application microsoft-teams
+   !
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
+   !
+   application-profile VIDEO
+      application CUSTOM-APPLICATION-1
+      application skype
+      category VIDEO1
+   !
+   field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
+      6.6.6.0/24
+   !
+   field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
+      42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+      192.168.144.1/32
+   !
+   field-set l4-port TCP-DEST-2
+      666, 777
+   !
+   field-set l4-port TCP-SRC-2
+      42
+!
+ip routing
+ip routing vrf IT
+no ip routing vrf MGMT
+ip routing vrf PROD
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.1:511
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.42.0/24 eq 32
+!
+route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
+   description Mark prefixes originated from the LAN
+   set extcommunity soo 192.168.42.1:511 additive
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
+   description Advertise local routes towards LAN
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
+   description Advertise routes received from WAN iBGP towards LAN
+   match route-type internal
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   set extcommunity soo 192.168.42.1:511 additive
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 192.168.42.1:511 additive
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 192.168.42.1
+   maximum-paths 16
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.144.1 peer group WAN-OVERLAY-PEERS
+   neighbor 192.168.144.1 description cv-pathfinder-pathfinder
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      no neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      path-selection
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   vrf default
+      rd 192.168.42.1:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+   !
+   vrf IT
+      rd 192.168.42.1:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
+      router-id 192.168.42.1
+      redistribute connected
+   !
+   vrf PROD
+      rd 192.168.42.1:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
+      router-id 192.168.42.1
+      redistribute connected
+!
+router traffic-engineering
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+management security
+   ssl profile profileA
+      tls versions 1.2
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
+stun
+   client
+      server-profile INET-cv-pathfinder-pathfinder-Ethernet1
+         ip address 10.7.7.7
+         ssl profile profileA
+      server-profile INET-cv-pathfinder-pathfinder-Ethernet3
+         ip address 10.9.9.9
+         ssl profile profileA
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
@@ -1,0 +1,335 @@
+!RANCID-CONTENT-TYPE: arista
+!
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
+flow tracking hardware
+   tracker FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 300000
+      exporter CV-TELEMETRY
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 3600000
+   no shutdown
+!
+service routing protocols model multi-agent
+!
+ip as-path access-list ASPATH-WAN permit 65000 any
+!
+hostname cv-pathfinder-custom-control-plane-policy-edge-2
+!
+router adaptive-virtual-topology
+   topology role edge
+   region AVD_Land_East id 43
+   zone AVD_Land_East-ZONE id 1
+   site Site511 id 511
+   !
+   policy DEFAULT-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile CUSTOM-CP-APP-PROFILE
+         avt profile CUSTOM-CP-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile CUSTOM-CP-POLICY
+      path-selection load-balance LB-CUSTOM-CP-POLICY
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-VIDEO
+      path-selection load-balance LB-DEFAULT-POLICY-VIDEO
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+      avt profile CUSTOM-CP-POLICY id 254
+   !
+   vrf IT
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+   !
+   vrf PROD
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+!
+router path-selection
+   tcp mss ceiling ipv4 ingress
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+         stun server-profile INET-cv-pathfinder-pathfinder-Ethernet1 INET-cv-pathfinder-pathfinder-Ethernet3
+      !
+      peer dynamic
+      !
+      peer static router-ip 192.168.144.1
+         name cv-pathfinder-pathfinder
+         ipv4 address 10.7.7.7
+         ipv4 address 10.9.9.9
+   !
+   load-balance policy LB-CUSTOM-CP-POLICY
+      hop count lowest
+      jitter 5
+      path-group INET
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
+   !
+   load-balance policy LB-DEFAULT-POLICY-VIDEO
+      path-group INET
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance IT
+!
+vrf instance MGMT
+!
+vrf instance PROD
+!
+ip security
+   !
+   ike policy CP-IKE-POLICY
+      local-id 192.168.142.2
+   !
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
+      dpd 10 50 clear
+      mode transport
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   key controller
+      profile DP-PROFILE
+!
+interface Dps1
+   description DPS Interface
+   mtu 9214
+   flow tracker hardware FLOW-TRACKER
+   ip address 192.168.142.2/32
+!
+interface Ethernet1
+   description ATT_666_peer3_Ethernet42
+   no shutdown
+   no switchport
+   flow tracker hardware FLOW-TRACKER
+   ip address dhcp
+   dhcp client accept default-route
+!
+interface Loopback0
+   description Router_ID
+   no shutdown
+   ip address 192.168.42.2/32
+!
+interface Vxlan1
+   description cv-pathfinder-custom-control-plane-policy-edge-2_VTEP
+   vxlan source-interface Dps1
+   vxlan udp-port 4789
+   vxlan vrf default vni 1
+   vxlan vrf IT vni 14
+   vxlan vrf PROD vni 42
+!
+application traffic recognition
+   !
+   application ipv4 APP-CONTROL-PLANE
+      destination prefix field-set PFX-PATHFINDERS
+   !
+   application ipv4 CUSTOM-APPLICATION-1
+      source prefix field-set CUSTOM-SRC-PREFIX-1
+      destination prefix field-set CUSTOM-DEST-PREFIX-1
+      protocol tcp
+   !
+   application ipv4 CUSTOM-APPLICATION-2
+      protocol tcp source port field-set TCP-SRC-2 destination port field-set TCP-DEST-2
+   !
+   category VIDEO1
+      application CUSTOM-APPLICATION-2
+      application microsoft-teams
+   !
+   application-profile CUSTOM-CP-APP-PROFILE
+      application APP-CONTROL-PLANE
+   !
+   application-profile VIDEO
+      application CUSTOM-APPLICATION-1
+      application skype
+      category VIDEO1
+   !
+   field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
+      6.6.6.0/24
+   !
+   field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
+      42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-PATHFINDERS
+      192.168.144.1/32
+   !
+   field-set l4-port TCP-DEST-2
+      666, 777
+   !
+   field-set l4-port TCP-SRC-2
+      42
+!
+ip routing
+ip routing vrf IT
+no ip routing vrf MGMT
+ip routing vrf PROD
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.2:511
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.42.0/24 eq 32
+!
+route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
+   description Mark prefixes originated from the LAN
+   set extcommunity soo 192.168.42.2:511 additive
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
+   description Advertise local routes towards LAN
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
+   description Advertise routes received from WAN iBGP towards LAN
+   match route-type internal
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   set extcommunity soo 192.168.42.2:511 additive
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 192.168.42.2:511 additive
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 192.168.42.2
+   maximum-paths 16
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.144.1 peer group WAN-OVERLAY-PEERS
+   neighbor 192.168.144.1 description cv-pathfinder-pathfinder
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      no neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      path-selection
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   vrf default
+      rd 192.168.42.2:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+   !
+   vrf IT
+      rd 192.168.42.2:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
+      router-id 192.168.42.2
+      redistribute connected
+   !
+   vrf PROD
+      rd 192.168.42.2:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
+      router-id 192.168.42.2
+      redistribute connected
+!
+router traffic-engineering
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+management security
+   ssl profile profileA
+      tls versions 1.2
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
+stun
+   client
+      server-profile INET-cv-pathfinder-pathfinder-Ethernet1
+         ip address 10.7.7.7
+         ssl profile profileA
+      server-profile INET-cv-pathfinder-pathfinder-Ethernet3
+         ip address 10.9.9.9
+         ssl profile profileA
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
@@ -1,0 +1,304 @@
+!RANCID-CONTENT-TYPE: arista
+!
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
+flow tracking hardware
+   tracker FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 300000
+      exporter CV-TELEMETRY
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 3600000
+   no shutdown
+!
+service routing protocols model multi-agent
+!
+ip as-path access-list ASPATH-WAN permit 65000 any
+!
+hostname cv-pathfinder-custom-control-plane-policy-edge-3
+!
+router adaptive-virtual-topology
+   topology role edge
+   region AVD_Land_East id 43
+   zone AVD_Land_East-ZONE id 1
+   site Site511 id 511
+   !
+   policy DEFAULT-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile CUSTOM-CP-APP-PROFILE
+         avt profile CUSTOM-CP-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile CUSTOM-CP-POLICY
+      path-selection load-balance LB-CUSTOM-CP-POLICY
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-VIDEO
+      path-selection load-balance LB-DEFAULT-POLICY-VIDEO
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+      avt profile CUSTOM-CP-POLICY id 254
+   !
+   vrf IT
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+   !
+   vrf PROD
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+!
+router path-selection
+   tcp mss ceiling ipv4 ingress
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+         stun server-profile INET-cv-pathfinder-pathfinder-Ethernet1 INET-cv-pathfinder-pathfinder-Ethernet3
+      !
+      peer dynamic
+      !
+      peer static router-ip 192.168.144.1
+         name cv-pathfinder-pathfinder
+         ipv4 address 10.7.7.7
+         ipv4 address 10.9.9.9
+   !
+   load-balance policy LB-CUSTOM-CP-POLICY
+      hop count lowest
+      jitter 5
+      path-group INET
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
+   !
+   load-balance policy LB-DEFAULT-POLICY-VIDEO
+      path-group INET
+!
+spanning-tree mode none
+!
+no enable password
+no aaa root
+!
+vrf instance IT
+!
+vrf instance MGMT
+!
+vrf instance PROD
+!
+ip security
+   !
+   ike policy CP-IKE-POLICY
+      local-id 192.168.142.3
+   !
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
+      dpd 10 50 clear
+      mode transport
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   key controller
+      profile DP-PROFILE
+!
+interface Dps1
+   description DPS Interface
+   mtu 9214
+   flow tracker hardware FLOW-TRACKER
+   ip address 192.168.142.3/32
+!
+interface Ethernet1
+   description ATT_666_peer3_Ethernet42
+   no shutdown
+   no switchport
+   flow tracker hardware FLOW-TRACKER
+   ip address dhcp
+   dhcp client accept default-route
+!
+interface Loopback0
+   description Router_ID
+   no shutdown
+   ip address 192.168.42.3/32
+!
+interface Vxlan1
+   description cv-pathfinder-custom-control-plane-policy-edge-3_VTEP
+   vxlan source-interface Dps1
+   vxlan udp-port 4789
+   vxlan vrf default vni 1
+   vxlan vrf IT vni 13
+   vxlan vrf PROD vni 42
+!
+application traffic recognition
+   !
+   application-profile CUSTOM-CP-APP-PROFILE
+      application google
+   !
+   application-profile VIDEO
+      application CUSTOM-APPLICATION-1
+      application skype
+!
+ip routing
+ip routing vrf IT
+no ip routing vrf MGMT
+ip routing vrf PROD
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.3:511
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.42.0/24 eq 32
+!
+route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
+   description Mark prefixes originated from the LAN
+   set extcommunity soo 192.168.42.3:511 additive
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
+   description Advertise local routes towards LAN
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
+   description Advertise routes received from WAN iBGP towards LAN
+   match route-type internal
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   set extcommunity soo 192.168.42.3:511 additive
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN deny 10
+   match extcommunity ECL-EVPN-SOO
+!
+route-map RM-EVPN-SOO-IN permit 20
+!
+route-map RM-EVPN-SOO-OUT permit 10
+   set extcommunity soo 192.168.42.3:511 additive
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 192.168.42.3
+   maximum-paths 16
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.144.1 peer group WAN-OVERLAY-PEERS
+   neighbor 192.168.144.1 description cv-pathfinder-pathfinder
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
+      neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      no neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      path-selection
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+   !
+   vrf default
+      rd 192.168.42.3:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+   !
+   vrf IT
+      rd 192.168.42.3:1000
+      route-target import evpn 1000:1000
+      route-target export evpn 1000:1000
+      router-id 192.168.42.3
+      redistribute connected
+   !
+   vrf PROD
+      rd 192.168.42.3:142
+      route-target import evpn 142:142
+      route-target export evpn 142:142
+      router-id 192.168.42.3
+      redistribute connected
+!
+router traffic-engineering
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+management security
+   ssl profile profileA
+      tls versions 1.2
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
+stun
+   client
+      server-profile INET-cv-pathfinder-pathfinder-Ethernet1
+         ip address 10.7.7.7
+         ssl profile profileA
+      server-profile INET-cv-pathfinder-pathfinder-Ethernet3
+         ip address 10.9.9.9
+         ssl profile profileA
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
@@ -1,0 +1,332 @@
+!RANCID-CONTENT-TYPE: arista
+!
+agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
+!
+flow tracking hardware
+   tracker FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 300000
+      exporter CV-TELEMETRY
+         collector 127.0.0.1
+         local interface Loopback0
+         template interval 3600000
+   no shutdown
+!
+service routing protocols model multi-agent
+!
+hostname cv-pathfinder-custom-control-plane-policy-pathfinder-1
+!
+router adaptive-virtual-topology
+   topology role pathfinder
+   !
+   policy DEFAULT-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   policy DEFAULT-POLICY-WITH-CP
+      !
+      match application-profile APP-PROFILE-CONTROL-PLANE
+         avt profile CUSTOM-CP-POLICY
+      !
+      match application-profile VIDEO
+         avt profile DEFAULT-POLICY-VIDEO
+      !
+      match application-profile default
+         avt profile DEFAULT-POLICY-DEFAULT
+   !
+   profile CUSTOM-CP-POLICY
+      path-selection load-balance LB-CUSTOM-CP-POLICY
+   !
+   profile DEFAULT-POLICY-DEFAULT
+      path-selection load-balance LB-DEFAULT-POLICY-DEFAULT
+   !
+   profile DEFAULT-POLICY-VIDEO
+      path-selection load-balance LB-DEFAULT-POLICY-VIDEO
+   !
+   vrf default
+      avt policy DEFAULT-POLICY-WITH-CP
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+      avt profile CUSTOM-CP-POLICY id 254
+   !
+   vrf IT
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+   !
+   vrf PROD
+      avt policy DEFAULT-POLICY
+      avt profile DEFAULT-POLICY-DEFAULT id 1
+      avt profile DEFAULT-POLICY-VIDEO id 3
+!
+router path-selection
+   peer dynamic source stun
+   tcp mss ceiling ipv4 ingress
+   !
+   path-group AWS id 105
+   !
+   path-group Equinix id 103
+   !
+   path-group INET id 101
+      ipsec profile CP-PROFILE
+      !
+      local interface Ethernet1
+      !
+      local interface Ethernet3
+      !
+      peer static router-ip 192.168.144.1
+         name cv-pathfinder-pathfinder
+         ipv4 address 10.7.7.7
+         ipv4 address 10.9.9.9
+   !
+   path-group LAN_HA id 65535
+      flow assignment lan
+   !
+   path-group LTE id 102
+   !
+   path-group MPLS id 100
+      keepalive interval 300 milliseconds failure-threshold 5 intervals
+      !
+      local interface Ethernet2
+      !
+      peer static router-ip 192.168.144.1
+         name cv-pathfinder-pathfinder
+         ipv4 address 172.16.0.1
+   !
+   path-group Satellite id 104
+   !
+   load-balance policy LB-CUSTOM-CP-POLICY
+      hop count lowest
+      jitter 5
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS priority 2
+   !
+   load-balance policy LB-DEFAULT-POLICY-DEFAULT
+      path-group INET
+      path-group LAN_HA
+      path-group LTE priority 42
+   !
+   load-balance policy LB-DEFAULT-POLICY-VIDEO
+      path-group INET
+      path-group LAN_HA
+      path-group MPLS
+!
+spanning-tree mode none
+!
+platform sfe data-plane cpu allocation maximum 1
+!
+no enable password
+no aaa root
+!
+vrf instance MGMT
+!
+ip security
+   !
+   ike policy CP-IKE-POLICY
+      local-id 192.168.144.1
+   !
+   sa policy CP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
+   !
+   profile CP-PROFILE
+      ike-policy CP-IKE-POLICY
+      sa-policy CP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+!
+interface Dps1
+   description DPS Interface
+   mtu 9214
+   flow tracker hardware FLOW-TRACKER
+   ip address 192.168.144.1/32
+!
+interface Ethernet1
+   description Bouygues_Telecom_777
+   no shutdown
+   no switchport
+   flow tracker hardware FLOW-TRACKER
+   ip address 10.7.7.7/31
+!
+interface Ethernet2
+   description Colt_10000
+   no shutdown
+   no switchport
+   flow tracker hardware FLOW-TRACKER
+   ip address 172.16.0.1/31
+!
+interface Ethernet3
+   description Another-ISP_999
+   no shutdown
+   no switchport
+   flow tracker hardware FLOW-TRACKER
+   ip address 10.9.9.9/31
+!
+interface Loopback0
+   description Router_ID
+   no shutdown
+   ip address 192.168.44.1/32
+!
+interface Vxlan1
+   description cv-pathfinder-custom-control-plane-policy-pathfinder-1_VTEP
+   vxlan source-interface Dps1
+   vxlan udp-port 4789
+   vxlan vrf default vni 1
+!
+application traffic recognition
+   !
+   application ipv4 APP-CONTROL-PLANE
+      source prefix field-set PFX-LOCAL-VTEP-IP
+   !
+   application ipv4 CUSTOM-APPLICATION-1
+      source prefix field-set CUSTOM-SRC-PREFIX-1
+      destination prefix field-set CUSTOM-DEST-PREFIX-1
+      protocol tcp
+   !
+   application ipv4 CUSTOM-APPLICATION-2
+      protocol tcp source port field-set TCP-SRC-2 destination port field-set TCP-DEST-2
+   !
+   category VIDEO1
+      application CUSTOM-APPLICATION-2
+      application microsoft-teams
+   !
+   application-profile APP-PROFILE-CONTROL-PLANE
+      application APP-CONTROL-PLANE
+   !
+   application-profile VIDEO
+      application CUSTOM-APPLICATION-1
+      application skype
+      category VIDEO1
+   !
+   field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
+      6.6.6.0/24
+   !
+   field-set ipv4 prefix CUSTOM-SRC-PREFIX-1
+      42.42.42.0/24
+   !
+   field-set ipv4 prefix PFX-LOCAL-VTEP-IP
+      192.168.144.1/32
+   !
+   field-set l4-port TCP-DEST-2
+      666, 777
+   !
+   field-set l4-port TCP-SRC-2
+      42
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.44.1:0
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.44.0/24 eq 32
+!
+ip route 0.0.0.0/0 10.7.7.6
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   set extcommunity soo 192.168.44.1:0 additive
+!
+route-map RM-EVPN-EXPORT-VRF-DEFAULT permit 10
+   match extcommunity ECL-EVPN-SOO
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 192.168.44.1
+   maximum-paths 16
+   update wait-install
+   no bgp default ipv4-unicast
+   bgp cluster-id 192.168.44.1
+   bgp listen range 192.168.142.0/24 peer-group WAN-OVERLAY-PEERS remote-as 65000
+   bgp listen range 192.168.143.0/24 peer-group WAN-OVERLAY-PEERS remote-as 65000
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
+   neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-OUT out
+   neighbor WAN-OVERLAY-PEERS peer group
+   neighbor WAN-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-OVERLAY-PEERS route-reflector-client
+   neighbor WAN-OVERLAY-PEERS bfd
+   neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
+   neighbor WAN-OVERLAY-PEERS send-community
+   neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   neighbor WAN-RR-OVERLAY-PEERS peer group
+   neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
+   neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS bfd
+   neighbor WAN-RR-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
+   neighbor WAN-RR-OVERLAY-PEERS ttl maximum-hops 1
+   neighbor WAN-RR-OVERLAY-PEERS send-community
+   neighbor WAN-RR-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.144.1 peer group WAN-RR-OVERLAY-PEERS
+   neighbor 192.168.144.1 description cv-pathfinder-pathfinder
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
+      next-hop resolution disabled
+   !
+   address-family ipv4
+      neighbor IPv4-UNDERLAY-PEERS activate
+      no neighbor WAN-OVERLAY-PEERS activate
+      no neighbor WAN-RR-OVERLAY-PEERS activate
+   !
+   address-family ipv4 sr-te
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
+   !
+   address-family link-state
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-OVERLAY-PEERS missing-policy direction out action deny
+      neighbor WAN-RR-OVERLAY-PEERS activate
+      path-selection role consumer propagator
+   !
+   address-family path-selection
+      bgp additional-paths receive
+      bgp additional-paths send any
+      neighbor WAN-OVERLAY-PEERS activate
+      neighbor WAN-RR-OVERLAY-PEERS activate
+   !
+   vrf default
+      rd 192.168.44.1:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      route-target export evpn route-map RM-EVPN-EXPORT-VRF-DEFAULT
+!
+router traffic-engineering
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+management security
+   ssl profile profileA
+      tls versions 1.2
+      trust certificate aristaDeviceCertProvisionerDefaultRootCA.crt
+      certificate profileA.crt key profileA.key
+!
+stun
+   server
+      local-interface Ethernet1
+      local-interface Ethernet2
+      local-interface Ethernet3
+      ssl profile profileA
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
@@ -1,0 +1,485 @@
+hostname: cv-pathfinder-custom-control-plane-policy-edge-1
+is_deployed: true
+router_bgp:
+  as: '65000'
+  router_id: 192.168.42.1
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 16
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-BGP-UNDERLAY-PEERS-IN
+    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
+  - name: WAN-OVERLAY-PEERS
+    type: wan
+    update_source: Dps1
+    bfd: true
+    password: htm4AZe9mIQOO1uiMuGgYQ==
+    send_community: all
+    maximum_routes: 0
+    remote_as: '65000'
+    ttl_maximum_hops: 1
+    bfd_timers:
+      interval: 1000
+      min_rx: 1000
+      multiplier: 10
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: WAN-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+      route_map_in: RM-EVPN-SOO-IN
+      route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    path_selection:
+      roles:
+        producer: true
+  address_family_path_selection:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    bgp:
+      additional_paths:
+        receive: true
+        send:
+          any: true
+  neighbors:
+  - ip_address: 192.168.144.1
+    peer_group: WAN-OVERLAY-PEERS
+    peer: cv-pathfinder-pathfinder
+    description: cv-pathfinder-pathfinder
+  vrfs:
+  - name: default
+    rd: 192.168.42.1:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+  - name: IT
+    router_id: 192.168.42.1
+    rd: 192.168.42.1:1000
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 1000:1000
+      export:
+      - address_family: evpn
+        route_targets:
+        - 1000:1000
+    redistribute_routes:
+    - source_protocol: connected
+  - name: PROD
+    router_id: 192.168.42.1
+    rd: 192.168.42.1:142
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 142:142
+      export:
+      - address_family: evpn
+        route_targets:
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+service_routing_protocols_model: multi-agent
+ip_routing: true
+transceiver_qsfp_default_mode_4x10: false
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+- name: IT
+  tenant: TenantA
+  ip_routing: true
+- name: PROD
+  tenant: TenantA
+  ip_routing: true
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ethernet_interfaces:
+- name: Ethernet1
+  peer_type: l3_interface
+  peer: peer3
+  peer_interface: Ethernet42
+  ip_address: dhcp
+  shutdown: false
+  type: routed
+  description: ATT_666_peer3_Ethernet42
+  dhcp_client_accept_default_route: true
+  flow_tracker:
+    hardware: FLOW-TRACKER
+loopback_interfaces:
+- name: Loopback0
+  description: Router_ID
+  shutdown: false
+  ip_address: 192.168.42.1/32
+as_path:
+  access_lists:
+  - name: ASPATH-WAN
+    entries:
+    - type: permit
+      match: '65000'
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.42.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    set:
+    - extcommunity soo 192.168.42.1:511 additive
+- name: RM-BGP-UNDERLAY-PEERS-IN
+  sequence_numbers:
+  - sequence: 40
+    type: permit
+    description: Mark prefixes originated from the LAN
+    set:
+    - extcommunity soo 192.168.42.1:511 additive
+- name: RM-BGP-UNDERLAY-PEERS-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    description: Advertise local routes towards LAN
+    match:
+    - extcommunity ECL-EVPN-SOO
+  - sequence: 20
+    type: permit
+    description: Advertise routes received from WAN iBGP towards LAN
+    match:
+    - route-type internal
+- name: RM-EVPN-SOO-IN
+  sequence_numbers:
+  - sequence: 10
+    type: deny
+    match:
+    - extcommunity ECL-EVPN-SOO
+  - sequence: 20
+    type: permit
+- name: RM-EVPN-SOO-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - extcommunity soo 192.168.42.1:511 additive
+- name: RM-EVPN-EXPORT-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
+flow_tracking:
+  hardware:
+    trackers:
+    - name: FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 300000
+      exporters:
+      - name: CV-TELEMETRY
+        collector:
+          host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 3600000
+    shutdown: false
+ip_extcommunity_lists:
+- name: ECL-EVPN-SOO
+  entries:
+  - type: permit
+    extcommunities: soo 192.168.42.1:511
+ip_security:
+  ike_policies:
+  - name: CP-IKE-POLICY
+    local_id: 192.168.142.1
+  sa_policies:
+  - name: DP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  profiles:
+  - name: DP-PROFILE
+    sa_policy: DP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890666
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  - name: CP-PROFILE
+    ike_policy: CP-IKE-POLICY
+    sa_policy: CP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  key_controller:
+    profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
+router_adaptive_virtual_topology:
+  topology_role: edge
+  region:
+    name: AVD_Land_East
+    id: 43
+  zone:
+    name: AVD_Land_East-ZONE
+    id: 1
+  site:
+    name: Site511
+    id: 511
+  profiles:
+  - name: CUSTOM-CP-POLICY
+    load_balance_policy: LB-CUSTOM-CP-POLICY
+  - name: DEFAULT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-POLICY-VIDEO
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: CUSTOM-CP-POLICY
+      id: 254
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: PROD
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: IT
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  policies:
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: CUSTOM-CP-POLICY
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY
+    matches:
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_path_selection:
+  tcp_mss_ceiling:
+    ipv4_segment_size: auto
+  path_groups:
+  - name: INET
+    id: 101
+    local_interfaces:
+    - name: Ethernet1
+      stun:
+        server_profiles:
+        - INET-cv-pathfinder-pathfinder-Ethernet1
+        - INET-cv-pathfinder-pathfinder-Ethernet3
+    dynamic_peers:
+      enabled: true
+    static_peers:
+    - router_ip: 192.168.144.1
+      name: cv-pathfinder-pathfinder
+      ipv4_addresses:
+      - 10.7.7.7
+      - 10.9.9.9
+    ipsec_profile: CP-PROFILE
+  load_balance_policies:
+  - name: LB-CUSTOM-CP-POLICY
+    path_groups:
+    - name: INET
+    jitter: 5
+    lowest_hop_count: true
+  - name: LB-DEFAULT-POLICY-VIDEO
+    path_groups:
+    - name: INET
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
+router_traffic_engineering:
+  enabled: true
+stun:
+  client:
+    server_profiles:
+    - name: INET-cv-pathfinder-pathfinder-Ethernet1
+      ip_address: 10.7.7.7
+      ssl_profile: profileA
+    - name: INET-cv-pathfinder-pathfinder-Ethernet3
+      ip_address: 10.9.9.9
+      ssl_profile: profileA
+application_traffic_recognition:
+  application_profiles:
+  - name: VIDEO
+    categories:
+    - name: VIDEO1
+    applications:
+    - name: CUSTOM-APPLICATION-1
+    - name: skype
+  - name: APP-PROFILE-CONTROL-PLANE
+    applications:
+    - name: APP-CONTROL-PLANE
+  categories:
+  - name: VIDEO1
+    applications:
+    - name: CUSTOM-APPLICATION-2
+    - name: microsoft-teams
+  applications:
+    ipv4_applications:
+    - name: CUSTOM-APPLICATION-1
+      protocols:
+      - tcp
+      src_prefix_set_name: CUSTOM-SRC-PREFIX-1
+      dest_prefix_set_name: CUSTOM-DEST-PREFIX-1
+    - name: CUSTOM-APPLICATION-2
+      protocols:
+      - tcp
+      tcp_src_port_set_name: TCP-SRC-2
+      tcp_dest_port_set_name: TCP-DEST-2
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
+  field_sets:
+    l4_ports:
+    - name: TCP-SRC-2
+      port_values:
+      - '42'
+    - name: TCP-DEST-2
+      port_values:
+      - '666'
+      - '777'
+    ipv4_prefixes:
+    - name: CUSTOM-SRC-PREFIX-1
+      prefix_values:
+      - 42.42.42.0/24
+    - name: CUSTOM-DEST-PREFIX-1
+      prefix_values:
+      - 6.6.6.0/24
+    - name: PFX-PATHFINDERS
+      prefix_values:
+      - 192.168.144.1/32
+dps_interfaces:
+- name: Dps1
+  description: DPS Interface
+  mtu: 9214
+  ip_address: 192.168.142.1/32
+  flow_tracker:
+    hardware: FLOW-TRACKER
+vxlan_interface:
+  Vxlan1:
+    description: cv-pathfinder-custom-control-plane-policy-edge-1_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Dps1
+      vrfs:
+      - name: default
+        vni: 1
+      - name: IT
+        vni: 14
+      - name: PROD
+        vni: 42
+metadata:
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: edge
+    - name: Region
+      value: AVD_Land_East
+    - name: Zone
+      value: AVD_Land_East-ZONE
+    - name: Site
+      value: Site511
+    interface_tags:
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: ATT
+      - name: Circuit
+        value: '666'
+  cv_pathfinder:
+    role: edge
+    ssl_profile: profileA
+    vtep_ip: 192.168.142.1
+    region: AVD_Land_East
+    zone: AVD_Land_East-ZONE
+    site: Site511
+    interfaces:
+    - name: Ethernet1
+      carrier: ATT
+      circuit_id: '666'
+      pathgroup: INET
+    pathfinders:
+    - vtep_ip: 192.168.144.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
@@ -1,0 +1,485 @@
+hostname: cv-pathfinder-custom-control-plane-policy-edge-2
+is_deployed: true
+router_bgp:
+  as: '65000'
+  router_id: 192.168.42.2
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 16
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-BGP-UNDERLAY-PEERS-IN
+    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
+  - name: WAN-OVERLAY-PEERS
+    type: wan
+    update_source: Dps1
+    bfd: true
+    password: htm4AZe9mIQOO1uiMuGgYQ==
+    send_community: all
+    maximum_routes: 0
+    remote_as: '65000'
+    ttl_maximum_hops: 1
+    bfd_timers:
+      interval: 1000
+      min_rx: 1000
+      multiplier: 10
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: WAN-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+      route_map_in: RM-EVPN-SOO-IN
+      route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    path_selection:
+      roles:
+        producer: true
+  address_family_path_selection:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    bgp:
+      additional_paths:
+        receive: true
+        send:
+          any: true
+  neighbors:
+  - ip_address: 192.168.144.1
+    peer_group: WAN-OVERLAY-PEERS
+    peer: cv-pathfinder-pathfinder
+    description: cv-pathfinder-pathfinder
+  vrfs:
+  - name: default
+    rd: 192.168.42.2:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+  - name: IT
+    router_id: 192.168.42.2
+    rd: 192.168.42.2:1000
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 1000:1000
+      export:
+      - address_family: evpn
+        route_targets:
+        - 1000:1000
+    redistribute_routes:
+    - source_protocol: connected
+  - name: PROD
+    router_id: 192.168.42.2
+    rd: 192.168.42.2:142
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 142:142
+      export:
+      - address_family: evpn
+        route_targets:
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+service_routing_protocols_model: multi-agent
+ip_routing: true
+transceiver_qsfp_default_mode_4x10: false
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+- name: IT
+  tenant: TenantA
+  ip_routing: true
+- name: PROD
+  tenant: TenantA
+  ip_routing: true
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ethernet_interfaces:
+- name: Ethernet1
+  peer_type: l3_interface
+  peer: peer3
+  peer_interface: Ethernet42
+  ip_address: dhcp
+  shutdown: false
+  type: routed
+  description: ATT_666_peer3_Ethernet42
+  dhcp_client_accept_default_route: true
+  flow_tracker:
+    hardware: FLOW-TRACKER
+loopback_interfaces:
+- name: Loopback0
+  description: Router_ID
+  shutdown: false
+  ip_address: 192.168.42.2/32
+as_path:
+  access_lists:
+  - name: ASPATH-WAN
+    entries:
+    - type: permit
+      match: '65000'
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.42.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    set:
+    - extcommunity soo 192.168.42.2:511 additive
+- name: RM-BGP-UNDERLAY-PEERS-IN
+  sequence_numbers:
+  - sequence: 40
+    type: permit
+    description: Mark prefixes originated from the LAN
+    set:
+    - extcommunity soo 192.168.42.2:511 additive
+- name: RM-BGP-UNDERLAY-PEERS-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    description: Advertise local routes towards LAN
+    match:
+    - extcommunity ECL-EVPN-SOO
+  - sequence: 20
+    type: permit
+    description: Advertise routes received from WAN iBGP towards LAN
+    match:
+    - route-type internal
+- name: RM-EVPN-SOO-IN
+  sequence_numbers:
+  - sequence: 10
+    type: deny
+    match:
+    - extcommunity ECL-EVPN-SOO
+  - sequence: 20
+    type: permit
+- name: RM-EVPN-SOO-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - extcommunity soo 192.168.42.2:511 additive
+- name: RM-EVPN-EXPORT-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
+flow_tracking:
+  hardware:
+    trackers:
+    - name: FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 300000
+      exporters:
+      - name: CV-TELEMETRY
+        collector:
+          host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 3600000
+    shutdown: false
+ip_extcommunity_lists:
+- name: ECL-EVPN-SOO
+  entries:
+  - type: permit
+    extcommunities: soo 192.168.42.2:511
+ip_security:
+  ike_policies:
+  - name: CP-IKE-POLICY
+    local_id: 192.168.142.2
+  sa_policies:
+  - name: DP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  profiles:
+  - name: DP-PROFILE
+    sa_policy: DP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890666
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  - name: CP-PROFILE
+    ike_policy: CP-IKE-POLICY
+    sa_policy: CP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  key_controller:
+    profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
+router_adaptive_virtual_topology:
+  topology_role: edge
+  region:
+    name: AVD_Land_East
+    id: 43
+  zone:
+    name: AVD_Land_East-ZONE
+    id: 1
+  site:
+    name: Site511
+    id: 511
+  profiles:
+  - name: CUSTOM-CP-POLICY
+    load_balance_policy: LB-CUSTOM-CP-POLICY
+  - name: DEFAULT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-POLICY-VIDEO
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: CUSTOM-CP-POLICY
+      id: 254
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: PROD
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: IT
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  policies:
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: CUSTOM-CP-APP-PROFILE
+      avt_profile: CUSTOM-CP-POLICY
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY
+    matches:
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_path_selection:
+  tcp_mss_ceiling:
+    ipv4_segment_size: auto
+  path_groups:
+  - name: INET
+    id: 101
+    local_interfaces:
+    - name: Ethernet1
+      stun:
+        server_profiles:
+        - INET-cv-pathfinder-pathfinder-Ethernet1
+        - INET-cv-pathfinder-pathfinder-Ethernet3
+    dynamic_peers:
+      enabled: true
+    static_peers:
+    - router_ip: 192.168.144.1
+      name: cv-pathfinder-pathfinder
+      ipv4_addresses:
+      - 10.7.7.7
+      - 10.9.9.9
+    ipsec_profile: CP-PROFILE
+  load_balance_policies:
+  - name: LB-CUSTOM-CP-POLICY
+    path_groups:
+    - name: INET
+    jitter: 5
+    lowest_hop_count: true
+  - name: LB-DEFAULT-POLICY-VIDEO
+    path_groups:
+    - name: INET
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
+router_traffic_engineering:
+  enabled: true
+stun:
+  client:
+    server_profiles:
+    - name: INET-cv-pathfinder-pathfinder-Ethernet1
+      ip_address: 10.7.7.7
+      ssl_profile: profileA
+    - name: INET-cv-pathfinder-pathfinder-Ethernet3
+      ip_address: 10.9.9.9
+      ssl_profile: profileA
+application_traffic_recognition:
+  application_profiles:
+  - name: VIDEO
+    categories:
+    - name: VIDEO1
+    applications:
+    - name: CUSTOM-APPLICATION-1
+    - name: skype
+  - name: CUSTOM-CP-APP-PROFILE
+    applications:
+    - name: APP-CONTROL-PLANE
+  categories:
+  - name: VIDEO1
+    applications:
+    - name: CUSTOM-APPLICATION-2
+    - name: microsoft-teams
+  applications:
+    ipv4_applications:
+    - name: CUSTOM-APPLICATION-1
+      protocols:
+      - tcp
+      src_prefix_set_name: CUSTOM-SRC-PREFIX-1
+      dest_prefix_set_name: CUSTOM-DEST-PREFIX-1
+    - name: CUSTOM-APPLICATION-2
+      protocols:
+      - tcp
+      tcp_src_port_set_name: TCP-SRC-2
+      tcp_dest_port_set_name: TCP-DEST-2
+    - name: APP-CONTROL-PLANE
+      dest_prefix_set_name: PFX-PATHFINDERS
+  field_sets:
+    l4_ports:
+    - name: TCP-SRC-2
+      port_values:
+      - '42'
+    - name: TCP-DEST-2
+      port_values:
+      - '666'
+      - '777'
+    ipv4_prefixes:
+    - name: CUSTOM-SRC-PREFIX-1
+      prefix_values:
+      - 42.42.42.0/24
+    - name: CUSTOM-DEST-PREFIX-1
+      prefix_values:
+      - 6.6.6.0/24
+    - name: PFX-PATHFINDERS
+      prefix_values:
+      - 192.168.144.1/32
+dps_interfaces:
+- name: Dps1
+  description: DPS Interface
+  mtu: 9214
+  ip_address: 192.168.142.2/32
+  flow_tracker:
+    hardware: FLOW-TRACKER
+vxlan_interface:
+  Vxlan1:
+    description: cv-pathfinder-custom-control-plane-policy-edge-2_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Dps1
+      vrfs:
+      - name: default
+        vni: 1
+      - name: IT
+        vni: 14
+      - name: PROD
+        vni: 42
+metadata:
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: edge
+    - name: Region
+      value: AVD_Land_East
+    - name: Zone
+      value: AVD_Land_East-ZONE
+    - name: Site
+      value: Site511
+    interface_tags:
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: ATT
+      - name: Circuit
+        value: '666'
+  cv_pathfinder:
+    role: edge
+    ssl_profile: profileA
+    vtep_ip: 192.168.142.2
+    region: AVD_Land_East
+    zone: AVD_Land_East-ZONE
+    site: Site511
+    interfaces:
+    - name: Ethernet1
+      carrier: ATT
+      circuit_id: '666'
+      pathgroup: INET
+    pathfinders:
+    - vtep_ip: 192.168.144.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
@@ -1,0 +1,445 @@
+hostname: cv-pathfinder-custom-control-plane-policy-edge-3
+is_deployed: true
+router_bgp:
+  as: '65000'
+  router_id: 192.168.42.3
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 16
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-BGP-UNDERLAY-PEERS-IN
+    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
+  - name: WAN-OVERLAY-PEERS
+    type: wan
+    update_source: Dps1
+    bfd: true
+    password: htm4AZe9mIQOO1uiMuGgYQ==
+    send_community: all
+    maximum_routes: 0
+    remote_as: '65000'
+    ttl_maximum_hops: 1
+    bfd_timers:
+      interval: 1000
+      min_rx: 1000
+      multiplier: 10
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: WAN-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  address_family_evpn:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+      route_map_in: RM-EVPN-SOO-IN
+      route_map_out: RM-EVPN-SOO-OUT
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    path_selection:
+      roles:
+        producer: true
+  address_family_path_selection:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    bgp:
+      additional_paths:
+        receive: true
+        send:
+          any: true
+  neighbors:
+  - ip_address: 192.168.144.1
+    peer_group: WAN-OVERLAY-PEERS
+    peer: cv-pathfinder-pathfinder
+    description: cv-pathfinder-pathfinder
+  vrfs:
+  - name: default
+    rd: 192.168.42.3:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+  - name: IT
+    router_id: 192.168.42.3
+    rd: 192.168.42.3:1000
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 1000:1000
+      export:
+      - address_family: evpn
+        route_targets:
+        - 1000:1000
+    redistribute_routes:
+    - source_protocol: connected
+  - name: PROD
+    router_id: 192.168.42.3
+    rd: 192.168.42.3:142
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 142:142
+      export:
+      - address_family: evpn
+        route_targets:
+        - 142:142
+    redistribute_routes:
+    - source_protocol: connected
+service_routing_protocols_model: multi-agent
+ip_routing: true
+transceiver_qsfp_default_mode_4x10: false
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+- name: IT
+  tenant: TenantA
+  ip_routing: true
+- name: PROD
+  tenant: TenantA
+  ip_routing: true
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ethernet_interfaces:
+- name: Ethernet1
+  peer_type: l3_interface
+  peer: peer3
+  peer_interface: Ethernet42
+  ip_address: dhcp
+  shutdown: false
+  type: routed
+  description: ATT_666_peer3_Ethernet42
+  dhcp_client_accept_default_route: true
+  flow_tracker:
+    hardware: FLOW-TRACKER
+loopback_interfaces:
+- name: Loopback0
+  description: Router_ID
+  shutdown: false
+  ip_address: 192.168.42.3/32
+as_path:
+  access_lists:
+  - name: ASPATH-WAN
+    entries:
+    - type: permit
+      match: '65000'
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.42.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    set:
+    - extcommunity soo 192.168.42.3:511 additive
+- name: RM-BGP-UNDERLAY-PEERS-IN
+  sequence_numbers:
+  - sequence: 40
+    type: permit
+    description: Mark prefixes originated from the LAN
+    set:
+    - extcommunity soo 192.168.42.3:511 additive
+- name: RM-BGP-UNDERLAY-PEERS-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    description: Advertise local routes towards LAN
+    match:
+    - extcommunity ECL-EVPN-SOO
+  - sequence: 20
+    type: permit
+    description: Advertise routes received from WAN iBGP towards LAN
+    match:
+    - route-type internal
+- name: RM-EVPN-SOO-IN
+  sequence_numbers:
+  - sequence: 10
+    type: deny
+    match:
+    - extcommunity ECL-EVPN-SOO
+  - sequence: 20
+    type: permit
+- name: RM-EVPN-SOO-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    set:
+    - extcommunity soo 192.168.42.3:511 additive
+- name: RM-EVPN-EXPORT-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - extcommunity ECL-EVPN-SOO
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
+flow_tracking:
+  hardware:
+    trackers:
+    - name: FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 300000
+      exporters:
+      - name: CV-TELEMETRY
+        collector:
+          host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 3600000
+    shutdown: false
+ip_extcommunity_lists:
+- name: ECL-EVPN-SOO
+  entries:
+  - type: permit
+    extcommunities: soo 192.168.42.3:511
+ip_security:
+  ike_policies:
+  - name: CP-IKE-POLICY
+    local_id: 192.168.142.3
+  sa_policies:
+  - name: DP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  profiles:
+  - name: DP-PROFILE
+    sa_policy: DP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890666
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  - name: CP-PROFILE
+    ike_policy: CP-IKE-POLICY
+    sa_policy: CP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+  key_controller:
+    profile: DP-PROFILE
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
+router_adaptive_virtual_topology:
+  topology_role: edge
+  region:
+    name: AVD_Land_East
+    id: 43
+  zone:
+    name: AVD_Land_East-ZONE
+    id: 1
+  site:
+    name: Site511
+    id: 511
+  profiles:
+  - name: CUSTOM-CP-POLICY
+    load_balance_policy: LB-CUSTOM-CP-POLICY
+  - name: DEFAULT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-POLICY-VIDEO
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: CUSTOM-CP-POLICY
+      id: 254
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: PROD
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: IT
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  policies:
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: CUSTOM-CP-APP-PROFILE
+      avt_profile: CUSTOM-CP-POLICY
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY
+    matches:
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_path_selection:
+  tcp_mss_ceiling:
+    ipv4_segment_size: auto
+  path_groups:
+  - name: INET
+    id: 101
+    local_interfaces:
+    - name: Ethernet1
+      stun:
+        server_profiles:
+        - INET-cv-pathfinder-pathfinder-Ethernet1
+        - INET-cv-pathfinder-pathfinder-Ethernet3
+    dynamic_peers:
+      enabled: true
+    static_peers:
+    - router_ip: 192.168.144.1
+      name: cv-pathfinder-pathfinder
+      ipv4_addresses:
+      - 10.7.7.7
+      - 10.9.9.9
+    ipsec_profile: CP-PROFILE
+  load_balance_policies:
+  - name: LB-CUSTOM-CP-POLICY
+    path_groups:
+    - name: INET
+    jitter: 5
+    lowest_hop_count: true
+  - name: LB-DEFAULT-POLICY-VIDEO
+    path_groups:
+    - name: INET
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
+router_traffic_engineering:
+  enabled: true
+stun:
+  client:
+    server_profiles:
+    - name: INET-cv-pathfinder-pathfinder-Ethernet1
+      ip_address: 10.7.7.7
+      ssl_profile: profileA
+    - name: INET-cv-pathfinder-pathfinder-Ethernet3
+      ip_address: 10.9.9.9
+      ssl_profile: profileA
+application_traffic_recognition:
+  application_profiles:
+  - name: CUSTOM-CP-APP-PROFILE
+    applications:
+    - name: google
+  - name: VIDEO
+    applications:
+    - name: CUSTOM-APPLICATION-1
+    - name: skype
+dps_interfaces:
+- name: Dps1
+  description: DPS Interface
+  mtu: 9214
+  ip_address: 192.168.142.3/32
+  flow_tracker:
+    hardware: FLOW-TRACKER
+vxlan_interface:
+  Vxlan1:
+    description: cv-pathfinder-custom-control-plane-policy-edge-3_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Dps1
+      vrfs:
+      - name: default
+        vni: 1
+      - name: IT
+        vni: 13
+      - name: PROD
+        vni: 42
+metadata:
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: edge
+    - name: Region
+      value: AVD_Land_East
+    - name: Zone
+      value: AVD_Land_East-ZONE
+    - name: Site
+      value: Site511
+    interface_tags:
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: ATT
+      - name: Circuit
+        value: '666'
+  cv_pathfinder:
+    role: edge
+    ssl_profile: profileA
+    vtep_ip: 192.168.142.3
+    region: AVD_Land_East
+    zone: AVD_Land_East-ZONE
+    site: Site511
+    interfaces:
+    - name: Ethernet1
+      carrier: ATT
+      circuit_id: '666'
+      pathgroup: INET
+    pathfinders:
+    - vtep_ip: 192.168.144.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
@@ -1,0 +1,601 @@
+hostname: cv-pathfinder-custom-control-plane-policy-pathfinder-1
+is_deployed: true
+router_bgp:
+  as: '65000'
+  router_id: 192.168.44.1
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 16
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+    route_map_in: RM-BGP-UNDERLAY-PEERS-IN
+    route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
+  - name: WAN-OVERLAY-PEERS
+    type: wan
+    update_source: Dps1
+    bfd: true
+    password: htm4AZe9mIQOO1uiMuGgYQ==
+    send_community: all
+    maximum_routes: 0
+    remote_as: '65000'
+    ttl_maximum_hops: 1
+    route_reflector_client: true
+    bfd_timers:
+      interval: 1000
+      min_rx: 1000
+      multiplier: 10
+  - name: WAN-RR-OVERLAY-PEERS
+    type: wan
+    update_source: Dps1
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    remote_as: '65000'
+    ttl_maximum_hops: 1
+    bfd_timers:
+      interval: 1000
+      min_rx: 1000
+      multiplier: 10
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: WAN-OVERLAY-PEERS
+      activate: false
+    - name: WAN-RR-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  bgp_cluster_id: 192.168.44.1
+  listen_ranges:
+  - prefix: 192.168.142.0/24
+    peer_group: WAN-OVERLAY-PEERS
+    remote_as: '65000'
+  - prefix: 192.168.143.0/24
+    peer_group: WAN-OVERLAY-PEERS
+    remote_as: '65000'
+  address_family_evpn:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    - name: WAN-RR-OVERLAY-PEERS
+      activate: true
+    next_hop:
+      resolution_disabled: true
+  address_family_ipv4_sr_te:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    - name: WAN-RR-OVERLAY-PEERS
+      activate: true
+  address_family_link_state:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+      missing_policy:
+        direction_out_action: deny
+    - name: WAN-RR-OVERLAY-PEERS
+      activate: true
+    path_selection:
+      roles:
+        consumer: true
+        propagator: true
+  address_family_path_selection:
+    peer_groups:
+    - name: WAN-OVERLAY-PEERS
+      activate: true
+    - name: WAN-RR-OVERLAY-PEERS
+      activate: true
+    bgp:
+      additional_paths:
+        receive: true
+        send:
+          any: true
+  neighbors:
+  - ip_address: 192.168.144.1
+    peer_group: WAN-RR-OVERLAY-PEERS
+    peer: cv-pathfinder-pathfinder
+    description: cv-pathfinder-pathfinder
+  vrfs:
+  - name: default
+    rd: 192.168.44.1:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
+service_routing_protocols_model: multi-agent
+ip_routing: true
+transceiver_qsfp_default_mode_4x10: false
+spanning_tree:
+  mode: none
+vrfs:
+- name: MGMT
+  ip_routing: false
+platform:
+  sfe:
+    data_plane_cpu_allocation_max: 1
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ethernet_interfaces:
+- name: Ethernet1
+  peer_type: l3_interface
+  ip_address: 10.7.7.7/31
+  shutdown: false
+  type: routed
+  description: Bouygues_Telecom_777
+  flow_tracker:
+    hardware: FLOW-TRACKER
+- name: Ethernet2
+  peer_type: l3_interface
+  ip_address: 172.16.0.1/31
+  shutdown: false
+  type: routed
+  description: Colt_10000
+  flow_tracker:
+    hardware: FLOW-TRACKER
+- name: Ethernet3
+  peer_type: l3_interface
+  ip_address: 10.9.9.9/31
+  shutdown: false
+  type: routed
+  description: Another-ISP_999
+  flow_tracker:
+    hardware: FLOW-TRACKER
+loopback_interfaces:
+- name: Loopback0
+  description: Router_ID
+  shutdown: false
+  ip_address: 192.168.44.1/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.44.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+    set:
+    - extcommunity soo 192.168.44.1:0 additive
+- name: RM-EVPN-EXPORT-VRF-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - extcommunity ECL-EVPN-SOO
+static_routes:
+- destination_address_prefix: 0.0.0.0/0
+  gateway: 10.7.7.6
+agents:
+- name: KernelFib
+  environment_variables:
+  - name: KERNELFIB_PROGRAM_ALL_ECMP
+    value: '1'
+flow_tracking:
+  hardware:
+    trackers:
+    - name: FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 300000
+      exporters:
+      - name: CV-TELEMETRY
+        collector:
+          host: 127.0.0.1
+        local_interface: Loopback0
+        template_interval: 3600000
+    shutdown: false
+ip_extcommunity_lists:
+- name: ECL-EVPN-SOO
+  entries:
+  - type: permit
+    extcommunities: soo 192.168.44.1:0
+ip_security:
+  ike_policies:
+  - name: CP-IKE-POLICY
+    local_id: 192.168.144.1
+  sa_policies:
+  - name: CP-SA-POLICY
+    esp:
+      encryption: aes256gcm128
+    pfs_dh_group: 14
+  profiles:
+  - name: CP-PROFILE
+    ike_policy: CP-IKE-POLICY
+    sa_policy: CP-SA-POLICY
+    connection: start
+    shared_key: ABCDEF1234567890
+    dpd:
+      interval: 10
+      time: 50
+      action: clear
+    mode: transport
+management_security:
+  ssl_profiles:
+  - name: profileA
+    certificate:
+      file: profileA.crt
+      key: profileA.key
+    trust_certificate:
+      certificates:
+      - aristaDeviceCertProvisionerDefaultRootCA.crt
+    tls_versions: '1.2'
+router_adaptive_virtual_topology:
+  topology_role: pathfinder
+  profiles:
+  - name: CUSTOM-CP-POLICY
+    load_balance_policy: LB-CUSTOM-CP-POLICY
+  - name: DEFAULT-POLICY-VIDEO
+    load_balance_policy: LB-DEFAULT-POLICY-VIDEO
+  - name: DEFAULT-POLICY-DEFAULT
+    load_balance_policy: LB-DEFAULT-POLICY-DEFAULT
+  vrfs:
+  - name: default
+    policy: DEFAULT-POLICY-WITH-CP
+    profiles:
+    - name: CUSTOM-CP-POLICY
+      id: 254
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: PROD
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  - name: IT
+    policy: DEFAULT-POLICY
+    profiles:
+    - name: DEFAULT-POLICY-VIDEO
+      id: 3
+    - name: DEFAULT-POLICY-DEFAULT
+      id: 1
+  policies:
+  - name: DEFAULT-POLICY-WITH-CP
+    matches:
+    - application_profile: APP-PROFILE-CONTROL-PLANE
+      avt_profile: CUSTOM-CP-POLICY
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+  - name: DEFAULT-POLICY
+    matches:
+    - application_profile: VIDEO
+      avt_profile: DEFAULT-POLICY-VIDEO
+    - application_profile: default
+      avt_profile: DEFAULT-POLICY-DEFAULT
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_path_selection:
+  tcp_mss_ceiling:
+    ipv4_segment_size: auto
+  path_groups:
+  - name: MPLS
+    id: 100
+    local_interfaces:
+    - name: Ethernet2
+    static_peers:
+    - router_ip: 192.168.144.1
+      name: cv-pathfinder-pathfinder
+      ipv4_addresses:
+      - 172.16.0.1
+    keepalive:
+      interval: 300
+      failure_threshold: 5
+  - name: INET
+    id: 101
+    local_interfaces:
+    - name: Ethernet1
+    - name: Ethernet3
+    static_peers:
+    - router_ip: 192.168.144.1
+      name: cv-pathfinder-pathfinder
+      ipv4_addresses:
+      - 10.7.7.7
+      - 10.9.9.9
+    ipsec_profile: CP-PROFILE
+  - name: LTE
+    id: 102
+  - name: Equinix
+    id: 103
+  - name: Satellite
+    id: 104
+  - name: AWS
+    id: 105
+  - name: LAN_HA
+    id: 65535
+    flow_assignment: lan
+  peer_dynamic_source: stun
+  load_balance_policies:
+  - name: LB-CUSTOM-CP-POLICY
+    path_groups:
+    - name: INET
+    - name: MPLS
+      priority: 2
+    - name: LAN_HA
+    jitter: 5
+    lowest_hop_count: true
+  - name: LB-DEFAULT-POLICY-VIDEO
+    path_groups:
+    - name: MPLS
+    - name: INET
+    - name: LAN_HA
+  - name: LB-DEFAULT-POLICY-DEFAULT
+    path_groups:
+    - name: INET
+    - name: LTE
+      priority: 42
+    - name: LAN_HA
+router_traffic_engineering:
+  enabled: true
+stun:
+  server:
+    local_interfaces:
+    - Ethernet1
+    - Ethernet2
+    - Ethernet3
+    ssl_profile: profileA
+application_traffic_recognition:
+  application_profiles:
+  - name: VIDEO
+    categories:
+    - name: VIDEO1
+    applications:
+    - name: CUSTOM-APPLICATION-1
+    - name: skype
+  - name: APP-PROFILE-CONTROL-PLANE
+    applications:
+    - name: APP-CONTROL-PLANE
+  categories:
+  - name: VIDEO1
+    applications:
+    - name: CUSTOM-APPLICATION-2
+    - name: microsoft-teams
+  applications:
+    ipv4_applications:
+    - name: CUSTOM-APPLICATION-1
+      protocols:
+      - tcp
+      src_prefix_set_name: CUSTOM-SRC-PREFIX-1
+      dest_prefix_set_name: CUSTOM-DEST-PREFIX-1
+    - name: CUSTOM-APPLICATION-2
+      protocols:
+      - tcp
+      tcp_src_port_set_name: TCP-SRC-2
+      tcp_dest_port_set_name: TCP-DEST-2
+    - name: APP-CONTROL-PLANE
+      src_prefix_set_name: PFX-LOCAL-VTEP-IP
+  field_sets:
+    l4_ports:
+    - name: TCP-SRC-2
+      port_values:
+      - '42'
+    - name: TCP-DEST-2
+      port_values:
+      - '666'
+      - '777'
+    ipv4_prefixes:
+    - name: CUSTOM-SRC-PREFIX-1
+      prefix_values:
+      - 42.42.42.0/24
+    - name: CUSTOM-DEST-PREFIX-1
+      prefix_values:
+      - 6.6.6.0/24
+    - name: PFX-LOCAL-VTEP-IP
+      prefix_values:
+      - 192.168.144.1/32
+dps_interfaces:
+- name: Dps1
+  description: DPS Interface
+  mtu: 9214
+  ip_address: 192.168.144.1/32
+  flow_tracker:
+    hardware: FLOW-TRACKER
+vxlan_interface:
+  Vxlan1:
+    description: cv-pathfinder-custom-control-plane-policy-pathfinder-1_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Dps1
+      vrfs:
+      - name: default
+        vni: 1
+metadata:
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: pathfinder
+    - name: PathfinderSet
+      value: PATHFINDERS
+    interface_tags:
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Bouygues_Telecom
+      - name: Circuit
+        value: '777'
+    - interface: Ethernet2
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Colt
+      - name: Circuit
+        value: '10000'
+    - interface: Ethernet3
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Another-ISP
+      - name: Circuit
+        value: '999'
+  cv_pathfinder:
+    role: pathfinder
+    ssl_profile: profileA
+    vtep_ip: 192.168.144.1
+    interfaces:
+    - name: Ethernet1
+      carrier: Bouygues_Telecom
+      circuit_id: '777'
+      pathgroup: INET
+      public_ip: 10.7.7.7
+    - name: Ethernet2
+      carrier: Colt
+      circuit_id: '10000'
+      pathgroup: MPLS
+      public_ip: 172.16.0.1
+    - name: Ethernet3
+      carrier: Another-ISP
+      circuit_id: '999'
+      pathgroup: INET
+      public_ip: 10.9.9.9
+    pathgroups:
+    - name: MPLS
+      carriers:
+      - name: Colt
+      - name: ATT-MPLS
+    - name: INET
+      carriers:
+      - name: Comcast
+      - name: ATT
+      - name: Bouygues_Telecom
+      - name: SFR
+      - name: Orange
+      - name: Another-ISP
+    - name: LTE
+      carriers:
+      - name: Comcast-5G
+    - name: Equinix
+    - name: Satellite
+      carriers:
+      - name: Inmrasat
+    - name: AWS
+      carriers:
+      - name: AWS-1
+    regions:
+    - name: AVD_Land_West
+      id: 42
+      zones:
+      - name: AVD_Land_West-ZONE
+        id: 1
+        sites:
+        - name: Site422
+          id: 422
+          location:
+            address: Somewhere
+        - name: Site423
+          id: 423
+          location:
+            address: Somewhere-warm
+    - name: AVD_Land_East
+      id: 43
+      zones:
+      - name: AVD_Land_East-ZONE
+        id: 1
+        sites:
+        - name: Site511
+          id: 511
+    vrfs:
+    - name: default
+      vni: 1
+      avts:
+      - constraints:
+          jitter: 5
+        id: 254
+        name: CUSTOM-CP-POLICY
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: MPLS
+          preference: alternate
+        - name: LAN_HA
+          preference: preferred
+      - id: 3
+        name: DEFAULT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: preferred
+        - name: LAN_HA
+          preference: preferred
+      - id: 1
+        name: DEFAULT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: LTE
+          preference: alternate
+        - name: LAN_HA
+          preference: preferred
+    - name: PROD
+      vni: 42
+      avts:
+      - id: 3
+        name: DEFAULT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: preferred
+        - name: LAN_HA
+          preference: preferred
+      - id: 1
+        name: DEFAULT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: LTE
+          preference: alternate
+        - name: LAN_HA
+          preference: preferred
+    - name: IT
+      vni: 14
+      avts:
+      - id: 3
+        name: DEFAULT-POLICY-VIDEO
+        pathgroups:
+        - name: MPLS
+          preference: preferred
+        - name: INET
+          preference: preferred
+        - name: LAN_HA
+          preference: preferred
+      - id: 1
+        name: DEFAULT-POLICY-DEFAULT
+        pathgroups:
+        - name: INET
+          preference: preferred
+        - name: LTE
+          preference: alternate
+        - name: LAN_HA
+          preference: preferred

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV-PATHFINDER_CUSTOM_CONTROL_PLANE_POLICY_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV-PATHFINDER_CUSTOM_CONTROL_PLANE_POLICY_TESTS.yml
@@ -1,0 +1,119 @@
+---
+# Testing CV pathfinder edge with custom control plane policy to make sure the correct
+# control plane policy can be overriden
+
+# Inheriting most values from CV_PATHFINDER_TESTS
+default_node_types:
+  - node_type: wan_rr
+    match_hostnames:
+      - "cv-pathfinder-custom-control-plane-policy-pathfinder.*"
+  - node_type: wan_router
+    match_hostnames:
+      - "cv-pathfinder-custom-control-plane-policy-edge.*"
+
+wan_router:
+  defaults:
+    loopback_ipv4_pool: 192.168.42.0/24
+    vtep_loopback_ipv4_pool: 192.168.142.0/24
+    filter:
+      always_include_vrfs_in_tenants: [TenantA]
+    bgp_as: 65000
+  # Testing HA and disabling HA
+  node_groups:
+    # SITE_HA_DISABLED
+    - group: Site511
+      cv_pathfinder_region: AVD_Land_East
+      cv_pathfinder_site: Site511
+      wan_ha:
+        enabled: False
+      nodes:
+        - name: cv-pathfinder-custom-control-plane-policy-edge-1
+          id: 1
+          l3_interfaces:
+            - name: Ethernet1
+              peer: peer3
+              peer_interface: Ethernet42
+              wan_carrier: ATT
+              wan_circuit_id: 666
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+        - name: cv-pathfinder-custom-control-plane-policy-edge-2
+          id: 2
+          l3_interfaces:
+            - name: Ethernet1
+              peer: peer3
+              peer_interface: Ethernet42
+              wan_carrier: ATT
+              wan_circuit_id: 666
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+        - name: cv-pathfinder-custom-control-plane-policy-edge-3
+          id: 3
+          l3_interfaces:
+            - name: Ethernet1
+              peer: peer3
+              peer_interface: Ethernet42
+              wan_carrier: ATT
+              wan_circuit_id: 666
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+
+wan_rr:
+  defaults:
+    loopback_ipv4_pool: 192.168.44.0/24
+    vtep_loopback_ipv4_pool: 192.168.144.0/24
+    data_plane_cpu_allocation_max: 1
+    bgp_as: 65000
+  nodes:
+    - name: cv-pathfinder-custom-control-plane-policy-pathfinder-1
+      id: 1
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: Bouygues_Telecom
+          wan_circuit_id: 777
+          static_routes:
+            - prefix: 0.0.0.0/0
+          ip_address: 10.7.7.7/31
+          peer_ip: 10.7.7.6
+        - name: Ethernet2
+          wan_carrier: Colt
+          wan_circuit_id: 10000
+          ip_address: 172.16.0.1/31
+        - name: Ethernet3
+          wan_carrier: Another-ISP
+          wan_circuit_id: 999
+          ip_address: 10.9.9.9/31
+
+wan_virtual_topologies:
+  vrfs:
+    - name: default
+      wan_vni: 1
+    - name: PROD
+      wan_vni: 42
+    - name: IT
+      wan_vni: 14
+    # Testing reusing the same policy as default VRF
+  control_plane_virtual_topology:
+    name: CUSTOM-CP-POLICY
+    path_groups:
+      - names: [INET]
+        preference: preferred
+      - names: [MPLS]
+        preference: alternate
+    lowest_hop_count: true
+    constraints:
+      jitter: 5
+  policies:
+    # Name of the DEFAULT-POLICY being overwritten
+    - name: DEFAULT-POLICY
+      default_virtual_topology:
+        path_groups:
+          - names: [INET]
+          - names: [LTE]
+            preference: 42
+      application_virtual_topologies:
+        - application_profile: VIDEO
+          path_groups:
+            - names: [MPLS, INET]
+              preference: preferred
+          id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-custom-control-plane-policy-edge-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-custom-control-plane-policy-edge-2.yml
@@ -1,0 +1,40 @@
+---
+# Testing CV pathfinder edge with custom control plane policy to make sure the correct
+# control plane policy can be overriden.
+# Also override the application profile name, but don't define it, so that
+# application profile name is custom but application is still auto generated
+
+wan_virtual_topologies:
+  vrfs:
+    - name: default
+      wan_vni: 1
+    - name: PROD
+      wan_vni: 42
+    - name: IT
+      wan_vni: 14
+    # Testing reusing the same policy as default VRF
+  control_plane_virtual_topology:
+    name: CUSTOM-CP-POLICY
+    path_groups:
+      - names: [INET]
+        preference: preferred
+      - names: [MPLS]
+        preference: alternate
+    lowest_hop_count: true
+    constraints:
+      jitter: 5
+    application_profile: CUSTOM-CP-APP-PROFILE
+  policies:
+    # Name of the DEFAULT-POLICY being overwritten
+    - name: DEFAULT-POLICY
+      default_virtual_topology:
+        path_groups:
+          - names: [INET]
+          - names: [LTE]
+            preference: 42
+      application_virtual_topologies:
+        - application_profile: VIDEO
+          path_groups:
+            - names: [MPLS, INET]
+              preference: preferred
+          id: 3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-custom-control-plane-policy-edge-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-custom-control-plane-policy-edge-3.yml
@@ -1,0 +1,53 @@
+---
+# Testing CV pathfinder edge with custom control plane policy to make sure the correct
+# control plane policy can be overriden.
+# Also override the application profile name, and define it, so that
+# we can override how control plane traffic is determined
+
+wan_virtual_topologies:
+  vrfs:
+    - name: default
+      wan_vni: 1
+    - name: PROD
+      wan_vni: 42
+    - name: IT
+      wan_vni: 13
+    # Testing reusing the same policy as default VRF
+  control_plane_virtual_topology:
+    name: CUSTOM-CP-POLICY
+    path_groups:
+      - names: [INET]
+        preference: preferred
+      - names: [MPLS]
+        preference: alternate
+    lowest_hop_count: true
+    constraints:
+      jitter: 5
+    application_profile: CUSTOM-CP-APP-PROFILE
+  policies:
+    # Name of the DEFAULT-POLICY being overwritten
+    - name: DEFAULT-POLICY
+      default_virtual_topology:
+        path_groups:
+          - names: [INET]
+          - names: [LTE]
+            preference: 42
+      application_virtual_topologies:
+        - application_profile: VIDEO
+          path_groups:
+            - names: [MPLS, INET]
+              preference: preferred
+          id: 3
+
+application_classification:
+  application_profiles:
+    - name: CUSTOM-CP-APP-PROFILE
+      applications:
+        - name: google
+    - name: VIDEO
+      # Testing categories filtering
+      applications:
+        # Testing applications in application-profiles filtering
+        - name: CUSTOM-APPLICATION-1
+        # Builtin application that should not raise
+        - name: skype

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -324,11 +324,21 @@ all:
                       hosts:
                         cv-pathfinder-pathfinder1:
                         cv-pathfinder-pathfinder2:
+                    CV-PATHFINDER_CUSTOM_CONTROL_PLANE_POLICY_TESTS:
+                      hosts:
+                        # Edge-1 and Pathfinder-1 override control plane policy but not app profile name
+                        cv-pathfinder-custom-control-plane-policy-edge-1:
+                        cv-pathfinder-custom-control-plane-policy-pathfinder-1:
+                        # Edge 2 overrides the profile name but doesn't define the profile
+                        cv-pathfinder-custom-control-plane-policy-edge-2:
+                        # Edge 3 overrides the profile name and also defines the profile
+                        cv-pathfinder-custom-control-plane-policy-edge-3:
             WAN_UNIT_TESTS:
               hosts:
                 autovpn-edge-no-default-policy:
                 cv-pathfinder-edge-no-default-policy:
                 cv-pathfinder-edge-custom-default-policy:
+
         UPLINK_P2P_VRFS_TESTS:
           hosts:
             UPLINK_P2P_VRFS_TESTS_SPINE1:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
@@ -14,6 +14,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;wan_vni</samp>](## "wan_virtual_topologies.vrfs.[].wan_vni") | Integer | Required |  | Min: 1<br>Max: 255 | Required for VRFs carried over AutoVPN or CV Pathfinder WAN.<br><br>A VRF can have different VNIs between the Datacenters and the WAN.<br>Note that if no VRF default is configured for WAN, AVD will automatically inject the VRF default with<br>`wan_vni` set to `1`.<br>In addition either `vrf_id` or `vrf_vni` must be set to enforce consistent route-targets across domains. |
     | [<samp>&nbsp;&nbsp;control_plane_virtual_topology</samp>](## "wan_virtual_topologies.control_plane_virtual_topology") | Dictionary |  |  |  | Always injected into the default VRF policy as the first entry.<br><br>By default, if no path-groups are specified, all locally available path-groups<br>are used in the generated load-balance policy.<br>ID is hardcoded to 254 for the AVT profile in CV Pathfinder mode. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.name") | String |  |  |  | Optional name, if not set `CONTROL-PLANE-PROFILE` is used. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;application_profile</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.application_profile") | String |  | `APP-PROFILE-CONTROL-PLANE` |  | The application profile to use for control plane traffic.<br><br>The application profile should be defined under `application_classification.application_profiles`.<br>If not defined AVD will auto generate an application profile using the provided name or the default value.<br><br>If not overwritten elsewhere, the application profile is generated matching one application matching the control plane traffic either sourced from or destined to the WAN route servers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.traffic_class") | Integer |  |  | Min: 0<br>Max: 7 | Set traffic-class for matched traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.dscp") | Integer |  |  | Min: 0<br>Max: 63 | Set DSCP for matched traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lowest_hop_count</samp>](## "wan_virtual_topologies.control_plane_virtual_topology.lowest_hop_count") | Boolean |  | `False` |  | Prefer paths with lowest hop-count.<br>Only applicable for `wan_mode: "cv-pathfinder"`. |
@@ -97,6 +98,14 @@
 
         # Optional name, if not set `CONTROL-PLANE-PROFILE` is used.
         name: <str>
+
+        # The application profile to use for control plane traffic.
+        #
+        # The application profile should be defined under `application_classification.application_profiles`.
+        # If not defined AVD will auto generate an application profile using the provided name or the default value.
+        #
+        # If not overwritten elsewhere, the application profile is generated matching one application matching the control plane traffic either sourced from or destined to the WAN route servers.
+        application_profile: <str; default="APP-PROFILE-CONTROL-PLANE">
 
         # Set traffic-class for matched traffic.
         traffic_class: <int; 0-7>

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/application_traffic_recognition.py
@@ -168,6 +168,14 @@ class ApplicationTrafficRecognitionMixin(UtilsMixin):
             )
 
         for policy in self._filtered_wan_policies:
+            if policy.get("is_default"):
+                _append_object_to_list_of_dicts(
+                    path="application_profiles",
+                    obj_name=self._wan_control_plane_application_profile_name,
+                    list_of_dicts=application_profiles,
+                    required=False,
+                )
+
             for match in get(policy, "matches", []):
                 application_profile = get(match, "application_profile", required=True)
                 if application_profile == self._wan_control_plane_application_profile_name:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -558,10 +558,8 @@ class UtilsMixin:
     def _wan_control_plane_application_profile_name(self) -> str:
         """
         Control plane application profile name
-
-        TODO: make this configurable
         """
-        return "APP-PROFILE-CONTROL-PLANE"
+        return get(self._hostvars, "wan_virtual_topologies.control_plane_virtual_topology.application_profile", default="APP-PROFILE-CONTROL-PLANE")
 
     @cached_property
     def _local_path_groups_connected_to_pathfinder(self) -> list:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -25304,6 +25304,12 @@
               "description": "Optional name, if not set `CONTROL-PLANE-PROFILE` is used.",
               "title": "Name"
             },
+            "application_profile": {
+              "type": "string",
+              "default": "APP-PROFILE-CONTROL-PLANE",
+              "description": "The application profile to use for control plane traffic.\n\nThe application profile should be defined under `application_classification.application_profiles`.\nIf not defined AVD will auto generate an application profile using the provided name or the default value.\n\nIf not overwritten elsewhere, the application profile is generated matching one application matching the control plane traffic either sourced from or destined to the WAN route servers.",
+              "title": "Application Profile"
+            },
             "traffic_class": {
               "type": "integer",
               "minimum": 0,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3929,6 +3929,21 @@ keys:
           name:
             type: str
             description: Optional name, if not set `CONTROL-PLANE-PROFILE` is used.
+          application_profile:
+            type: str
+            default: APP-PROFILE-CONTROL-PLANE
+            description: 'The application profile to use for control plane traffic.
+
+
+              The application profile should be defined under `application_classification.application_profiles`.
+
+              If not defined AVD will auto generate an application profile using the
+              provided name or the default value.
+
+
+              If not overwritten elsewhere, the application profile is generated matching
+              one application matching the control plane traffic either sourced from
+              or destined to the WAN route servers.'
       policies:
         type: list
         description: "List of virtual toplogies policies.\n\nFor AutoVPN, each item

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_virtual_topologies.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_virtual_topologies.schema.yml
@@ -71,6 +71,16 @@ keys:
           name:
             type: str
             description: Optional name, if not set `CONTROL-PLANE-PROFILE` is used.
+          application_profile:
+            type: str
+            default: APP-PROFILE-CONTROL-PLANE
+            description: |-
+              The application profile to use for control plane traffic.
+
+              The application profile should be defined under `application_classification.application_profiles`.
+              If not defined AVD will auto generate an application profile using the provided name or the default value.
+
+              If not overwritten elsewhere, the application profile is generated matching one application matching the control plane traffic either sourced from or destined to the WAN route servers.
       policies:
         type: list
         description: |-


### PR DESCRIPTION
## Change Summary
We provide user to either configure the control plane policy or we auto generate it. Add a molecule test to test the overriding.

## Related Issue(s)

Fixes https://github.com/aristanetworks/avd-internal/issues/143

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
1.) Override control plane policy test
2.) Introduce application_profile parameter in control_plane_virtual_topology so that we can override APP-PROFILE-CONTROL-PLANE name.
3.) Added optional definition, i.e user can just override the name without defining the profile in application classification in which case we will auto-generate the profile definition ( same as what we are doing now for APP-PROFILE-CONTROL-PLANE) 
4.) Alternatively, he also wants to override the application classification as well, he can just define the profile in application classification section


## How to test
`molecule`

## Checklist

### User Checklist

- [ ] Fix schema https://github.com/aristanetworks/avd/blob/devel/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_virtual_topologies.schema.yml#L73
    
    Can you change the default value to be <VRF-DEFAULT-POLICY-NAME>-CONTROL-PLANE in the schema description for name?

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
