### PR TITLE
Refactor(eos_designs): Make Flow tracking enabled on Dps1 interface only

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
@@ -147,7 +147,6 @@ interface Ethernet1
    description ATT_666_peer3_Ethernet42
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
@@ -147,7 +147,6 @@ interface Ethernet1
    description ATT_666_peer3_Ethernet42
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
@@ -147,7 +147,6 @@ interface Ethernet1
    description ATT_666_peer3_Ethernet42
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
@@ -152,21 +152,18 @@ interface Ethernet1
    description Bouygues_Telecom_777
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 10.7.7.7/31
 !
 interface Ethernet2
    description Colt_10000
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.16.0.1/31
 !
 interface Ethernet3
    description Another-ISP_999
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 10.9.9.9/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -157,7 +157,6 @@ interface Ethernet1
    description ATT_666
    no shutdown
    no switchport
-   flow tracker hardware custom_flow_track_name
    ip address dhcp
    dhcp client accept default-route
 !
@@ -165,14 +164,12 @@ interface Ethernet2
    description Colt_10555
    no shutdown
    no switchport
-   flow tracker hardware custom_flow_track_name
    ip address 172.15.5.5/31
 !
 interface Ethernet3
    description Comcast-5G_AF830
    no shutdown
    no switchport
-   flow tracker hardware custom_flow_track_name
    ip address 172.20.20.20/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -151,7 +151,6 @@ interface Ethernet1
    description ATT_666
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -159,14 +158,12 @@ interface Ethernet2
    description Colt_10555
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.15.5.5/31
 !
 interface Ethernet3
    description Comcast-5G_AF830
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.20.20.20/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -234,7 +234,6 @@ interface Ethernet1
    description ATT_666_peer3_Ethernet42
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -242,14 +241,12 @@ interface Ethernet2
    description Colt_10555
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.15.5.5/31
 !
 interface Ethernet3
    description Comcast-5G_AF830
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.20.20.20/31
 !
 interface Ethernet52
@@ -257,7 +254,6 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.1/31
 !
 interface Ethernet52.142
@@ -265,7 +261,6 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.1/31
 !
@@ -274,7 +269,6 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.1/31
 !
@@ -283,7 +277,6 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -213,14 +213,12 @@ interface Ethernet1
    description Inmrasat_S511
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
 !
 interface Ethernet2
    description AWS-1_212
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -228,7 +226,6 @@ interface Ethernet3
    description ATT_404
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -237,7 +234,6 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.3/31
 !
 interface Ethernet52.142
@@ -245,7 +241,6 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.3/31
 !
@@ -254,7 +249,6 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.3/31
 !
@@ -263,7 +257,6 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -219,7 +219,6 @@ interface Ethernet1
    description ATT_423-01
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -228,7 +227,6 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.5/31
 !
 interface Ethernet52.142
@@ -236,7 +234,6 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.5/31
 !
@@ -245,7 +242,6 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.5/31
 !
@@ -254,7 +250,6 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.5/31
 !
@@ -263,7 +258,6 @@ interface Ethernet53
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.7/31
 !
 interface Ethernet53.142
@@ -271,7 +265,6 @@ interface Ethernet53.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.7/31
 !
@@ -280,7 +273,6 @@ interface Ethernet53.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.7/31
 !
@@ -289,7 +281,6 @@ interface Ethernet53.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.7/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -230,7 +230,6 @@ interface Ethernet2
    description Colt_10423
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.15.6.6/31
 !
 interface Ethernet52
@@ -238,7 +237,6 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.9/31
 !
 interface Ethernet52.142
@@ -246,7 +244,6 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.9/31
 !
@@ -255,7 +252,6 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.9/31
 !
@@ -264,7 +260,6 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.9/31
 !
@@ -273,7 +268,6 @@ interface Ethernet53
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.11/31
 !
 interface Ethernet53.142
@@ -281,7 +275,6 @@ interface Ethernet53.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.11/31
 !
@@ -290,7 +283,6 @@ interface Ethernet53.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.11/31
 !
