### PR TITLE
Feat(eos_designs): Allow to disable IPsec on dynamic peers for a path-group avd

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-edge.cfg
@@ -25,10 +25,19 @@ router path-selection
          name autovpn-rr2
          ipv4 address 10.8.8.8
    !
+   path-group MPLS id 100
+      !
+      local interface Ethernet2
+      !
+      peer dynamic
+         ipsec disabled
+   !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
       path-group INET
+      path-group MPLS
    !
    load-balance policy LB-DEFAULT-AUTOVPN-POLICY-IT
+      path-group MPLS
       path-group INET priority 2
    !
    load-balance policy LB-PROD-AUTOVPN-POLICY-DEFAULT
@@ -100,6 +109,12 @@ interface Ethernet1
    no switchport
    ip address dhcp
    dhcp client accept default-route
+!
+interface Ethernet2
+   description MPLS-SP-1_Cat6
+   no shutdown
+   no switchport
+   ip address 10.14.14.14/31
 !
 interface Loopback0
    description Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -78,11 +78,13 @@ router path-selection
       peer dynamic
    !
    path-group MPLS id 100
+      ipsec profile CP-PROFILE
       !
       local interface Ethernet2
          stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
       !
       peer dynamic
+         ipsec disabled
       !
       peer static router-ip 192.168.144.1
          name cv-pathfinder-pathfinder

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -132,6 +132,7 @@ router path-selection
          stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
       !
       peer dynamic
+         ipsec disabled
       !
       peer static router-ip 192.168.144.1
          name cv-pathfinder-pathfinder

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -124,6 +124,7 @@ router path-selection
          stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
       !
       peer dynamic
+         ipsec disabled
       !
       peer static router-ip 192.168.144.1
          name cv-pathfinder-pathfinder

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -152,6 +152,7 @@ router path-selection
          stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
       !
       peer dynamic
+         ipsec disabled
       !
       peer static router-ip 192.168.144.1
          name cv-pathfinder-pathfinder

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -152,6 +152,7 @@ router path-selection
          stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
       !
       peer dynamic
+         ipsec disabled
       !
       peer static router-ip 192.168.144.1
          name cv-pathfinder-pathfinder

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-edge.yml
@@ -108,6 +108,12 @@ ethernet_interfaces:
   type: routed
   description: Comcast_666
   dhcp_client_accept_default_route: true
+- name: Ethernet2
+  peer_type: l3_interface
+  ip_address: 10.14.14.14/31
+  shutdown: false
+  type: routed
+  description: MPLS-SP-1_Cat6
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -205,12 +211,21 @@ router_path_selection:
       ipv4_addresses:
       - 10.8.8.8
     ipsec_profile: AUTOVPN
+  - name: MPLS
+    id: 100
+    local_interfaces:
+    - name: Ethernet2
+    dynamic_peers:
+      enabled: true
+      ipsec: false
   load_balance_policies:
   - name: LB-DEFAULT-AUTOVPN-POLICY-CONTROL-PLANE
     path_groups:
     - name: INET
+    - name: MPLS
   - name: LB-DEFAULT-AUTOVPN-POLICY-IT
     path_groups:
+    - name: MPLS
     - name: INET
       priority: 2
   - name: LB-PROD-AUTOVPN-POLICY-VOICE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -335,11 +335,13 @@ router_path_selection:
         - MPLS-cv-pathfinder-pathfinder-Ethernet2
     dynamic_peers:
       enabled: true
+      ipsec: false
     static_peers:
     - router_ip: 192.168.144.1
       name: cv-pathfinder-pathfinder
       ipv4_addresses:
       - 172.16.0.1
+    ipsec_profile: CP-PROFILE
   - name: LTE
     id: 102
     local_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -510,6 +510,7 @@ router_path_selection:
         - MPLS-cv-pathfinder-pathfinder-Ethernet2
     dynamic_peers:
       enabled: true
+      ipsec: false
     static_peers:
     - router_ip: 192.168.144.1
       name: cv-pathfinder-pathfinder

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -561,6 +561,7 @@ router_path_selection:
         - MPLS-cv-pathfinder-pathfinder-Ethernet2
     dynamic_peers:
       enabled: true
+      ipsec: false
     static_peers:
     - router_ip: 192.168.144.1
       name: cv-pathfinder-pathfinder

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -573,6 +573,7 @@ router_path_selection:
         - MPLS-cv-pathfinder-pathfinder-Ethernet2
     dynamic_peers:
       enabled: true
