### PR TITLE
Feat(eos_designs): Dot1x unauthorized access|native vlan membership egress to ethernet interfaces via port_profile

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
@@ -96,6 +96,18 @@ interface Ethernet13
    channel-group 12 mode active
    spanning-tree portfast
    spanning-tree bpdufilter enable
+!
+interface Ethernet14
+   description DOT1X_UNAUTHORIZED
+   no shutdown
+   switchport trunk native vlan 123
+   switchport trunk allowed vlan 1,2,3,4,5,6,7,123,234
+   switchport mode trunk
+   switchport
+   dot1x unauthorized access vlan membership egress
+   dot1x unauthorized native vlan membership egress
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
@@ -112,6 +112,23 @@ ethernet_interfaces:
   native_vlan: 123
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: 'True'
+- name: Ethernet14
+  peer: DOT1X_UNAUTHORIZED
+  peer_type: server
+  port_profile: INDIVIDUAL_TRUNK
+  description: DOT1X_UNAUTHORIZED
+  shutdown: false
+  type: switched
+  mode: trunk
+  vlans: 1,2,3,4,5,6,7,123,234
+  native_vlan_tag: false
+  native_vlan: 123
+  spanning_tree_portfast: edge
+  spanning_tree_bpdufilter: 'True'
+  dot1x:
+    unauthorized:
+      access_vlan_membership_egress: true
+      native_vlan_membership_egress: true
 port_channel_interfaces:
 - name: Port-Channel5
   description: OLD_SW-1/5_PORT_CHANNEL_DESCRIPTION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
@@ -58,6 +58,11 @@ servers:
             mode: individual
             individual:
               profile: INDIVIDUAL_TRUNK
+  - name: DOT1X_UNAUTHORIZED
+    adapters:
+      - switches: [connected_endpoints]
+        switch_ports: [Ethernet14]
+        profile: INDIVIDUAL_TRUNK
 
 port_profiles:
   - profile: INDIVIDUAL_TRUNK
@@ -67,3 +72,7 @@ port_profiles:
     native_vlan: 123
     spanning_tree_portfast: "edge"
     spanning_tree_bpdufilter: True
