### PR TITLE
Feat(eos_cli_config_gen): Add l4 to application traffic recognition

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
@@ -56,7 +56,7 @@ interface Management1
 
 | Name | Protocols | Protocol Ranges | TCP Source Port Set | TCP Destination Port Set | UDP Source Port Set | UDP Destination Port Set |
 | ---- | --------- | --------------- | ------------------- | ------------------------ | ------------------- | ------------------------ |
-| l4-app-1 | tcp, udp | - | src_port_set1 | dest_port_set1 | src_port_set2 | dest_port_set2 |
+| l4-app-1 | tcp, udp | - | src_port_set1 | dest_port_set1 | src_port_set1 | dest_port_set1 |
 
 ### Application Profiles
 
@@ -142,7 +142,7 @@ application traffic recognition
    !
    application l4 l4-app-1
       protocol tcp source port field-set src_port_set1 destination port field-set dest_port_set1
-      protocol udp source port field-set src_port_set2 destination port field-set dest_port_set2
+      protocol udp source port field-set src_port_set1 destination port field-set dest_port_set1
    !
    category best-effort
       application aimini service peer-to-peer

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
@@ -52,6 +52,12 @@ interface Management1
 | user_defined_app1 | src_prefix_set1 | dest_prefix_set1 | udp, tcp | 25 | src_port_set1 | dest_port_set1 | src_port_set2 | dest_port_set2 |
 | user_defined_app2 | src_prefix_set2 | dest_prefix_set2 | pim, icmp, tcp | 21, 7-11 | - | - | - | - |
 
+#### Layer 4 Applications
+
+| Name | Protocols | Protocol Ranges | TCP Source Port Set | TCP Destination Port Set | UDP Source Port Set | UDP Destination Port Set |
+| ---- | --------- | --------------- | ------------------- | ------------------------ | ------------------- | ------------------------ |
+| l4-app-1 | tcp, udp | - | src_port_set1 | dest_port_set1 | src_port_set2 | dest_port_set2 |
+
 ### Application Profiles
 
 #### Application Profile Name app_profile_1
@@ -133,6 +139,10 @@ application traffic recognition
       protocol pim
       protocol tcp
       protocol 7-11, 21
+   !
+   application l4 l4-app-1
+      protocol tcp source port field-set src_port_set1 destination port field-set dest_port_set1
+      protocol udp source port field-set src_port_set2 destination port field-set dest_port_set2
    !
    category best-effort
       application aimini service peer-to-peer

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/application-traffic-recognition.md
@@ -57,6 +57,7 @@ interface Management1
 | Name | Protocols | Protocol Ranges | TCP Source Port Set | TCP Destination Port Set | UDP Source Port Set | UDP Destination Port Set |
 | ---- | --------- | --------------- | ------------------- | ------------------------ | ------------------- | ------------------------ |
 | l4-app-1 | tcp, udp | - | src_port_set1 | dest_port_set1 | src_port_set1 | dest_port_set1 |
+| l4-app-2 | tcp | 27, 41-44 | - | - | - | - |
 
 ### Application Profiles
 
@@ -143,6 +144,10 @@ application traffic recognition
    application l4 l4-app-1
       protocol tcp source port field-set src_port_set1 destination port field-set dest_port_set1
       protocol udp source port field-set src_port_set1 destination port field-set dest_port_set1
+   !
+   application l4 l4-app-2
+      protocol tcp
+      protocol 27, 41-44
    !
    category best-effort
       application aimini service peer-to-peer

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
@@ -34,6 +34,10 @@ application traffic recognition
       protocol tcp
       protocol 7-11, 21
    !
+   application l4 l4-app-1
+      protocol tcp source port field-set src_port_set1 destination port field-set dest_port_set1
+      protocol udp source port field-set src_port_set2 destination port field-set dest_port_set2
+   !
    category best-effort
       application aimini service peer-to-peer
       application apple_update service software-update

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
@@ -38,6 +38,10 @@ application traffic recognition
       protocol tcp source port field-set src_port_set1 destination port field-set dest_port_set1
       protocol udp source port field-set src_port_set1 destination port field-set dest_port_set1
    !
+   application l4 l4-app-2
+      protocol tcp
+      protocol 27, 41-44
+   !
    category best-effort
       application aimini service peer-to-peer
       application apple_update service software-update

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/application-traffic-recognition.cfg
@@ -36,7 +36,7 @@ application traffic recognition
    !
    application l4 l4-app-1
       protocol tcp source port field-set src_port_set1 destination port field-set dest_port_set1
-      protocol udp source port field-set src_port_set2 destination port field-set dest_port_set2
+      protocol udp source port field-set src_port_set1 destination port field-set dest_port_set1
    !
    category best-effort
       application aimini service peer-to-peer

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
@@ -98,6 +98,12 @@ application_traffic_recognition:
         tcp_dest_port_set_name: dest_port_set1
         udp_src_port_set_name: src_port_set1
         udp_dest_port_set_name: dest_port_set1
+      - name: l4-app-2
+        protocols:
+          - tcp
+        protocol_ranges:
+          - "27"
+          - "41-44"
   application_profiles:
     - name: app_profile_2
       applications:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
@@ -89,6 +89,15 @@ application_traffic_recognition:
         dest_prefix_set_name: dest_prefix_set1
         tcp_src_port_set_name: src_port_set1
         tcp_dest_port_set_name: dest_port_set1
+    l4_applications:
+      - name: l4-app-1
+        protocols:
+          - tcp
+          - udp
+        tcp_src_port_set_name: src_port_set1
+        tcp_dest_port_set_name: dest_port_set1
+        udp_src_port_set_name: src_port_set2
+        udp_dest_port_set_name: dest_port_set2
   application_profiles:
     - name: app_profile_2
       applications:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/application-traffic-recognition.yml
@@ -96,8 +96,8 @@ application_traffic_recognition:
           - udp
         tcp_src_port_set_name: src_port_set1
         tcp_dest_port_set_name: dest_port_set1
-        udp_src_port_set_name: src_port_set2
-        udp_dest_port_set_name: dest_port_set2
+        udp_src_port_set_name: src_port_set1
+        udp_dest_port_set_name: dest_port_set1
   application_profiles:
     - name: app_profile_2
       applications:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/application-traffic-recognition.md
@@ -35,6 +35,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l4_applications</samp>](## "application_traffic_recognition.applications.l4_applications") | List, items: Dictionary |  |  |  | List of user defined L4 applications. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_traffic_recognition.applications.l4_applications.[].name") | String | Required, Unique |  |  | Application name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocol_ranges") | List, items: String |  |  |  | Acccept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocol_ranges.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;application_profiles</samp>](## "application_traffic_recognition.application_profiles") | List, items: Dictionary |  |  |  | Group of applications. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_traffic_recognition.application_profiles.[].name") | String |  |  |  | Application Profile name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;applications</samp>](## "application_traffic_recognition.application_profiles.[].applications") | List, items: Dictionary |  |  |  | List of applications part of the application profile. |
@@ -117,6 +127,52 @@
               - <str; "ahp" | "esp" | "icmp" | "igmp" | "ospf" | "pim" | "rsvp" | "tcp" | "udp" | "vrrp">
 
             # Accept protocol value(s) or range(s).
+            # Protocol values can be between 1 and 255.
+            protocol_ranges:
+              - <str>
+
+            # Name of field set for UDP source ports.
+            #
+            # When the `protocols` list contain both `tcp` and `udp`, this key value
+            # must be the same as `tcp_src_port_set_name`.
+            udp_src_port_set_name: <str>
+
+            # Name of field set for TCP source ports.
+            #
+            # When the `protocols` list contain both `tcp` and `udp`, this key value
+            # must be the same as `udp_src_port_set_name`.
+            tcp_src_port_set_name: <str>
+
+            # Name of field set for UDP destination ports.
+            #
+            # When the `protocols` list contain both `tcp` and `udp`, this key value
+            # must be the same as `tcp_dest_port_set_name`.
+            udp_dest_port_set_name: <str>
+
+            # Name of field set for TCP destination ports.
+            #
+            # When the `protocols` list contain both `tcp` and `udp`, this key value
+            # must be the same as `udp_dest_port_set_name`.
+            tcp_dest_port_set_name: <str>
+
+        # List of user defined L4 applications.
+        l4_applications:
+
+            # Application name.
+          - name: <str; required; unique>
+
+            # List of protocols to consider for this application.
+            #
+            # To use port field-sets (source, destination or both), the list
+            # must contain only one or two protocols, either `tcp` or `udp`.
+            # When using both protocols, one line is rendered for each in the configuration,
+            # hence the field-sets must have the same value for `tcp_src_port_set_name` and
+            # `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
+            # if set in order to generate valid configuration in EOS.
+            protocols:
+              - <str; "ahp" | "esp" | "icmp" | "igmp" | "ospf" | "pim" | "rsvp" | "tcp" | "udp" | "vrrp">
+
+            # Acccept protocol value(s) or range(s).
             # Protocol values can be between 1 and 255.
             protocol_ranges:
               - <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/application-traffic-recognition.md
@@ -39,7 +39,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_traffic_recognition.applications.l4_applications.[].name") | String | Required, Unique |  |  | Application name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocol_ranges") | List, items: String |  |  |  | Acccept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocol_ranges") | List, items: String |  |  |  | Accept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocol_ranges.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
@@ -172,7 +172,7 @@
             protocols:
               - <str; "ahp" | "esp" | "icmp" | "igmp" | "ospf" | "pim" | "rsvp" | "tcp" | "udp" | "vrrp">
 
