### PR TITLE
Refactor(eos_designs): CV Pathfinder metadata updates

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -437,6 +437,7 @@ metadata:
         value: AF830
   cv_pathfinder:
     role: edge
+    ssl_profile: STUN-DTLS
     vtep_ip: 192.168.255.1
     region: AVD_Land_West
     zone: AVD_Land_West-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -600,6 +600,7 @@ metadata:
         value: '212'
   cv_pathfinder:
     role: edge
+    ssl_profile: profileA
     vtep_ip: 192.168.142.2
     region: AVD_Land_East
     zone: AVD_Land_East-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -445,6 +445,7 @@ metadata:
         value: AF830
   cv_pathfinder:
     role: edge
+    ssl_profile: STUN-DTLS
     vtep_ip: 192.168.255.1
     region: AVD_Land_East
     zone: AVD_Land_East-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -708,6 +708,7 @@ metadata:
         value: AF830
   cv_pathfinder:
     role: edge
+    ssl_profile: profileA
     vtep_ip: 192.168.142.1
     region: AVD_Land_East
     zone: AVD_Land_East-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -756,6 +756,7 @@ metadata:
         value: 423-01
   cv_pathfinder:
     role: edge
+    ssl_profile: profileA
     vtep_ip: 192.168.142.2
     region: AVD_Land_West
     zone: AVD_Land_West-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -753,6 +753,7 @@ metadata:
         value: '10423'
   cv_pathfinder:
     role: edge
+    ssl_profile: profileA
     vtep_ip: 192.168.142.3
     region: AVD_Land_West
     zone: AVD_Land_West-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -789,6 +789,7 @@ metadata:
         value: lan
   cv_pathfinder:
     role: transit region
+    ssl_profile: profileA
     vtep_ip: 192.168.143.1
     region: AVD_Land_West
     zone: AVD_Land_West-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -789,6 +789,7 @@ metadata:
         value: lan
   cv_pathfinder:
     role: transit region
+    ssl_profile: profileA
     vtep_ip: 192.168.143.2
     region: AVD_Land_West
     zone: AVD_Land_West-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -380,6 +380,7 @@ metadata:
         value: '999'
   cv_pathfinder:
     role: edge
+    ssl_profile: STUN-DTLS
     vtep_ip: 192.168.2.1
     region: region1
     zone: region1-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -393,6 +393,7 @@ metadata:
         value: '999'
   cv_pathfinder:
     role: edge
+    ssl_profile: STUN-DTLS
     vtep_ip: 192.168.2.2
     region: region1
     zone: region1-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
@@ -492,6 +492,7 @@ metadata:
         value: DC1-INET-3
   cv_pathfinder:
     role: edge
+    ssl_profile: STUN-DTLS
     vtep_ip: 10.255.1.1
     region: Global
     zone: Global-ZONE

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
@@ -492,6 +492,7 @@ metadata:
         value: DC1-INET-4
   cv_pathfinder:
     role: edge
+    ssl_profile: STUN-DTLS
     vtep_ip: 10.255.1.2
     region: Global
     zone: Global-ZONE

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
@@ -13,7 +13,14 @@ from .models import CVDevice, CVPathfinderMetadata, DeployToCvResult
 LOGGER = getLogger(__name__)
 
 CV_PATHFINDER_METADATA_STUDIO_ID = "studio-avd-pathfinder-metadata"
-CV_PATHFINDER_DEFAULT_STUDIO_INPUTS = {"pathfinders": [], "pathgroups": [], "regions": [], "routers": [], "vrfs": [], "version": "3"}
+CV_PATHFINDER_DEFAULT_STUDIO_INPUTS = {
+    "pathfinders": [],
+    "pathgroups": [],
+    "regions": [],
+    "routers": [],
+    "vrfs": [],
+    "version": "3.1",
+}
 
 
 def update_general_metadata(metadata: dict, studio_inputs: dict) -> None:
@@ -213,9 +220,12 @@ async def deploy_cv_pathfinder_metadata_to_cv(cv_pathfinder_metadata: list[CVPat
     )
 
     # Ensure the metadata studio schema match our supported version
-    if (studio_version := existing_studio_inputs.get("version")) != "3":
+    if (studio_version := existing_studio_inputs.get("version")) != "3.1":
         LOGGER.warning(
-            "deploy_cv_pathfinder_metadata_to_cv: Got invalid metadata studio version '%s'. This plugin only accepts version '3'. Skipping upload of metadata.",
+            (
+                "deploy_cv_pathfinder_metadata_to_cv: Got invalid metadata studio version '%s'. "
+                "This plugin only accepts version '3.1'. Skipping upload of metadata."
+            ),
             studio_version,
         )
         return

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
@@ -43,6 +43,7 @@ class CvPathfinderMixin:
         # Edge or transit
         return {
             "role": self.shared_utils.cv_pathfinder_role,
+            "ssl_profile": self.shared_utils.wan_stun_dtls_profile_name,
             "vtep_ip": self.shared_utils.vtep_ip,
             "region": self.shared_utils.wan_region["name"],
             "zone": self.shared_utils.wan_zone["name"],


### PR DESCRIPTION
Pending CV backend changed before merging.

## Change Summary

<!-- Enter short PR description -->
CV Pathfinder metadata updates

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.deploy_to_cv`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Verify schema version of metadata studio to be 3.1
- Add SSL profile per wan_router
- Rename metadata studio id

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested manually by uploading the new metadata studio to my test tenant and deleted the old one. Then reran the playbook and verified data got updated in the new metadata studio.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
