### PR TITLE
Refactor: Fix typo to render flow-tracking for LAN subif in WAN case

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-common-path-group.cfg
@@ -217,6 +217,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.3/31
 !
@@ -225,6 +226,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.3/31
 !
@@ -233,6 +235,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf IT
    ip address 172.17.0.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -255,6 +255,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.1/31
 !
@@ -263,6 +264,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.1/31
 !
@@ -271,6 +273,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf IT
    ip address 172.17.0.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -236,6 +236,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.5/31
 !
@@ -244,6 +245,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.5/31
 !
@@ -252,6 +254,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf IT
    ip address 172.17.0.5/31
 !
@@ -268,6 +271,7 @@ interface Ethernet53.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.7/31
 !
@@ -276,6 +280,7 @@ interface Ethernet53.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.7/31
 !
@@ -284,6 +289,7 @@ interface Ethernet53.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf IT
    ip address 172.17.0.7/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -235,6 +235,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.9/31
 !
@@ -243,6 +244,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.9/31
 !
@@ -251,6 +253,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf IT
    ip address 172.17.0.9/31
 !
@@ -267,6 +270,7 @@ interface Ethernet53.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.11/31
 !
@@ -275,6 +279,7 @@ interface Ethernet53.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.11/31
 !
@@ -283,6 +288,7 @@ interface Ethernet53.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf IT
    ip address 172.17.0.11/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -300,6 +300,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.1/31
 !
@@ -308,6 +309,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.1/31
 !
@@ -316,6 +318,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf IT
    ip address 172.17.0.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -300,6 +300,7 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.3/31
 !
@@ -308,6 +309,7 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.3/31
 !
@@ -316,6 +318,7 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
+   flow tracker hardware WAN-FLOW-TRACKER
    vrf IT
    ip address 172.17.0.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-common-path-group.yml
@@ -181,6 +181,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.3/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet2.142
@@ -192,6 +194,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.3/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet2.666
@@ -203,6 +207,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.3/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet1
   peer_type: l3_interface
   ip_address: dhcp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -191,6 +191,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.1/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet1.142
@@ -202,6 +204,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.1/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet1.666
@@ -213,6 +217,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.1/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet1
   peer_type: l3_interface
   peer: peer3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -209,6 +209,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.5/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet1.142
@@ -220,6 +222,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.5/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet1.666
@@ -231,6 +235,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.5/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet53
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1
@@ -253,6 +259,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.7/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet53.142
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1.142
@@ -264,6 +272,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.7/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet53.666
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1.666
@@ -275,6 +285,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.7/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet1
   peer_type: l3_interface
   ip_address: dhcp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -209,6 +209,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.9/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet2.142
@@ -220,6 +222,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.9/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet2.666
@@ -231,6 +235,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.9/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet53
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2
@@ -253,6 +259,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.11/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet53.142
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2.142
@@ -264,6 +272,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.11/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet53.666
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2.666
@@ -275,6 +285,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.11/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.15.6.6/31

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -216,6 +216,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.1/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet1.142
@@ -227,6 +229,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.1/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet1.666
@@ -238,6 +242,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.1/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet1.42
   peer_type: l3_interface
   ip_address: dhcp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -216,6 +216,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.3/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet2.142
@@ -227,6 +229,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.3/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet2.666
@@ -238,6 +242,8 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.3/31
+  flow_tracker:
+    hardware: WAN-FLOW-TRACKER
 - name: Ethernet1.42
   peer_type: l3_interface
   ip_address: dhcp

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
@@ -194,7 +194,7 @@ class EthernetInterfacesMixin(UtilsMixin):
 
                     # Configuring flow tracking on LAN interfaces
                     if self.shared_utils.is_cv_pathfinder_client:
-                        ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
+                        ethernet_subinterface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                     ethernet_subinterface = {key: value for key, value in ethernet_subinterface.items() if value is not None}
                     append_if_not_duplicate(


### PR DESCRIPTION
## Change Summary

Typo in the file that made flow-tracking config not generated for subinterfaces

## Related Issue(s)

Untracked report from field

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Fix typo

## How to test

molecue

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
