### PR TITLE
Doc(plugins): Fix wrong module name in eos_designs_structured_config module doc

### DIFF
--- a/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/eos_designs_structured_config.md
+++ b/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/eos_designs_structured_config.md
@@ -17,7 +17,7 @@ Generate AVD EOS Designs structured configuration
 
 ## Synopsis
 
-The `arista.avd.eos_designs_facts` module is an Ansible Action Plugin providing the following capabilities:
+The `arista.avd.eos_designs_structured_config` module is an Ansible Action Plugin providing the following capabilities:
 
 - Validates input variables according to eos_designs schema
 - Generates structured configuration

--- a/ansible_collections/arista/avd/plugins/modules/eos_designs_structured_config.py
+++ b/ansible_collections/arista/avd/plugins/modules/eos_designs_structured_config.py
@@ -9,7 +9,7 @@ version_added: "4.0.0"
 author: Arista Ansible Team (@aristanetworks)
 short_description: Generate AVD EOS Designs structured configuration
 description: |-
-  The `arista.avd.eos_designs_facts` module is an Ansible Action Plugin providing the following capabilities:
+  The `arista.avd.eos_designs_structured_config` module is an Ansible Action Plugin providing the following capabilities:
 
   - Validates input variables according to eos_designs schema
   - Generates structured configuration


### PR DESCRIPTION
## Related Issue(s)

Fixes #3793 

## Component(s) name

`plugins`

## Proposed changes

Fix the reported typo

## How to test

doc update

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
