### PR TITLE
Feat(eos_designs): Allow custom name for pathfinder Flow tracker tracker and exporter settings

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
-      record export on inactive timeout 70000
-      record export on interval 5000
-      exporter DPI-EXPORTER
+   tracker custom_flow_track_name
+      record export on inactive timeout 50000
+      record export on interval 300331
+      exporter ayush_exporter
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 40000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -150,14 +150,14 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware custom_flow_track_name
    ip address 192.168.255.1/32
 !
 interface Ethernet1
    description ATT_666
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware custom_flow_track_name
    ip address dhcp
    dhcp client accept default-route
 !
@@ -165,14 +165,14 @@ interface Ethernet2
    description Colt_10555
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware custom_flow_track_name
    ip address 172.15.5.5/31
 !
 interface Ethernet3
    description Comcast-5G_AF830
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware custom_flow_track_name
    ip address 172.20.20.20/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -186,21 +186,21 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.142.2/32
 !
 interface Ethernet1
    description Inmrasat_S511
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address dhcp
 !
 interface Ethernet2
    description AWS-1_212
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -209,7 +209,7 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.3/31
 !
 interface Ethernet52.142
@@ -217,7 +217,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.3/31
 !
@@ -226,7 +226,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.3/31
 !
@@ -235,7 +235,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -144,14 +144,14 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.255.1/32
 !
 interface Ethernet1
    description ATT_666
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -159,14 +159,14 @@ interface Ethernet2
    description Colt_10555
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.15.5.5/31
 !
 interface Ethernet3
    description Comcast-5G_AF830
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.20.20.20/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -217,14 +217,14 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.142.1/32
 !
 interface Ethernet1
    description ATT_666_peer3_Ethernet42
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -232,14 +232,14 @@ interface Ethernet2
    description Colt_10555
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.15.5.5/31
 !
 interface Ethernet3
    description Comcast-5G_AF830
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.20.20.20/31
 !
 interface Ethernet52
@@ -247,7 +247,7 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.1/31
 !
 interface Ethernet52.142
@@ -255,7 +255,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.1/31
 !
@@ -264,7 +264,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.1/31
 !
@@ -273,7 +273,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -212,14 +212,14 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.142.2/32
 !
 interface Ethernet1
    description ATT_423-01
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -228,7 +228,7 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.5/31
 !
 interface Ethernet52.142
@@ -236,7 +236,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.5/31
 !
@@ -245,7 +245,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.5/31
 !
@@ -254,7 +254,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.5/31
 !
@@ -263,7 +263,7 @@ interface Ethernet53
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.7/31
 !
 interface Ethernet53.142
@@ -271,7 +271,7 @@ interface Ethernet53.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.7/31
 !
@@ -280,7 +280,7 @@ interface Ethernet53.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.7/31
 !
@@ -289,7 +289,7 @@ interface Ethernet53.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.7/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -212,14 +212,14 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.142.3/32
 !
 interface Ethernet2
    description Colt_10423
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.15.6.6/31
 !
 interface Ethernet52
@@ -227,7 +227,7 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.9/31
 !
 interface Ethernet52.142
@@ -235,7 +235,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.9/31
 !
@@ -244,7 +244,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.9/31
 !
@@ -253,7 +253,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.9/31
 !
@@ -262,7 +262,7 @@ interface Ethernet53
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.11/31
 !
 interface Ethernet53.142
@@ -270,7 +270,7 @@ interface Ethernet53.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.11/31
 !
@@ -279,7 +279,7 @@ interface Ethernet53.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.11/31
 !
@@ -288,7 +288,7 @@ interface Ethernet53.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.11/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -228,28 +228,28 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.144.1/32
 !
 interface Ethernet1
    description Bouygues_Telecom_777
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 10.7.7.7/31
 !
 interface Ethernet2
    description Colt_10000
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.16.0.1/31
 !
 interface Ethernet3
    description Another-ISP_999
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 10.9.9.9/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -231,14 +231,14 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.144.2/32
 !
 interface Ethernet1
    description Orange_888
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 10.8.8.8/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -238,21 +238,21 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.144.3/32
 !
 interface Ethernet1
    description SFR_999
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 10.9.9.9/31
 !
 interface Ethernet2
    description ATT-MPLS_10999
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.19.9.9/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -261,7 +261,7 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.143.1/32
 !
 interface Ethernet1
@@ -272,7 +272,7 @@ interface Ethernet1.42
    description Comcast
    no shutdown
    encapsulation dot1q vlan 42
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -284,7 +284,7 @@ interface Ethernet2.42
    description Colt_10666
    no shutdown
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.16.6.6/31
 !
 interface Ethernet52
@@ -292,7 +292,7 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.1/31
 !
 interface Ethernet52.142
@@ -300,7 +300,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.1/31
 !
@@ -309,7 +309,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.1/31
 !
@@ -318,7 +318,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -261,7 +261,7 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.143.2/32
 !
 interface Ethernet1
