### PR TITLE
Fix(plugins): YAML Dumper/Loader not working without libyaml

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/yaml_dumper.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/yaml_dumper.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 try:
     from yaml import CSafeDumper as YamlDumper
 except ImportError:
-    from yaml import YamlDumper
+    from yaml import SafeDumper as YamlDumper
 
 
 # https://ttl255.com/yaml-anchors-and-aliases-and-how-to-disable-them/

--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/yaml_loader.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/yaml_loader.py
@@ -6,6 +6,6 @@ from __future__ import annotations
 try:
     from yaml import CLoader as YamlLoader
 except ImportError:
-    from yaml import YamlLoader
+    from yaml import Loader as YamlLoader
 
 __all__ = ["YamlLoader"]


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
YAML Dumper not working without libyaml

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Minimal impact since this is not used widely (yet).
Affecting:
- PyAVD when running from an unsupported install without libyaml
- deploy_to_cv when running without libyaml