-            # Acccept protocol value(s) or range(s).
+            # Accept protocol value(s) or range(s).
             # Protocol values can be between 1 and 255.
             protocol_ranges:
               - <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/application-traffic-recognition.md
@@ -27,24 +27,24 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].name") | String | Required, Unique |  |  | Application name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;src_prefix_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].src_prefix_set_name") | String |  |  |  | Source prefix set name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dest_prefix_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].dest_prefix_set_name") | String |  |  |  | Destination prefix set name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].protocol_ranges") | List, items: String |  |  |  | Accept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].protocol_ranges.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l4_applications</samp>](## "application_traffic_recognition.applications.l4_applications") | List, items: Dictionary |  |  |  | List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_traffic_recognition.applications.l4_applications.[].name") | String | Required, Unique |  |  | Application name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocol_ranges") | List, items: String |  |  |  | Accept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocol_ranges.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.l4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;application_profiles</samp>](## "application_traffic_recognition.application_profiles") | List, items: Dictionary |  |  |  | Group of applications. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_traffic_recognition.application_profiles.[].name") | String |  |  |  | Application Profile name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;applications</samp>](## "application_traffic_recognition.application_profiles.[].applications") | List, items: Dictionary |  |  |  | List of applications part of the application profile. |
@@ -116,7 +116,6 @@
             dest_prefix_set_name: <str>
 
             # List of protocols to consider for this application.
-            #
             # To use port field-sets (source, destination or both), the list
             # must contain only one or two protocols, either `tcp` or `udp`.
             # When using both protocols, one line is rendered for each in the configuration,
@@ -132,25 +131,21 @@
               - <str>
 
             # Name of field set for UDP source ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `tcp_src_port_set_name`.
             udp_src_port_set_name: <str>
 
             # Name of field set for TCP source ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `udp_src_port_set_name`.
             tcp_src_port_set_name: <str>
 
             # Name of field set for UDP destination ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `tcp_dest_port_set_name`.
             udp_dest_port_set_name: <str>
 
             # Name of field set for TCP destination ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `udp_dest_port_set_name`.
             tcp_dest_port_set_name: <str>
@@ -162,7 +157,6 @@
           - name: <str; required; unique>
 
             # List of protocols to consider for this application.
-            #
             # To use port field-sets (source, destination or both), the list
             # must contain only one or two protocols, either `tcp` or `udp`.
             # When using both protocols, one line is rendered for each in the configuration,
@@ -178,25 +172,21 @@
               - <str>
 
             # Name of field set for UDP source ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `tcp_src_port_set_name`.
             udp_src_port_set_name: <str>
 
             # Name of field set for TCP source ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `udp_src_port_set_name`.
             tcp_src_port_set_name: <str>
 
             # Name of field set for UDP destination ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `tcp_dest_port_set_name`.
             udp_dest_port_set_name: <str>
 
             # Name of field set for TCP destination ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `udp_dest_port_set_name`.
             tcp_dest_port_set_name: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/application-traffic-recognition.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/application-traffic-recognition.md
@@ -23,7 +23,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_values</samp>](## "application_traffic_recognition.field_sets.ipv4_prefixes.[].prefix_values") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.field_sets.ipv4_prefixes.[].prefix_values.[]") | String |  |  |  | IP prefix (ex 1.2.3.0/24). |
     | [<samp>&nbsp;&nbsp;applications</samp>](## "application_traffic_recognition.applications") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_applications</samp>](## "application_traffic_recognition.applications.ipv4_applications") | List, items: Dictionary |  |  |  | List of user defined IPv4 applications. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_applications</samp>](## "application_traffic_recognition.applications.ipv4_applications") | List, items: Dictionary |  |  |  | List of user defined IPv4 applications. The name should be unique over all defined applications (ipv4 and l4). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].name") | String | Required, Unique |  |  | Application name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;src_prefix_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].src_prefix_set_name") | String |  |  |  | Source prefix set name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dest_prefix_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].dest_prefix_set_name") | String |  |  |  | Destination prefix set name. |
@@ -35,7 +35,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_traffic_recognition.applications.ipv4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l4_applications</samp>](## "application_traffic_recognition.applications.l4_applications") | List, items: Dictionary |  |  |  | List of user defined L4 applications. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l4_applications</samp>](## "application_traffic_recognition.applications.l4_applications") | List, items: Dictionary |  |  |  | List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_traffic_recognition.applications.l4_applications.[].name") | String | Required, Unique |  |  | Application name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_traffic_recognition.applications.l4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
@@ -103,7 +103,7 @@
               - <str>
       applications:
 
-        # List of user defined IPv4 applications.
+        # List of user defined IPv4 applications. The name should be unique over all defined applications (ipv4 and l4).
         ipv4_applications:
 
             # Application name.
@@ -155,7 +155,7 @@
             # must be the same as `udp_dest_port_set_name`.
             tcp_dest_port_set_name: <str>
 
-        # List of user defined L4 applications.
+        # List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4).
         l4_applications:
 
             # Application name.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -954,7 +954,7 @@
                   },
                   "protocol_ranges": {
                     "type": "array",
-                    "description": "Acccept protocol value(s) or range(s).\nProtocol values can be between 1 and 255.",
+                    "description": "Accept protocol value(s) or range(s).\nProtocol values can be between 1 and 255.",
                     "items": {
                       "type": "string"
                     },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -920,6 +920,76 @@
                 ]
               },
               "title": "IPv4 Applications"
+            },
+            "l4_applications": {
+              "type": "array",
+              "description": "List of user defined L4 applications.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Application name.",
+                    "title": "Name"
+                  },
+                  "protocols": {
+                    "type": "array",
+                    "description": "List of protocols to consider for this application.\n\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "ahp",
+                        "esp",
+                        "icmp",
+                        "igmp",
+                        "ospf",
+                        "pim",
+                        "rsvp",
+                        "tcp",
+                        "udp",
+                        "vrrp"
+                      ]
+                    },
+                    "title": "Protocols"
+                  },
+                  "protocol_ranges": {
+                    "type": "array",
+                    "description": "Acccept protocol value(s) or range(s).\nProtocol values can be between 1 and 255.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Protocol Ranges"
+                  },
+                  "udp_src_port_set_name": {
+                    "type": "string",
+                    "description": "Name of field set for UDP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
+                    "title": "UDP Src Port Set Name"
+                  },
+                  "tcp_src_port_set_name": {
+                    "type": "string",
+                    "description": "Name of field set for TCP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
+                    "title": "TCP Src Port Set Name"
+                  },
+                  "udp_dest_port_set_name": {
+                    "type": "string",
+                    "description": "Name of field set for UDP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
+                    "title": "UDP Dest Port Set Name"
+                  },
+                  "tcp_dest_port_set_name": {
+                    "type": "string",
+                    "description": "Name of field set for TCP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
+                    "title": "TCP Dest Port Set Name"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "title": "L4 Applications"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -843,7 +843,7 @@
           "properties": {
             "ipv4_applications": {
               "type": "array",
-              "description": "List of user defined IPv4 applications.",
+              "description": "List of user defined IPv4 applications. The name should be unique over all defined applications (ipv4 and l4).",
               "items": {
                 "type": "object",
                 "properties": {
@@ -923,7 +923,7 @@
             },
             "l4_applications": {
               "type": "array",
-              "description": "List of user defined L4 applications.",
+              "description": "List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4).",
               "items": {
                 "type": "object",
                 "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -864,7 +864,7 @@
                   },
                   "protocols": {
                     "type": "array",
-                    "description": "List of protocols to consider for this application.\n\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
+                    "description": "List of protocols to consider for this application.\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
                     "items": {
                       "type": "string",
                       "enum": [
@@ -892,22 +892,22 @@
                   },
                   "udp_src_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for UDP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
+                    "description": "Name of field set for UDP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
                     "title": "UDP Src Port Set Name"
                   },
                   "tcp_src_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for TCP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
+                    "description": "Name of field set for TCP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
                     "title": "TCP Src Port Set Name"
                   },
                   "udp_dest_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for UDP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
+                    "description": "Name of field set for UDP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
                     "title": "UDP Dest Port Set Name"
                   },
                   "tcp_dest_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for TCP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
+                    "description": "Name of field set for TCP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
                     "title": "TCP Dest Port Set Name"
                   }
                 },
@@ -934,7 +934,7 @@
                   },
                   "protocols": {
                     "type": "array",
-                    "description": "List of protocols to consider for this application.\n\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
+                    "description": "List of protocols to consider for this application.\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
                     "items": {
                       "type": "string",
                       "enum": [
@@ -962,22 +962,22 @@
                   },
                   "udp_src_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for UDP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
+                    "description": "Name of field set for UDP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
                     "title": "UDP Src Port Set Name"
                   },
                   "tcp_src_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for TCP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
+                    "description": "Name of field set for TCP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
                     "title": "TCP Src Port Set Name"
                   },
                   "udp_dest_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for UDP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
+                    "description": "Name of field set for UDP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
                     "title": "UDP Dest Port Set Name"
                   },
                   "tcp_dest_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for TCP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