@@ -272,7 +272,7 @@ interface Ethernet1.42
    description Comcast
    no shutdown
    encapsulation dot1q vlan 42
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -284,7 +284,7 @@ interface Ethernet2.42
    description Colt_10666
    no shutdown
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.16.6.6/31
 !
 interface Ethernet52
@@ -292,7 +292,7 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.3/31
 !
 interface Ethernet52.142
@@ -300,7 +300,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.3/31
 !
@@ -309,7 +309,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.3/31
 !
@@ -318,7 +318,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -99,14 +99,14 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.2.1/32
 !
 interface Ethernet1
    description Comcast_999
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 10.9.9.9/31
 !
 interface Ethernet2
@@ -114,7 +114,7 @@ interface Ethernet2
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf VRF1
    ip address 10.0.10.1/24
 !
@@ -122,7 +122,7 @@ interface Ethernet2.100
    description My vlan 100
    no shutdown
    encapsulation dot1q vlan 100
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf VRF1
    ip address 10.0.100.1/24
    ipv6 enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -3,13 +3,13 @@
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
 flow tracking hardware
-   tracker WAN-FLOW-TRACKER
+   tracker FLOW-TRACKER
       record export on inactive timeout 70000
-      record export on interval 5000
+      record export on interval 300000
       exporter DPI-EXPORTER
          collector 127.0.0.1
          local interface Loopback0
-         template interval 5000
+         template interval 3000000
    no shutdown
 !
 service routing protocols model multi-agent
@@ -99,14 +99,14 @@ ip security
 interface Dps1
    description DPS Interface
    mtu 9214
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 192.168.2.2/32
 !
 interface Ethernet1
    description Comcast_999
    no shutdown
    no switchport
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    ip address 10.9.9.1/31
 !
 interface Ethernet2
@@ -120,7 +120,7 @@ interface Ethernet2.10
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 10
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf VRF1
    ip address 10.0.10.1/24
 !
@@ -128,7 +128,7 @@ interface Ethernet2.100
    description My vlan 100
    no shutdown
    encapsulation dot1q vlan 100
-   flow tracker hardware WAN-FLOW-TRACKER
+   flow tracker hardware FLOW-TRACKER
    vrf VRF1
    ip address 10.0.100.1/24
    ipv6 enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -6,10 +6,10 @@ flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
       record export on interval 300000
-      exporter DPI-EXPORTER
+      exporter CV-TELEMETRY
          collector 127.0.0.1
          local interface Loopback0
-         template interval 3000000
+         template interval 3600000
    no shutdown
 !
 service routing protocols model multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -113,7 +113,7 @@ ethernet_interfaces:
   description: ATT_666
   dhcp_client_accept_default_route: true
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: custom_flow_track_name
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.15.5.5/31
@@ -121,7 +121,7 @@ ethernet_interfaces:
   type: routed
   description: Colt_10555
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: custom_flow_track_name
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.20.20.20/31
@@ -129,7 +129,7 @@ ethernet_interfaces:
   type: routed
   description: Comcast-5G_AF830
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: custom_flow_track_name
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -177,16 +177,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: custom_flow_track_name
       record_export:
-        on_inactive_timeout: 70000
-        on_interval: 5000
+        on_inactive_timeout: 50000
+        on_interval: 300331
       exporters:
-      - name: DPI-EXPORTER
+      - name: ayush_exporter
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 40000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -387,7 +387,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.255.1/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: custom_flow_track_name
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-edge-custom-default-policy_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -303,11 +303,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -169,7 +169,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 172.17.0.3/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet2.1000
@@ -182,7 +182,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.3/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet2.142
@@ -195,7 +195,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.3/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet2.666
@@ -208,7 +208,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.3/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet1
   peer_type: l3_interface
   ip_address: dhcp
@@ -216,7 +216,7 @@ ethernet_interfaces:
   type: routed
   description: Inmrasat_S511
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: dhcp
@@ -225,7 +225,7 @@ ethernet_interfaces:
   description: AWS-1_212
   dhcp_client_accept_default_route: true
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -298,16 +298,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -544,7 +544,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.142.2/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-edge-no-common-path-group_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -199,11 +199,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -130,7 +130,7 @@ ethernet_interfaces:
   description: ATT_666
   dhcp_client_accept_default_route: true
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.15.5.5/31
@@ -138,7 +138,7 @@ ethernet_interfaces:
   type: routed
   description: Colt_10555
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.20.20.20/31
@@ -146,7 +146,7 @@ ethernet_interfaces:
   type: routed
   description: Comcast-5G_AF830
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -194,16 +194,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -393,7 +393,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.255.1/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-edge-no-default-policy_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -179,7 +179,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 172.17.0.1/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet1.1000
@@ -192,7 +192,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.1/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet1.142
@@ -205,7 +205,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.1/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet1.666
@@ -218,7 +218,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.1/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet1
   peer_type: l3_interface
   peer: peer3
