### PR TITLE
Feat(eos_designs): Allow custom name for LAN_HA path-group

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -104,7 +104,7 @@ router adaptive-virtual-topology
 router path-selection
    tcp mss ceiling ipv4 ingress
    !
-   path-group arista-ha id 65535
+   path-group CUSTOM_LAN_HA id 65535
       ipsec profile DP-PROFILE
       flow assignment lan
       !
@@ -131,34 +131,34 @@ router path-selection
          ipv4 address 172.16.0.1
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
-      path-group arista-ha
+      path-group CUSTOM_LAN_HA
       path-group MPLS
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group arista-ha
+      path-group CUSTOM_LAN_HA
       path-group MPLS priority 4223
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
-      path-group arista-ha
+      path-group CUSTOM_LAN_HA
       path-group MPLS
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
-      path-group arista-ha
+      path-group CUSTOM_LAN_HA
       path-group MPLS
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT
-      path-group arista-ha
+      path-group CUSTOM_LAN_HA
       path-group MPLS priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VIDEO
       loss-rate 42.0
-      path-group arista-ha
+      path-group CUSTOM_LAN_HA
       path-group MPLS
    !
    load-balance policy LB-PROD-AVT-POLICY-VOICE
       hop count lowest
       jitter 42
-      path-group arista-ha
+      path-group CUSTOM_LAN_HA
       path-group MPLS
 !
 spanning-tree mode none

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -104,7 +104,7 @@ router adaptive-virtual-topology
 router path-selection
    tcp mss ceiling ipv4 ingress
    !
-   path-group LAN_HA id 65535
+   path-group arista-ha id 65535
       ipsec profile DP-PROFILE
       flow assignment lan
       !
@@ -131,34 +131,34 @@ router path-selection
          ipv4 address 172.16.0.1
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
-      path-group LAN_HA
+      path-group arista-ha
       path-group MPLS
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-DEFAULT
-      path-group LAN_HA
+      path-group arista-ha
       path-group MPLS priority 4223
    !
    load-balance policy LB-DEFAULT-AVT-POLICY-VIDEO
-      path-group LAN_HA
+      path-group arista-ha
       path-group MPLS
    !
    load-balance policy LB-DEFAULT-POLICY-DEFAULT
-      path-group LAN_HA
+      path-group arista-ha
       path-group MPLS
    !
    load-balance policy LB-PROD-AVT-POLICY-DEFAULT
-      path-group LAN_HA
+      path-group arista-ha
       path-group MPLS priority 2
    !
    load-balance policy LB-PROD-AVT-POLICY-VIDEO
       loss-rate 42.0
-      path-group LAN_HA
+      path-group arista-ha
       path-group MPLS
    !
    load-balance policy LB-PROD-AVT-POLICY-VOICE
       hop count lowest
       jitter 42
-      path-group LAN_HA
+      path-group arista-ha
       path-group MPLS
 !
 spanning-tree mode none

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -582,7 +582,7 @@ router_path_selection:
     keepalive:
       interval: 300
       failure_threshold: 5
-  - name: arista-ha
+  - name: CUSTOM_LAN_HA
     id: 65535
     flow_assignment: lan
     local_interfaces:
@@ -598,36 +598,36 @@ router_path_selection:
   load_balance_policies:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
-    - name: arista-ha
+    - name: CUSTOM_LAN_HA
     - name: MPLS
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
     path_groups:
-    - name: arista-ha
+    - name: CUSTOM_LAN_HA
     - name: MPLS
   - name: LB-DEFAULT-AVT-POLICY-DEFAULT
     path_groups:
-    - name: arista-ha
+    - name: CUSTOM_LAN_HA
     - name: MPLS
       priority: 4223
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
-    - name: arista-ha
+    - name: CUSTOM_LAN_HA
     - name: MPLS
     jitter: 42
     lowest_hop_count: true
   - name: LB-PROD-AVT-POLICY-VIDEO
     path_groups:
-    - name: arista-ha
+    - name: CUSTOM_LAN_HA
     - name: MPLS
     loss_rate: '42.0'
   - name: LB-PROD-AVT-POLICY-DEFAULT
     path_groups:
-    - name: arista-ha
+    - name: CUSTOM_LAN_HA
     - name: MPLS
       priority: 2
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
-    - name: arista-ha
+    - name: CUSTOM_LAN_HA
     - name: MPLS
 router_traffic_engineering:
   enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -582,7 +582,7 @@ router_path_selection:
     keepalive:
       interval: 300
       failure_threshold: 5
-  - name: LAN_HA
+  - name: arista-ha
     id: 65535
     flow_assignment: lan
     local_interfaces:
@@ -598,36 +598,36 @@ router_path_selection:
   load_balance_policies:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
     path_groups:
-    - name: LAN_HA
+    - name: arista-ha
     - name: MPLS
   - name: LB-DEFAULT-AVT-POLICY-VIDEO
     path_groups:
