### PR TITLE
Fix(eos_designs): Do not generate DP IPsec profile when HA ipsec is disabled

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -225,9 +225,6 @@ vrf instance TRANSIT
 !
 ip security
    !
-   ike policy DP-IKE-POLICY
-      local-id 192.168.143.1
-   !
    ike policy CP-IKE-POLICY
       local-id 192.168.143.1
    !
@@ -240,7 +237,6 @@ ip security
       pfs dh-group 14
    !
    profile DP-PROFILE
-      ike-policy DP-IKE-POLICY
       sa-policy DP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890666

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -225,9 +225,6 @@ vrf instance TRANSIT
 !
 ip security
    !
-   ike policy DP-IKE-POLICY
-      local-id 192.168.143.2
-   !
    ike policy CP-IKE-POLICY
       local-id 192.168.143.2
    !
@@ -240,7 +237,6 @@ ip security
       pfs dh-group 14
    !
    profile DP-PROFILE
-      ike-policy DP-IKE-POLICY
       sa-policy DP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890666

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -397,8 +397,6 @@ ip_extcommunity_lists:
     extcommunities: soo 192.168.43.1:422
 ip_security:
   ike_policies:
-  - name: DP-IKE-POLICY
-    local_id: 192.168.143.1
   - name: CP-IKE-POLICY
     local_id: 192.168.143.1
   sa_policies:
@@ -412,7 +410,6 @@ ip_security:
     pfs_dh_group: 14
   profiles:
   - name: DP-PROFILE
-    ike_policy: DP-IKE-POLICY
     sa_policy: DP-SA-POLICY
     connection: start
     shared_key: ABCDEF1234567890666

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -397,8 +397,6 @@ ip_extcommunity_lists:
     extcommunities: soo 192.168.43.1:422
 ip_security:
   ike_policies:
-  - name: DP-IKE-POLICY
-    local_id: 192.168.143.2
   - name: CP-IKE-POLICY
     local_id: 192.168.143.2
   sa_policies:
@@ -412,7 +410,6 @@ ip_security:
     pfs_dh_group: 14
   profiles:
   - name: DP-PROFILE
-    ike_policy: DP-IKE-POLICY
     sa_policy: DP-SA-POLICY
     connection: start
     shared_key: ABCDEF1234567890666

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -421,6 +421,10 @@ class WanMixin:
         return self.is_cv_pathfinder_client and get(self.switch_data_combined, "wan_ha.enabled", default=True) and len(self.switch_data_node_group_nodes) == 2
 
     @cached_property
+    def wan_ha_ipsec(self: SharedUtils) -> bool:
+        return self.wan_ha and get(self.switch_data_combined, "wan_ha.ipsec", default=True)
+
+    @cached_property
     def wan_ha_path_group_name(self: SharedUtils) -> str:
         """
         Return HA path group name for the WAN design.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/ip_security.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/ip_security.py
@@ -46,7 +46,7 @@ class IpSecurityMixin(UtilsMixin):
         """
         In place update of ip_security
         """
-        if self.shared_utils.wan_ha:
+        if self.shared_utils.wan_ha_ipsec:
             ike_policy_name = get(data_plane_config, "ike_policy_name", default="DP-IKE-POLICY")
         else:
             ike_policy_name = None
@@ -55,7 +55,7 @@ class IpSecurityMixin(UtilsMixin):
         key = get(data_plane_config, "shared_key", required=True)
 
         # IKE policy for data-plane is not required for dynamic tunnels except for HA cases
-        if self.shared_utils.wan_ha:
+        if self.shared_utils.wan_ha_ipsec:
             ip_security["ike_policies"].append(self._ike_policy(ike_policy_name))
         ip_security["sa_policies"].append(self._sa_policy(sa_policy_name))
         ip_security["profiles"].append(self._profile(profile_name, ike_policy_name, sa_policy_name, key))

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_path_selection.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_path_selection.py
@@ -134,7 +134,7 @@ class RouterPathSelectionMixin(UtilsMixin):
                 ],
             }
         )
-        if get(self.shared_utils.switch_data_combined, "wan_ha.ipsec", default=True):
+        if self.shared_utils.wan_ha_ipsec:
             ha_path_group["ipsec_profile"] = self._dp_ipsec_profile_name
 
         return ha_path_group


### PR DESCRIPTION
## Change Summary

Current code properly does not render the path-selection ipsec config for LAN_HA path-group if `wan_ha.ipsec: False` but still generates the IKE policy and add it to the profile.

This PR fixes this

## Related Issue(s)

Found by systest

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
cf summary

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
