### PR TITLE
Refactor(eos_designs): Set `default_underlay_routing_protocol: none` for wan_rr and wan_router

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -14,8 +14,6 @@ flow tracking hardware
 !
 service routing protocols model multi-agent
 !
-ip as-path access-list ASPATH-WAN permit 65100 any
-!
 hostname uplink_lan_wan_router1
 !
 router adaptive-virtual-topology
@@ -157,18 +155,6 @@ ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.1.1:1
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.1.0/24 eq 32
-!
-route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
-   description Mark prefixes originated from the LAN
-   set extcommunity soo 192.168.1.1:1 additive
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -14,8 +14,6 @@ flow tracking hardware
 !
 service routing protocols model multi-agent
 !
-ip as-path access-list ASPATH-WAN permit 65100 any
-!
 hostname uplink_lan_wan_router2
 !
 router adaptive-virtual-topology
@@ -163,18 +161,6 @@ ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.1.2:2
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.1.0/24 eq 32
-!
-route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
-   description Mark prefixes originated from the LAN
-   set extcommunity soo 192.168.1.2:2 additive
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 10
-   description Advertise local routes towards LAN
-   match extcommunity ECL-EVPN-SOO
-!
-route-map RM-BGP-UNDERLAY-PEERS-OUT permit 20
-   description Advertise routes received from WAN iBGP towards LAN
-   match route-type internal
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -135,12 +135,6 @@ loopback_interfaces:
   description: Router_ID
   shutdown: false
   ip_address: 192.168.1.1/32
-as_path:
-  access_lists:
-  - name: ASPATH-WAN
-    entries:
-    - type: permit
-      match: '65100'
 prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
@@ -155,25 +149,6 @@ route_maps:
     - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
     set:
     - extcommunity soo 192.168.1.1:1 additive
-- name: RM-BGP-UNDERLAY-PEERS-IN
-  sequence_numbers:
-  - sequence: 40
-    type: permit
-    description: Mark prefixes originated from the LAN
-    set:
-    - extcommunity soo 192.168.1.1:1 additive
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -144,12 +144,6 @@ loopback_interfaces:
   description: Router_ID
   shutdown: false
   ip_address: 192.168.1.2/32
-as_path:
-  access_lists:
-  - name: ASPATH-WAN
-    entries:
-    - type: permit
-      match: '65100'
 prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
@@ -164,25 +158,6 @@ route_maps:
     - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
     set:
     - extcommunity soo 192.168.1.2:2 additive
-- name: RM-BGP-UNDERLAY-PEERS-IN
-  sequence_numbers:
-  - sequence: 40
-    type: permit
-    description: Mark prefixes originated from the LAN
-    set:
-    - extcommunity soo 192.168.1.2:2 additive
-- name: RM-BGP-UNDERLAY-PEERS-OUT
-  sequence_numbers:
-  - sequence: 10
-    type: permit
-    description: Advertise local routes towards LAN
-    match:
-    - extcommunity ECL-EVPN-SOO
-  - sequence: 20
-    type: permit
-    description: Advertise routes received from WAN iBGP towards LAN
-    match:
-    - route-type internal
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -1,6 +1,9 @@
 ---
 # Testing cv-pathfinder
 wan_mode: cv-pathfinder
+# Have all the router in the examples use eBGP as underlay routing protocol -
+# the default is "none" for WAN routers"
+underlay_routing_protocol: ebgp
 
 cv_pathfinder_regions:
   - name: AVD_Land_West

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/node_type_keys.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_designs_shared_utils/node_type_keys.py
@@ -65,6 +65,7 @@ DEFAULT_NODE_TYPE_KEYS = {
             "type": "wan_router",
             "default_evpn_role": "client",
             "default_wan_role": "client",
+            "default_underlay_routing_protocol": "none",
             "default_overlay_routing_protocol": "ibgp",
             "vtep": True,
             "network_services": {
@@ -76,6 +77,7 @@ DEFAULT_NODE_TYPE_KEYS = {
             "type": "wan_rr",
             "default_evpn_role": "server",
             "default_wan_role": "server",
+            "default_underlay_routing_protocol": "none",
             "default_overlay_routing_protocol": "ibgp",
             "vtep": True,
             "network_services": {

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/wan-preview.md
@@ -149,12 +149,10 @@ The HA tunnel will come up properly today but route redistribution will be missi
 
 The following table indicates the settings:
 
-| Node Type Key | Underlay Router | Uplink Type | Default EVPN Role | L2 Network Services | L3 Network Services | VTEP | MLAG Support | Connected Endpoints | Defaut WAN Role | Default CV Pathfinder Role |
-| ------------- | --------------- | ----------- | ----------------- | ------------------- | ------------------- | ---- | ------------ | ------------------- | --------------- | -------------------------- |
-| wan_rr        | ✅               | p2p         | server            | ✘                   | ✅                   | ✅    | ✘            | ✘                   | server          | pathfinder                 |
-| wan_router    | ✅               | p2p         | client            | ✘                   | ✅                   | ✅    | ✘            | ✘                   | client          | edge                       |
-
-All these node types are defined with `default_underlay_routing_protocol: none` and `default_overlay_routing_protocol: ibgp`.
+| Node Type Key | Underlay Router | Uplink Type | Default EVPN Role | L2 Network Services | L3 Network Services | VTEP | MLAG Support | Connected Endpoints | Defaut WAN Role | Default CV Pathfinder Role | Default Underlay Routing Protocol | Default Overlay Routing Protocol |
+| ------------- | --------------- | ----------- | ----------------- | ------------------- | ------------------- | ---- | ------------ | ------------------- | --------------- | -------------------------- | --------------------------------- | -------------------------------- |
+| wan_rr        | ✅               | p2p         | server            | ✘                   | ✅                   | ✅    | ✘            | ✘                   | server          | pathfinder                 | none                           | iBGP                             |
+| wan_router    | ✅               | p2p         | client            | ✘                   | ✅                   | ✅    | ✘            | ✘                   | client          | edge                       | none                           | iBGP                             |
 
 ### WAN Settings
 


### PR DESCRIPTION
## Change Summary

The rational behind this change is that most WAN edge sites would be single router with LAN. Having this config will prevent some eBGP config to be generated when not needed (which should also be looked into).

This can still be overwritten of course as done in molecule.

## Component(s) name

`arista.avd.eos_designs`

## How to test

molecule

## Checklist
### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