-    - name: LAN_HA
+    - name: arista-ha
     - name: MPLS
   - name: LB-DEFAULT-AVT-POLICY-DEFAULT
     path_groups:
-    - name: LAN_HA
+    - name: arista-ha
     - name: MPLS
       priority: 4223
   - name: LB-PROD-AVT-POLICY-VOICE
     path_groups:
-    - name: LAN_HA
+    - name: arista-ha
     - name: MPLS
     jitter: 42
     lowest_hop_count: true
   - name: LB-PROD-AVT-POLICY-VIDEO
     path_groups:
-    - name: LAN_HA
+    - name: arista-ha
     - name: MPLS
     loss_rate: '42.0'
   - name: LB-PROD-AVT-POLICY-DEFAULT
     path_groups:
-    - name: LAN_HA
+    - name: arista-ha
     - name: MPLS
       priority: 2
   - name: LB-DEFAULT-POLICY-DEFAULT
     path_groups:
-    - name: LAN_HA
+    - name: arista-ha
     - name: MPLS
 router_traffic_engineering:
   enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge2B.yml
@@ -3,4 +3,4 @@
 # Other variables inherited from CV_PATHFINDER_TESTS
 
 wan_ha:
-  lan_ha_path_group_name: arista-ha
+  lan_ha_path_group_name: CUSTOM_LAN_HA

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge2B.yml
@@ -1,0 +1,6 @@
+---
+# Testing CV pathfinder edge, override LAN_HA path group name
+# Other variables inherited from CV_PATHFINDER_TESTS
+
+wan_ha:
+  lan_ha_path_group_name: arista-ha

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -425,10 +425,8 @@ class WanMixin:
         """
         Return HA path group name for the WAN design.
         Used in both network services and overlay python modules.
-
-        TODO make this configurable
         """
-        return "LAN_HA"
+        return get(self.hostvars, "wan_ha.lan_ha_path_group_name", default="LAN_HA")
 
     @cached_property
     def is_first_ha_peer(self: SharedUtils) -> bool:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