+                    "description": "Name of field set for TCP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
                     "title": "TCP Dest Port Set Name"
                   }
                 },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -509,7 +509,8 @@ keys:
         keys:
           ipv4_applications:
             type: list
-            description: List of user defined IPv4 applications.
+            description: List of user defined IPv4 applications. The name should be
+              unique over all defined applications (ipv4 and l4).
             primary_key: name
             $ref: eos_cli_config_gen#/$defs/application_traffic_recognition_application
             items:
@@ -526,7 +527,8 @@ keys:
                   description: Destination prefix set name.
           l4_applications:
             type: list
-            description: List of user defined L4 applications.
+            description: List of user defined L4 applications. The name should be
+              unique over all defined applications (ipv4 and l4).
             primary_key: name
             $ref: eos_cli_config_gen#/$defs/application_traffic_recognition_application
             items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -512,9 +512,9 @@ keys:
             description: List of user defined IPv4 applications. The name should be
               unique over all defined applications (ipv4 and l4).
             primary_key: name
-            $ref: eos_cli_config_gen#/$defs/application_traffic_recognition_application
             items:
               type: dict
+              $ref: eos_cli_config_gen#/$defs/application_traffic_recognition_application
               keys:
                 name:
                   type: str
@@ -530,9 +530,9 @@ keys:
             description: List of user defined L4 applications. The name should be
               unique over all defined applications (ipv4 and l4).
             primary_key: name
-            $ref: eos_cli_config_gen#/$defs/application_traffic_recognition_application
             items:
               type: dict
+              $ref: eos_cli_config_gen#/$defs/application_traffic_recognition_application
               keys:
                 name:
                   type: str
@@ -16476,81 +16476,79 @@ keys:
               '
 $defs:
   application_traffic_recognition_application:
-    type: list
-    items:
-      type: dict
-      keys:
-        protocols:
-          type: list
-          description: 'List of protocols to consider for this application.
+    type: dict
+    keys:
+      protocols:
+        type: list
+        description: 'List of protocols to consider for this application.
 
 
-            To use port field-sets (source, destination or both), the list
+          To use port field-sets (source, destination or both), the list
 
-            must contain only one or two protocols, either `tcp` or `udp`.
+          must contain only one or two protocols, either `tcp` or `udp`.
 
-            When using both protocols, one line is rendered for each in the configuration,
+          When using both protocols, one line is rendered for each in the configuration,
 
-            hence the field-sets must have the same value for `tcp_src_port_set_name`
-            and
+          hence the field-sets must have the same value for `tcp_src_port_set_name`
+          and
 
-            `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
+          `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
 
-            if set in order to generate valid configuration in EOS.'
-          items:
-            type: str
-            valid_values:
-            - ahp
-            - esp
-            - icmp
-            - igmp
-            - ospf
-            - pim
-            - rsvp
-            - tcp
-            - udp
-            - vrrp
-        protocol_ranges:
-          type: list
-          description: 'Accept protocol value(s) or range(s).
-
-            Protocol values can be between 1 and 255.'
-          items:
-            type: str
-            convert_types:
-            - int
-        udp_src_port_set_name:
+          if set in order to generate valid configuration in EOS.'
+        items:
           type: str
-          description: 'Name of field set for UDP source ports.
+          valid_values:
+          - ahp
+          - esp
+          - icmp
+          - igmp
+          - ospf
+          - pim
+          - rsvp
+          - tcp
+          - udp
+          - vrrp
+      protocol_ranges:
+        type: list
+        description: 'Accept protocol value(s) or range(s).
 
-
-            When the `protocols` list contain both `tcp` and `udp`, this key value
-
-            must be the same as `tcp_src_port_set_name`.'
-        tcp_src_port_set_name:
+          Protocol values can be between 1 and 255.'
+        items:
           type: str
-          description: 'Name of field set for TCP source ports.
+          convert_types:
+          - int
+      udp_src_port_set_name:
+        type: str
+        description: 'Name of field set for UDP source ports.
 
 
-            When the `protocols` list contain both `tcp` and `udp`, this key value
+          When the `protocols` list contain both `tcp` and `udp`, this key value
 
-            must be the same as `udp_src_port_set_name`.'
-        udp_dest_port_set_name:
-          type: str
-          description: 'Name of field set for UDP destination ports.
-
-
-            When the `protocols` list contain both `tcp` and `udp`, this key value
-
-            must be the same as `tcp_dest_port_set_name`.'
-        tcp_dest_port_set_name:
-          type: str
-          description: 'Name of field set for TCP destination ports.
+          must be the same as `tcp_src_port_set_name`.'
+      tcp_src_port_set_name:
+        type: str
+        description: 'Name of field set for TCP source ports.
 
 
-            When the `protocols` list contain both `tcp` and `udp`, this key value
+          When the `protocols` list contain both `tcp` and `udp`, this key value
 
-            must be the same as `udp_dest_port_set_name`.'
+          must be the same as `udp_src_port_set_name`.'
+      udp_dest_port_set_name:
+        type: str
+        description: 'Name of field set for UDP destination ports.
+
+
+          When the `protocols` list contain both `tcp` and `udp`, this key value
+
+          must be the same as `tcp_dest_port_set_name`.'
+      tcp_dest_port_set_name:
+        type: str
+        description: 'Name of field set for TCP destination ports.
+
+
+          When the `protocols` list contain both `tcp` and `udp`, this key value
+
+          must be the same as `udp_dest_port_set_name`.'
   flow_tracking:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -511,6 +511,7 @@ keys:
             type: list
             description: List of user defined IPv4 applications.
             primary_key: name
+            $ref: eos_cli_config_gen#/$defs/application_traffic_recognition_application
             items:
               type: dict
               keys:
@@ -523,168 +524,17 @@ keys:
                 dest_prefix_set_name:
                   type: str
                   description: Destination prefix set name.
-                protocols:
-                  type: list
-                  description: 'List of protocols to consider for this application.
-
-
-                    To use port field-sets (source, destination or both), the list
-
-                    must contain only one or two protocols, either `tcp` or `udp`.
-
-                    When using both protocols, one line is rendered for each in the
-                    configuration,
-
-                    hence the field-sets must have the same value for `tcp_src_port_set_name`
-                    and
-
-                    `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
-
-                    if set in order to generate valid configuration in EOS.'
-                  items:
-                    type: str
-                    valid_values:
-                    - ahp
-                    - esp
-                    - icmp
-                    - igmp
-                    - ospf
-                    - pim
-                    - rsvp
-                    - tcp
-                    - udp
-                    - vrrp
-                protocol_ranges:
-                  type: list
-                  description: 'Accept protocol value(s) or range(s).
-
-                    Protocol values can be between 1 and 255.'
-                  items:
-                    type: str
-                    convert_types:
-                    - int
-                udp_src_port_set_name:
-                  type: str
-                  description: 'Name of field set for UDP source ports.
-
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key
-                    value
-
-                    must be the same as `tcp_src_port_set_name`.'
-                tcp_src_port_set_name:
-                  type: str
-                  description: 'Name of field set for TCP source ports.
-
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key
-                    value
-
-                    must be the same as `udp_src_port_set_name`.'
-                udp_dest_port_set_name:
-                  type: str
-                  description: 'Name of field set for UDP destination ports.
-
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key
-                    value
-
-                    must be the same as `tcp_dest_port_set_name`.'
-                tcp_dest_port_set_name:
-                  type: str
-                  description: 'Name of field set for TCP destination ports.
-
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key
-                    value
-
-                    must be the same as `udp_dest_port_set_name`.'
           l4_applications:
             type: list
             description: List of user defined L4 applications.
             primary_key: name
+            $ref: eos_cli_config_gen#/$defs/application_traffic_recognition_application
             items:
               type: dict
               keys:
                 name:
                   type: str
                   description: Application name.
-                protocols:
-                  type: list
-                  description: 'List of protocols to consider for this application.
-
-
-                    To use port field-sets (source, destination or both), the list
-
-                    must contain only one or two protocols, either `tcp` or `udp`.
-
-                    When using both protocols, one line is rendered for each in the
-                    configuration,
-
-                    hence the field-sets must have the same value for `tcp_src_port_set_name`
-                    and
-
-                    `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
-
-                    if set in order to generate valid configuration in EOS.'
-                  items:
-                    type: str
-                    valid_values:
-                    - ahp
-                    - esp
-                    - icmp
-                    - igmp
-                    - ospf
-                    - pim
-                    - rsvp
-                    - tcp
-                    - udp
-                    - vrrp
-                protocol_ranges:
-                  type: list
-                  description: 'Acccept protocol value(s) or range(s).
-
-                    Protocol values can be between 1 and 255.'
-                  items:
-                    type: str
-                    convert_types:
-                    - int
-                udp_src_port_set_name:
-                  type: str
-                  description: 'Name of field set for UDP source ports.
-
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key
-                    value
-
-                    must be the same as `tcp_src_port_set_name`.'
-                tcp_src_port_set_name:
-                  type: str
-                  description: 'Name of field set for TCP source ports.
-
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key
-                    value
-
-                    must be the same as `udp_src_port_set_name`.'
-                udp_dest_port_set_name:
-                  type: str
-                  description: 'Name of field set for UDP destination ports.
-
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key
-                    value
-
-                    must be the same as `tcp_dest_port_set_name`.'
-                tcp_dest_port_set_name:
-                  type: str
-                  description: 'Name of field set for TCP destination ports.
-
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key
-                    value
-
-                    must be the same as `udp_dest_port_set_name`.'
       application_profiles:
         type: list
         description: Group of applications.
