### PR TITLE
Feat(eos_designs): Support access_group_in/out under network services SVI configuration and SVI profiles natively

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -524,6 +524,8 @@ interface Vlan411
    vrf Tenant_D_OP_Zone
    ip address 10.3.11.2/24
    ipv6 address 2001:db8:311::2/64
+   ip access-group ACL_IN in
+   ip access-group ACL_OUT out
    ipv6 virtual-router address 2001:db8:311::1
    ip virtual-router address 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -489,6 +489,8 @@ interface Vlan411
    vrf Tenant_D_OP_Zone
    ip address 10.3.11.3/24
    ipv6 address 2001:db8:311::3/64
+   ip access-group ACL_IN in
+   ip access-group ACL_OUT out
    ipv6 virtual-router address 2001:db8:311::1
    ip virtual-router address 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -318,6 +318,8 @@ interface Vlan411
    vrf Tenant_D_OP_Zone
    ip address 10.3.11.4/24
    ipv6 address 2001:db8:311::4/64
+   ip access-group ACL_IN in
+   ip access-group ACL_OUT out
    ipv6 virtual-router address 2001:db8:311::1
    ip virtual-router address 10.3.11.1/24
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -1102,6 +1102,8 @@ vlan_interfaces:
   - 10.3.11.1/24
   ipv6_virtual_router_addresses:
   - 2001:db8:311::1
+  access_group_in: ACL_IN
+  access_group_out: ACL_OUT
   vrf: Tenant_D_OP_Zone
 - name: Vlan412
   tenant: Tenant_D

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -1048,6 +1048,8 @@ vlan_interfaces:
   - 10.3.11.1/24
   ipv6_virtual_router_addresses:
   - 2001:db8:311::1
+  access_group_in: ACL_IN
+  access_group_out: ACL_OUT
   vrf: Tenant_D_OP_Zone
 - name: Vlan412
   tenant: Tenant_D

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -809,6 +809,8 @@ vlan_interfaces:
   - 10.3.11.1/24
   ipv6_virtual_router_addresses:
   - 2001:db8:311::1
+  access_group_in: ACL_IN
+  access_group_out: ACL_OUT
   vrf: Tenant_D_OP_Zone
 - name: Vlan412
   tenant: Tenant_D

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
@@ -22,6 +22,8 @@ tenant_d:
             enabled: True
             ip_virtual_router_addresses: [ 10.3.11.1/24 ]
             ipv6_virtual_router_addresses: [ "2001:db8:311::1" ]
+            access_group_in: ACL_IN
+            access_group_out: ACL_OUT
             nodes:
               - node: DC1-LEAF2A
                 ip_address: 10.3.11.2/24

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
@@ -38,6 +38,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_virtual_router_addresses.[]") | String |  |  |  | IPv4_address/Mask or IPv4_address<br>IPv4_address/Mask will also configure a static route to the SVI per best practice.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_virtual_router_addresses</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_virtual_router_addresses") | List, items: String |  |  |  | IPv6 VARP addresses.<br>Requires an IPv6 address to be configured on the SVI.<br>If ipv6_address_virtuals is also set, ipv6_virtual_router_addresses will take precedence<br>_if_ there is an ipv6_address configured for the node.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].access_group_in") | String |  |  |  | Access-group is assigned on an interface to filter the data packets as they enter the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].access_group_out") | String |  |  |  | Access-group is assigned on an interface to filter the data packets as they leave the interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
@@ -70,6 +72,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_virtual_router_addresses.[]") | String |  |  |  | IPv4_address/Mask or IPv4_address<br>IPv4_address/Mask will also configure a static route to the SVI per best practice.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_virtual_router_addresses</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_virtual_router_addresses") | List, items: String |  |  |  | IPv6 VARP addresses.<br>Requires an IPv6 address to be configured on the SVI.<br>If ipv6_address_virtuals is also set, ipv6_virtual_router_addresses will take precedence<br>_if_ there is an ipv6_address configured for the node.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].access_group_in") | String |  |  |  | Access-group is assigned on an interface to filter the data packets as they enter the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].access_group_out") | String |  |  |  | Access-group is assigned on an interface to filter the data packets as they leave the interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
@@ -213,6 +217,12 @@
                         # IPv6_address
                       - <str>
 
+                    # Access-group is assigned on an interface to filter the data packets as they enter the interface.
+                    access_group_in: <str>
+
+                    # Access-group is assigned on an interface to filter the data packets as they leave the interface.
+                    access_group_out: <str>
+
                     # IP helper for DHCP relay
                     ip_helpers:
 
@@ -335,6 +345,12 @@
 
                     # IPv6_address
                   - <str>
+
+                # Access-group is assigned on an interface to filter the data packets as they enter the interface.
+                access_group_in: <str>
+
+                # Access-group is assigned on an interface to filter the data packets as they leave the interface.
+                access_group_out: <str>
 
                 # IP helper for DHCP relay
                 ip_helpers:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
