### PR TITLE
Fix(plugins): Add support for python3.9 for get_all_with_path

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/utils/get_all.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/utils/get_all.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
+from __future__ import annotations
+
 from typing import Any, Generator
 
 from ansible_collections.arista.avd.plugins.plugin_utils.errors import AristaAvdMissingVariableError


### PR DESCRIPTION
## Change Summary

PR #3725 introduced incompatible changes with python 3.9
This PR adds backward compatibility for the same.