@@ -16623,6 +16473,82 @@ keys:
 
               '
 $defs:
+  application_traffic_recognition_application:
+    type: list
+    items:
+      type: dict
+      keys:
+        protocols:
+          type: list
+          description: 'List of protocols to consider for this application.
+
+
+            To use port field-sets (source, destination or both), the list
+
+            must contain only one or two protocols, either `tcp` or `udp`.
+
+            When using both protocols, one line is rendered for each in the configuration,
+
+            hence the field-sets must have the same value for `tcp_src_port_set_name`
+            and
+
+            `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
+
+            if set in order to generate valid configuration in EOS.'
+          items:
+            type: str
+            valid_values:
+            - ahp
+            - esp
+            - icmp
+            - igmp
+            - ospf
+            - pim
+            - rsvp
+            - tcp
+            - udp
+            - vrrp
+        protocol_ranges:
+          type: list
+          description: 'Accept protocol value(s) or range(s).
+
+            Protocol values can be between 1 and 255.'
+          items:
+            type: str
+            convert_types:
+            - int
+        udp_src_port_set_name:
+          type: str
+          description: 'Name of field set for UDP source ports.
+
+
+            When the `protocols` list contain both `tcp` and `udp`, this key value
+
+            must be the same as `tcp_src_port_set_name`.'
+        tcp_src_port_set_name:
+          type: str
+          description: 'Name of field set for TCP source ports.
+
+
+            When the `protocols` list contain both `tcp` and `udp`, this key value
+
+            must be the same as `udp_src_port_set_name`.'
+        udp_dest_port_set_name:
+          type: str
+          description: 'Name of field set for UDP destination ports.
+
+
+            When the `protocols` list contain both `tcp` and `udp`, this key value
+
+            must be the same as `tcp_dest_port_set_name`.'
+        tcp_dest_port_set_name:
+          type: str
+          description: 'Name of field set for TCP destination ports.
+
+
+            When the `protocols` list contain both `tcp` and `udp`, this key value
+
+            must be the same as `udp_dest_port_set_name`.'
   flow_tracking:
     type: dict
     keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -599,6 +599,92 @@ keys:
                     value
 
                     must be the same as `udp_dest_port_set_name`.'
+          l4_applications:
+            type: list
+            description: List of user defined L4 applications.
+            primary_key: name
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Application name.
+                protocols:
+                  type: list
+                  description: 'List of protocols to consider for this application.
+
+
+                    To use port field-sets (source, destination or both), the list
+
+                    must contain only one or two protocols, either `tcp` or `udp`.
+
+                    When using both protocols, one line is rendered for each in the
+                    configuration,
+
+                    hence the field-sets must have the same value for `tcp_src_port_set_name`
+                    and
+
+                    `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
+
+                    if set in order to generate valid configuration in EOS.'
+                  items:
+                    type: str
+                    valid_values:
+                    - ahp
+                    - esp
+                    - icmp
+                    - igmp
+                    - ospf
+                    - pim
+                    - rsvp
+                    - tcp
+                    - udp
+                    - vrrp
+                protocol_ranges:
+                  type: list
+                  description: 'Acccept protocol value(s) or range(s).
+
+                    Protocol values can be between 1 and 255.'
+                  items:
+                    type: str
+                    convert_types:
+                    - int
+                udp_src_port_set_name:
+                  type: str
+                  description: 'Name of field set for UDP source ports.
+
+
+                    When the `protocols` list contain both `tcp` and `udp`, this key
+                    value
+
+                    must be the same as `tcp_src_port_set_name`.'
+                tcp_src_port_set_name:
+                  type: str
+                  description: 'Name of field set for TCP source ports.
+
+
+                    When the `protocols` list contain both `tcp` and `udp`, this key
+                    value
+
+                    must be the same as `udp_src_port_set_name`.'
+                udp_dest_port_set_name:
+                  type: str
+                  description: 'Name of field set for UDP destination ports.
+
+
+                    When the `protocols` list contain both `tcp` and `udp`, this key
+                    value
+
+                    must be the same as `tcp_dest_port_set_name`.'
+                tcp_dest_port_set_name:
+                  type: str
+                  description: 'Name of field set for TCP destination ports.
+
+
+                    When the `protocols` list contain both `tcp` and `udp`, this key
+                    value
+
+                    must be the same as `udp_dest_port_set_name`.'
       application_profiles:
         type: list
         description: Group of applications.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -16482,7 +16482,6 @@ $defs:
         type: list
         description: 'List of protocols to consider for this application.
 
-
           To use port field-sets (source, destination or both), the list
 
           must contain only one or two protocols, either `tcp` or `udp`.
@@ -16521,14 +16520,12 @@ $defs:
         type: str
         description: 'Name of field set for UDP source ports.
 
-
           When the `protocols` list contain both `tcp` and `udp`, this key value
 
           must be the same as `tcp_src_port_set_name`.'
       tcp_src_port_set_name:
         type: str
         description: 'Name of field set for TCP source ports.
-
 
           When the `protocols` list contain both `tcp` and `udp`, this key value
 
@@ -16537,14 +16534,12 @@ $defs:
         type: str
         description: 'Name of field set for UDP destination ports.
 
-
           When the `protocols` list contain both `tcp` and `udp`, this key value
 
           must be the same as `tcp_dest_port_set_name`.'
       tcp_dest_port_set_name:
         type: str
         description: 'Name of field set for TCP destination ports.
-
 
           When the `protocols` list contain both `tcp` and `udp`, this key value
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
@@ -82,7 +82,6 @@ keys:
             type: list
             description: List of user defined IPv4 applications. The name should be unique over all defined applications (ipv4 and l4).
             primary_key: name
-            $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"
             items:
               type: dict
               $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
@@ -85,6 +85,7 @@ keys:
             $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"
             items:
               type: dict
+              $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"
               keys:
                 name:
                   type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
@@ -101,6 +101,7 @@ keys:
             primary_key: name
             items:
               type: dict
+              $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"
               keys:
                 name:
                   type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
@@ -82,6 +82,7 @@ keys:
             type: list
             description: List of user defined IPv4 applications.
             primary_key: name
+            $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"
             items:
               type: dict
               keys:
@@ -94,138 +95,17 @@ keys:
                 dest_prefix_set_name:
                   type: str
                   description: Destination prefix set name.
-                protocols:
-                  type: list
-                  description: |-
-                    List of protocols to consider for this application.
-
-                    To use port field-sets (source, destination or both), the list
-                    must contain only one or two protocols, either `tcp` or `udp`.
-                    When using both protocols, one line is rendered for each in the configuration,
-                    hence the field-sets must have the same value for `tcp_src_port_set_name` and
-                    `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
-                    if set in order to generate valid configuration in EOS.
-                  items:
-                    type: str
-                    valid_values:
-                      - ahp
-                      - esp
-                      - icmp
-                      - igmp
-                      - ospf
-                      - pim
-                      - rsvp
-                      - tcp
-                      - udp
-                      - vrrp
-                protocol_ranges:
-                  type: list
-                  description: |-
-                    Accept protocol value(s) or range(s).
-                    Protocol values can be between 1 and 255.
-                  items:
-                    type: str
-                    convert_types:
-                      - int
-                udp_src_port_set_name:
-                  type: str
-                  description: |-
-                    Name of field set for UDP source ports.
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key value
-                    must be the same as `tcp_src_port_set_name`.
-                tcp_src_port_set_name:
-                  type: str
-                  description: |-
-                    Name of field set for TCP source ports.
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key value
-                    must be the same as `udp_src_port_set_name`.
-                udp_dest_port_set_name:
-                  type: str
-                  description: |-
-                    Name of field set for UDP destination ports.
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key value
-                    must be the same as `tcp_dest_port_set_name`.
-                tcp_dest_port_set_name:
-                  type: str
-                  description: |-
-                    Name of field set for TCP destination ports.
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key value
-                    must be the same as `udp_dest_port_set_name`.
           l4_applications:
             type: list
             description: List of user defined L4 applications.
             primary_key: name
+            $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"
             items:
               type: dict
               keys:
                 name:
                   type: str
                   description: Application name.
-                protocols:
-                  type: list
-                  description: |-
-                    List of protocols to consider for this application.
-
-                    To use port field-sets (source, destination or both), the list
-                    must contain only one or two protocols, either `tcp` or `udp`.
-                    When using both protocols, one line is rendered for each in the configuration,
-                    hence the field-sets must have the same value for `tcp_src_port_set_name` and
-                    `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
-                    if set in order to generate valid configuration in EOS.
-                  items:
-                    type: str
-                    valid_values:
-                      - ahp
-                      - esp
-                      - icmp
-                      - igmp
-                      - ospf
-                      - pim
-                      - rsvp
-                      - tcp
-                      - udp
-                      - vrrp
-                protocol_ranges:
-                  type: list
-                  description: |-
-                    Acccept protocol value(s) or range(s).
-                    Protocol values can be between 1 and 255.
-                  items:
-                    type: str
-                    convert_types:
-                      - int
-                udp_src_port_set_name:
-                  type: str
-                  description: |-
-                    Name of field set for UDP source ports.
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key value
-                    must be the same as `tcp_src_port_set_name`.
-                tcp_src_port_set_name:
-                  type: str
-                  description: |-
-                    Name of field set for TCP source ports.
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key value
-                    must be the same as `udp_src_port_set_name`.
-                udp_dest_port_set_name:
-                  type: str
-                  description: |-
-                    Name of field set for UDP destination ports.
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key value
-                    must be the same as `tcp_dest_port_set_name`.
-                tcp_dest_port_set_name:
-                  type: str
-                  description: |-
-                    Name of field set for TCP destination ports.
-
-                    When the `protocols` list contain both `tcp` and `udp`, this key value
-                    must be the same as `udp_dest_port_set_name`.
       application_profiles:
         type: list
         description: Group of applications.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