+      ipsec: false
     static_peers:
     - router_ip: 192.168.144.1
       name: cv-pathfinder-pathfinder

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -573,6 +573,7 @@ router_path_selection:
         - MPLS-cv-pathfinder-pathfinder-Ethernet2
     dynamic_peers:
       enabled: true
+      ipsec: false
     static_peers:
     - router_ip: 192.168.144.1
       name: cv-pathfinder-pathfinder

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
@@ -83,7 +83,9 @@ wan_rr:
 
 wan_path_groups:
   - name: MPLS
-    ipsec: False
+    ipsec:
+      static_peers: false
+      dynamic_peers: false
     id: 100
   - name: INET
     id: 101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AUTOVPN_TESTS.yml
@@ -55,6 +55,10 @@ wan_router:
           wan_circuit_id: 666
           ip_address: dhcp
           dhcp_accept_default_route: true
+        - name: Ethernet2
+          wan_carrier: MPLS-SP-1
+          wan_circuit_id: Cat6
+          ip_address: 10.14.14.14/31
 
 wan_rr:
   defaults:
@@ -97,6 +101,8 @@ wan_carriers:
     path_group: INET
   - name: ATT
     path_group: INET
+  - name: MPLS-SP-1
+    path_group: MPLS
 
 # SVI and L2VLAN is inserted to ensure these are *not* rendered.
 tenants:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -242,7 +242,9 @@ wan_rr:
 
 wan_path_groups:
   - name: MPLS
-    ipsec: false
+    ipsec:
+      static_peers: false
+      dynamic_peers: false
     # TODO remove one once auto-id is implemented - for now required in schema
     id: 100
     dps_keepalive:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/autovpn-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/autovpn-edge-no-default-policy.yml
@@ -53,7 +53,9 @@ wan_router:
 
 wan_path_groups:
   - name: MPLS
-    ipsec: False
+    ipsec:
+      static_peers: false
+      dynamic_peers: false
     id: 100
   - name: INET
     id: 101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-custom-default-policy.yml
@@ -68,7 +68,8 @@ wan_router:
 
 wan_path_groups:
   - name: MPLS
-    ipsec: false
+    ipsec:
+      static_peers: false
     # TODO remove one once auto-id is implemented - for now required in schema
     id: 100
   - name: INET

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-no-default-policy.yml
@@ -75,7 +75,8 @@ wan_router:
 
 wan_path_groups:
   - name: MPLS