@@ -299,7 +291,6 @@ interface Ethernet53.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.11/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -246,21 +246,18 @@ interface Ethernet1
    description Bouygues_Telecom_777
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 10.7.7.7/31
 !
 interface Ethernet2
    description Colt_10000
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.16.0.1/31
 !
 interface Ethernet3
    description Another-ISP_999
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 10.9.9.9/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -249,7 +249,6 @@ interface Ethernet1
    description Orange_888
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 10.8.8.8/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -256,14 +256,12 @@ interface Ethernet1
    description SFR_999
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 10.9.9.9/31
 !
 interface Ethernet2
    description ATT-MPLS_10999
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.19.9.9/31
 !
 interface Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -279,7 +279,6 @@ interface Ethernet1.42
    description Comcast
    no shutdown
    encapsulation dot1q vlan 42
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -291,7 +290,6 @@ interface Ethernet2.42
    description Colt_10666
    no shutdown
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    ip address 172.16.6.6/31
 !
 interface Ethernet52
@@ -299,7 +297,6 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.1/31
 !
 interface Ethernet52.142
@@ -307,7 +304,6 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.1/31
 !
@@ -316,7 +312,6 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.1/31
 !
@@ -325,7 +320,6 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.1/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -279,7 +279,6 @@ interface Ethernet1.42
    description Comcast
    no shutdown
    encapsulation dot1q vlan 42
-   flow tracker hardware FLOW-TRACKER
    ip address dhcp
    dhcp client accept default-route
 !
@@ -291,7 +290,6 @@ interface Ethernet2.42
    description Colt_10666
    no shutdown
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    ip address 172.16.6.6/31
 !
 interface Ethernet52
@@ -299,7 +297,6 @@ interface Ethernet52
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 172.17.0.3/31
 !
 interface Ethernet52.142
@@ -307,7 +304,6 @@ interface Ethernet52.142
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 142
-   flow tracker hardware FLOW-TRACKER
    vrf PROD
    ip address 172.17.0.3/31
 !
@@ -316,7 +312,6 @@ interface Ethernet52.666
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 666
-   flow tracker hardware FLOW-TRACKER
    vrf ATTRACTED-VRF-FROM-UPLINK
    ip address 172.17.0.3/31
 !
@@ -325,7 +320,6 @@ interface Ethernet52.1000
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 1000
-   flow tracker hardware FLOW-TRACKER
    vrf IT
    ip address 172.17.0.3/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -106,7 +106,6 @@ interface Ethernet1
    description Comcast_999
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 10.9.9.9/31
 !
 interface Ethernet2
@@ -114,7 +113,6 @@ interface Ethernet2
    no shutdown
    mtu 9214
    no switchport
-   flow tracker hardware FLOW-TRACKER
    vrf VRF1
    ip address 10.0.10.1/24
 !
@@ -122,7 +120,6 @@ interface Ethernet2.100
    description My vlan 100
    no shutdown
    encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
    vrf VRF1
    ip address 10.0.100.1/24
    ipv6 enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -106,7 +106,6 @@ interface Ethernet1
    description Comcast_999
    no shutdown
    no switchport
-   flow tracker hardware FLOW-TRACKER
    ip address 10.9.9.1/31
 !
 interface Ethernet2
@@ -120,7 +119,6 @@ interface Ethernet2.10
    no shutdown
    mtu 9214
    encapsulation dot1q vlan 10
-   flow tracker hardware FLOW-TRACKER
    vrf VRF1
    ip address 10.0.10.1/24
 !
@@ -128,7 +126,6 @@ interface Ethernet2.100
    description My vlan 100
    no shutdown
    encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
    vrf VRF1
    ip address 10.0.100.1/24
    ipv6 enable

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
@@ -139,8 +139,6 @@ ethernet_interfaces:
   type: routed
   description: ATT_666_peer3_Ethernet42
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
@@ -139,8 +139,6 @@ ethernet_interfaces:
   type: routed
   description: ATT_666_peer3_Ethernet42
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
@@ -139,8 +139,6 @@ ethernet_interfaces:
   type: routed
   description: ATT_666_peer3_Ethernet42
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
@@ -139,24 +139,18 @@ ethernet_interfaces:
   shutdown: false
   type: routed
   description: Bouygues_Telecom_777
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.16.0.1/31
   shutdown: false
   type: routed
   description: Colt_10000
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 10.9.9.9/31
   shutdown: false
   type: routed
   description: Another-ISP_999
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -112,24 +112,18 @@ ethernet_interfaces:
   type: routed
   description: ATT_666
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: custom_flow_track_name
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.15.5.5/31
   shutdown: false
   type: routed
   description: Colt_10555