@@ -229,7 +229,7 @@ ethernet_interfaces:
   description: ATT_666_peer3_Ethernet42
   dhcp_client_accept_default_route: true
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.15.5.5/31
@@ -237,7 +237,7 @@ ethernet_interfaces:
   type: routed
   description: Colt_10555
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.20.20.20/31
@@ -245,7 +245,7 @@ ethernet_interfaces:
   type: routed
   description: Comcast-5G_AF830
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -336,16 +336,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -644,7 +644,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.142.1/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-edge_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -341,11 +341,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -413,11 +413,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -197,7 +197,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 172.17.0.5/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet1.1000
@@ -210,7 +210,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.5/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet1.142
@@ -223,7 +223,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.5/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet1.666
@@ -236,7 +236,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.5/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet53
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1
@@ -247,7 +247,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 172.17.0.7/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet53.1000
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1.1000
@@ -260,7 +260,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.7/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet53.142
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1.142
@@ -273,7 +273,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.7/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet53.666
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1.666
@@ -286,7 +286,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.7/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet1
   peer_type: l3_interface
   ip_address: dhcp
@@ -295,7 +295,7 @@ ethernet_interfaces:
   description: ATT_423-01
   dhcp_client_accept_default_route: true
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -408,16 +408,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -698,7 +698,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.142.2/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-edge2A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -197,7 +197,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 172.17.0.9/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet2.1000
@@ -210,7 +210,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.9/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet2.142
@@ -223,7 +223,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.9/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet2.666
@@ -236,7 +236,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.9/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet53
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2
@@ -247,7 +247,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 172.17.0.11/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet53.1000
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2.1000
@@ -260,7 +260,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.11/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet53.142
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2.142
@@ -273,7 +273,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.11/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet53.666
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2.666
@@ -286,7 +286,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.11/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.15.6.6/31
@@ -294,7 +294,7 @@ ethernet_interfaces:
   type: routed
   description: Colt_10423
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -407,16 +407,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -695,7 +695,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.142.3/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-edge2B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -412,11 +412,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -113,7 +113,7 @@ ethernet_interfaces:
   type: routed
   description: Bouygues_Telecom_777
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.16.0.1/31
@@ -121,7 +121,7 @@ ethernet_interfaces:
   type: routed
   description: Colt_10000
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 10.9.9.9/31
@@ -129,7 +129,7 @@ ethernet_interfaces:
   type: routed
   description: Another-ISP_999
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -166,16 +166,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -474,7 +474,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.144.1/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-pathfinder_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -171,11 +171,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -183,11 +183,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -144,7 +144,7 @@ ethernet_interfaces:
   type: routed
   description: Orange_888
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -178,16 +178,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -487,7 +487,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.144.2/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-pathfinder1_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -144,7 +144,7 @@ ethernet_interfaces:
   type: routed
   description: SFR_999
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.19.9.9/31
@@ -152,7 +152,7 @@ ethernet_interfaces:
   type: routed
   description: ATT-MPLS_10999
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -186,16 +186,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -506,7 +506,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.144.3/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-pathfinder2_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -191,11 +191,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -204,7 +204,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 172.17.0.1/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet1.1000
@@ -217,7 +217,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.1/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet1.142
@@ -230,7 +230,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.1/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet1.666
@@ -243,7 +243,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.1/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet1.42
   peer_type: l3_interface
   ip_address: dhcp
@@ -253,7 +253,7 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 42
   dhcp_client_accept_default_route: true
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2.42
   peer_type: l3_interface
   ip_address: 172.16.6.6/31
@@ -262,7 +262,7 @@ ethernet_interfaces:
   description: Colt_10666
   encapsulation_dot1q_vlan: 666
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet1
   type: routed
   peer_type: l3_interface
@@ -379,16 +379,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -725,7 +725,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.143.1/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-transit1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -384,11 +384,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -204,7 +204,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 172.17.0.3/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet2.1000
@@ -217,7 +217,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.3/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet2.142
@@ -230,7 +230,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.3/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet2.666
@@ -243,7 +243,7 @@ ethernet_interfaces:
   mtu: 9214
   ip_address: 172.17.0.3/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet1.42
   peer_type: l3_interface
   ip_address: dhcp
@@ -253,7 +253,7 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 42
   dhcp_client_accept_default_route: true
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2.42
   peer_type: l3_interface
   ip_address: 172.16.6.6/31
@@ -262,7 +262,7 @@ ethernet_interfaces:
   description: Colt_10666
   encapsulation_dot1q_vlan: 666
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet1
   type: routed
   peer_type: l3_interface
@@ -379,16 +379,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -725,7 +725,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.143.2/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: cv-pathfinder-transit1B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -384,11 +384,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -213,11 +213,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -111,7 +111,7 @@ ethernet_interfaces:
   ip_address: 10.0.10.1/24
   mtu: 9214
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2.100
   peer: uplink_lan_l2leaf
   peer_interface: Ethernet1 VLAN 100
@@ -126,7 +126,7 @@ ethernet_interfaces:
   ipv6_enable: true
   eos_cli: comment yo
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
   _custom_key: custom_value
 - name: Ethernet1
   peer_type: l3_interface
