### PR TITLE
Feat(plugins): Add "unique_keys" in avdschema.

### DIFF
--- a/ansible_collections/arista/avd/docs/contribution/input-variable-validation.md
+++ b/ansible_collections/arista/avd/docs/contribution/input-variable-validation.md
@@ -235,6 +235,7 @@ The meta-schema does not allow for other keys to be set in the schema.
 | <samp>min_length</samp> | Integer | | | | Minimum length |
 | <samp>primary_key</samp> | String | | | Pattern: `^[a-z][a-z0-9_]*$` | Name of a primary key in a list of dictionaries.<br>The configured key is implicitly required and must have unique values between the list elements |
 | <samp>secondary_key</samp> | String | | | Pattern: `^[a-z][a-z0-9_]*$` | Name of a secondary key, which is used with `convert_types:['dict']` in case of values not being dictionaries |
+| <samp>unique_keys</samp> | List, items: String | | | Item Pattern: `^[a-z][a-z0-9_]*$` | Name of a key in a list of dictionaries.<br>The configured key must have unique values between the list elements.<br>This can also be a variable path using dot-notation like `parent_key.child_key` in case of nested lists of dictionaries. |
 | <samp>display_name</samp> | String | | | Regex Pattern: `"^[^\n]+$"` | Free text display name for forms and documentation (single line) |
 | <samp>description</samp> | String | | | Minimum Length: 1 | Free text description for forms and documentation (multi line) |
 | <samp>required</samp> | Boolean | | | | Set if variable is required |

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
@@ -214,6 +214,16 @@
                             "pattern": "^[a-z][a-z0-9_]*$",
                             "description": "Name of a secondary key, which is used with `convert_types:[dict]` in case of values not being dictionaries."
                         },
+                        "unique_keys": {
+                            "type": "array",
+                            "description": "List of types to auto-convert from.\nFor 'list of dicts' auto-conversion is supported from 'dict' if 'primary_key' is set on the list schema\nFor other list item types conversion from dict will use the keys as list items.",
+                            "items": {
+                                "type": "string",
+                                "$comment": "The regex here matches valid key names",
+                                "pattern": "^[a-z][a-z0-9_\\.]*$",
+                                "description": "Name of a key in a list of dictionaries.\nThe configured key must have unique values between the list elements\nThis can also be a variable path using dot-notation like 'parent_key.child_key' in case of nested lists of dictionaries."
+                            }
+                        },
                         "display_name": { "$ref": "#/$defs/display_name" },
                         "description": { "$ref": "#/$defs/description" },
                         "required": { "$ref": "#/$defs/required" },

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.json
@@ -221,7 +221,7 @@
                                 "type": "string",
                                 "$comment": "The regex here matches valid key names",
                                 "pattern": "^[a-z][a-z0-9_\\.]*$",
-                                "description": "Name of a key in a list of dictionaries.\nThe configured key must have unique values between the list elements\nThis can also be a variable path using dot-notation like 'parent_key.child_key' in case of nested lists of dictionaries."
+                                "description": "Name of a key in a list of dictionaries.\nThe configured key must have unique values between the list elements.\nThis can also be a variable path using dot-notation like 'parent_key.child_key' in case of nested lists of dictionaries."
                             }
                         },
                         "display_name": { "$ref": "#/$defs/display_name" },

--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdvalidator.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdvalidator.py
@@ -5,7 +5,7 @@ from collections import ChainMap
 
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
 from ansible_collections.arista.avd.plugins.plugin_utils.schema.refresolver import create_refresolver
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get_all
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import get_all, get_all_with_path, get_indices_of_duplicate_items
 
 try:
     import jsonschema
@@ -19,11 +19,42 @@ else:
     JSONSCHEMA_IMPORT_ERROR = None
 
 
