### PR TITLE
Feat(deploy_to_cv): Add support for waiting for Change Control to be completed before returning

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/change_control.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/change_control.py
@@ -34,10 +34,10 @@ if TYPE_CHECKING:
 LOGGER = getLogger(__name__)
 
 CHANGE_CONTROL_STATUS_MAP = {
-    "COMPLETED": ChangeControlStatus.COMPLETED,
-    "UNSPECIFIED": ChangeControlStatus.UNSPECIFIED,
-    "RUNNING": ChangeControlStatus.RUNNING,
-    "SCHEDULED": ChangeControlStatus.SCHEDULED,
+    "completed": ChangeControlStatus.COMPLETED,
+    "unspecified": ChangeControlStatus.UNSPECIFIED,
+    "running": ChangeControlStatus.RUNNING,
+    "scheduled": ChangeControlStatus.SCHEDULED,
 }
 
 
@@ -182,10 +182,10 @@ class ChangeControlMixin:
         except Exception as e:
             raise get_cv_client_exception(e, f"Change Control ID '{change_control_id}'") or e
 
-    async def wait_for_change_control_complete(
+    async def wait_for_change_control_state(
         self: CVClient,
         cc_id: str,
-        state="COMPLETED",
+        state: Literal["completed", "unspecified", "running", "scheduled"]
         timeout: float = 3600.0,
     ) -> ChangeControl:
         """

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/change_control.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/change_control.py
@@ -185,7 +185,7 @@ class ChangeControlMixin:
     async def wait_for_change_control_state(
         self: CVClient,
         cc_id: str,
-        state: Literal["completed", "unspecified", "running", "scheduled"]
+        state: Literal["completed", "unspecified", "running", "scheduled"],
         timeout: float = 3600.0,
     ) -> ChangeControl:
         """

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/change_control.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/change_control.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from logging import getLogger
 from typing import TYPE_CHECKING, Literal
 
-from ..api.arista.changecontrol.v1 import (  # ChangeControlConfigResponse,; ChangeControlConfigStreamRequest,
+from ..api.arista.changecontrol.v1 import (
     ApproveConfig,
     ApproveConfigServiceStub,
     ApproveConfigSetRequest,

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/change_control.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/change_control.py
@@ -124,7 +124,7 @@ class ChangeControlMixin:
         Get Change Control using arista.changecontrol.v1.ChangeControlService.GetOne API
 
         Parameters:
-            change_control_id: Unique identifier the Change Control.
+            change_control_id: Unique identifier of the Change Control.
             timestamp: Timestamp for the change control information to be approved. \
                 This must be using the aristaproto._DateTime subclass which contains nanosecond information.
             description: Description to set on the approval.
@@ -160,7 +160,7 @@ class ChangeControlMixin:
         Set Change Control details using arista.changecontrol.v1.ChangeControlConfigService.Set API
 
         Parameters:
-            change_control_id: Unique identifier the Change Control.
+            change_control_id: Unique identifier of the Change Control.
             description: Description to add for the start request.
             timeout: Timeout in seconds.
 
@@ -193,9 +193,9 @@ class ChangeControlMixin:
         Blocks until a reponse is returned or timed out.
 
         Parameters:
-            cc_id: Unique identifier the change control.
-            state: Requested state of change control.
-            timeout: Timeout in seconds for the Workspace to build.
+            cc_id: Unique identifier of the change control.
+            state: Change Control state to wait for.
+            timeout: Timeout in seconds for the Change Control to reach the expected state.
 
         Returns:
             Full change control object
@@ -211,8 +211,7 @@ class ChangeControlMixin:
         try:
             responses = client.subscribe(request, metadata=self._metadata, timeout=timeout)
             async for response in responses:
-                # print(response, flush=true)
-                LOGGER.debug("Response: '%s.'", response)
+                LOGGER.debug("wait_for_change_control_complete: Response is '%s.'", response)
                 if hasattr(response, "value"):
                     if response.value.status == CHANGE_CONTROL_STATUS_MAP[state]:
                         LOGGER.info("wait_for_change_control_complete: Got response for request '%s': %s", cc_id, response.value.status)

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/exceptions.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/exceptions.py
@@ -70,3 +70,7 @@ class CVWorkspaceSubmitFailed(CVClientException):
 
 class CVWorkspaceStateTimeout(CVClientException):
     """Timed out waiting for Workspace to get to the expected state"""
+
+
+class CVChangeControlFailed(CVClientException):
+    """Status of ChangeControl failed during execution"""

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/exceptions.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/client/exceptions.py
@@ -73,4 +73,4 @@ class CVWorkspaceStateTimeout(CVClientException):
 
 
 class CVChangeControlFailed(CVClientException):
-    """Status of ChangeControl failed during execution"""
+    """CloudVision ChangeControl failed during execution"""

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/create_workspace_on_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/create_workspace_on_cv.py
@@ -22,9 +22,9 @@ async def create_workspace_on_cv(workspace: CVWorkspace, cv_client: CVClient) ->
     try:
         existing_workspace = await cv_client.get_workspace(workspace_id=workspace.id)
         if existing_workspace.state == WorkspaceState.PENDING:
-            workspace.final_state = "pending"
+            workspace.state = "pending"
         else:
             raise CVResourceInvalidState("The requested workspace is not in state 'pending'")
     except CVResourceNotFound:
         await cv_client.create_workspace(workspace_id=workspace.id, display_name=workspace.name, description=workspace.description)
-        workspace.final_state = "pending"
+        workspace.state = "pending"

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_to_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_to_cv.py
@@ -63,7 +63,7 @@ async def deploy_to_cv(
             The `final_state` property will be inplace updated in the given CVWorkSpace object.
         change_control: CloudVision Change Control to create for the deployment. \
             It is not supported to reuse an existing Change Control, so the `id` field should not be set in the given CVChangeControl object. \
-            The `id` and `final_state` properties will be inplace updated in the given CVChangeControl object.
+            The `id` and `state` properties will be inplace updated in the given CVChangeControl object.
         configs: Configs to be deployed using the "Static Configlet Studio".
         device_tags: Device Tags to be deployed and assigned.
         interface_tags: Interface Tags to be deployed and assigned.

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_to_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_to_cv.py
@@ -60,7 +60,7 @@ async def deploy_to_cv(
         cloudvision: CloudVision instance to deploy to.
         workspace: CloudVision Workspace to create or use for the deployment. \
             If the Workspace already exists, it must be in 'pending' state. \
-            The `final_state` property will be inplace updated in the given CVWorkSpace object.
+            The `state` property will be inplace updated in the given CVWorkSpace object.
         change_control: CloudVision Change Control to create for the deployment. \
             It is not supported to reuse an existing Change Control, so the `id` field should not be set in the given CVChangeControl object. \
             The `id` and `state` properties will be inplace updated in the given CVChangeControl object.
@@ -198,7 +198,7 @@ async def deploy_to_cv(
             # Build, submit or abandon Workspace. If failed, we always abandon.
             if result.failed:
                 await cv_client.abandon_workspace(workspace_id=result.workspace.id)
-                result.workspace.final_state = "abandoned"
+                result.workspace.state = "abandoned"
                 return result
 
             await finalize_workspace_on_cv(workspace=result.workspace, cv_client=cv_client)

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/finalize_change_control_on_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/finalize_change_control_on_cv.py
@@ -86,7 +86,7 @@ async def finalize_change_control_on_cv(change_control: CVChangeControl, cv_clie
     if change_control.requested_state == "running":
         return
 
-    cv_change_control = await cv_client.wait_for_change_control_complete(cc_id=change_control.id, state="COMPLETED")
+    cv_change_control = await cv_client.wait_for_change_control_state(cc_id=change_control.id, state="completed")
     if cv_change_control.error is not None:
         change_control.final_state = "failed"
         LOGGER.info("finalize_change_control_on_cv: %s", change_control)

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/finalize_change_control_on_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/finalize_change_control_on_cv.py
@@ -22,7 +22,7 @@ CHANGE_CONTROL_STATUS_TO_FINAL_STATE_MAP = {
 CHANGE_CONTROL_APPROVAL_TO_FINAL_STATE_MAP = {True: "approved", False: None}
 
 
-def get_change_control_final_state(cv_change_control: ChangeControl) -> str:
+def get_change_control_state(cv_change_control: ChangeControl) -> str:
     return (
         CHANGE_CONTROL_STATUS_TO_FINAL_STATE_MAP[cv_change_control.status]
         or CHANGE_CONTROL_APPROVAL_TO_FINAL_STATE_MAP[cv_change_control.approve.value]
@@ -35,7 +35,7 @@ def get_change_control_final_state(cv_change_control: ChangeControl) -> str:
 async def finalize_change_control_on_cv(change_control: CVChangeControl, cv_client: CVClient) -> None:
     """
     Update and finalize a Change Control on CloudVision from the given result.CVChangeControl object.
-    Depending on the requested final_state the Change Control will be left in pending approval, approved, started, completed or canceled.
+    Depending on the requested state the Change Control will be left in pending approval, approved, started, completed or canceled.
     In-place update the CVChangeControl object.
     """
 
@@ -44,7 +44,7 @@ async def finalize_change_control_on_cv(change_control: CVChangeControl, cv_clie
     cv_change_control = await cv_client.get_change_control(change_control_id=change_control.id)
 
     # Update missing fields on our local model with data from the CloudVision object.
-    change_control.final_state = get_change_control_final_state(cv_change_control=cv_change_control)
+    change_control.state = get_change_control_state(cv_change_control=cv_change_control)
     if change_control.description is None:
         change_control.name = cv_change_control.change.name
     if change_control.description is None:
@@ -57,7 +57,7 @@ async def finalize_change_control_on_cv(change_control: CVChangeControl, cv_clie
         await cv_client.set_change_control(change_control_id=change_control.id, name=change_control.name, description=change_control.description)
         # Update the local copy to get the exact "last updated" timestamp needed for approval.
         cv_change_control = await cv_client.get_change_control(change_control_id=change_control.id)
-        change_control.final_state = get_change_control_final_state(cv_change_control=cv_change_control)
+        change_control.state = get_change_control_state(cv_change_control=cv_change_control)
         LOGGER.info("finalize_change_control_on_cv: %s", change_control)
 
     # If requested state is "pending approval" we are done
@@ -67,11 +67,11 @@ async def finalize_change_control_on_cv(change_control: CVChangeControl, cv_clie
     # TODO: Add cancel/delete
 
     # For all other requested states we first need to approve.
-    if not change_control.final_state == "approved":
+    if not change_control.state == "approved":
         await cv_client.approve_change_control(
             change_control_id=change_control.id, timestamp=cv_change_control.change.time, description="Automatic approval by AVD"
         )
-        change_control.final_state = "approved"
+        change_control.state = "approved"
         LOGGER.info("finalize_change_control_on_cv: %s", change_control)
 
     # If requested state is "approved" we are done.
@@ -79,7 +79,7 @@ async def finalize_change_control_on_cv(change_control: CVChangeControl, cv_clie
         return
 
     await cv_client.start_change_control(change_control_id=change_control.id, description="Automatically started by AVD")
-    change_control.final_state = "running"
+    change_control.state = "running"
     LOGGER.info("finalize_change_control_on_cv: %s", change_control)
 
     # If requested state is "running" we are done.
@@ -88,11 +88,11 @@ async def finalize_change_control_on_cv(change_control: CVChangeControl, cv_clie
 
     cv_change_control = await cv_client.wait_for_change_control_state(cc_id=change_control.id, state="completed")
     if cv_change_control.error is not None:
-        change_control.final_state = "failed"
+        change_control.state = "failed"
         LOGGER.info("finalize_change_control_on_cv: %s", change_control)
         raise CVChangeControlFailed(f"Change control failed during execution {change_control.id}: {cv_change_control.error}")
 
-    change_control.final_state = "completed"
+    change_control.state = "completed"
     LOGGER.info("finalize_change_control_on_cv: %s", change_control)
 
     # If requested state is "Completed" we are done.

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/models.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/models.py
@@ -92,7 +92,7 @@ class CVWorkspace:
     """
     force: bool = False
     """ Force submit the workspace even if some devices are not actively streaming to CloudVision."""
-    final_state: Literal["pending", "built", "submitted", "build failed", "submit failed", "abandoned", "deleted"] | None = None
+    state: Literal["pending", "built", "submitted", "build failed", "submit failed", "abandoned", "deleted"] | None = None
     """The final state of the Workspace. Do not set this manually."""
     change_control_id: str | None = None
     """Do not set this manually."""

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/models.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/models.py
@@ -33,7 +33,7 @@ class CVChangeControl:
     - `"completed"`: Approve and start the Change Control. Wait for the Change Control to be completed.
     - `"deleted"`: Create and delete the Change Control. Used for dry-run where no changes will be committed to the network.
     """
-    final_state: Literal["pending approval", "approved", "running", "completed", "deleted", "failed"] | None = None
+    state: Literal["pending approval", "approved", "running", "completed", "deleted", "failed"] | None = None
 
 
 @dataclass

--- a/ansible_collections/arista/avd/roles/deploy_to_cv/README.md
+++ b/ansible_collections/arista/avd/roles/deploy_to_cv/README.md
@@ -209,7 +209,7 @@ cv_submit_workspace: true
 # If set, configurations will not be validated for non-streaming devices.
 cv_submit_workspace_force: false
 
-# Approve, Start and wait for Change Control to Complete. Otherwise the Change Control will be left in "pending approval" mode.
+# Approve, start and wait for the Change Control to Complete. Otherwise the Change Control will be left in "pending approval" mode.
 # Only applicable if cv_submit_workspace is true.
 cv_run_change_control: false
 

--- a/ansible_collections/arista/avd/roles/deploy_to_cv/README.md
+++ b/ansible_collections/arista/avd/roles/deploy_to_cv/README.md
@@ -209,7 +209,7 @@ cv_submit_workspace: true
 # If set, configurations will not be validated for non-streaming devices.
 cv_submit_workspace_force: false
 
-# Approve and Start Change Control. Otherwise the Change Control will be left in "pending approval" mode.
+# Approve, Start and wait for Change Control to Complete. Otherwise the Change Control will be left in "pending approval" mode.
 # Only applicable if cv_submit_workspace is true.
 cv_run_change_control: false
 

--- a/ansible_collections/arista/avd/roles/deploy_to_cv/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/deploy_to_cv/tasks/main.yml
@@ -41,7 +41,7 @@
     change_control:
       name: "{{ cv_change_control_name | arista.avd.default }}"
       description: "{{ cv_change_control_description | arista.avd.default }}"
-      requested_state: "{{ 'running' if cv_run_change_control else 'pending approval' }}"
+      requested_state: "{{ 'completed' if cv_run_change_control else 'pending approval' }}"
     timeouts:
       workspace_build_timeout: "{{ cv_workspace_build_timeout }}"
     return_details: "{{ cv_register_detailed_results }}"

--- a/ansible_collections/arista/avd/roles/deploy_to_cv/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/deploy_to_cv/tasks/main.yml
@@ -45,3 +45,4 @@
     timeouts:
       workspace_build_timeout: "{{ cv_workspace_build_timeout }}"
     return_details: "{{ cv_register_detailed_results }}"
+  register: deploy_to_cv_results


### PR DESCRIPTION
## Change Summary

When `change_control.requested_state` is set to `completed`, the module will wait for the change control to complete before returning. 

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.deploy_to_cv`

## Proposed changes
```yaml
 arista.avd.deploy_to_cv:
    change_control:
      requested_state: completed
```

## How to test
Set `requested_state: completed` in `arista.avd.deploy_to_cv`
```yaml
 arista.avd.deploy_to_cv:
    change_control:
      requested_state: completed
```
The module will wait until the change control is completed and return( with errors, if any )

## Checklist
### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x ] My code has been rebased from devel before I start
- [ x ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
