### PR TITLE
Doc(eos_cli_config_gen): Add Dps1 to flow tracking output in device config

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/flow-tracking.md
@@ -7,6 +7,7 @@
 - [Monitoring](#monitoring)
   - [Flow Tracking](#flow-tracking)
 - [Interfaces](#interfaces)
+  - [DPS Interfaces](#dps-interfaces)
   - [Ethernet Interfaces](#ethernet-interfaces)
   - [Port-Channel Interfaces](#port-channel-interfaces)
 
@@ -74,7 +75,7 @@ interface Management1
 | ------------ | --------------------------------- | ------------------------- | ------------------- | ---------- |
 | T1 | 3666 | 5666 | 0 |  |
 | T2 | - | - | 1 | Ethernet40 |
-| T3 | - | - | 4 | Ethernet41<br>Port-Channel42 |
+| T3 | - | - | 4 | Dps1<br>Ethernet41<br>Port-Channel42 |
 
 ##### Exporters Summary
 
@@ -139,6 +140,22 @@ flow tracking hardware
 ```
 
 ## Interfaces
+
+### DPS Interfaces
+
+#### DPS Interfaces Summary
+
+| Interface | IP address | Shutdown | MTU | Flow tracker(s) | TCP MSS Ceiling |
+| --------- | ---------- | -------- | --- | --------------- | --------------- |
+| Dps1 | - | - | - | Hardware: T3 |  |
+
+#### DPS Interfaces Device Configuration
+
+```eos
+!
+interface Dps1
+   flow tracker hardware T3
+```
 
 ### Ethernet Interfaces
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/flow-tracking.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/flow-tracking.cfg
@@ -59,6 +59,9 @@ interface Port-Channel42
    flow tracker hardware T3
    flow tracker sampled T3
 !
+interface Dps1
+   flow tracker hardware T3
+!
 interface Ethernet40
    switchport
    flow tracker hardware T2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/flow-tracking.yml
@@ -111,3 +111,8 @@ port_channel_interfaces:
     flow_tracker:
       sampled: T3
       hardware: T3
+
+dps_interfaces:
+  - name: Dps1
+    flow_tracker:
+      hardware: T3

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-tracking.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/flow-tracking.j2
@@ -47,6 +47,11 @@
 {%                 set count_exporter = tracker.exporters | arista.avd.default([]) | length %}
 {%                 set applied_on = [] %}
 {%                 set table_size = tracker.table_size | arista.avd.default('-') %}
+{%                 for dps_interface in dps_interfaces | arista.avd.default([]) %}
+{%                     if dps_interface.flow_tracker.sampled is arista.avd.defined(tracker.name) %}
+{%                         do applied_on.append(dps_interface.name) %}
+{%                     endif %}
+{%                 endfor %}
 {%                 for ethernet_interface in ethernet_interfaces | arista.avd.default([]) %}
 {%                     if ethernet_interface.flow_tracker.sampled is arista.avd.defined(tracker.name) %}
 {%                         do applied_on.append(ethernet_interface.name) %}
@@ -68,6 +73,11 @@
 {%                     set count_exporter = tracker.exporters | arista.avd.default([]) | length %}
 {%                     set applied_on = [] %}
 {%                     set table_size = tracker.table_size | arista.avd.default('-') %}
+{%                     for dps_interface in dps_interfaces | arista.avd.default([]) %}
+{%                         if dps_interface.flow_tracker.sampled is arista.avd.defined(tracker.name) %}
+{%                             do applied_on.append(dps_interface.name) %}
+{%                         endif %}
+{%                     endfor %}
 {%                     for ethernet_interface in ethernet_interfaces | arista.avd.default([]) %}
 {%                         if ethernet_interface.flow_tracker.sampled is arista.avd.defined(tracker.name) %}
 {%                             do applied_on.append(ethernet_interface.name) %}
@@ -121,6 +131,11 @@
 {%                 set on_interval = tracker.record_export.on_interval | arista.avd.default("-") %}
 {%                 set count_exporter = tracker.exporters | arista.avd.default([]) | length %}
 {%                 set applied_on = [] %}
+{%                 for dps_interface in dps_interfaces | arista.avd.default([]) %}
+{%                     if dps_interface.flow_tracker.hardware is arista.avd.defined(tracker.name) %}
+{%                         do applied_on.append(dps_interface.name) %}
+{%                     endif %}
+{%                 endfor %}
 {%                 for ethernet_interface in ethernet_interfaces | arista.avd.default([]) %}
 {%                     if ethernet_interface.flow_tracker.hardware is arista.avd.defined(tracker.name) %}
 {%                         do applied_on.append(ethernet_interface.name) %}


### PR DESCRIPTION
## Change Summary

Dps1 missing from documentation table

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add it

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