@@ -135,7 +135,7 @@ ethernet_interfaces:
   type: routed
   description: Comcast_999
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -208,16 +208,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -338,7 +338,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.2.1/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: uplink_lan_wan_router1_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -120,7 +120,7 @@ ethernet_interfaces:
   ip_address: 10.0.10.1/24
   mtu: 9214
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2.100
   peer: uplink_lan_l2leaf
   peer_interface: Ethernet2 VLAN 100
@@ -135,7 +135,7 @@ ethernet_interfaces:
   ipv6_enable: true
   eos_cli: comment yo
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
   _custom_key: custom_value
 - name: Ethernet1
   peer_type: l3_interface
@@ -144,7 +144,7 @@ ethernet_interfaces:
   type: routed
   description: Comcast_999
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -217,16 +217,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -347,7 +347,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 192.168.2.2/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: uplink_lan_wan_router2_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -222,11 +222,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge-custom-default-policy.yml
@@ -7,6 +7,15 @@ underlay_routing_protocol: none
 
 bgp_as: 65000
 
+flow_tracking_settings:
+  flow_tracker_name: custom_flow_track_name
+  record_export:
+    on_inactive_timeout: 50000
+    on_interval: 300331
+  exporter:
+    name: ayush_exporter
+    template_interval: 40000
+
 cv_pathfinder_regions:
   - name: AVD_Land_West
     id: 42

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
@@ -142,7 +142,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 10.255.255.1/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer: dc1-leaf1b
   peer_interface: Ethernet6
@@ -153,7 +153,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 10.255.255.3/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.18.3.2/24
@@ -161,7 +161,7 @@ ethernet_interfaces:
   type: routed
   description: mpls-sp-1_DC1-MPLS-3
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet4
   peer_type: l3_interface
   ip_address: 100.64.3.2/24
@@ -169,7 +169,7 @@ ethernet_interfaces:
   type: routed
   description: isp-1_DC1-INET-3
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -282,16 +282,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -444,7 +444,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 10.255.1.1/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: dc1-wan1_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
@@ -287,11 +287,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
@@ -142,7 +142,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 10.255.255.5/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer: dc1-leaf1b
   peer_interface: Ethernet7
@@ -153,7 +153,7 @@ ethernet_interfaces:
   type: routed
   ip_address: 10.255.255.7/31
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.18.4.2/24
@@ -161,7 +161,7 @@ ethernet_interfaces:
   type: routed
   description: mpls-sp-1_DC1-MPLS-4
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 - name: Ethernet4
   peer_type: l3_interface
   ip_address: 100.64.4.2/24
@@ -169,7 +169,7 @@ ethernet_interfaces:
   type: routed
   description: isp-1_DC1-INET-4
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID
@@ -282,16 +282,16 @@ agents:
 flow_tracking:
   hardware:
     trackers:
-    - name: WAN-FLOW-TRACKER
+    - name: FLOW-TRACKER
       record_export:
         on_inactive_timeout: 70000
-        on_interval: 5000
+        on_interval: 300000
       exporters:
       - name: DPI-EXPORTER
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 5000
+        template_interval: 3000000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO
@@ -444,7 +444,7 @@ dps_interfaces:
   mtu: 9214
   ip_address: 10.255.1.2/32
   flow_tracker:
-    hardware: WAN-FLOW-TRACKER
+    hardware: FLOW-TRACKER
 vxlan_interface:
   Vxlan1:
     description: dc1-wan2_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
@@ -287,11 +287,11 @@ flow_tracking:
         on_inactive_timeout: 70000
         on_interval: 300000
       exporters:
-      - name: DPI-EXPORTER
+      - name: CV-TELEMETRY
         collector:
           host: 127.0.0.1
         local_interface: Loopback0
-        template_interval: 3000000
+        template_interval: 3600000
     shutdown: false
 ip_extcommunity_lists:
 - name: ECL-EVPN-SOO

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -371,11 +371,8 @@ class WanMixin:
         """
         Return the name of the WAN flow tracking object
         Used in both network services, underlay and overlay python modules.
-
-        TODO make this configurable
-        TODO may need to return exporter name also later
         """
-        return "WAN-FLOW-TRACKER"
+        return get(self.hostvars, "flow_tracking_settings.flow_tracker_name", default="FLOW-TRACKER")
 
     @cached_property
     def is_cv_pathfinder_router(self: SharedUtils) -> bool:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/flow-tracking-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/flow-tracking-settings.md