-  flow_tracker:
-    hardware: custom_flow_track_name
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.20.20.20/31
   shutdown: false
   type: routed
   description: Comcast-5G_AF830
-  flow_tracker:
-    hardware: custom_flow_track_name
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -129,24 +129,18 @@ ethernet_interfaces:
   type: routed
   description: ATT_666
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.15.5.5/31
   shutdown: false
   type: routed
   description: Colt_10555
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.20.20.20/31
   shutdown: false
   type: routed
   description: Comcast-5G_AF830
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -178,8 +178,6 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.1/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet1.1000
@@ -191,8 +189,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.1/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet1.142
@@ -204,8 +200,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.1/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet1.666
@@ -217,8 +211,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.1/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet1
   peer_type: l3_interface
   peer: peer3
@@ -228,24 +220,18 @@ ethernet_interfaces:
   type: routed
   description: ATT_666_peer3_Ethernet42
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.15.5.5/31
   shutdown: false
   type: routed
   description: Colt_10555
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.20.20.20/31
   shutdown: false
   type: routed
   description: Comcast-5G_AF830
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -176,8 +176,6 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.3/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet2.1000
@@ -189,8 +187,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.3/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet2.142
@@ -202,8 +198,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.3/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-disabled-leaf
   peer_interface: Ethernet2.666
@@ -215,16 +209,12 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.3/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet1
   peer_type: l3_interface
   ip_address: dhcp
   shutdown: false
   type: routed
   description: Inmrasat_S511
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: dhcp
@@ -232,8 +222,6 @@ ethernet_interfaces:
   type: routed
   description: AWS-1_212
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: dhcp
@@ -241,8 +229,6 @@ ethernet_interfaces:
   type: routed
   description: ATT_404
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -196,8 +196,6 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.5/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet1.1000
@@ -209,8 +207,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.5/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet1.142
@@ -222,8 +218,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.5/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet1.666
@@ -235,8 +229,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.5/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet53
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1
@@ -246,8 +238,6 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.7/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet53.1000
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1.1000
@@ -259,8 +249,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.7/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet53.142
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1.142
@@ -272,8 +260,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.7/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet53.666
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet1.666
@@ -285,8 +271,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.7/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet1
   peer_type: l3_interface
   ip_address: dhcp
@@ -294,8 +278,6 @@ ethernet_interfaces:
   type: routed
   description: ATT_423-01
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -196,8 +196,6 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.9/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet2.1000
@@ -209,8 +207,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.9/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet2.142
@@ -222,8 +218,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.9/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf2A
   peer_interface: Ethernet2.666
@@ -235,8 +229,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.9/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet53
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2
@@ -246,8 +238,6 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.11/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet53.1000
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2.1000
@@ -259,8 +249,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.11/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet53.142
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2.142
@@ -272,8 +260,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.11/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet53.666
   peer: site-ha-enabled-leaf2B
   peer_interface: Ethernet2.666
@@ -285,16 +271,12 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.11/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.15.6.6/31
   shutdown: false
   type: routed
   description: Colt_10423
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -112,24 +112,18 @@ ethernet_interfaces:
   shutdown: false
   type: routed
   description: Bouygues_Telecom_777
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.16.0.1/31
   shutdown: false
   type: routed
   description: Colt_10000
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 10.9.9.9/31
   shutdown: false
   type: routed
   description: Another-ISP_999
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -143,8 +143,6 @@ ethernet_interfaces:
   shutdown: false
   type: routed
   description: Orange_888
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -143,16 +143,12 @@ ethernet_interfaces:
   shutdown: false
   type: routed
   description: SFR_999
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer_type: l3_interface
   ip_address: 172.19.9.9/31
   shutdown: false
   type: routed
   description: ATT-MPLS_10999
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -203,8 +203,6 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.1/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet1.1000
@@ -216,8 +214,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.1/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet1.142
@@ -229,8 +225,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.1/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet1.666
@@ -242,8 +236,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.1/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet1.42
   peer_type: l3_interface
   ip_address: dhcp