@@ -99,7 +99,6 @@ keys:
             type: list
             description: List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4).
             primary_key: name
-            $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"
             items:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
@@ -155,6 +155,77 @@ keys:
 
                     When the `protocols` list contain both `tcp` and `udp`, this key value
                     must be the same as `udp_dest_port_set_name`.
+          l4_applications:
+            type: list
+            description: List of user defined L4 applications.
+            primary_key: name
+            items:
+              type: dict
+              keys:
+                name:
+                  type: str
+                  description: Application name.
+                protocols:
+                  type: list
+                  description: |-
+                    List of protocols to consider for this application.
+
+                    To use port field-sets (source, destination or both), the list
+                    must contain only one or two protocols, either `tcp` or `udp`.
+                    When using both protocols, one line is rendered for each in the configuration,
+                    hence the field-sets must have the same value for `tcp_src_port_set_name` and
+                    `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
+                    if set in order to generate valid configuration in EOS.
+                  items:
+                    type: str
+                    valid_values:
+                      - ahp
+                      - esp
+                      - icmp
+                      - igmp
+                      - ospf
+                      - pim
+                      - rsvp
+                      - tcp
+                      - udp
+                      - vrrp
+                protocol_ranges:
+                  type: list
+                  description: |-
+                    Acccept protocol value(s) or range(s).
+                    Protocol values can be between 1 and 255.
+                  items:
+                    type: str
+                    convert_types:
+                      - int
+                udp_src_port_set_name:
+                  type: str
+                  description: |-
+                    Name of field set for UDP source ports.
+
+                    When the `protocols` list contain both `tcp` and `udp`, this key value
+                    must be the same as `tcp_src_port_set_name`.
+                tcp_src_port_set_name:
+                  type: str
+                  description: |-
+                    Name of field set for TCP source ports.
+
+                    When the `protocols` list contain both `tcp` and `udp`, this key value
+                    must be the same as `udp_src_port_set_name`.
+                udp_dest_port_set_name:
+                  type: str
+                  description: |-
+                    Name of field set for UDP destination ports.
+
+                    When the `protocols` list contain both `tcp` and `udp`, this key value
+                    must be the same as `tcp_dest_port_set_name`.
+                tcp_dest_port_set_name:
+                  type: str
+                  description: |-
+                    Name of field set for TCP destination ports.
+
+                    When the `protocols` list contain both `tcp` and `udp`, this key value
+                    must be the same as `udp_dest_port_set_name`.
       application_profiles:
         type: list
         description: Group of applications.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/application_traffic_recognition.schema.yml
@@ -80,7 +80,7 @@ keys:
         keys:
           ipv4_applications:
             type: list
-            description: List of user defined IPv4 applications.
+            description: List of user defined IPv4 applications. The name should be unique over all defined applications (ipv4 and l4).
             primary_key: name
             $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"
             items:
@@ -97,7 +97,7 @@ keys:
                   description: Destination prefix set name.
           l4_applications:
             type: list
-            description: List of user defined L4 applications.
+            description: List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4).
             primary_key: name
             $ref: "eos_cli_config_gen#/$defs/application_traffic_recognition_application"
             items:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/defs_application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/defs_application_traffic_recognition.schema.yml
@@ -7,66 +7,61 @@
 type: dict
 $defs:
   application_traffic_recognition_application:
-      type: dict
-      keys:
-        protocols:
-          type: list
-          description: |-
-            List of protocols to consider for this application.
-
-            To use port field-sets (source, destination or both), the list
-            must contain only one or two protocols, either `tcp` or `udp`.
-            When using both protocols, one line is rendered for each in the configuration,
-            hence the field-sets must have the same value for `tcp_src_port_set_name` and
-            `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
-            if set in order to generate valid configuration in EOS.
-          items:
-            type: str
-            valid_values:
-              - ahp
-              - esp
-              - icmp
-              - igmp
-              - ospf
-              - pim
-              - rsvp
-              - tcp
-              - udp
-              - vrrp
-        protocol_ranges:
-          type: list
-          description: |-
-            Accept protocol value(s) or range(s).
-            Protocol values can be between 1 and 255.
-          items:
-            type: str
-            convert_types:
-              - int
-        udp_src_port_set_name:
+    type: dict
+    keys:
+      protocols:
+        type: list
+        description: |-
+          List of protocols to consider for this application.
+          To use port field-sets (source, destination or both), the list
+          must contain only one or two protocols, either `tcp` or `udp`.
+          When using both protocols, one line is rendered for each in the configuration,
+          hence the field-sets must have the same value for `tcp_src_port_set_name` and
+          `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
+          if set in order to generate valid configuration in EOS.
+        items:
           type: str
-          description: |-
-            Name of field set for UDP source ports.
-
-            When the `protocols` list contain both `tcp` and `udp`, this key value
-            must be the same as `tcp_src_port_set_name`.
-        tcp_src_port_set_name:
+          valid_values:
+            - ahp
+            - esp
+            - icmp
+            - igmp
+            - ospf
+            - pim
+            - rsvp
+            - tcp
+            - udp
+            - vrrp
+      protocol_ranges:
+        type: list
+        description: |-
+          Accept protocol value(s) or range(s).
+          Protocol values can be between 1 and 255.
+        items:
           type: str
-          description: |-
-            Name of field set for TCP source ports.
-
-            When the `protocols` list contain both `tcp` and `udp`, this key value
-            must be the same as `udp_src_port_set_name`.
-        udp_dest_port_set_name:
-          type: str
-          description: |-
-            Name of field set for UDP destination ports.
-
-            When the `protocols` list contain both `tcp` and `udp`, this key value
-            must be the same as `tcp_dest_port_set_name`.
-        tcp_dest_port_set_name:
-          type: str
-          description: |-
-            Name of field set for TCP destination ports.
-
-            When the `protocols` list contain both `tcp` and `udp`, this key value
-            must be the same as `udp_dest_port_set_name`.
+          convert_types:
+            - int
+      udp_src_port_set_name:
+        type: str
+        description: |-
+          Name of field set for UDP source ports.
+          When the `protocols` list contain both `tcp` and `udp`, this key value
+          must be the same as `tcp_src_port_set_name`.
+      tcp_src_port_set_name:
+        type: str
+        description: |-
+          Name of field set for TCP source ports.
+          When the `protocols` list contain both `tcp` and `udp`, this key value
+          must be the same as `udp_src_port_set_name`.
+      udp_dest_port_set_name:
+        type: str
+        description: |-
+          Name of field set for UDP destination ports.
+          When the `protocols` list contain both `tcp` and `udp`, this key value
+          must be the same as `tcp_dest_port_set_name`.
+      tcp_dest_port_set_name:
+        type: str
+        description: |-
+          Name of field set for TCP destination ports.
+          When the `protocols` list contain both `tcp` and `udp`, this key value
+          must be the same as `udp_dest_port_set_name`.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/defs_application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/defs_application_traffic_recognition.schema.yml
@@ -7,8 +7,6 @@
 type: dict
 $defs:
   application_traffic_recognition_application:
-    type: list
-    items:
       type: dict
       keys:
         protocols:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/defs_application_traffic_recognition.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/defs_application_traffic_recognition.schema.yml
@@ -1,0 +1,74 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+$defs:
+  application_traffic_recognition_application:
+    type: list
+    items:
+      type: dict
+      keys:
+        protocols:
+          type: list
+          description: |-
+            List of protocols to consider for this application.
+
+            To use port field-sets (source, destination or both), the list
+            must contain only one or two protocols, either `tcp` or `udp`.
+            When using both protocols, one line is rendered for each in the configuration,
+            hence the field-sets must have the same value for `tcp_src_port_set_name` and
+            `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
+            if set in order to generate valid configuration in EOS.
+          items:
+            type: str
+            valid_values:
+              - ahp
+              - esp
+              - icmp
+              - igmp
+              - ospf
+              - pim
+              - rsvp
+              - tcp
+              - udp
+              - vrrp
+        protocol_ranges:
+          type: list
+          description: |-
+            Accept protocol value(s) or range(s).
+            Protocol values can be between 1 and 255.
+          items:
+            type: str
+            convert_types:
+              - int
+        udp_src_port_set_name:
+          type: str
+          description: |-
+            Name of field set for UDP source ports.
+
+            When the `protocols` list contain both `tcp` and `udp`, this key value
+            must be the same as `tcp_src_port_set_name`.
+        tcp_src_port_set_name:
+          type: str
+          description: |-
+            Name of field set for TCP source ports.
+
+            When the `protocols` list contain both `tcp` and `udp`, this key value
+            must be the same as `udp_src_port_set_name`.
+        udp_dest_port_set_name:
+          type: str
+          description: |-
+            Name of field set for UDP destination ports.
+
+            When the `protocols` list contain both `tcp` and `udp`, this key value
+            must be the same as `tcp_dest_port_set_name`.
+        tcp_dest_port_set_name:
+          type: str
+          description: |-
+            Name of field set for TCP destination ports.
+
+            When the `protocols` list contain both `tcp` and `udp`, this key value
+            must be the same as `udp_dest_port_set_name`.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/application-traffic-recognition.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/application-traffic-recognition.j2
@@ -28,6 +28,22 @@
 | {{ application.name }} | {{ src_prefix }} | {{ dest_prefix }} | {{ protocol }} | {{ protocol_ranges }} | {{ tcp_src_port }} | {{ tcp_dest_port }} | {{ udp_src_port }} | {{ udp_dest_port }} |
 {%             endfor %}
 {%         endif %}
