### PR TITLE
Refactor(eos_designs): Make id mandatory for AVTs when mode is cv-pathfinder

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-avt-id-cv-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-avt-id-cv-pathfinder.yml
@@ -1,0 +1,94 @@
+---
+# Testing missing id for a policy
+wan_mode: cv-pathfinder
+# Disabling underlay for tests
+underlay_routing_protocol: none
+
+bgp_as: 65000
+
+cv_pathfinder_regions:
+  - name: AVD_Land_West
+    id: 42
+    description: AVD Region
+    sites:
+      - name: Site422
+        id: 422
+        location: Somewhere
+
+bgp_peer_groups:
+  wan_overlay_peers:
+    password: "htm4AZe9mIQOO1uiMuGgYQ=="
+    listen_range_prefixes:
+      - 192.168.255.0/24
+
+wan_route_servers:
+  - hostname: cv-pathfinder-pathfinder
+    vtep_ip: 10.10.10.10
+    path_groups:
+      - name: INET
+        interfaces:
+          - name: Ethernet1
+            ip_address: 192.168.55.55/24
+
+wan_ipsec_profiles:
+  control_plane:
+    shared_key: ABCDEF1234567890
+  data_plane:
+    shared_key: ABCDEF1234567890666
+
+default_node_types:
+  - node_type: wan_router
+    match_hostnames:
+      - "missing-avt-id-cv-pathfinder"
+
+wan_router:
+  defaults:
+    loopback_ipv4_pool: 192.168.42.0/24
+    vtep_loopback_ipv4_pool: 192.168.255.0/24
+    filter:
+      always_include_vrfs_in_tenants: [TenantA]
+  nodes:
+    - name: missing-avt-id-cv-pathfinder
+      cv_pathfinder_region: AVD_Land_West
+      cv_pathfinder_site: Site422
+      id: 1
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: ATT
+          wan_circuit_id: 666
+          dhcp_accept_default_route: true
+          ip_address: dhcp
+
+wan_path_groups:
+  - name: INET
+    id: 101
+
+wan_carriers:
+  - name: ATT
+    path_group: INET
+
+tenants:
+  - name: TenantA
+    vrfs:
+      - name: default
+        vrf_id: 1
+      - name: PROD
+        vrf_id: 42
+
+wan_virtual_topologies:
+  vrfs:
+    - name: PROD
+      wan_vni: 42
+  policies:
+    - name: DEFAULT-POLICY
+      default_virtual_topology:
+        drop_unmatched: true
+      application_virtual_topologies:
+        - application_profile: TEST
+          # no id
+
+application_classification:
+  application_profiles:
+    - name: TEST
+
+expected_error_message: "Missing mandatory `id` in `wan_virtual_topologies.policies[DEFAULT-POLICY].application_virtual_topologies[TEST]` when `wan_mode` is 'cv-pathfinder"

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -86,6 +86,8 @@ all:
         failure-missing-evpn-multicast-l3-with-pim:
         failure-missing-evpn-multicast-peg-rps:
         failure-duplicate-evpn-vlan-bundle-name:
+        missing-avt-id-cv-pathfinder:
+        missing-data-plane_cpu-allocation-max:
         ntp-settings-server-vrf-missing-mgmt-ip:
         ntp-settings-server-vrf-missing-inband-mgmt-interface:
         source-interfaces-domain-lookup-duplicate-vrf:
@@ -104,7 +106,6 @@ all:
         source-interfaces-tacacs-missing-inband-mgmt-interface:
         source-interfaces-tacacs-missing-mgmt-ip:
         ul-filter-evpn-default-vrf-services:
-        missing-data-plane_cpu-allocation-max:
       children:
         duplicate-ip-address-router-bgp:
           hosts:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-virtual-topologies.md