@@ -252,8 +244,6 @@ ethernet_interfaces:
   description: Comcast
   encapsulation_dot1q_vlan: 42
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2.42
   peer_type: l3_interface
   ip_address: 172.16.6.6/31
@@ -261,8 +251,6 @@ ethernet_interfaces:
   type: l3dot1q
   description: Colt_10666
   encapsulation_dot1q_vlan: 666
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet1
   type: routed
   peer_type: l3_interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -203,8 +203,6 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.17.0.3/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.1000
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet2.1000
@@ -216,8 +214,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 1000
   mtu: 9214
   ip_address: 172.17.0.3/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.142
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet2.142
@@ -229,8 +225,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 142
   mtu: 9214
   ip_address: 172.17.0.3/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet52.666
   peer: site-ha-enabled-leaf1
   peer_interface: Ethernet2.666
@@ -242,8 +236,6 @@ ethernet_interfaces:
   encapsulation_dot1q_vlan: 666
   mtu: 9214
   ip_address: 172.17.0.3/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet1.42
   peer_type: l3_interface
   ip_address: dhcp
@@ -252,8 +244,6 @@ ethernet_interfaces:
   description: Comcast
   encapsulation_dot1q_vlan: 42
   dhcp_client_accept_default_route: true
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2.42
   peer_type: l3_interface
   ip_address: 172.16.6.6/31
@@ -261,8 +251,6 @@ ethernet_interfaces:
   type: l3dot1q
   description: Colt_10666
   encapsulation_dot1q_vlan: 666
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet1
   type: routed
   peer_type: l3_interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -110,8 +110,6 @@ ethernet_interfaces:
   vrf: VRF1
   ip_address: 10.0.10.1/24
   mtu: 9214
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2.100
   peer: uplink_lan_l2leaf
   peer_interface: Ethernet1 VLAN 100
@@ -125,8 +123,6 @@ ethernet_interfaces:
   ipv6_address: cafe::cafe/64
   ipv6_enable: true
   eos_cli: comment yo
-  flow_tracker:
-    hardware: FLOW-TRACKER
   _custom_key: custom_value
 - name: Ethernet1
   peer_type: l3_interface
@@ -134,8 +130,6 @@ ethernet_interfaces:
   shutdown: false
   type: routed
   description: Comcast_999
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -119,8 +119,6 @@ ethernet_interfaces:
   vrf: VRF1
   ip_address: 10.0.10.1/24
   mtu: 9214
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2.100
   peer: uplink_lan_l2leaf
   peer_interface: Ethernet2 VLAN 100
@@ -134,8 +132,6 @@ ethernet_interfaces:
   ipv6_address: cafe::cafe/64
   ipv6_enable: true
   eos_cli: comment yo
-  flow_tracker:
-    hardware: FLOW-TRACKER
   _custom_key: custom_value
 - name: Ethernet1
   peer_type: l3_interface
@@ -143,8 +139,6 @@ ethernet_interfaces:
   shutdown: false
   type: routed
   description: Comcast_999
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
@@ -141,8 +141,6 @@ ethernet_interfaces:
   mtu: 1500
   type: routed
   ip_address: 10.255.255.1/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer: dc1-leaf1b
   peer_interface: Ethernet6
@@ -152,24 +150,18 @@ ethernet_interfaces:
   mtu: 1500
   type: routed
   ip_address: 10.255.255.3/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.18.3.2/24
   shutdown: false
   type: routed
   description: mpls-sp-1_DC1-MPLS-3
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet4
   peer_type: l3_interface
   ip_address: 100.64.3.2/24
   shutdown: false
   type: routed
   description: isp-1_DC1-INET-3
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
@@ -141,8 +141,6 @@ ethernet_interfaces:
   mtu: 1500
   type: routed
   ip_address: 10.255.255.5/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet2
   peer: dc1-leaf1b
   peer_interface: Ethernet7
@@ -152,24 +150,18 @@ ethernet_interfaces:
   mtu: 1500
   type: routed
   ip_address: 10.255.255.7/31
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet3
   peer_type: l3_interface
   ip_address: 172.18.4.2/24
   shutdown: false
   type: routed
   description: mpls-sp-1_DC1-MPLS-4