+{%         if application_traffic_recognition.applications.l4_applications is arista.avd.defined %}
+
+#### Layer 4 Applications
+
+| Name | Protocols | Protocol Ranges | TCP Source Port Set | TCP Destination Port Set | UDP Source Port Set | UDP Destination Port Set |
+| ---- | --------- | --------------- | ------------------- | ------------------------ | ------------------- | ------------------------ |
+{%             for application in application_traffic_recognition.applications.l4_applications | arista.avd.natural_sort('name') %}
+{%                 set tcp_src_port = application.tcp_src_port_set_name | arista.avd.default("-") %}
+{%                 set tcp_dest_port = application.tcp_dest_port_set_name | arista.avd.default("-") %}
+{%                 set udp_src_port = application.udp_src_port_set_name | arista.avd.default("-") %}
+{%                 set udp_dest_port = application.udp_dest_port_set_name | arista.avd.default("-") %}
+{%                 set protocol_ranges = ", ".join(application.protocol_ranges | arista.avd.default(["-"])) %}
+{%                 set protocol = ", ".join(application.protocols | arista.avd.default(["-"])) %}
+| {{ application.name }} | {{ protocol }} | {{ protocol_ranges }} | {{ tcp_src_port }} | {{ tcp_dest_port }} | {{ udp_src_port }} | {{ udp_dest_port }} |
+{%             endfor %}
+{%         endif %}
 {%     endif %}
 {%     if application_traffic_recognition.application_profiles is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/application-traffic-recognition.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/application-traffic-recognition.j2
@@ -41,6 +41,33 @@ application traffic recognition
       protocol {{ application.protocol_ranges | arista.avd.natural_sort('name') | join(", ") }}
 {%             endif %}
 {%         endfor %}
+{%         for application in application_traffic_recognition.applications.l4_applications | arista.avd.natural_sort('name') %}
+   !
+   application l4 {{ application.name }}
+{%             for protocol in application.protocols | arista.avd.natural_sort() %}
+{%                 set config = [protocol] %}
+{%                 if protocol == "tcp" %}
+{%                     if application.tcp_src_port_set_name is arista.avd.defined %}
+{%                         do config.append("source port field-set " + application.tcp_src_port_set_name) %}
+{%                     endif %}
+{%                     if application.tcp_dest_port_set_name is arista.avd.defined %}
+{%                         do config.append("destination port field-set " + application.tcp_dest_port_set_name) %}
+{%                     endif %}
+{%                 endif %}
+{%                 if protocol == "udp" %}
+{%                     if application.udp_src_port_set_name is arista.avd.defined %}
+{%                         do config.append("source port field-set " + application.udp_src_port_set_name) %}
+{%                     endif %}
+{%                     if application.udp_dest_port_set_name is arista.avd.defined %}
+{%                         do config.append("destination port field-set " + application.udp_dest_port_set_name) %}
+{%                     endif %}
+{%                 endif %}
+      protocol {{ config | join(" ") }}
+{%             endfor %}
+{%             if application.protocol_ranges is arista.avd.defined %}
+      protocol {{ application.protocol_ranges | arista.avd.natural_sort('name') | join(", ") }}
+{%             endif %}
+{%         endfor %}
 {%     endif %}
 {# categories #}
 {%     for category in application_traffic_recognition.categories | arista.avd.natural_sort('name') %}

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/application-classification.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/application-classification.md
@@ -39,7 +39,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_classification.applications.l4_applications.[].name") | String | Required, Unique |  |  | Application name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_classification.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.applications.l4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_classification.applications.l4_applications.[].protocol_ranges") | List, items: String |  |  |  | Acccept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_classification.applications.l4_applications.[].protocol_ranges") | List, items: String |  |  |  | Accept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.applications.l4_applications.[].protocol_ranges.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_classification.applications.l4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_classification.applications.l4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
@@ -172,7 +172,7 @@
             protocols:
               - <str; "ahp" | "esp" | "icmp" | "igmp" | "ospf" | "pim" | "rsvp" | "tcp" | "udp" | "vrrp">
 
-            # Acccept protocol value(s) or range(s).
+            # Accept protocol value(s) or range(s).
             # Protocol values can be between 1 and 255.
             protocol_ranges:
               - <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/application-classification.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/application-classification.md
@@ -27,24 +27,24 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_classification.applications.ipv4_applications.[].name") | String | Required, Unique |  |  | Application name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;src_prefix_set_name</samp>](## "application_classification.applications.ipv4_applications.[].src_prefix_set_name") | String |  |  |  | Source prefix set name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dest_prefix_set_name</samp>](## "application_classification.applications.ipv4_applications.[].dest_prefix_set_name") | String |  |  |  | Destination prefix set name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_classification.applications.ipv4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_classification.applications.ipv4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.applications.ipv4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_classification.applications.ipv4_applications.[].protocol_ranges") | List, items: String |  |  |  | Accept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.applications.ipv4_applications.[].protocol_ranges.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l4_applications</samp>](## "application_classification.applications.l4_applications") | List, items: Dictionary |  |  |  | List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_classification.applications.l4_applications.[].name") | String | Required, Unique |  |  | Application name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_classification.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_classification.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.applications.l4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_classification.applications.l4_applications.[].protocol_ranges") | List, items: String |  |  |  | Accept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.applications.l4_applications.[].protocol_ranges.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_classification.applications.l4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_classification.applications.l4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_classification.applications.l4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_classification.applications.l4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_classification.applications.l4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_classification.applications.l4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_classification.applications.l4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_classification.applications.l4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;application_profiles</samp>](## "application_classification.application_profiles") | List, items: Dictionary |  |  |  | Group of applications. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_classification.application_profiles.[].name") | String |  |  |  | Application Profile name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;applications</samp>](## "application_classification.application_profiles.[].applications") | List, items: Dictionary |  |  |  | List of applications part of the application profile. |
@@ -116,7 +116,6 @@
             dest_prefix_set_name: <str>
 
             # List of protocols to consider for this application.
-            #
             # To use port field-sets (source, destination or both), the list
             # must contain only one or two protocols, either `tcp` or `udp`.
             # When using both protocols, one line is rendered for each in the configuration,
@@ -132,25 +131,21 @@
               - <str>
 
             # Name of field set for UDP source ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `tcp_src_port_set_name`.
             udp_src_port_set_name: <str>
 
             # Name of field set for TCP source ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `udp_src_port_set_name`.
             tcp_src_port_set_name: <str>
 
             # Name of field set for UDP destination ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `tcp_dest_port_set_name`.
             udp_dest_port_set_name: <str>
 
             # Name of field set for TCP destination ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `udp_dest_port_set_name`.
             tcp_dest_port_set_name: <str>
@@ -162,7 +157,6 @@
           - name: <str; required; unique>
 
             # List of protocols to consider for this application.
-            #
             # To use port field-sets (source, destination or both), the list
             # must contain only one or two protocols, either `tcp` or `udp`.
             # When using both protocols, one line is rendered for each in the configuration,
@@ -178,25 +172,21 @@
               - <str>
 
             # Name of field set for UDP source ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `tcp_src_port_set_name`.
             udp_src_port_set_name: <str>
 
             # Name of field set for TCP source ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `udp_src_port_set_name`.
             tcp_src_port_set_name: <str>
 
             # Name of field set for UDP destination ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `tcp_dest_port_set_name`.
             udp_dest_port_set_name: <str>
 
             # Name of field set for TCP destination ports.
-            #
             # When the `protocols` list contain both `tcp` and `udp`, this key value
             # must be the same as `udp_dest_port_set_name`.
             tcp_dest_port_set_name: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/application-classification.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/application-classification.md
@@ -35,6 +35,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l4_applications</samp>](## "application_classification.applications.l4_applications") | List, items: Dictionary |  |  |  | List of user defined L4 applications. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_classification.applications.l4_applications.[].name") | String | Required, Unique |  |  | Application name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_classification.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.applications.l4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol_ranges</samp>](## "application_classification.applications.l4_applications.[].protocol_ranges") | List, items: String |  |  |  | Acccept protocol value(s) or range(s).<br>Protocol values can be between 1 and 255. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.applications.l4_applications.[].protocol_ranges.[]") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_src_port_set_name</samp>](## "application_classification.applications.l4_applications.[].udp_src_port_set_name") | String |  |  |  | Name of field set for UDP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_classification.applications.l4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_classification.applications.l4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_classification.applications.l4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;application_profiles</samp>](## "application_classification.application_profiles") | List, items: Dictionary |  |  |  | Group of applications. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_classification.application_profiles.[].name") | String |  |  |  | Application Profile name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;applications</samp>](## "application_classification.application_profiles.[].applications") | List, items: Dictionary |  |  |  | List of applications part of the application profile. |
@@ -117,6 +127,52 @@
               - <str; "ahp" | "esp" | "icmp" | "igmp" | "ospf" | "pim" | "rsvp" | "tcp" | "udp" | "vrrp">
 
             # Accept protocol value(s) or range(s).
+            # Protocol values can be between 1 and 255.
+            protocol_ranges:
+              - <str>
+
+            # Name of field set for UDP source ports.
+            #
+            # When the `protocols` list contain both `tcp` and `udp`, this key value
+            # must be the same as `tcp_src_port_set_name`.
+            udp_src_port_set_name: <str>
+
+            # Name of field set for TCP source ports.
+            #
+            # When the `protocols` list contain both `tcp` and `udp`, this key value
+            # must be the same as `udp_src_port_set_name`.
+            tcp_src_port_set_name: <str>
+
+            # Name of field set for UDP destination ports.
+            #
+            # When the `protocols` list contain both `tcp` and `udp`, this key value
+            # must be the same as `tcp_dest_port_set_name`.
+            udp_dest_port_set_name: <str>
+
+            # Name of field set for TCP destination ports.
+            #
+            # When the `protocols` list contain both `tcp` and `udp`, this key value
+            # must be the same as `udp_dest_port_set_name`.
+            tcp_dest_port_set_name: <str>
+
+        # List of user defined L4 applications.
+        l4_applications:
+
+            # Application name.
+          - name: <str; required; unique>
+
+            # List of protocols to consider for this application.
+            #
+            # To use port field-sets (source, destination or both), the list
+            # must contain only one or two protocols, either `tcp` or `udp`.
+            # When using both protocols, one line is rendered for each in the configuration,
+            # hence the field-sets must have the same value for `tcp_src_port_set_name` and
+            # `udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`
+            # if set in order to generate valid configuration in EOS.
+            protocols:
+              - <str; "ahp" | "esp" | "icmp" | "igmp" | "ospf" | "pim" | "rsvp" | "tcp" | "udp" | "vrrp">
+
+            # Acccept protocol value(s) or range(s).
             # Protocol values can be between 1 and 255.
             protocol_ranges:
               - <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/application-classification.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/application-classification.md
@@ -23,7 +23,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_values</samp>](## "application_classification.field_sets.ipv4_prefixes.[].prefix_values") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.field_sets.ipv4_prefixes.[].prefix_values.[]") | String |  |  |  | IP prefix (ex 1.2.3.0/24). |
     | [<samp>&nbsp;&nbsp;applications</samp>](## "application_classification.applications") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_applications</samp>](## "application_classification.applications.ipv4_applications") | List, items: Dictionary |  |  |  | List of user defined IPv4 applications. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_applications</samp>](## "application_classification.applications.ipv4_applications") | List, items: Dictionary |  |  |  | List of user defined IPv4 applications. The name should be unique over all defined applications (ipv4 and l4). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_classification.applications.ipv4_applications.[].name") | String | Required, Unique |  |  | Application name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;src_prefix_set_name</samp>](## "application_classification.applications.ipv4_applications.[].src_prefix_set_name") | String |  |  |  | Source prefix set name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dest_prefix_set_name</samp>](## "application_classification.applications.ipv4_applications.[].dest_prefix_set_name") | String |  |  |  | Destination prefix set name. |
@@ -35,7 +35,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_src_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].tcp_src_port_set_name") | String |  |  |  | Name of field set for TCP source ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_src_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_dest_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].udp_dest_port_set_name") | String |  |  |  | Name of field set for UDP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `tcp_dest_port_set_name`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tcp_dest_port_set_name</samp>](## "application_classification.applications.ipv4_applications.[].tcp_dest_port_set_name") | String |  |  |  | Name of field set for TCP destination ports.<br><br>When the `protocols` list contain both `tcp` and `udp`, this key value<br>must be the same as `udp_dest_port_set_name`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l4_applications</samp>](## "application_classification.applications.l4_applications") | List, items: Dictionary |  |  |  | List of user defined L4 applications. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l4_applications</samp>](## "application_classification.applications.l4_applications") | List, items: Dictionary |  |  |  | List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "application_classification.applications.l4_applications.[].name") | String | Required, Unique |  |  | Application name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "application_classification.applications.l4_applications.[].protocols") | List, items: String |  |  |  | List of protocols to consider for this application.<br><br>To use port field-sets (source, destination or both), the list<br>must contain only one or two protocols, either `tcp` or `udp`.<br>When using both protocols, one line is rendered for each in the configuration,<br>hence the field-sets must have the same value for `tcp_src_port_set_name` and<br>`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`<br>if set in order to generate valid configuration in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "application_classification.applications.l4_applications.[].protocols.[]") | String |  |  | Valid Values:<br>- <code>ahp</code><br>- <code>esp</code><br>- <code>icmp</code><br>- <code>igmp</code><br>- <code>ospf</code><br>- <code>pim</code><br>- <code>rsvp</code><br>- <code>tcp</code><br>- <code>udp</code><br>- <code>vrrp</code> |  |
@@ -103,7 +103,7 @@
               - <str>
       applications:
 
-        # List of user defined IPv4 applications.
+        # List of user defined IPv4 applications. The name should be unique over all defined applications (ipv4 and l4).
         ipv4_applications:
 
             # Application name.
@@ -155,7 +155,7 @@
             # must be the same as `udp_dest_port_set_name`.
             tcp_dest_port_set_name: <str>
 
-        # List of user defined L4 applications.
+        # List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4).
         l4_applications:
 
             # Application name.

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -135,7 +135,7 @@
           "properties": {
             "ipv4_applications": {
               "type": "array",
-              "description": "List of user defined IPv4 applications.",
+              "description": "List of user defined IPv4 applications. The name should be unique over all defined applications (ipv4 and l4).",
               "items": {
                 "type": "object",
                 "properties": {
@@ -215,7 +215,7 @@
             },
             "l4_applications": {
               "type": "array",
-              "description": "List of user defined L4 applications.",
+              "description": "List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4).",
               "items": {
                 "type": "object",
                 "properties": {
@@ -16688,7 +16688,7 @@
                     "properties": {
                       "ipv4_applications": {
                         "type": "array",
-                        "description": "List of user defined IPv4 applications.",
+                        "description": "List of user defined IPv4 applications. The name should be unique over all defined applications (ipv4 and l4).",
                         "items": {
                           "type": "object",
                           "properties": {
@@ -16768,7 +16768,7 @@
                       },
                       "l4_applications": {
                         "type": "array",
-                        "description": "List of user defined L4 applications.",
+                        "description": "List of user defined L4 applications. The name should be unique over all defined applications (ipv4 and l4).",
                         "items": {
                           "type": "object",
                           "properties": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -246,7 +246,7 @@
                   },
                   "protocol_ranges": {
                     "type": "array",
-                    "description": "Acccept protocol value(s) or range(s).\nProtocol values can be between 1 and 255.",
+                    "description": "Accept protocol value(s) or range(s).\nProtocol values can be between 1 and 255.",
                     "items": {
                       "type": "string"
                     },
@@ -16799,7 +16799,7 @@
                             },
                             "protocol_ranges": {
                               "type": "array",
-                              "description": "Acccept protocol value(s) or range(s).\nProtocol values can be between 1 and 255.",
+                              "description": "Accept protocol value(s) or range(s).\nProtocol values can be between 1 and 255.",
                               "items": {
                                 "type": "string"
                               },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -156,7 +156,7 @@
                   },
                   "protocols": {
                     "type": "array",
-                    "description": "List of protocols to consider for this application.\n\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
+                    "description": "List of protocols to consider for this application.\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
                     "items": {
                       "type": "string",
                       "enum": [
@@ -184,22 +184,22 @@
                   },
                   "udp_src_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for UDP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
+                    "description": "Name of field set for UDP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
                     "title": "UDP Src Port Set Name"
                   },
                   "tcp_src_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for TCP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
+                    "description": "Name of field set for TCP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
                     "title": "TCP Src Port Set Name"
                   },
                   "udp_dest_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for UDP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
+                    "description": "Name of field set for UDP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
                     "title": "UDP Dest Port Set Name"
                   },
                   "tcp_dest_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for TCP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
+                    "description": "Name of field set for TCP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
                     "title": "TCP Dest Port Set Name"
                   }
                 },
@@ -226,7 +226,7 @@
                   },
                   "protocols": {
                     "type": "array",
-                    "description": "List of protocols to consider for this application.\n\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
+                    "description": "List of protocols to consider for this application.\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
                     "items": {
                       "type": "string",
                       "enum": [
@@ -254,22 +254,22 @@
                   },
                   "udp_src_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for UDP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
+                    "description": "Name of field set for UDP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
                     "title": "UDP Src Port Set Name"
                   },
                   "tcp_src_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for TCP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
+                    "description": "Name of field set for TCP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
                     "title": "TCP Src Port Set Name"
                   },
                   "udp_dest_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for UDP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
+                    "description": "Name of field set for UDP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
                     "title": "UDP Dest Port Set Name"
                   },
                   "tcp_dest_port_set_name": {
                     "type": "string",
-                    "description": "Name of field set for TCP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
+                    "description": "Name of field set for TCP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
                     "title": "TCP Dest Port Set Name"
                   }
                 },
@@ -16709,7 +16709,7 @@
                             },
                             "protocols": {
                               "type": "array",
-                              "description": "List of protocols to consider for this application.\n\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
+                              "description": "List of protocols to consider for this application.\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
                               "items": {
                                 "type": "string",
                                 "enum": [
@@ -16737,22 +16737,22 @@
                             },
                             "udp_src_port_set_name": {
                               "type": "string",
-                              "description": "Name of field set for UDP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
+                              "description": "Name of field set for UDP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
                               "title": "UDP Src Port Set Name"
                             },
                             "tcp_src_port_set_name": {
                               "type": "string",
-                              "description": "Name of field set for TCP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
+                              "description": "Name of field set for TCP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
                               "title": "TCP Src Port Set Name"
                             },
                             "udp_dest_port_set_name": {
                               "type": "string",
-                              "description": "Name of field set for UDP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
+                              "description": "Name of field set for UDP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
                               "title": "UDP Dest Port Set Name"
                             },
                             "tcp_dest_port_set_name": {
                               "type": "string",
-                              "description": "Name of field set for TCP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
+                              "description": "Name of field set for TCP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
                               "title": "TCP Dest Port Set Name"
                             }
                           },
@@ -16779,7 +16779,7 @@
                             },
                             "protocols": {
                               "type": "array",
-                              "description": "List of protocols to consider for this application.\n\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
+                              "description": "List of protocols to consider for this application.\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
                               "items": {
                                 "type": "string",
                                 "enum": [
@@ -16807,22 +16807,22 @@
                             },
                             "udp_src_port_set_name": {
                               "type": "string",
-                              "description": "Name of field set for UDP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
+                              "description": "Name of field set for UDP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
                               "title": "UDP Src Port Set Name"
                             },
                             "tcp_src_port_set_name": {
                               "type": "string",
-                              "description": "Name of field set for TCP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
+                              "description": "Name of field set for TCP source ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
                               "title": "TCP Src Port Set Name"
                             },
                             "udp_dest_port_set_name": {
                               "type": "string",
-                              "description": "Name of field set for UDP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
+                              "description": "Name of field set for UDP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
                               "title": "UDP Dest Port Set Name"
                             },
                             "tcp_dest_port_set_name": {
                               "type": "string",
-                              "description": "Name of field set for TCP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
+                              "description": "Name of field set for TCP destination ports.\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
                               "title": "TCP Dest Port Set Name"
                             }
                           },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -212,6 +212,76 @@
                 ]
               },
               "title": "IPv4 Applications"
+            },
+            "l4_applications": {
+              "type": "array",
+              "description": "List of user defined L4 applications.",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "Application name.",
+                    "title": "Name"
+                  },
+                  "protocols": {
+                    "type": "array",
+                    "description": "List of protocols to consider for this application.\n\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
+                    "items": {
+                      "type": "string",
+                      "enum": [
+                        "ahp",
+                        "esp",
+                        "icmp",
+                        "igmp",
+                        "ospf",
+                        "pim",
+                        "rsvp",
+                        "tcp",
+                        "udp",
+                        "vrrp"
+                      ]
+                    },
+                    "title": "Protocols"
+                  },
+                  "protocol_ranges": {
+                    "type": "array",
+                    "description": "Acccept protocol value(s) or range(s).\nProtocol values can be between 1 and 255.",
+                    "items": {
+                      "type": "string"
+                    },
+                    "title": "Protocol Ranges"
+                  },
+                  "udp_src_port_set_name": {
+                    "type": "string",
+                    "description": "Name of field set for UDP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
+                    "title": "UDP Src Port Set Name"
+                  },
+                  "tcp_src_port_set_name": {
+                    "type": "string",
+                    "description": "Name of field set for TCP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
+                    "title": "TCP Src Port Set Name"
+                  },
+                  "udp_dest_port_set_name": {
+                    "type": "string",
+                    "description": "Name of field set for UDP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
+                    "title": "UDP Dest Port Set Name"
+                  },
+                  "tcp_dest_port_set_name": {
+                    "type": "string",
+                    "description": "Name of field set for TCP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
+                    "title": "TCP Dest Port Set Name"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "required": [
+                  "name"
+                ]
+              },
+              "title": "L4 Applications"
             }
           },
           "additionalProperties": false,
