### PR TITLE
Fix(eos_designs): Make metadata cloudvision tags name case sensitive

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/generate-cv-tags-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/generate-cv-tags-1.yml
@@ -100,7 +100,7 @@ metadata:
       value: myvalue
     - name: dynamic_device_tag
       value: '65000'
-    - name: uppercase_device_tag
+    - name: UPPERCASE_DEVICE_TAG
       value: something with spaces
     interface_tags:
     - interface: Ethernet1
@@ -109,5 +109,5 @@ metadata:
         value: myinterfacevalue
       - name: dynamic_interface_tag
         value: Someotherdevice
-      - name: uppercase_interface_tag
+      - name: UPPERCASE_INTERFACE_TAG
         value: something else with spaces

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-tags.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-tags.md
@@ -11,11 +11,11 @@
     | [<samp>generate_cv_tags</samp>](## "generate_cv_tags") | Dictionary |  |  |  | PREVIEW: This key is currently not supported<br>Generate CloudVision Tags based on AVD data. |
     | [<samp>&nbsp;&nbsp;topology_hints</samp>](## "generate_cv_tags.topology_hints") | Boolean |  | `False` |  | Enable the generation of CloudVision Topology Tags (hints). |
     | [<samp>&nbsp;&nbsp;interface_tags</samp>](## "generate_cv_tags.interface_tags") | List, items: Dictionary |  |  |  | List of interface tags that should be generated. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "generate_cv_tags.interface_tags.[].name") | String | Required, Unique |  | Value is converted to lower case. | Tag name to be assigned to generated tags. Tag names must be lower case. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "generate_cv_tags.interface_tags.[].name") | String | Required, Unique |  |  | Tag name to be assigned to generated tags. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;data_path</samp>](## "generate_cv_tags.interface_tags.[].data_path") | String |  |  |  | Structured config field/key path to be used to find the value for the tag. Dot notation is supported to reference values inside dictionaries.<br>For Example: 'data_path: channel_group.id' would set the tag with the value of the channel id of the interface. If there is no channel id, the tag is not created.<br>`data_path` is ignored if `value` is set. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "generate_cv_tags.interface_tags.[].value") | String |  |  |  | Value to be assigned to the tag. |
     | [<samp>&nbsp;&nbsp;device_tags</samp>](## "generate_cv_tags.device_tags") | List, items: Dictionary |  |  |  | List of device tags that should be generated. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "generate_cv_tags.device_tags.[].name") | String | Required |  | Value is converted to lower case. | Tag name to be assigned to generated tags. Tag names must be lower case. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "generate_cv_tags.device_tags.[].name") | String | Required |  |  | Tag name to be assigned to generated tags. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;data_path</samp>](## "generate_cv_tags.device_tags.[].data_path") | String |  |  |  | Structured config field/key path to be used to find the value for the tag. Dot notation is supported to reference values inside dictionaries.<br>For Example: 'data_path: router_bfd.multihop.interval' would set the tag with the value of the interval for multihop bfd. If this value is not specified in the structured config, the tag is not created.<br>`data_path` is ignored if `value` is set. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "generate_cv_tags.device_tags.[].value") | String |  |  |  | Value to be assigned to the tag. |
     | [<samp>node_type_keys</samp>](## "node_type_keys") | List, items: Dictionary |  |  |  | Define Node Type Keys, to specify the properties of each node type in the fabric.<br>This allows for complete customization of the fabric layout and functionality.<br>`node_type_keys` should be defined in top level group_var for the fabric.<br>The default values will be overridden if defining this key, so it is recommended to copy the defaults and modify them.<br> |
@@ -39,7 +39,7 @@
       # List of interface tags that should be generated.
       interface_tags:
 
-          # Tag name to be assigned to generated tags. Tag names must be lower case.
+          # Tag name to be assigned to generated tags.
         - name: <str; required; unique>
 
           # Structured config field/key path to be used to find the value for the tag. Dot notation is supported to reference values inside dictionaries.
@@ -53,7 +53,7 @@
       # List of device tags that should be generated.
       device_tags:
 
-          # Tag name to be assigned to generated tags. Tag names must be lower case.
+          # Tag name to be assigned to generated tags.
         - name: <str; required>
 
           # Structured config field/key path to be used to find the value for the tag. Dot notation is supported to reference values inside dictionaries.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5159,7 +5159,7 @@
             "description": "Each tag can either have a static value or a dynamic value sourced from structured configuration.",
             "properties": {
               "name": {
-                "description": "Tag name to be assigned to generated tags. Tag names must be lower case.",
+                "description": "Tag name to be assigned to generated tags.",
                 "type": "string",
                 "title": "Name"
               },
@@ -5192,7 +5192,7 @@
             "description": "Each tag can either have a static value or a dynamic value sourced from structured configuration.",
             "properties": {
               "name": {
-                "description": "Tag name to be assigned to generated tags. Tag names must be lower case.",
+                "description": "Tag name to be assigned to generated tags.",
                 "type": "string",
                 "title": "Name"
               },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -1291,9 +1291,7 @@ keys:
             sourced from structured configuration.
           keys:
             name:
-              description: Tag name to be assigned to generated tags. Tag names must
-                be lower case.
-              convert_to_lower_case: true
+              description: Tag name to be assigned to generated tags.
               required: true
               type: str
             data_path:
@@ -1319,9 +1317,7 @@ keys:
             sourced from structured configuration.
           keys:
             name:
-              description: Tag name to be assigned to generated tags. Tag names must
-                be lower case.
-              convert_to_lower_case: true
+              description: Tag name to be assigned to generated tags.
               required: true
               type: str
             data_path:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/generate_cv_tags.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/generate_cv_tags.schema.yml
@@ -27,8 +27,7 @@ keys:
           description: Each tag can either have a static value or a dynamic value sourced from structured configuration.
           keys:
             name:
-              description: Tag name to be assigned to generated tags. Tag names must be lower case.
-              convert_to_lower_case: true
+              description: Tag name to be assigned to generated tags.
               required: true
               type: str
             data_path:
@@ -48,8 +47,7 @@ keys:
           description: Each tag can either have a static value or a dynamic value sourced from structured configuration.
           keys:
             name:
-              description: Tag name to be assigned to generated tags. Tag names must be lower case.
-              convert_to_lower_case: true
+              description: Tag name to be assigned to generated tags.
               required: true
               type: str
             data_path:


### PR DESCRIPTION
## Change Summary

Make metadata cv_tags name value case sensitive

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Update schema to remove `convert_to_lower_case: true` for `interface_tags.[].name` and  `device_tags.[].name`
  

## How to test

This input:

```yaml
generate_cv_tags:
  device_tags:
    - name: Access-Pod
      value: IDF1
    - name: Campus-Pod
      value: H5
    - name: Campus
      value: OHVLab
    - name: Role
      value: Member-Leaf
```

Should generate this:

```yaml
metadata:
  cv_tags:
    device_tags:
    - name: Access-Pod
      value: IDF1
    - name: Campus-Pod
      value: H5
    - name: Campus
      value: OHVLab
    - name: Role
      value: Member-Leaf
```

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
