### PR TITLE
Refactor(eos_designs): Force WAN HA to be either enabled or disabled

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -121,6 +121,8 @@ wan_router:
       uplink_type: p2p-vrfs
       uplink_switches: [ site-ha-enabled-leaf2A, site-ha-enabled-leaf2B ]
       uplink_interfaces: [ Ethernet52, Ethernet53 ]
+      wan_ha:
+        enabled: true # TODO AVD4.8.0: Remove once WAN HA is GA.
       nodes:
         - name: cv-pathfinder-edge2A
           id: 2
@@ -153,6 +155,7 @@ wan_router:
       cv_pathfinder_transit_mode: region
       # Disable HA IPsec
       wan_ha:
+        enabled: true # TODO AVD4.8.0: Remove once WAN HA is GA.
         ipsec: false
       nodes:
         - name: cv-pathfinder-transit1A

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/inventory/group_vars/DC1_WAN.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/inventory/group_vars/DC1_WAN.yml
@@ -12,6 +12,8 @@ wan_router: # dynamic_key: node_type
     uplink_interfaces: [Ethernet1, Ethernet2]
     uplink_switches: [dc1-leaf1a, dc1-leaf1b]
     uplink_type: p2p-vrfs
+    wan_ha:
+      enabled: true # TODO: AVD 4.8.0 Remove this once WAN HA is out of preview
   node_groups:
     - group: DC1-WAN
       bgp_as: 65000

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/wan.py
@@ -426,7 +426,19 @@ class WanMixin:
         """
         Only trigger HA if 2 cv_pathfinder clients are in the same group and wan_ha.enabled is true
         """
-        return self.is_cv_pathfinder_client and get(self.switch_data_combined, "wan_ha.enabled", default=True) and len(self.switch_data_node_group_nodes) == 2
+        if not (self.is_cv_pathfinder_client and len(self.switch_data_node_group_nodes) == 2):
+            return False
+
+        if (ha_enabled := get(self.switch_data_combined, "wan_ha.enabled")) is None:
+            raise AristaAvdError(
+                (
+                    "Placing two WAN routers in a common node group will trigger WAN HA in a future AVD release. "
+                    "Currently WAN HA is in preview, so it will not be automatically enabled. "
+                    "To avoid unplanned configuration changes once the feature is released, "
+                    "it is currently required to set 'wan_ha.enabled' to 'true' or 'false'."
+                )
+            )
+        return ha_enabled
 
     @cached_property
     def wan_ha_ipsec(self: SharedUtils) -> bool:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Force WAN HA to be either enabled or disabled

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Placing two WAN routers in a common node group will trigger WAN HA in a future AVD release.
Currently WAN HA is in preview, so it will not be automatically enabled.
To avoid unplanned configuration changes once the feature is released,
it is currently required to set 'wan_ha.enabled' to 'true' or 'false'.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Tested manually:
![image](https://github.com/aristanetworks/avd/assets/48674677/9843c136-1689-4cca-8b36-e17fcd0b4741)

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