@@ -28,6 +28,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].nodes.[].ip_virtual_router_addresses.[]") | String |  |  |  | IPv4_address/Mask or IPv4_address<br>IPv4_address/Mask will also configure a static route to the SVI per best practice.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_virtual_router_addresses</samp>](## "svi_profiles.[].nodes.[].ipv6_virtual_router_addresses") | List, items: String |  |  |  | IPv6 VARP addresses.<br>Requires an IPv6 address to be configured on the SVI.<br>If ipv6_address_virtuals is also set, ipv6_virtual_router_addresses will take precedence<br>_if_ there is an ipv6_address configured for the node.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].nodes.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group_in</samp>](## "svi_profiles.[].nodes.[].access_group_in") | String |  |  |  | Access-group is assigned on an interface to filter the data packets as they enter the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_group_out</samp>](## "svi_profiles.[].nodes.[].access_group_out") | String |  |  |  | Access-group is assigned on an interface to filter the data packets as they leave the interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "svi_profiles.[].nodes.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "svi_profiles.[].nodes.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "svi_profiles.[].nodes.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
@@ -61,6 +63,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].ip_virtual_router_addresses.[]") | String |  |  |  | IPv4_address/Mask or IPv4_address<br>IPv4_address/Mask will also configure a static route to the SVI per best practice.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_virtual_router_addresses</samp>](## "svi_profiles.[].ipv6_virtual_router_addresses") | List, items: String |  |  |  | IPv6 VARP addresses.<br>Requires an IPv6 address to be configured on the SVI.<br>If ipv6_address_virtuals is also set, ipv6_virtual_router_addresses will take precedence<br>_if_ there is an ipv6_address configured for the node.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_in</samp>](## "svi_profiles.[].access_group_in") | String |  |  |  | Access-group is assigned on an interface to filter the data packets as they enter the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_group_out</samp>](## "svi_profiles.[].access_group_out") | String |  |  |  | Access-group is assigned on an interface to filter the data packets as they leave the interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "svi_profiles.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "svi_profiles.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "svi_profiles.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
@@ -169,6 +173,12 @@
 
                 # IPv6_address
               - <str>
+
+            # Access-group is assigned on an interface to filter the data packets as they enter the interface.
+            access_group_in: <str>
+
+            # Access-group is assigned on an interface to filter the data packets as they leave the interface.
+            access_group_out: <str>
 
             # IP helper for DHCP relay
             ip_helpers:
@@ -295,6 +305,12 @@
 
             # IPv6_address
           - <str>
+
+        # Access-group is assigned on an interface to filter the data packets as they enter the interface.
+        access_group_in: <str>
+
+        # Access-group is assigned on an interface to filter the data packets as they leave the interface.
+        access_group_out: <str>
 
         # IP helper for DHCP relay
         ip_helpers:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vlan_interfaces.py
@@ -140,6 +140,12 @@ class VlanInterfacesMixin(UtilsMixin):
                 # If any anycast IPs are set, we also enable link-local IPv6 per best practice, unless specifically disabled with 'ipv6_enable: false'
                 vlan_interface_config["ipv6_enable"] = default(vlan_interface_config["ipv6_enable"], True)
 
+        if access_group_in := svi.get("access_group_in"):
+            vlan_interface_config["access_group_in"] = access_group_in
+
+        if access_group_out := svi.get("access_group_out"):
+            vlan_interface_config["access_group_out"] = access_group_out
+
         if vrf["name"] != "default":
             vlan_interface_config["vrf"] = vrf["name"]
 

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -21898,6 +21898,16 @@
                   },
                   "title": "IPv6 Virtual Router Addresses"
                 },
+                "access_group_in": {
+                  "type": "string",
+                  "description": "Access-group is assigned on an interface to filter the data packets as they enter the interface.",
+                  "title": "Access Group In"
+                },
+                "access_group_out": {
+                  "type": "string",
+                  "description": "Access-group is assigned on an interface to filter the data packets as they leave the interface.",
+                  "title": "Access Group Out"
+                },
                 "ip_helpers": {
                   "type": "array",
                   "description": "IP helper for DHCP relay",
@@ -23633,6 +23643,16 @@
               "description": "IPv6_address"
             },
             "title": "IPv6 Virtual Router Addresses"
+          },
+          "access_group_in": {
+            "type": "string",
+            "description": "Access-group is assigned on an interface to filter the data packets as they enter the interface.",
+            "title": "Access Group In"
+          },
+          "access_group_out": {
+            "type": "string",
+            "description": "Access-group is assigned on an interface to filter the data packets as they leave the interface.",
+            "title": "Access Group Out"
           },
           "ip_helpers": {
             "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -8638,6 +8638,14 @@ $defs:
         items:
           type: str
           description: IPv6_address
+      access_group_in:
+        type: str
+        description: Access-group is assigned on an interface to filter the data packets
+          as they enter the interface.
+      access_group_out:
+        type: str
+        description: Access-group is assigned on an interface to filter the data packets
+          as they leave the interface.
       ip_helpers:
         type: list
         primary_key: ip_helper

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_svi_settings.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_svi_settings.schema.yml
@@ -80,6 +80,12 @@ $defs:
         items:
           type: str
           description: IPv6_address
+      access_group_in:
+        type: str
+        description: Access-group is assigned on an interface to filter the data packets as they enter the interface.
+      access_group_out:
+        type: str
+        description: Access-group is assigned on an interface to filter the data packets as they leave the interface.
       ip_helpers:
         type: list
         primary_key: ip_helper


### PR DESCRIPTION
## Change Summary

Add support for applying ip access-lists to SVIs and SVI profiles in eos_designs network services natively.

## Related Issue(s)

Fixes #3448 

## Component(s) name

`arista.avd.eos_designs`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