-    ipsec: false
+    ipsec:
+      dynamic_peers: false
     # TODO remove one once auto-id is implemented - for now required in schema
     id: 100
   - name: INET

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-path-groups.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-path-groups.md
@@ -11,8 +11,10 @@
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "wan_path_groups.[].name") | String | Required, Unique |  |  | Path-group name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "wan_path_groups.[].id") | Integer | Required |  |  | Path-group id.<br><br>TODO: Required until an auto ID algorithm is implemented. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "wan_path_groups.[].description") | String |  |  |  | Additional information about the path-group for documentation purposes. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipsec</samp>](## "wan_path_groups.[].ipsec") | Boolean |  | `True` |  | Flag to configure IPsec at the path-group level.<br><br>When set to `true`, IPsec is enabled for both the static and dynamic peers. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;import_path_groups</samp>](## "wan_path_groups.[].import_path_groups") | List, items: Dictionary |  |  |  | List of [ath-groups to import in this path-group. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipsec</samp>](## "wan_path_groups.[].ipsec") | Dictionary |  |  |  | Configuration of IPSec at the path-group level. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic_peers</samp>](## "wan_path_groups.[].ipsec.dynamic_peers") | Boolean |  | `True` |  | Enable IPSec for dynamic peers. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_peers</samp>](## "wan_path_groups.[].ipsec.static_peers") | Boolean |  | `True` |  | Enable IPSec for static peers. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;import_path_groups</samp>](## "wan_path_groups.[].import_path_groups") | List, items: Dictionary |  |  |  | List of path-groups to import in this path-group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;remote</samp>](## "wan_path_groups.[].import_path_groups.[].remote") | String |  |  |  | Remote path-group to import. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local</samp>](## "wan_path_groups.[].import_path_groups.[].local") | String |  |  |  | Optional, if not set, the path-group `name` is used as local. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dps_keepalive</samp>](## "wan_path_groups.[].dps_keepalive") | Dictionary |  |  |  | Period between the transmission of consecutive keepalive messages, and failure threshold. |
@@ -37,12 +39,16 @@
         # Additional information about the path-group for documentation purposes.
         description: <str>
 
-        # Flag to configure IPsec at the path-group level.
-        #
-        # When set to `true`, IPsec is enabled for both the static and dynamic peers.
-        ipsec: <bool; default=True>
+        # Configuration of IPSec at the path-group level.
+        ipsec:
 
-        # List of [ath-groups to import in this path-group.
+          # Enable IPSec for dynamic peers.
+          dynamic_peers: <bool; default=True>
+
+          # Enable IPSec for static peers.
+          static_peers: <bool; default=True>
+
+        # List of path-groups to import in this path-group.
         import_path_groups:
 
             # Remote path-group to import.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24988,14 +24988,31 @@
             "title": "Description"
           },
           "ipsec": {
-            "type": "boolean",
-            "description": "Flag to configure IPsec at the path-group level.\n\nWhen set to `true`, IPsec is enabled for both the static and dynamic peers.",
-            "default": true,
+            "type": "object",
+            "description": "Configuration of IPSec at the path-group level.",
+            "properties": {
+              "dynamic_peers": {
+                "type": "boolean",
+                "description": "Enable IPSec for dynamic peers.",
+                "default": true,
+                "title": "Dynamic Peers"
+              },
+              "static_peers": {
+                "type": "boolean",
+                "description": "Enable IPSec for static peers.",
+                "default": true,
+                "title": "Static Peers"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
             "title": "Ipsec"
           },
           "import_path_groups": {
             "type": "array",
-            "description": "List of [ath-groups to import in this path-group.",
+            "description": "List of path-groups to import in this path-group.",
             "items": {
               "type": "object",
               "properties": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3629,15 +3629,20 @@ keys:
           description: Additional information about the path-group for documentation
             purposes.
         ipsec:
-          type: bool
-          description: 'Flag to configure IPsec at the path-group level.
-
-
-            When set to `true`, IPsec is enabled for both the static and dynamic peers.'
-          default: true
+          type: dict
+          description: Configuration of IPSec at the path-group level.
+          keys:
+            dynamic_peers:
+              type: bool
+              description: Enable IPSec for dynamic peers.
+              default: true
+            static_peers:
+              type: bool
+              description: Enable IPSec for static peers.
+              default: true
         import_path_groups:
           type: list
-          description: List of [ath-groups to import in this path-group.
+          description: List of path-groups to import in this path-group.
           items:
             type: dict
             keys:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_path_groups.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_path_groups.schema.yml
@@ -31,15 +31,21 @@ keys:
           type: str
           description: Additional information about the path-group for documentation purposes.
         ipsec:
-          type: bool
+          type: dict
           description: |-
-            Flag to configure IPsec at the path-group level.
-
-            When set to `true`, IPsec is enabled for both the static and dynamic peers.
-          default: true
+            Configuration of IPSec at the path-group level.
+          keys:
+            dynamic_peers:
+              type: bool
+              description: Enable IPSec for dynamic peers.
+              default: true
+            static_peers:
+              type: bool
+              description: Enable IPSec for static peers.
+              default: true
         import_path_groups:
           type: list
-          description: List of [ath-groups to import in this path-group.
+          description: List of path-groups to import in this path-group.
           items:
             type: dict
             keys:


### PR DESCRIPTION
## Change Summary

A new knob in the schema for path_groups to allow to disable ipsec for dynamic_peers


## Related Issue(s)

Fixes #3671

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
A new knob in the schema for path_groups to allow to disable ipsec for dynamic_peers
```
# Existing model
wan_path_groups:
  - name: <str>
    # Flag to configure IPsec at the path-group level.
    #
    # When set to `true`, IPsec is enabled for both the static and dynamic peers.
    ipsec: <bool; default=True>
```

Update to
```
# Existing model
wan_path_groups:
  - name: <str>
    # Path-group IPSec configuration
    ipsec:
        # When set to `true`, IPsec is enabled for dynamic peers.
        dynamic_peers: <bool; default=True>
        # When set to `true`, IPsec is enabled for static peers.
        static_peers: <bool; default=True>
```
        
## How to test
molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