+    dot1x:
+      unauthorized:
+        access_vlan_membership_egress: True
+        native_vlan_membership_egress: True

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/connected-endpoints.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/connected-endpoints.md
@@ -72,6 +72,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_timeout_ignore</samp>](## "<connected_endpoints_keys.key>.[].adapters.[].dot1x.timeout.reauth_timeout_ignore") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "<connected_endpoints_keys.key>.[].adapters.[].dot1x.timeout.tx_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "<connected_endpoints_keys.key>.[].adapters.[].dot1x.reauthorization_request_limit") | Integer |  |  | Min: 1<br>Max: 10 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unauthorized</samp>](## "<connected_endpoints_keys.key>.[].adapters.[].dot1x.unauthorized") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_vlan_membership_egress</samp>](## "<connected_endpoints_keys.key>.[].adapters.[].dot1x.unauthorized.access_vlan_membership_egress") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;native_vlan_membership_egress</samp>](## "<connected_endpoints_keys.key>.[].adapters.[].dot1x.unauthorized.native_vlan_membership_egress") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poe</samp>](## "<connected_endpoints_keys.key>.[].adapters.[].poe") | Dictionary |  |  |  | Power Over Ethernet settings applied on port. Only configured if platform supports PoE. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disabled</samp>](## "<connected_endpoints_keys.key>.[].adapters.[].poe.disabled") | Boolean |  | `False` |  | Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "<connected_endpoints_keys.key>.[].adapters.[].poe.priority") | String |  |  | Valid Values:<br>- <code>critical</code><br>- <code>high</code><br>- <code>medium</code><br>- <code>low</code> | Prioritize a port's power in the event that one of the switch's power supplies loses power |
@@ -300,6 +303,9 @@
                 reauth_timeout_ignore: <bool>
                 tx_period: <int; 1-65535>
               reauthorization_request_limit: <int; 1-10>
+              unauthorized:
+                access_vlan_membership_egress: <bool>
+                native_vlan_membership_egress: <bool>
 
             # Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
             poe:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-ports.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-ports.md
@@ -64,6 +64,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_timeout_ignore</samp>](## "network_ports.[].dot1x.timeout.reauth_timeout_ignore") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "network_ports.[].dot1x.timeout.tx_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "network_ports.[].dot1x.reauthorization_request_limit") | Integer |  |  | Min: 1<br>Max: 10 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unauthorized</samp>](## "network_ports.[].dot1x.unauthorized") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_vlan_membership_egress</samp>](## "network_ports.[].dot1x.unauthorized.access_vlan_membership_egress") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;native_vlan_membership_egress</samp>](## "network_ports.[].dot1x.unauthorized.native_vlan_membership_egress") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;poe</samp>](## "network_ports.[].poe") | Dictionary |  |  |  | Power Over Ethernet settings applied on port. Only configured if platform supports PoE. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disabled</samp>](## "network_ports.[].poe.disabled") | Boolean |  | `False` |  | Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "network_ports.[].poe.priority") | String |  |  | Valid Values:<br>- <code>critical</code><br>- <code>high</code><br>- <code>medium</code><br>- <code>low</code> | Prioritize a port's power in the event that one of the switch's power supplies loses power |
@@ -272,6 +275,9 @@
             reauth_timeout_ignore: <bool>
             tx_period: <int; 1-65535>
           reauthorization_request_limit: <int; 1-10>
+          unauthorized:
+            access_vlan_membership_egress: <bool>
+            native_vlan_membership_egress: <bool>
 
         # Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
         poe:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/port-profiles.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/port-profiles.md
@@ -61,6 +61,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauth_timeout_ignore</samp>](## "port_profiles.[].dot1x.timeout.reauth_timeout_ignore") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tx_period</samp>](## "port_profiles.[].dot1x.timeout.tx_period") | Integer |  |  | Min: 1<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reauthorization_request_limit</samp>](## "port_profiles.[].dot1x.reauthorization_request_limit") | Integer |  |  | Min: 1<br>Max: 10 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unauthorized</samp>](## "port_profiles.[].dot1x.unauthorized") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_vlan_membership_egress</samp>](## "port_profiles.[].dot1x.unauthorized.access_vlan_membership_egress") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;native_vlan_membership_egress</samp>](## "port_profiles.[].dot1x.unauthorized.native_vlan_membership_egress") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;poe</samp>](## "port_profiles.[].poe") | Dictionary |  |  |  | Power Over Ethernet settings applied on port. Only configured if platform supports PoE. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disabled</samp>](## "port_profiles.[].poe.disabled") | Boolean |  | `False` |  | Disable PoE on a POE capable port. PoE is enabled on all ports that support it by default in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "port_profiles.[].poe.priority") | String |  |  | Valid Values:<br>- <code>critical</code><br>- <code>high</code><br>- <code>medium</code><br>- <code>low</code> | Prioritize a port's power in the event that one of the switch's power supplies loses power |
@@ -258,6 +261,9 @@
             reauth_timeout_ignore: <bool>
             tx_period: <int; 1-65535>
           reauthorization_request_limit: <int; 1-10>
+          unauthorized:
+            access_vlan_membership_egress: <bool>
+            native_vlan_membership_egress: <bool>
 
         # Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
         poe:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -9441,6 +9441,24 @@
                 "minimum": 1,
                 "maximum": 10,
                 "title": "Reauthorization Request Limit"
+              },
+              "unauthorized": {
+                "type": "object",
+                "properties": {
+                  "access_vlan_membership_egress": {
+                    "type": "boolean",
+                    "title": "Access VLAN Membership Egress"
+                  },
+                  "native_vlan_membership_egress": {
+                    "type": "boolean",
+                    "title": "Native VLAN Membership Egress"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Unauthorized"
               }
             },
             "additionalProperties": false,
@@ -15732,6 +15750,24 @@
                 "minimum": 1,
                 "maximum": 10,
                 "title": "Reauthorization Request Limit"
+              },
+              "unauthorized": {
+                "type": "object",
+                "properties": {
+                  "access_vlan_membership_egress": {
+                    "type": "boolean",
+                    "title": "Access VLAN Membership Egress"
+                  },
+                  "native_vlan_membership_egress": {
+                    "type": "boolean",
+                    "title": "Native VLAN Membership Egress"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Unauthorized"
               }
             },
             "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -4426,6 +4426,13 @@ $defs:
             - str
             min: 1
             max: 10
+          unauthorized:
+            type: dict
+            keys:
+              access_vlan_membership_egress:
+                type: bool
+              native_vlan_membership_egress:
+                type: bool
       poe:
         $ref: eos_cli_config_gen#/keys/ethernet_interfaces/items/keys/poe
         type: dict

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_adapter_config.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/defs_adapter_config.schema.yml
@@ -248,6 +248,13 @@ $defs:
               - str
             min: 1
             max: 10
+          unauthorized:
+            type: dict
+            keys:
+              access_vlan_membership_egress:
+                type: bool
+              native_vlan_membership_egress:
+                type: bool
       poe:
         $ref: eos_cli_config_gen#/keys/ethernet_interfaces/items/keys/poe
         type: dict


### PR DESCRIPTION
## Change Summary

Add eos_design support for Dot1x unauthorized access|native vlan membership egress to ethernet interfaces via port_profile.

## Related Issue(s)

Fixes #3765 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Added keys for unauthorized access|native vlan membership egress in adapter schema.
Added one more interface in tests and executed molecule.

## How to test

Add keys for Dot1x unauthorized access|native vlan membership egress under port-profile\dot1x in input files.

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