@@ -16695,6 +16765,76 @@
                           ]
                         },
                         "title": "IPv4 Applications"
+                      },
+                      "l4_applications": {
+                        "type": "array",
+                        "description": "List of user defined L4 applications.",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "name": {
+                              "type": "string",
+                              "description": "Application name.",
+                              "title": "Name"
+                            },
+                            "protocols": {
+                              "type": "array",
+                              "description": "List of protocols to consider for this application.\n\nTo use port field-sets (source, destination or both), the list\nmust contain only one or two protocols, either `tcp` or `udp`.\nWhen using both protocols, one line is rendered for each in the configuration,\nhence the field-sets must have the same value for `tcp_src_port_set_name` and\n`udp_src_port_set_name` and for `tcp_dest_port_set_name` and `udp_dest_port_set_name`\nif set in order to generate valid configuration in EOS.",
+                              "items": {
+                                "type": "string",
+                                "enum": [
+                                  "ahp",
+                                  "esp",
+                                  "icmp",
+                                  "igmp",
+                                  "ospf",
+                                  "pim",
+                                  "rsvp",
+                                  "tcp",
+                                  "udp",
+                                  "vrrp"
+                                ]
+                              },
+                              "title": "Protocols"
+                            },
+                            "protocol_ranges": {
+                              "type": "array",
+                              "description": "Acccept protocol value(s) or range(s).\nProtocol values can be between 1 and 255.",
+                              "items": {
+                                "type": "string"
+                              },
+                              "title": "Protocol Ranges"
+                            },
+                            "udp_src_port_set_name": {
+                              "type": "string",
+                              "description": "Name of field set for UDP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_src_port_set_name`.",
+                              "title": "UDP Src Port Set Name"
+                            },
+                            "tcp_src_port_set_name": {
+                              "type": "string",
+                              "description": "Name of field set for TCP source ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_src_port_set_name`.",
+                              "title": "TCP Src Port Set Name"
+                            },
+                            "udp_dest_port_set_name": {
+                              "type": "string",
+                              "description": "Name of field set for UDP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `tcp_dest_port_set_name`.",
+                              "title": "UDP Dest Port Set Name"
+                            },
+                            "tcp_dest_port_set_name": {
+                              "type": "string",
+                              "description": "Name of field set for TCP destination ports.\n\nWhen the `protocols` list contain both `tcp` and `udp`, this key value\nmust be the same as `udp_dest_port_set_name`.",
+                              "title": "TCP Dest Port Set Name"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "required": [
+                            "name"
+                          ]
+                        },
+                        "title": "L4 Applications"
                       }
                     },
                     "additionalProperties": false,


### PR DESCRIPTION
## Change Summary

To support MSS-G, this PR adds the ability to generate configuration for L4 applications. This is basically a subnet of the existing IPv4 Application, but without the ability to fix prefixes

## Related Issue(s)

This partially addresses #3769 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
This feature re-uses the existing IPv4 application datamodel, but without the source and destination prefix options.


## How to test
Tested with molecule + EOS 4.31.2F
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