@@ -8,8 +8,8 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>wan_edge</samp>](## "wan_edge") <span style="color:red">removed</span> | Dictionary |  |  |  | The `wan_edge` node type was introduced and removed while the AVD WAN feature was in PREVIEW MODE.<br>Migrate your existing edge nodes to using `wan_router` node_type.<span style="color:red">This key was removed. Support was removed in AVD version 4.6.0-dev1. Use <samp>wan_router</samp> instead.</span> |
-    | [<samp>wan_ha</samp>](## "wan_ha") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;lan_ha_path_group_name</samp>](## "wan_ha.lan_ha_path_group_name") | String |  | `LAN_HA` |  | PREVIEW: This key is currently not supported<br><br>When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.<br>This key allows to overwrite the default LAN HA path-group name. |
+    | [<samp>wan_ha</samp>](## "wan_ha") | Dictionary |  |  |  | PREVIEW: This key is currently not supported |
+    | [<samp>&nbsp;&nbsp;lan_ha_path_group_name</samp>](## "wan_ha.lan_ha_path_group_name") | String |  | `LAN_HA` |  | When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.<br>This key allows to overwrite the default LAN HA path-group name. |
     | [<samp>wan_ipsec_profiles</samp>](## "wan_ipsec_profiles") | Dictionary |  |  |  | PREVIEW: This key is currently not supported<br><br>Define IPsec profiles parameters for WAN configuration. |
     | [<samp>&nbsp;&nbsp;control_plane</samp>](## "wan_ipsec_profiles.control_plane") | Dictionary | Required |  |  | PREVIEW: This key is currently not supported |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ike_policy_name</samp>](## "wan_ipsec_profiles.control_plane.ike_policy_name") | String |  | `CP-IKE-POLICY` |  | Name of the IKE policy. |
@@ -37,10 +37,9 @@
 === "YAML"
 
     ```yaml
+    # PREVIEW: This key is currently not supported
     wan_ha:
 
-      # PREVIEW: This key is currently not supported
-      #
       # When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.
       # This key allows to overwrite the default LAN HA path-group name.
       lan_ha_path_group_name: <str; default="LAN_HA">

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
@@ -8,6 +8,8 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>wan_edge</samp>](## "wan_edge") <span style="color:red">removed</span> | Dictionary |  |  |  | The `wan_edge` node type was introduced and removed while the AVD WAN feature was in PREVIEW MODE.<br>Migrate your existing edge nodes to using `wan_router` node_type.<span style="color:red">This key was removed. Support was removed in AVD version 4.6.0-dev1. Use <samp>wan_router</samp> instead.</span> |
+    | [<samp>wan_ha</samp>](## "wan_ha") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;lan_ha_path_group_name</samp>](## "wan_ha.lan_ha_path_group_name") | String |  | `LAN_HA` |  | PREVIEW: This key is currently not supported<br><br>When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.<br>This key allows to overwrite the default LAN HA path-group name. |
     | [<samp>wan_ipsec_profiles</samp>](## "wan_ipsec_profiles") | Dictionary |  |  |  | PREVIEW: This key is currently not supported<br><br>Define IPsec profiles parameters for WAN configuration. |
     | [<samp>&nbsp;&nbsp;control_plane</samp>](## "wan_ipsec_profiles.control_plane") | Dictionary | Required |  |  | PREVIEW: This key is currently not supported |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ike_policy_name</samp>](## "wan_ipsec_profiles.control_plane.ike_policy_name") | String |  | `CP-IKE-POLICY` |  | Name of the IKE policy. |
@@ -35,6 +37,14 @@
 === "YAML"
 
     ```yaml
+    wan_ha:
+
+      # PREVIEW: This key is currently not supported
+      #
+      # When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.
+      # This key allows to overwrite the default LAN HA path-group name.
+      lan_ha_path_group_name: <str; default="LAN_HA">
+
     # PREVIEW: This key is currently not supported
     #
     # Define IPsec profiles parameters for WAN configuration.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24869,12 +24869,13 @@
       "title": "Wan Carriers"
     },
     "wan_ha": {
+      "description": "PREVIEW: This key is currently not supported",
       "type": "object",
       "properties": {
         "lan_ha_path_group_name": {
           "type": "string",
           "default": "LAN_HA",
-          "description": "PREVIEW: This key is currently not supported\n\nWhen WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.\nThis key allows to overwrite the default LAN HA path-group name.",
+          "description": "When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.\nThis key allows to overwrite the default LAN HA path-group name.",
           "title": "Lan Ha Path Group Name"
         }
       },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -24868,6 +24868,22 @@
       },
       "title": "Wan Carriers"
     },
+    "wan_ha": {
+      "type": "object",
+      "properties": {
+        "lan_ha_path_group_name": {
+          "type": "string",
+          "default": "LAN_HA",
+          "description": "PREVIEW: This key is currently not supported\n\nWhen WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.\nThis key allows to overwrite the default LAN HA path-group name.",
+          "title": "Lan Ha Path Group Name"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^_.+$": {}
+      },
+      "title": "Wan Ha"
+    },
     "wan_ipsec_profiles": {
       "description": "PREVIEW: This key is currently not supported\n\nDefine IPsec profiles parameters for WAN configuration.",
       "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3546,6 +3546,21 @@ keys:
       new_key: wan_router
       removed: true
       remove_in_version: 4.6.0-dev1
+  wan_ha:
+    documentation_options:
+      table: wan-settings
+    type: dict
+    keys:
+      lan_ha_path_group_name:
+        type: str
+        default: LAN_HA
+        description: 'PREVIEW: This key is currently not supported
+
+
+          When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default
+          path-group is injected to form DPS tunnels over LAN.
+
+          This key allows to overwrite the default LAN HA path-group name.'
   wan_ipsec_profiles:
     documentation_options:
       table: wan-settings

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3549,16 +3549,14 @@ keys:
   wan_ha:
     documentation_options:
       table: wan-settings
+    description: 'PREVIEW: This key is currently not supported'
     type: dict
     keys:
       lan_ha_path_group_name:
         type: str
         default: LAN_HA
-        description: 'PREVIEW: This key is currently not supported
-
-
-          When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default
-          path-group is injected to form DPS tunnels over LAN.
+        description: 'When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`,
+          a default path-group is injected to form DPS tunnels over LAN.
 
           This key allows to overwrite the default LAN HA path-group name.'
   wan_ipsec_profiles:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_ha.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_ha.schema.yml
@@ -9,13 +9,13 @@ keys:
   wan_ha:
     documentation_options:
       table: wan-settings
+    description: |-
+      PREVIEW: This key is currently not supported
     type: dict
     keys:
       lan_ha_path_group_name:
         type: str
         default: LAN_HA
         description: |-
-          PREVIEW: This key is currently not supported
-
           When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.
           This key allows to overwrite the default LAN HA path-group name.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_ha.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/wan_ha.schema.yml
@@ -1,0 +1,21 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  wan_ha:
+    documentation_options:
+      table: wan-settings
+    type: dict
+    keys:
+      lan_ha_path_group_name:
+        type: str
+        default: LAN_HA
+        description: |-
+          PREVIEW: This key is currently not supported
+
+          When WAN HA is enabled for a site if `wan_mode: cv-pathfinder`, a default path-group is injected to form DPS tunnels over LAN.
+          This key allows to overwrite the default LAN HA path-group name.


### PR DESCRIPTION
## Change Summary
pr title

## Related Issue(s)


## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Add a new key cv_pathfinder_ha, which can be used to add any global ha parameters which might come.

## How to test
molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