-  flow_tracker:
-    hardware: FLOW-TRACKER
 - name: Ethernet4
   peer_type: l3_interface
   ip_address: 100.64.4.2/24
   shutdown: false
   type: routed
   description: isp-1_DC1-INET-4
-  flow_tracker:
-    hardware: FLOW-TRACKER
 loopback_interfaces:
 - name: Loopback0
   description: Router_ID

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -265,3 +265,8 @@ TODO
 ### Defining policies
 
 TODO
+
+### Flow tracking
+
+For scalabilty reasons, flow-tracking is enabled only on Dps1 interface by default.
+It can be added on WAN and LAN interfaces using `custom_structured_configuration`.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/ethernet_interfaces.py
@@ -109,9 +109,10 @@ class EthernetInterfacesMixin(UtilsMixin):
                 if link.get("underlay_multicast") is True:
                     ethernet_interface["pim"] = {"ipv4": {"sparse_mode": True}}
 
+                # TODO: allow to enable flow tracking once toggle is in place
                 # Configuring flow tracking on LAN interfaces
-                if self.shared_utils.is_cv_pathfinder_client:
-                    ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
+                # if self.shared_utils.is_cv_pathfinder_client:
+                #    ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                 # Structured Config
                 ethernet_interface["struct_cfg"] = link.get("structured_config")
@@ -193,9 +194,10 @@ class EthernetInterfacesMixin(UtilsMixin):
                     if subinterface.get("ip_address") is not None:
                         ethernet_subinterface.update({"ip_address": f"{subinterface['ip_address']}/{subinterface['prefix_length']}"}),
 
+                    # TODO: allow to enable flow tracking once toggle is in place
                     # Configuring flow tracking on LAN interfaces
-                    if self.shared_utils.is_cv_pathfinder_client:
-                        ethernet_subinterface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
+                    # if self.shared_utils.is_cv_pathfinder_client:
+                    #    ethernet_subinterface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                     ethernet_subinterface = {key: value for key, value in ethernet_subinterface.items() if value is not None}
                     append_if_not_duplicate(
@@ -246,9 +248,10 @@ class EthernetInterfacesMixin(UtilsMixin):
                     "shutdown": False,
                 }
 
+                # TODO: allow to enable flow tracking once toggle is in place
                 # Configuring flow tracking on LAN interfaces
-                if self.shared_utils.is_cv_pathfinder_client:
-                    ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
+                # if self.shared_utils.is_cv_pathfinder_client:
+                #    ethernet_interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
                 append_if_not_duplicate(
                     list_of_dicts=ethernet_interfaces,

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/underlay/utils.py
@@ -195,8 +195,9 @@ class UtilsMixin:
         if ip_address == "dhcp" and l3_interface.get("dhcp_accept_default_route", True):
             interface["dhcp_client_accept_default_route"] = True
 
-        if self.shared_utils.is_cv_pathfinder_router:
-            interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
+        # TODO: enable flow tracking once toggle is in place
+        # if self.shared_utils.is_cv_pathfinder_router:
+        #    interface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
         return strip_empties_from_dict(interface)
 
@@ -278,8 +279,9 @@ class UtilsMixin:
         # Adding IP helpers and OSPF via a common function also used for SVIs on L3 switches.
         self.shared_utils.get_additional_svi_config(subinterface, svi, vrf)
 
+        # TODO: enable flow tracking once toggle is in place
         # Configuring flow tracking on LAN interfaces of WAN routers
-        if self.shared_utils.is_cv_pathfinder_client:
-            subinterface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
+        # if self.shared_utils.is_cv_pathfinder_client:
+        #    subinterface["flow_tracker"] = {"hardware": self.shared_utils.wan_flow_tracker_name}
 
         return strip_empties_from_dict(subinterface)


### PR DESCRIPTION
## Change Summary

After discussion with engineering, enabling by default Flow tracking for WAN design scenario only on Dps1 interface to keep sane default.
It can be enabled on WAN and LAN interfaces depending on the design and scale using custom_structured_configuration.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Cf summary

## How to test

molcule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