+def _unique_keys_validator(validator, unique_keys: list[str], instance: list, schema: dict):
+    if not validator.is_type(unique_keys, "list"):
+        return
+
+    if not validator.is_type(instance, "list") or not instance:
+        return
+
+    if not all(validator.is_type(element, "dict") for element in instance):
+        return
+
+    for unique_key in unique_keys:
+        if not (paths_and_values := tuple(get_all_with_path(instance, unique_key))):
+            # No values matching the unique key, check the next unique_key
+            continue
+
+        # Separate all paths and values
+        paths, values = zip(*paths_and_values)
+
+        key = unique_key.split(".")[-1]
+        is_nested_key = unique_key != key
+
+        # Find any duplicate values and emit errors for each index.
+        for duplicate_value, duplicate_indices in get_indices_of_duplicate_items(values):
+            for duplicate_index in duplicate_indices:
+                yield jsonschema.ValidationError(
+                    f"The value '{duplicate_value}' is not unique between all {'nested ' if is_nested_key else ''}list items as required.",
+                    path=[*paths[duplicate_index], key],
+                    schema_path=["items"],
+                )
+
+
 def _primary_key_validator(validator, primary_key: str, instance: list, schema: dict):
     if not validator.is_type(primary_key, "str"):
         return
 
-    if not validator.is_type(instance, "list"):
+    if not validator.is_type(instance, "list") or not instance:
         return
 
     if not all(validator.is_type(element, "dict") for element in instance):
@@ -32,8 +63,8 @@ def _primary_key_validator(validator, primary_key: str, instance: list, schema: 
     if not all(element.get(primary_key) is not None for element in instance):
         yield jsonschema.ValidationError(f"Primary key '{primary_key}' is not set on all items as required.")
 
-    if len(set(element.get(primary_key) for element in instance)) < len(instance):
-        yield jsonschema.ValidationError(f"Values of Primary key '{primary_key}' are not unique as required.")
+    # Reusing the unique keys validator
+    yield from _unique_keys_validator(validator, [primary_key], instance, schema)
 
 
 def _keys_validator(validator, keys: dict, instance: dict, schema: dict):
@@ -140,6 +171,7 @@ class AvdValidator:
                 "pattern": jsonschema._validators.pattern,
                 "items": jsonschema._validators.items,
                 "primary_key": _primary_key_validator,
+                "unique_keys": _unique_keys_validator,
                 "keys": _keys_validator,
                 "dynamic_keys": _dynamic_keys_validator,
             },

--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/__init__.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/__init__.py
@@ -8,7 +8,8 @@ from .compile_searchpath import compile_searchpath
 from .cprofile_decorator import cprofile
 from .default import default
 from .get import get
-from .get_all import get_all
+from .get_all import get_all, get_all_with_path
+from .get_indices_of_duplicate_items import get_indices_of_duplicate_items
 from .get_ip_from_pool import get_ip_from_pool
 from .get_item import get_item
 from .get_templar import get_templar