@@ -1,0 +1,41 @@
+<!--
+  ~ Copyright (c) 2024 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>flow_tracking_settings</samp>](## "flow_tracking_settings") | Dictionary |  |  |  | Define the flow tracking parameters for this topology. |
+    | [<samp>&nbsp;&nbsp;flow_tracker_name</samp>](## "flow_tracking_settings.flow_tracker_name") | String |  | `FLOW-TRACKER` |  | Flow Tracker Name |
+    | [<samp>&nbsp;&nbsp;record_export</samp>](## "flow_tracking_settings.record_export") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_inactive_timeout</samp>](## "flow_tracking_settings.record_export.on_inactive_timeout") | Integer |  | `70000` | Min: 3000<br>Max: 900000 | Flow record inactive export timeout in milliseconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_interval</samp>](## "flow_tracking_settings.record_export.on_interval") | Integer |  | `300000` | Min: 1000<br>Max: 36000000 | Flow record export interval in milliseconds |
+    | [<samp>&nbsp;&nbsp;exporter</samp>](## "flow_tracking_settings.exporter") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "flow_tracking_settings.exporter.name") | String |  | `DPI-EXPORTER` |  | Exporter Name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;template_interval</samp>](## "flow_tracking_settings.exporter.template_interval") | Integer |  | `3000000` | Min: 5000<br>Max: 3600000 | Template interval in milliseconds |
+
+=== "YAML"
+
+    ```yaml
+    # Define the flow tracking parameters for this topology.
+    flow_tracking_settings:
+
+      # Flow Tracker Name
+      flow_tracker_name: <str; default="FLOW-TRACKER">
+      record_export:
+
+        # Flow record inactive export timeout in milliseconds
+        on_inactive_timeout: <int; 3000-900000; default=70000>
+
+        # Flow record export interval in milliseconds
+        on_interval: <int; 1000-36000000; default=300000>
+      exporter:
+
+        # Exporter Name
+        name: <str; default="DPI-EXPORTER">
+
+        # Template interval in milliseconds
+        template_interval: <int; 5000-3600000; default=3000000>
+    ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/flow-tracking-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/flow-tracking-settings.md
@@ -8,13 +8,13 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>flow_tracking_settings</samp>](## "flow_tracking_settings") | Dictionary |  |  |  | Define the flow tracking parameters for this topology. |
-    | [<samp>&nbsp;&nbsp;flow_tracker_name</samp>](## "flow_tracking_settings.flow_tracker_name") | String |  | `FLOW-TRACKER` |  | Flow Tracker Name |
+    | [<samp>&nbsp;&nbsp;flow_tracker_name</samp>](## "flow_tracking_settings.flow_tracker_name") | String |  | `FLOW-TRACKER` |  | Flow Tracker Name. |
     | [<samp>&nbsp;&nbsp;record_export</samp>](## "flow_tracking_settings.record_export") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_inactive_timeout</samp>](## "flow_tracking_settings.record_export.on_inactive_timeout") | Integer |  | `70000` | Min: 3000<br>Max: 900000 | Flow record inactive export timeout in milliseconds |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_interval</samp>](## "flow_tracking_settings.record_export.on_interval") | Integer |  | `300000` | Min: 1000<br>Max: 36000000 | Flow record export interval in milliseconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_inactive_timeout</samp>](## "flow_tracking_settings.record_export.on_inactive_timeout") | Integer |  | `70000` | Min: 3000<br>Max: 900000 | Flow record inactive export timeout in milliseconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_interval</samp>](## "flow_tracking_settings.record_export.on_interval") | Integer |  | `300000` | Min: 1000<br>Max: 36000000 | Flow record export interval in milliseconds. |
     | [<samp>&nbsp;&nbsp;exporter</samp>](## "flow_tracking_settings.exporter") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "flow_tracking_settings.exporter.name") | String |  | `CV-TELEMETRY` |  | Exporter Name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;template_interval</samp>](## "flow_tracking_settings.exporter.template_interval") | Integer |  | `3600000` | Min: 5000<br>Max: 3600000 | Template interval in milliseconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "flow_tracking_settings.exporter.name") | String |  | `CV-TELEMETRY` |  | Exporter Name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;template_interval</samp>](## "flow_tracking_settings.exporter.template_interval") | Integer |  | `3600000` | Min: 5000<br>Max: 3600000 | Template interval in milliseconds. |
 
 === "YAML"
 
@@ -22,20 +22,20 @@
     # Define the flow tracking parameters for this topology.
     flow_tracking_settings:
 
-      # Flow Tracker Name
+      # Flow Tracker Name.
       flow_tracker_name: <str; default="FLOW-TRACKER">
       record_export:
 
-        # Flow record inactive export timeout in milliseconds
+        # Flow record inactive export timeout in milliseconds.
         on_inactive_timeout: <int; 3000-900000; default=70000>
 
-        # Flow record export interval in milliseconds
+        # Flow record export interval in milliseconds.
         on_interval: <int; 1000-36000000; default=300000>
       exporter:
 
-        # Exporter Name
+        # Exporter Name.
         name: <str; default="CV-TELEMETRY">
 
-        # Template interval in milliseconds
+        # Template interval in milliseconds.
         template_interval: <int; 5000-3600000; default=3600000>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/flow-tracking-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/flow-tracking-settings.md
@@ -13,8 +13,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_inactive_timeout</samp>](## "flow_tracking_settings.record_export.on_inactive_timeout") | Integer |  | `70000` | Min: 3000<br>Max: 900000 | Flow record inactive export timeout in milliseconds |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;on_interval</samp>](## "flow_tracking_settings.record_export.on_interval") | Integer |  | `300000` | Min: 1000<br>Max: 36000000 | Flow record export interval in milliseconds |
     | [<samp>&nbsp;&nbsp;exporter</samp>](## "flow_tracking_settings.exporter") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "flow_tracking_settings.exporter.name") | String |  | `DPI-EXPORTER` |  | Exporter Name |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;template_interval</samp>](## "flow_tracking_settings.exporter.template_interval") | Integer |  | `3000000` | Min: 5000<br>Max: 3600000 | Template interval in milliseconds |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "flow_tracking_settings.exporter.name") | String |  | `CV-TELEMETRY` |  | Exporter Name |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;template_interval</samp>](## "flow_tracking_settings.exporter.template_interval") | Integer |  | `3600000` | Min: 5000<br>Max: 3600000 | Template interval in milliseconds |
 
 === "YAML"
 
@@ -34,8 +34,8 @@
       exporter:
 
         # Exporter Name
-        name: <str; default="DPI-EXPORTER">
+        name: <str; default="CV-TELEMETRY">
 
         # Template interval in milliseconds
-        template_interval: <int; 5000-3600000; default=3000000>
+        template_interval: <int; 5000-3600000; default=3600000>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -264,6 +264,12 @@ The tags will only be generated when `wan_mode` is set to `cv-pathfinder`.
 
 TODO - cover here WAN hierarchy, wan mode, route-servers, path-groups and carriers and how they are linked together.
 
+#### Flow Tracking Settings
+
+--8<--
+roles/eos_designs/docs/tables/flow-tracking-settings.md
+--8<--
+
 ### WAN interfaces
 
 TODO

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -111,20 +111,6 @@ The HA tunnel will come up properly today but route redistribution will be missi
 
 - Zones are not configurable for CV Pathfinder. All sites are being configured in a default zone `<region_name>-ZONE` with ID `1`.
 - Because of the previous point, in `eos_designs`, the `transit` node type is always configured as `transit region`.
-- For `cv-pathfinder` mode, the following flow-tracking configuration is applied
-    without any customization possible:
-
-    ```eos
-    flow tracking hardware
-       tracker WAN-FLOW-TRACKER
-        record export on inactive timeout 70000
-        record export on interval 5000
-        exporter DPI-EXPORTER
-         collector 127.0.0.1
-         local interface Loopback0
-         template interval 5000
-    ```
-
 - All Pathfinders must be able to create a full mesh
 - No IPv6 support
 - For WAN interfaces, NAT IP on the Pathfinder side can be supported using the `wan_route_servers.path_groups.interfaces` key.
@@ -216,6 +202,12 @@ roles/eos_designs/docs/tables/wan-virtual-topologies.md
 roles/eos_designs/docs/tables/application-classification.md
 --8<--
 
+#### Flow Tracking Settings
+
+--8<--
+roles/eos_designs/docs/tables/flow-tracking-settings.md
+--8<--
+
 #### New BGP peer-group
 
 --8<--
@@ -263,12 +255,6 @@ The tags will only be generated when `wan_mode` is set to `cv-pathfinder`.
 ### Global settings
 
 TODO - cover here WAN hierarchy, wan mode, route-servers, path-groups and carriers and how they are linked together.
-
-#### Flow Tracking Settings
-
---8<--
-roles/eos_designs/docs/tables/flow-tracking-settings.md
---8<--
 
 ### WAN interfaces
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/flow_tracking.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/flow_tracking.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 from functools import cached_property
 
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get
+
 from .utils import UtilsMixin
 
 
@@ -18,19 +20,24 @@ class FlowTrackingMixin(UtilsMixin):
     def flow_tracking(self) -> dict | None:
         """
         Return structured config for flow_tracking
-
-        TODO: Make this configurable.
         """
         if not self.shared_utils.is_cv_pathfinder_router:
             return None
 
+        flow_tracking = get(self._hostvars, "flow_tracking_settings", default={})
+        exporter_name = get(flow_tracking, "exporter.name", default="DPI-EXPORTER")
+        template_interval = get(flow_tracking, "exporter.template_interval", default=3000000)
+        on_inactive_timeout = get(flow_tracking, "record_export.on_inactive_timeout", default=70000)
+        on_interval = get(flow_tracking, "record_export.on_interval", default=300000)
         return {
             "hardware": {
                 "trackers": [
                     {
                         "name": self.shared_utils.wan_flow_tracker_name,
-                        "record_export": {"on_inactive_timeout": 70000, "on_interval": 5000},
-                        "exporters": [{"name": "DPI-EXPORTER", "collector": {"host": "127.0.0.1"}, "local_interface": "Loopback0", "template_interval": 5000}],
+                        "record_export": {"on_inactive_timeout": on_inactive_timeout, "on_interval": on_interval},
+                        "exporters": [
+                            {"name": exporter_name, "collector": {"host": "127.0.0.1"}, "local_interface": "Loopback0", "template_interval": template_interval}
+                        ],
                     }
                 ],
                 "shutdown": False,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/flow_tracking.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/flow_tracking.py
@@ -25,10 +25,11 @@ class FlowTrackingMixin(UtilsMixin):
             return None
 
         flow_tracking = get(self._hostvars, "flow_tracking_settings", default={})
-        exporter_name = get(flow_tracking, "exporter.name", default="DPI-EXPORTER")
-        template_interval = get(flow_tracking, "exporter.template_interval", default=3000000)
+        exporter_name = get(flow_tracking, "exporter.name", default="CV-TELEMETRY")
+        template_interval = get(flow_tracking, "exporter.template_interval", default=3600000)
         on_inactive_timeout = get(flow_tracking, "record_export.on_inactive_timeout", default=70000)
         on_interval = get(flow_tracking, "record_export.on_interval", default=300000)
+
         return {
             "hardware": {
                 "trackers": [

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5033,6 +5033,73 @@
       "type": "string",
       "title": "Fabric Name"
     },
+    "flow_tracking_settings": {
+      "description": "Define the flow tracking parameters for this topology.",
+      "type": "object",
+      "properties": {
+        "flow_tracker_name": {
+          "type": "string",
+          "default": "FLOW-TRACKER",
+          "description": "Flow Tracker Name",
+          "title": "Flow Tracker Name"
+        },
+        "record_export": {
+          "type": "object",
+          "properties": {
+            "on_inactive_timeout": {
+              "description": "Flow record inactive export timeout in milliseconds",
+              "type": "integer",
+              "minimum": 3000,
+              "maximum": 900000,
+              "default": 70000,
+              "title": "On Inactive Timeout"
+            },
+            "on_interval": {
+              "type": "integer",
+              "minimum": 1000,
+              "maximum": 36000000,
+              "default": 300000,
+              "description": "Flow record export interval in milliseconds",
+              "title": "On Interval"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Record Export"
+        },
+        "exporter": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "type": "string",
+              "default": "DPI-EXPORTER",
+              "description": "Exporter Name",
+              "title": "Name"
+            },
+            "template_interval": {
+              "description": "Template interval in milliseconds",
+              "type": "integer",
+              "minimum": 5000,
+              "maximum": 3600000,
+              "default": 3000000,
+              "title": "Template Interval"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Exporter"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^_.+$": {}
+      },
+      "title": "Flow Tracking Settings"
+    },
     "generate_cv_tags": {
       "type": "object",
       "description": "PREVIEW: This key is currently not supported\nGenerate CloudVision Tags based on AVD data.",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5074,7 +5074,7 @@
           "properties": {
             "name": {
               "type": "string",
-              "default": "DPI-EXPORTER",
+              "default": "CV-TELEMETRY",
               "description": "Exporter Name",
               "title": "Name"
             },
@@ -5083,7 +5083,7 @@
               "type": "integer",
               "minimum": 5000,
               "maximum": 3600000,
-              "default": 3000000,
+              "default": 3600000,
               "title": "Template Interval"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5040,14 +5040,14 @@
         "flow_tracker_name": {
           "type": "string",
           "default": "FLOW-TRACKER",
-          "description": "Flow Tracker Name",
+          "description": "Flow Tracker Name.",
           "title": "Flow Tracker Name"
         },
         "record_export": {
           "type": "object",
           "properties": {
             "on_inactive_timeout": {
-              "description": "Flow record inactive export timeout in milliseconds",
+              "description": "Flow record inactive export timeout in milliseconds.",
               "type": "integer",
               "minimum": 3000,
               "maximum": 900000,
@@ -5059,7 +5059,7 @@
               "minimum": 1000,
               "maximum": 36000000,
               "default": 300000,
-              "description": "Flow record export interval in milliseconds",
+              "description": "Flow record export interval in milliseconds.",
               "title": "On Interval"
             }
           },
@@ -5075,11 +5075,11 @@
             "name": {
               "type": "string",
               "default": "CV-TELEMETRY",
-              "description": "Exporter Name",
+              "description": "Exporter Name.",
               "title": "Name"
             },
             "template_interval": {
-              "description": "Template interval in milliseconds",
+              "description": "Template interval in milliseconds.",
               "type": "integer",
               "minimum": 5000,
               "maximum": 3600000,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1198,6 +1198,48 @@ keys:
       in the Fabric, **must** be an inventory group name.
     type: str
     required: true
+  flow_tracking_settings:
+    description: Define the flow tracking parameters for this topology.
+    type: dict
+    keys:
+      flow_tracker_name:
+        type: str
+        default: FLOW-TRACKER
+        description: Flow Tracker Name
+      record_export:
+        type: dict
+        keys:
+          on_inactive_timeout:
+            description: Flow record inactive export timeout in milliseconds
+            type: int
+            convert_types:
+            - str
+            min: 3000
+            max: 900000
+            default: 70000
+          on_interval:
+            type: int
+            convert_types:
+            - str
+            min: 1000
+            max: 36000000
+            default: 300000
+            description: Flow record export interval in milliseconds
+      exporter:
+        type: dict
+        keys:
+          name:
+            type: str
+            default: DPI-EXPORTER
+            description: Exporter Name
+          template_interval:
+            description: Template interval in milliseconds
+            type: int
+            convert_types:
+            - str
+            min: 5000
+            max: 3600000
+            default: 3000000
   generate_cv_tags:
     documentation_options:
       table: cloudvision-tags

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1205,12 +1205,12 @@ keys:
       flow_tracker_name:
         type: str
         default: FLOW-TRACKER
-        description: Flow Tracker Name
+        description: Flow Tracker Name.
       record_export:
         type: dict
         keys:
           on_inactive_timeout:
-            description: Flow record inactive export timeout in milliseconds
+            description: Flow record inactive export timeout in milliseconds.
             type: int
             convert_types:
             - str
@@ -1224,16 +1224,16 @@ keys:
             min: 1000
             max: 36000000
             default: 300000
-            description: Flow record export interval in milliseconds
+            description: Flow record export interval in milliseconds.
       exporter:
         type: dict
         keys:
           name:
             type: str
             default: CV-TELEMETRY
-            description: Exporter Name
+            description: Exporter Name.
           template_interval:
-            description: Template interval in milliseconds
+            description: Template interval in milliseconds.
             type: int
             convert_types:
             - str

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1230,7 +1230,7 @@ keys:
         keys:
           name:
             type: str
-            default: DPI-EXPORTER
+            default: CV-TELEMETRY
             description: Exporter Name
           template_interval:
             description: Template interval in milliseconds
@@ -1239,7 +1239,7 @@ keys:
             - str
             min: 5000
             max: 3600000
-            default: 3000000
+            default: 3600000
   generate_cv_tags:
     documentation_options:
       table: cloudvision-tags

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/flow_tracking_settings.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/flow_tracking_settings.schema.yml
@@ -1,0 +1,51 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  flow_tracking_settings:
+    description: |-
+      Define the flow tracking parameters for this topology.
+    type: dict
+    keys:
+      flow_tracker_name:
+        type: str
+        default: FLOW-TRACKER
+        description: Flow Tracker Name
+      record_export:
+        type: dict
+        keys:
+          on_inactive_timeout:
+            description: Flow record inactive export timeout in milliseconds
+            type: int
+            convert_types:
+              - str
+            min: 3000
+            max: 900000
+            default: 70000
+          on_interval:
+            type: int
+            convert_types:
+              - str
+            min: 1000
+            max: 36000000
+            default: 300000
+            description: Flow record export interval in milliseconds
+      exporter:
+        type: dict
+        keys:
+          name:
+            type: str
+            default: DPI-EXPORTER
+            description: Exporter Name
+          template_interval:
+            description: Template interval in milliseconds
+            type: int
+            convert_types:
+              - str
+            min: 5000
+            max: 3600000
+            default: 3000000

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/flow_tracking_settings.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/flow_tracking_settings.schema.yml
@@ -39,7 +39,7 @@ keys:
         keys:
           name:
             type: str
-            default: DPI-EXPORTER
+            default: CV-TELEMETRY
             description: Exporter Name
           template_interval:
             description: Template interval in milliseconds
@@ -48,4 +48,4 @@ keys:
               - str
             min: 5000
             max: 3600000
-            default: 3000000
+            default: 3600000

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/flow_tracking_settings.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/flow_tracking_settings.schema.yml
@@ -14,12 +14,12 @@ keys:
       flow_tracker_name:
         type: str
         default: FLOW-TRACKER
-        description: Flow Tracker Name
+        description: Flow Tracker Name.
       record_export:
         type: dict
         keys:
           on_inactive_timeout:
-            description: Flow record inactive export timeout in milliseconds
+            description: Flow record inactive export timeout in milliseconds.
             type: int
             convert_types:
               - str
@@ -33,16 +33,16 @@ keys:
             min: 1000
             max: 36000000
             default: 300000
-            description: Flow record export interval in milliseconds
+            description: Flow record export interval in milliseconds.
       exporter:
         type: dict
         keys:
           name:
             type: str
             default: CV-TELEMETRY
-            description: Exporter Name
+            description: Exporter Name.
           template_interval:
-            description: Template interval in milliseconds
+            description: Template interval in milliseconds.
             type: int
             convert_types:
               - str


### PR DESCRIPTION
## Change Summary
Currently we generate flow tracking config using predefined names and time values. Add a top level schema to allow overriding those settings.

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Add a top level key flow_tracking_settings:

```
flow_tracking_settings: <dict>
    flow_tracker_name : <str, default=WAN-FLOW-TRACKER>
    record_export: <dict>
         on_inactive_timeout: <int, default=70000 (70s)>
         on_interval: <int, default = 300000 (300s) >
   exporter: <dict>
        name: <str, default=DPI-EXPORTER>
        template_interval: <int, default=300000 ( 300s ) > 
```



## How to test
molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
