### PR TITLE
Feat(eos_designs): Add Vxlan1 VRF VNI for WAN VRFs on Pathfinders

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -106,6 +106,7 @@ interface Vxlan1
    vxlan source-interface Dps1
    vxlan udp-port 4789
    vxlan vrf default vni 1
+   vxlan vrf PROD vni 42
 !
 application traffic recognition
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -105,6 +105,7 @@ interface Vxlan1
    vxlan source-interface Dps1
    vxlan udp-port 4789
    vxlan vrf default vni 1
+   vxlan vrf PROD vni 42
 !
 application traffic recognition
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
@@ -179,6 +179,8 @@ interface Vxlan1
    vxlan source-interface Dps1
    vxlan udp-port 4789
    vxlan vrf default vni 1
+   vxlan vrf IT vni 14
+   vxlan vrf PROD vni 42
 !
 application traffic recognition
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -272,7 +272,11 @@ interface Vxlan1
    description cv-pathfinder-pathfinder_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 166
    vxlan vrf default vni 1
+   vxlan vrf IT vni 100
+   vxlan vrf PROD vni 42
+   vxlan vrf TRANSIT vni 66
 !
 application traffic recognition
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -261,7 +261,11 @@ interface Vxlan1
    description cv-pathfinder-pathfinder1_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 166
    vxlan vrf default vni 1
+   vxlan vrf IT vni 100
+   vxlan vrf PROD vni 42
+   vxlan vrf TRANSIT vni 66
 !
 application traffic recognition
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -275,7 +275,11 @@ interface Vxlan1
    description cv-pathfinder-pathfinder2_VTEP
    vxlan source-interface Dps1
    vxlan udp-port 4789
+   vxlan vrf ATTRACTED-VRF-FROM-UPLINK vni 166
    vxlan vrf default vni 1
+   vxlan vrf IT vni 100
+   vxlan vrf PROD vni 42
+   vxlan vrf TRANSIT vni 66
 !
 application traffic recognition
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -266,3 +266,5 @@ vxlan_interface:
       vrfs:
       - name: default
         vni: 1
+      - name: PROD
+        vni: 42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -268,3 +268,5 @@ vxlan_interface:
       vrfs:
       - name: default
         vni: 1
+      - name: PROD
+        vni: 42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
@@ -426,6 +426,10 @@ vxlan_interface:
       vrfs:
       - name: default
         vni: 1
+      - name: PROD
+        vni: 42
+      - name: IT
+        vni: 14
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -495,6 +495,14 @@ vxlan_interface:
       vrfs:
       - name: default
         vni: 1
+      - name: PROD
+        vni: 42
+      - name: IT
+        vni: 100
+      - name: TRANSIT
+        vni: 66
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 166
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -508,6 +508,14 @@ vxlan_interface:
       vrfs:
       - name: default
         vni: 1
+      - name: PROD
+        vni: 42
+      - name: IT
+        vni: 100
+      - name: TRANSIT
+        vni: 66
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 166
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -527,6 +527,14 @@ vxlan_interface:
       vrfs:
       - name: default
         vni: 1
+      - name: PROD
+        vni: 42
+      - name: IT
+        vni: 100
+      - name: TRANSIT
+        vni: 66
+      - name: ATTRACTED-VRF-FROM-UPLINK
+        vni: 166
 metadata:
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/vxlan_interface.py
@@ -87,6 +87,28 @@ class VxlanInterfaceMixin(UtilsMixin):
                         context_keys=["id", "vni"],
                     )
 
+        if self.shared_utils.is_wan_server:
+            # loop through wan_vrfs and add VRF VNI if not present
+            for vrf in self._filtered_wan_vrfs:
+                # Duplicate check is not done on the actual list of vlans, but instead on our local "vnis" list.
+                # This is necessary to find duplicate VNIs across multiple object types.
+                vrf_data = {"name": vrf["name"], "vni": vrf["wan_vni"]}
+                append_if_not_duplicate(
+                    list_of_dicts=vnis,
+                    primary_key="vni",
+                    new_dict=vrf_data,
+                    context="VXLAN VNIs for VRFs",
+                    context_keys=["id", "name", "vni"],
+                )
+                # Here we append to the actual list of VRFs, so duplication check is on the VRF here.
+                append_if_not_duplicate(
+                    list_of_dicts=vrfs,
+                    primary_key="name",
+                    new_dict=vrf_data,
+                    context="VXLAN VNIs for VRFs",
+                    context_keys=["name", "vni"],
+                )
+
         if vlans:
             vxlan["vlans"] = vlans
 


### PR DESCRIPTION
## Change Summary

These VXLAN config statements should not require to have the pathfinder including the VRF. They can be picked up from the `wan_virtual_topologies.vrfs` statement.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Additional logic in `network_services/vxlan_interfaces.py`

## How to test
molcule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
