### PR TITLE
Refactor(deploy_to_cv): Set default values for constraints in metadata studio

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -650,7 +650,9 @@ metadata:
           preference: alternate
         - name: LAN_HA
           preference: preferred
-      - id: 4
+      - constraints:
+          lossrate: 42.0
+        id: 4
         name: PROD-AVT-POLICY-VIDEO
         pathgroups:
         - name: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -641,7 +641,9 @@ metadata:
           preference: alternate
         - name: LAN_HA
           preference: preferred
-      - id: 4
+      - constraints:
+          lossrate: 42.0
+        id: 4
         name: PROD-AVT-POLICY-VIDEO
         pathgroups:
         - name: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -671,7 +671,9 @@ metadata:
           preference: alternate
         - name: LAN_HA
           preference: preferred
-      - id: 4
+      - constraints:
+          lossrate: 42.0
+        id: 4
         name: PROD-AVT-POLICY-VIDEO
         pathgroups:
         - name: MPLS

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
@@ -33,7 +33,7 @@ def update_general_metadata(metadata: dict, studio_inputs: dict) -> None:
             constraints: dict = avt.setdefault("constraints", {})
             constraints.setdefault("latency", 4294967295)
             constraints.setdefault("jitter", 4294967295)
-            constraints.setdefault("lossrate", 99)
+            constraints.setdefault("lossrate", 99.0)
 
     studio_inputs.update(
         {

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
@@ -33,7 +33,7 @@ def update_general_metadata(metadata: dict, studio_inputs: dict) -> None:
             constraints: dict = avt.setdefault("constraints", {})
             constraints.setdefault("latency", 4294967295)
             constraints.setdefault("jitter", 4294967295)
-            constraints.setdefault("loss_rate", 99)
+            constraints.setdefault("lossrate", 99)
 
     studio_inputs.update(
         {

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
@@ -29,7 +29,7 @@ def update_general_metadata(metadata: dict, studio_inputs: dict) -> None:
     """
     # Temporary fix for default values in metadata studio
     for vrf in get(metadata, "vrfs", default=[]):
-        for avt in vrf.get("avts", default=[]):
+        for avt in get(vrf, "avts", default=[]):
             constraints: dict = avt.setdefault("constraints", {})
             constraints.setdefault("latency", 4294967295)
             constraints.setdefault("jitter", 4294967295)

--- a/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/cv_client/deploy_to_cv/deploy_cv_pathfinder_metadata_to_cv.py
@@ -27,6 +27,14 @@ def update_general_metadata(metadata: dict, studio_inputs: dict) -> None:
     """
     In-place update general metadata in studio_inputs.
     """
+    # Temporary fix for default values in metadata studio
+    for vrf in get(metadata, "vrfs", default=[]):
+        for avt in vrf.get("avts", default=[]):
+            constraints: dict = avt.setdefault("constraints", {})
+            constraints.setdefault("latency", 4294967295)
+            constraints.setdefault("jitter", 4294967295)
+            constraints.setdefault("loss_rate", 99)
+
     studio_inputs.update(
         {
             "pathgroups": [

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6360,6 +6360,8 @@ keys:
                             type: int
                           lossrate:
                             type: str
+                            convert_types:
+                            - float
                       description:
                         type: str
                       id:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/metadata.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/metadata.schema.yml
@@ -163,6 +163,8 @@ keys:
                             type: int
                           lossrate:
                             type: str
+                            convert_types:
+                              - float
                       description:
                         type: str
                       id:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/metadata/cv_pathfinder.py
@@ -162,7 +162,7 @@ class CvPathfinderMixin:
                         "constraints": {
                             "jitter": lb_policy.get("jitter"),
                             "latency": lb_policy.get("latency"),
-                            "lossrate": float(lb_policy["lossrate"]) if "lossrate" in lb_policy else None,
+                            "lossrate": float(lb_policy["loss_rate"]) if "loss_rate" in lb_policy else None,
                         },
                         "description": "",  # TODO: Not sure we have this field anywhere
                         "id": profile["id"],


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Set default values for constraints in metadata studio

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Fix bug for `loss_rate` vs `lossrate`.
- Always set `constraints` in metadata studio.
  - using default values matching EOS defaults.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Manual testing.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
