### PR TITLE
Fix(eos_cli_config_gen): Comply with EOS tacacs servers configuration order

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/aaa.md
@@ -81,9 +81,9 @@ Global timeout: 10 seconds
 ```eos
 !
 tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 <removed>
+tacacs-server host 10.10.10.249 timeout 23 key 7 <removed>
 tacacs-server host 10.10.10.158 key 7 <removed>
 tacacs-server host 10.10.10.159 key 8a <removed>
-tacacs-server host 10.10.10.249 timeout 23 key 7 <removed>
 tacacs-server timeout 10
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/aaa.cfg
@@ -9,9 +9,9 @@ radius-server host 10.10.10.249 key 7 071B245F5A
 radius-server host 10.10.10.158 key 7 071B245F5A
 !
 tacacs-server host 10.10.10.157 single-connection vrf mgt key 7 071B245F5A
+tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 tacacs-server host 10.10.10.158 key 7 071B245F5A
 tacacs-server host 10.10.10.159 key 8a $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
-tacacs-server host 10.10.10.249 timeout 23 key 7 071B245F5A
 tacacs-server timeout 10
 !
 aaa group server tacacs+ TACACS1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tacacs-servers.j2
@@ -6,7 +6,7 @@
 {# eos - tacacs servers #}
 {% if tacacs_servers is arista.avd.defined %}
 !
-{%     for host in tacacs_servers.hosts | arista.avd.natural_sort %}
+{%     for host in tacacs_servers.hosts %}
 {%         if host.host is arista.avd.defined %}
 {%             set host_cli = "tacacs-server host " ~ host.host %}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Comply with EOS tacacs servers configuration order

## Related Issue(s)

Fixes #3708 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Remove sorting on for loop tacacs_servers.hosts

## How to test

Molecule tests updated, no longer sorting.