@@ -32,6 +33,8 @@ __all__ = [
     "default",
     "get",
     "get_all",
+    "get_all_with_path",
+    "get_indices_of_duplicate_items",
     "get_ip_from_pool",
     "get_item",
     "get_templar",

--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/get_all.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/get_all.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
+from typing import Any, Generator
+
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError
 
 
@@ -60,3 +62,48 @@ def get_all(data, path: str, required: bool = False, org_path=None):
             return [value]
 
     return []
+
+
+def get_all_with_path(data, path: str, _current_path: list[str | int] | None = None) -> Generator[tuple[list[str | int], Any], None, None]:
+    """
+    Get all values from data matching a data path including the path they were found in.
+
+    Path supports dot-notation like "foo.bar" to do deeper lookups. Lists will be unpacked recursively.
+    Returns an empty list if the path is not found and required is False.
+
+    Parameters
+    ----------
+    data : any
+        Data to walk through
+    path : str
+        Data Path - supporting dot-notation for nested dictionaries/lists
+    _current_path : list[str|int]
+        Internal variable used for tracking the full path even when called recursively
+
+    Returns
+    -------
+    Generator yielding Tuples (<path>, <value>) for all values from data matching a data path.
+
+    """
+    if _current_path is None:
+        _current_path = []
+
+    path_elements = str(path).split(".")
+    if isinstance(data, list):
+        for index, data_item in enumerate(data):
+            yield from get_all_with_path(data_item, path, _current_path=[*_current_path, index])
+
+    elif isinstance(data, dict):
+        value = data.get(path_elements[0])
+
+        if value is None:
+            return
+
+        if len(path_elements) > 1:
+            yield from get_all_with_path(value, ".".join(path_elements[1:]), _current_path=[*_current_path, path_elements[0]])
+            return
+
+        else:
+            yield (_current_path, value)
+
+    return

--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/get_indices_of_duplicate_items.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/get_indices_of_duplicate_items.py
@@ -1,0 +1,15 @@
+# Copyright (c) 2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from collections import defaultdict
+from typing import Any, Generator
+
+
+def get_indices_of_duplicate_items(values: list) -> Generator[tuple[Any, list[int]], None, None]:
+    """
+    Returns a Generator of Tuples with (<value>, [<indices of duplicate items>])
+    """
+    counters = defaultdict(list)
+    for index, item in enumerate(values):
+        counters[item].append(index)
+    return ((value, indices) for value, indices in counters.items() if len(indices) > 1)

--- a/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdschema.py
+++ b/ansible_collections/arista/avd/tests/unit/plugins/plugin_utils/schema/test_avdschema.py
@@ -89,13 +89,16 @@ UNIQUE_KEYS_VALID_DATA = [
         {"key": "a", "nested_list": [{"nested_list_key": 1}, {"nested_list_key": 2}]},
         {"key": "b", "nested_list": [{"nested_list_key": 3}, {"nested_list_key": 4}]},
     ],
+    [
+        {"key": "a", "nested_list": [{"nested_list_key": 1}, {}]},
+        {"nested_list": [{"nested_list_key": 3}, {"nested_list_key": 4}]},
+    ],
+    [],
+    [{}],
+    [{"nested_list": []}],
 ]
 
 UNIQUE_KEYS_INVALID_DATA = [
-    [
-        {"key": "a", "nested_list": [{"nested_list_key": 1}, {"nested_list_key": 2}]},
-        {"key": "b", "nested_list": [{"nested_list_key": 3}, {"nested_list_key": 4}]},
-    ],
     [
         {"key": "a", "nested_list": [{"nested_list_key": 1}, {"nested_list_key": 2}]},
         {"key": "b", "nested_list": [{"nested_list_key": 3}, {"nested_list_key": 3}]},
@@ -251,8 +254,12 @@ class TestAvdSchema:
     @pytest.mark.parametrize("INVALID_DATA", UNIQUE_KEYS_INVALID_DATA)
     def test_avd_schema_validate_unique_keys_invalid_data(self, TEST_SCHEMA, INVALID_DATA):
         try:
-            for validation_error in AvdSchema(TEST_SCHEMA).validate(INVALID_DATA):
+            validation_errors = tuple(AvdSchema(TEST_SCHEMA).validate(INVALID_DATA))
+            if not validation_errors:
+                assert False, "did NOT fail validation"
+            for validation_error in validation_errors:
                 assert isinstance(validation_error, AvdValidationError)
                 assert validation_error.path.endswith((".key", ".nested_list_key"))
+
         except Exception as e:
             assert False, f"AvdSchema(UNIQUE_KEYS_SCHEMAS).validate(UNIQUE_KEYS_INVALID_DATA) raised an exception: {e}"

--- a/python-avd/schema_tools/metaschema/meta_schema_model.py
+++ b/python-avd/schema_tools/metaschema/meta_schema_model.py
@@ -383,6 +383,12 @@ class AvdSchemaList(AvdSchemaBaseModel):
     """
     secondary_key: str | None = Field(None, pattern=KEY_PATTERN)
     """Name of a secondary key, which is used with `convert_types:[dict]` in case of values not being dictionaries."""
+    unique_keys: list[str] | None = None
+    """
+    Name of a key in a list of dictionaries.
+    The configured key must have unique values between the list elements.
+    This can also be a variable path using dot-notation like 'parent_key.child_key' in case of nested lists of dictionaries.
+    """
 
     # Type of schema docs generators to use for this schema field.
     _table_row_generator = TableRowGenList


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add "unique_keys" in avdschema.

## Component(s) name

AVD Schema validation

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Support `unique_keys` in the AVD Meta schema so we can validate uniqueness of one or more keys which is not the `primary_key`.
Also supports checking uniqueness across nested data models by using dot-notated variable path.

Limitation: If the test for nested keys overlap with the primary_key of an underlying dict, it will emit errors from both checks. This should be solved by removing `primary_key` on the nested dict, and just set `required: true` on the key instead.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added unit tests for both positive and negative cases.
Also tested manually with `cv_pathfinder_regions` where we want `unique_keys: [name, sites.name"` to ensure unique site names across multiple regions.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