@@ -30,7 +30,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;application_virtual_topologies</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies") | List, items: Dictionary |  |  |  | List of application specific virtual topologies. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;application_profile</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].application_profile") | String | Required, Unique |  |  | The application profile to use for this virtual topology. It must be a defined `application_profile`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].name") | String |  |  |  | Optional name, if not set `<policy_name>-<application_profile>` is used. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].id") | Integer |  |  | Min: 2<br>Max: 253 | ID of the AVT in each VRFs. ID must be unique across all virtual topologies in a policy.<br>ID 1 is reserved for the default_virtual_toplogy.<br>ID 254 is reserved for the control_plane_virtual_topology. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].id") | Integer |  |  | Min: 2<br>Max: 253 | ID of the AVT in each VRFs. ID must be unique across all virtual topologies in a policy.<br>ID 1 is reserved for the default_virtual_toplogy.<br>ID 254 is reserved for the control_plane_virtual_topology.<br><br>`id` is required when `wan_mode` is 'cv-pathfinder'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;traffic_class</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].traffic_class") | Integer |  |  | Min: 0<br>Max: 7 | Set traffic-class for matched traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].dscp") | Integer |  |  | Min: 0<br>Max: 63 | Set DSCP for matched traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;lowest_hop_count</samp>](## "wan_virtual_topologies.policies.[].application_virtual_topologies.[].lowest_hop_count") | Boolean |  | `False` |  | Prefer paths with lowest hop-count.<br>Only applicable for `wan_mode: "cv-pathfinder"`. |
@@ -172,6 +172,8 @@
               # ID of the AVT in each VRFs. ID must be unique across all virtual topologies in a policy.
               # ID 1 is reserved for the default_virtual_toplogy.
               # ID 254 is reserved for the control_plane_virtual_topology.
+              #
+              # `id` is required when `wan_mode` is 'cv-pathfinder'.
               id: <int; 2-253>
 
               # Set traffic-class for matched traffic.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_adaptive_virtual_topology.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/router_adaptive_virtual_topology.py
@@ -106,7 +106,16 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
                         "traffic_class": get(application_virtual_topology, "traffic_class"),
                         "dscp": get(application_virtual_topology, "dscp"),
                         # Storing id as _id to avoid schema validation and be able to pick up in VRFs
-                        "_id": get(application_virtual_topology, "id"),
+                        "_id": get(
+                            application_virtual_topology,
+                            "id",
+                            required=True,
+                            org_key=(
+                                f"Missing mandatory `id` in "
+                                f"`wan_virtual_topologies.policies[{avt_policy['name']}].application_virtual_topologies[{application_profile}]` "
+                                "when `wan_mode` is 'cv-pathfinder"
+                            ),
+                        ),
                     }
                 )
 

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -25339,7 +25339,7 @@
                       "type": "integer",
                       "minimum": 2,
                       "maximum": 253,
-                      "description": "ID of the AVT in each VRFs. ID must be unique across all virtual topologies in a policy.\nID 1 is reserved for the default_virtual_toplogy.\nID 254 is reserved for the control_plane_virtual_topology.",
+                      "description": "ID of the AVT in each VRFs. ID must be unique across all virtual topologies in a policy.\nID 1 is reserved for the default_virtual_toplogy.\nID 254 is reserved for the control_plane_virtual_topology.\n\n`id` is required when `wan_mode` is 'cv-pathfinder'.",
                       "title": "ID"
                     },
                     "traffic_class": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3929,7 +3929,10 @@ keys:
 
                       ID 1 is reserved for the default_virtual_toplogy.
 
-                      ID 254 is reserved for the control_plane_virtual_topology.'
+                      ID 254 is reserved for the control_plane_virtual_topology.
+
+
+                      `id` is required when `wan_mode` is ''cv-pathfinder''.'
             default_virtual_topology:
               type: dict
               description: 'Default match for the policy.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_virtual_topologies.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_virtual_topologies.schema.yml
@@ -128,6 +128,8 @@ keys:
                       ID of the AVT in each VRFs. ID must be unique across all virtual topologies in a policy.
                       ID 1 is reserved for the default_virtual_toplogy.
                       ID 254 is reserved for the control_plane_virtual_topology.
+
+                      `id` is required when `wan_mode` is 'cv-pathfinder'.
             default_virtual_topology:
               type: dict
               description: |-


### PR DESCRIPTION
## Change Summary

Without an ID when mode is `cv-pathfinder` it is not possible to generate the config

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Checking in code

## How to test

Negative unit test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
