### PR TITLE
Fix(eos_designs): Use WAN VNI for cv-pathfinder metadata

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -624,7 +624,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: PROD
-      vni: 142
+      vni: 42
       avts:
       - constraints:
           jitter: 42
@@ -658,7 +658,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: IT
-      vni: 1000
+      vni: 100
       avts:
       - id: 3
         name: DEFAULT-AVT-POLICY-VIDEO
@@ -704,7 +704,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: ATTRACTED-VRF-FROM-UPLINK
-      vni: 666
+      vni: 166
       avts:
       - id: 1
         name: DEFAULT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -611,7 +611,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: PROD
-      vni: 142
+      vni: 42
       avts:
       - constraints:
           jitter: 42
@@ -645,7 +645,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: IT
-      vni: 1000
+      vni: 100
       avts:
       - id: 3
         name: DEFAULT-AVT-POLICY-VIDEO
@@ -691,7 +691,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: ATTRACTED-VRF-FROM-UPLINK
-      vni: 666
+      vni: 166
       avts:
       - id: 1
         name: DEFAULT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -643,7 +643,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: PROD
-      vni: 142
+      vni: 42
       avts:
       - constraints:
           jitter: 42
@@ -677,7 +677,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: IT
-      vni: 1000
+      vni: 100
       avts:
       - id: 3
         name: DEFAULT-AVT-POLICY-VIDEO
@@ -723,7 +723,7 @@ metadata:
         - name: MPLS
           preference: alternate
     - name: ATTRACTED-VRF-FROM-UPLINK
-      vni: 666
+      vni: 166
       avts:
       - id: 1
         name: DEFAULT-POLICY-DEFAULT

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from ansible_collections.arista.avd.plugins.filter.convert_dicts import convert_dicts
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdError
 from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, get_item
 
@@ -184,27 +183,18 @@ class CvPathfinderMixin:
         ]
 
     @cached_property
-    def _all_vrfs_from_all_tenants(self: AvdStructuredConfigMetadata) -> list[dict]:
+    def _wan_virtual_topologies_vrfs(self: AvdStructuredConfigMetadata) -> list[dict]:
         """
-        Unfiltered list of VRFs found under tenants.
+        Unfiltered list of VRFs found under wan_virtual_topologies.
         Used to find VNI for each VRF used in cv_pathfinder.
-
-        We cannot use filtered_tenants since pathfinders do not necessarily have all VRFs defined in the policies.
-
-        Potential issue with this is if some VRFs are defined multiple times with different information.
         """
-        all_vrfs = [
-            vrf
-            for network_services_key in self.shared_utils.network_services_keys
-            for tenant in convert_dicts(get(self._hostvars, network_services_key["name"]), "name")
-            for vrf in tenant["vrfs"]
-        ]
-        # Add the default WAN VRF at the end. Will only be reached if default VRF was not defined in inputs
-        all_vrfs.append({"name": "default", "vrf_id": 1})
-        return all_vrfs
+        return get(self._hostvars, "wan_virtual_topologies.vrfs", default=[])
 
     def _get_vni_for_vrf_name(self: AvdStructuredConfigMetadata, vrf_name: str):
-        if (vrf := get_item(self._all_vrfs_from_all_tenants, "name", vrf_name)) is None:
-            raise AristaAvdError(f"Unable to find VNI for VRF {vrf_name} during generation of cv_pathfinder metadata.")
+        if (vrf := get_item(self._wan_virtual_topologies_vrfs, "name", vrf_name)) is None or (wan_vni := vrf.get("wan_vni")) is None:
+            if vrf_name == "default":
+                return 1
 
-        return self.shared_utils.get_vrf_vni(vrf)
+            raise AristaAvdError(f"Unable to find the WAN VNI for VRF {vrf_name} during generation of cv_pathfinder metadata.")
+
+        return wan_vni


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Use WAN VNI for cv-pathfinder metadata

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Set VNI in CV-Pathfinder metadata based on `wan_virtual_topologies.vrfs[].wan_vni` instead of VNI from network services.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing molecule is reflecting the correct VNI now.

Also tested removing the default VRF from inputs, and it was still getting VNI `1` as it should.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
