### PR TITLE
Fix: Remove "not RFC1918 IPs" from examples.

### DIFF
--- a/ansible_collections/arista/avd/examples/campus-fabric/README.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/README.md
@@ -151,16 +151,16 @@ Details on this feature can be found [here](../../roles/eos_designs/docs/input-v
 
 | Node   | Management0     | Vlan10    |
 | ------ | --------------- | --------- |
-| SPINE1 | 172.100.100.101 | 10.10.10.2  |
-| SPINE2 | 172.100.100.102 | 10.10.10.3  |
-| LEAF1A | 172.100.100.103 | 10.10.10.6  |
-| LEAF1B | 172.100.100.104 | 10.10.10.7  |
-| LEAF2A | 172.100.100.105 | 10.10.10.8  |
-| LEAF3A | 172.100.100.106 | 10.10.10.9  |
-| LEAF3B | 172.100.100.107 | 10.10.10.10 |
-| LEAF3C | 172.100.100.108 | 10.10.10.11 |
-| LEAF3D | 172.100.100.109 | 10.10.10.12 |
-| LEAF3E | 172.100.100.110 | 10.10.10.13 |
+| SPINE1 | 172.16.100.101 | 10.10.10.2  |
+| SPINE2 | 172.16.100.102 | 10.10.10.3  |
+| LEAF1A | 172.16.100.103 | 10.10.10.6  |
+| LEAF1B | 172.16.100.104 | 10.10.10.7  |
+| LEAF2A | 172.16.100.105 | 10.10.10.8  |
+| LEAF3A | 172.16.100.106 | 10.10.10.9  |
+| LEAF3B | 172.16.100.107 | 10.10.10.10 |
+| LEAF3C | 172.16.100.108 | 10.10.10.11 |
+| LEAF3D | 172.16.100.109 | 10.10.10.12 |
+| LEAF3E | 172.16.100.110 | 10.10.10.13 |
 
 In Campus Networks, having a dedicated out-of-band management network in each IDF is uncommon. Therefore, you can easily disable configuring the Management0 interface and the management VRF by adding these variables to the `DC1_LEAFS.yml` group_vars.
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1A.md
@@ -49,7 +49,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.103/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.103/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -65,7 +65,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.103/24
+   ip address 172.16.100.103/24
 ```
 
 ### IP Name Servers
@@ -1469,14 +1469,14 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 | default | 0.0.0.0/0 | 10.10.10.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF1B.md
@@ -49,7 +49,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.104/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.104/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -65,7 +65,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.104/24
+   ip address 172.16.100.104/24
 ```
 
 ### IP Name Servers
@@ -1469,14 +1469,14 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 | default | 0.0.0.0/0 | 10.10.10.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF2A.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.105/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.105/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -64,7 +64,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.105/24
+   ip address 172.16.100.105/24
 ```
 
 ### IP Name Servers
@@ -6835,14 +6835,14 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 | default | 0.0.0.0/0 | 10.10.10.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3A.md
@@ -49,7 +49,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.106/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.106/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -65,7 +65,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.106/24
+   ip address 172.16.100.106/24
 ```
 
 ### IP Name Servers
@@ -2576,14 +2576,14 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 | default | 0.0.0.0/0 | 10.10.10.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3B.md
@@ -49,7 +49,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.107/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.107/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -65,7 +65,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.107/24
+   ip address 172.16.100.107/24
 ```
 
 ### IP Name Servers
@@ -2576,14 +2576,14 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 | default | 0.0.0.0/0 | 10.10.10.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3C.md
@@ -46,7 +46,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.108/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.108/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -62,7 +62,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.108/24
+   ip address 172.16.100.108/24
 ```
 
 ### IP Name Servers
@@ -2465,14 +2465,14 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 | default | 0.0.0.0/0 | 10.10.10.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3D.md
@@ -46,7 +46,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.109/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.109/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -62,7 +62,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.109/24
+   ip address 172.16.100.109/24
 ```
 
 ### IP Name Servers
@@ -2465,14 +2465,14 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 | default | 0.0.0.0/0 | 10.10.10.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/LEAF3E.md
@@ -46,7 +46,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.110/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.110/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -62,7 +62,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.110/24
+   ip address 172.16.100.110/24
 ```
 
 ### IP Name Servers
@@ -2465,14 +2465,14 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 | default | 0.0.0.0/0 | 10.10.10.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 ```
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE1.md
@@ -50,7 +50,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.101/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.101/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -66,7 +66,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.101/24
+   ip address 172.16.100.101/24
 ```
 
 ### IP Name Servers
@@ -616,13 +616,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ```
 
 ### Router OSPF

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/devices/SPINE2.md
@@ -50,7 +50,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.102/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.102/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -66,7 +66,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.102/24
+   ip address 172.16.100.102/24
 ```
 
 ### IP Name Servers
@@ -616,13 +616,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ```
 
 ### Router OSPF

--- a/ansible_collections/arista/avd/examples/campus-fabric/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/campus-fabric/documentation/fabric/DC1_FABRIC-documentation.md
@@ -17,16 +17,16 @@
 
 | POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
 | --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
-| DC1_FABRIC | leaf | LEAF1A | 172.100.100.103/24 | cEOSLab | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF1B | 172.100.100.104/24 | cEOSLab | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF2A | 172.100.100.105/24 | 720XP | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF3A | 172.100.100.106/24 | cEOSLab | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF3B | 172.100.100.107/24 | cEOSLab | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF3C | 172.100.100.108/24 | cEOSLab | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF3D | 172.100.100.109/24 | cEOSLab | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF3E | 172.100.100.110/24 | cEOSLab | Provisioned | - |
-| DC1_FABRIC | l3spine | SPINE1 | 172.100.100.101/24 | cEOSLab | Provisioned | - |
-| DC1_FABRIC | l3spine | SPINE2 | 172.100.100.102/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF1A | 172.16.100.103/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF1B | 172.16.100.104/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF2A | 172.16.100.105/24 | 720XP | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3A | 172.16.100.106/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3B | 172.16.100.107/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3C | 172.16.100.108/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3D | 172.16.100.109/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3E | 172.16.100.110/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | l3spine | SPINE1 | 172.16.100.101/24 | cEOSLab | Provisioned | - |
+| DC1_FABRIC | l3spine | SPINE2 | 172.16.100.102/24 | cEOSLab | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/group_vars/DC1.yml
@@ -14,7 +14,7 @@ aaa_authorization:
     default: local
 
 # OOB Management network default gateway.
-mgmt_gateway: 172.100.100.1
+mgmt_gateway: 172.16.100.1
 mgmt_interface: Management0
 
 # dns servers.

--- a/ansible_collections/arista/avd/examples/campus-fabric/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/group_vars/DC1_FABRIC.yml
@@ -39,10 +39,10 @@ l3spine:
       nodes:
         - name: SPINE1
           id: 1
-          mgmt_ip: 172.100.100.101/24
+          mgmt_ip: 172.16.100.101/24
         - name: SPINE2
           id: 2
-          mgmt_ip: 172.100.100.102/24
+          mgmt_ip: 172.16.100.102/24
 
 # IDF - Leaf Switches
 leaf:
@@ -63,12 +63,12 @@ leaf:
       nodes:
         - name: LEAF1A
           id: 3
-          mgmt_ip: 172.100.100.103/24
+          mgmt_ip: 172.16.100.103/24
           uplink_switches: [SPINE1]
           uplink_switch_interfaces: [Ethernet1]
         - name: LEAF1B
           id: 4
-          mgmt_ip: 172.100.100.104/24
+          mgmt_ip: 172.16.100.104/24
           uplink_switches: [SPINE2]
           uplink_switch_interfaces: [Ethernet1]
     - group: IDF2
@@ -79,7 +79,7 @@ leaf:
       nodes:
         - name: LEAF2A
           id: 5
-          mgmt_ip: 172.100.100.105/24
+          mgmt_ip: 172.16.100.105/24
           uplink_interfaces: [Ethernet1/1, Ethernet1/3]
           uplink_switches: [SPINE1, SPINE2]
           uplink_switch_interfaces: [Ethernet49/1, Ethernet49/1]
@@ -93,11 +93,11 @@ leaf:
       nodes:
         - name: LEAF3A
           id: 6
-          mgmt_ip: 172.100.100.106/24
+          mgmt_ip: 172.16.100.106/24
           uplink_switch_interfaces: [Ethernet50/1, Ethernet50/1]
         - name: LEAF3B
           id: 7
-          mgmt_ip: 172.100.100.107/24
+          mgmt_ip: 172.16.100.107/24
           uplink_switch_interfaces: [Ethernet51/1, Ethernet51/1]
     - group: IDF3_3C
       mlag: false
@@ -106,7 +106,7 @@ leaf:
       nodes:
         - name: LEAF3C
           id: 8
-          mgmt_ip: 172.100.100.108/24
+          mgmt_ip: 172.16.100.108/24
           uplink_switch_interfaces: [Ethernet97/3, Ethernet97/3]
     - group: IDF3_3D
       mlag: false
@@ -115,7 +115,7 @@ leaf:
       nodes:
         - name: LEAF3D
           id: 9
-          mgmt_ip: 172.100.100.109/24
+          mgmt_ip: 172.16.100.109/24
           uplink_switch_interfaces: [Ethernet97/4, Ethernet97/4]
     - group: IDF3_3E
       mlag: false
@@ -124,7 +124,7 @@ leaf:
       nodes:
         - name: LEAF3E
           id: 10
-          mgmt_ip: 172.100.100.110/24
+          mgmt_ip: 172.16.100.110/24
           uplink_switch_interfaces: [Ethernet98/1, Ethernet98/1]
 
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1A.cfg
@@ -1037,7 +1037,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.103/24
+   ip address 172.16.100.103/24
 !
 interface Vlan10
    description Inband Management
@@ -1061,7 +1061,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1B.cfg
@@ -1037,7 +1037,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.104/24
+   ip address 172.16.100.104/24
 !
 interface Vlan10
    description Inband Management
@@ -1061,7 +1061,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF2A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF2A.cfg
@@ -6059,7 +6059,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.105/24
+   ip address 172.16.100.105/24
 !
 interface Vlan10
    description Inband Management
@@ -6068,7 +6068,7 @@ interface Vlan10
    ip address 10.10.10.8/24
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3A.cfg
@@ -2041,7 +2041,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.106/24
+   ip address 172.16.100.106/24
 !
 interface Vlan10
    description Inband Management
@@ -2065,7 +2065,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3B.cfg
@@ -2041,7 +2041,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.107/24
+   ip address 172.16.100.107/24
 !
 interface Vlan10
    description Inband Management
@@ -2065,7 +2065,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3C.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3C.cfg
@@ -1979,7 +1979,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.108/24
+   ip address 172.16.100.108/24
 !
 interface Vlan10
    description Inband Management
@@ -1988,7 +1988,7 @@ interface Vlan10
    ip address 10.10.10.11/24
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3D.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3D.cfg
@@ -1979,7 +1979,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.109/24
+   ip address 172.16.100.109/24
 !
 interface Vlan10
    description Inband Management
@@ -1988,7 +1988,7 @@ interface Vlan10
    ip address 10.10.10.12/24
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3E.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3E.cfg
@@ -1979,7 +1979,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.110/24
+   ip address 172.16.100.110/24
 !
 interface Vlan10
    description Inband Management
@@ -1988,7 +1988,7 @@ interface Vlan10
    ip address 10.10.10.13/24
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ip route 0.0.0.0/0 10.10.10.1
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE1.cfg
@@ -146,7 +146,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.101/24
+   ip address 172.16.100.101/24
 !
 interface Vlan10
    description Inband Management
@@ -238,7 +238,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 router ospf 100
    router-id 172.16.1.1

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE2.cfg
@@ -146,7 +146,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.102/24
+   ip address 172.16.100.102/24
 !
 interface Vlan10
    description Inband Management
@@ -238,7 +238,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 router ospf 100
    router-id 172.16.1.2

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
@@ -36,8 +36,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.103/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.103/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
@@ -36,8 +36,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.104/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.104/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
@@ -35,8 +35,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.105/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.105/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
@@ -36,8 +36,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.106/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.106/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
@@ -36,8 +36,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.107/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.107/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
@@ -35,8 +35,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.108/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.108/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
@@ -35,8 +35,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.109/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.109/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 - destination_address_prefix: 0.0.0.0/0
   gateway: 10.10.10.1
 service_routing_protocols_model: multi-agent
@@ -35,8 +35,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.110/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.110/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -35,8 +35,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.101/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.101/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 service_routing_protocols_model: multi-agent
 ip_routing: true
 vlan_internal_order:
@@ -35,8 +35,8 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.102/24
-  gateway: 172.100.100.1
+  ip_address: 172.16.100.102/24
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/campus-fabric/inventory.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/inventory.yml
@@ -7,27 +7,27 @@ DC1:
         DC1_SPINES:
           hosts:
             SPINE1:
-              ansible_host: 172.100.100.101
+              ansible_host: 172.16.100.101
             SPINE2:
-              ansible_host: 172.100.100.102
+              ansible_host: 172.16.100.102
         DC1_LEAFS:
           hosts:
             LEAF1A:
-              ansible_host: 172.100.100.103
+              ansible_host: 172.16.100.103
             LEAF1B:
-              ansible_host: 172.100.100.104
+              ansible_host: 172.16.100.104
             LEAF2A:
-              ansible_host: 172.100.100.105
+              ansible_host: 172.16.100.105
             LEAF3A:
-              ansible_host: 172.100.100.106
+              ansible_host: 172.16.100.106
             LEAF3B:
-              ansible_host: 172.100.100.107
+              ansible_host: 172.16.100.107
             LEAF3C:
-              ansible_host: 172.100.100.108
+              ansible_host: 172.16.100.108
             LEAF3D:
-              ansible_host: 172.100.100.109
+              ansible_host: 172.16.100.109
             LEAF3E:
-              ansible_host: 172.100.100.110
+              ansible_host: 172.16.100.110
     DC1_NETWORK_SERVICES:
       children:
         DC1_LEAFS:

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF1A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF1A.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.103/24
+   ip address 172.16.100.103/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF1B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF1B.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.104/24
+   ip address 172.16.100.104/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF2A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF2A.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.105/24
+   ip address 172.16.100.105/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3A.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.106/24
+   ip address 172.16.100.106/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3B.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.107/24
+   ip address 172.16.100.107/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3C.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3C.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.108/24
+   ip address 172.16.100.108/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3D.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3D.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.109/24
+   ip address 172.16.100.109/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3E.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/LEAF3E.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.110/24
+   ip address 172.16.100.110/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/SPINE1.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.101/24
+   ip address 172.16.100.101/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/switch-basic-configurations/SPINE2.cfg
@@ -21,9 +21,9 @@ management api netconf
    transport ssh default
 !
 interface Management0
-   ip address 172.100.100.102/24
+   ip address 172.16.100.102/24
 !
 no ip routing
 !
-ip route 0.0.0.0/0 172.100.100.1
+ip route 0.0.0.0/0 172.16.100.1
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/README.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/README.md
@@ -253,7 +253,7 @@ In this section, only additions to the previous example will be discussed. The o
     --8<--
 ```
 
-1. Define a new IP Pool named "DCI_IP_pool" using the prefix "172.100.100.0/24" to assign IP addresses.
+1. Define a new IP Pool named "DCI_IP_pool" using the prefix "172.16.100.0/24" to assign IP addresses.
 2. Define a new link profile called "DCI_profile" using the previously created IP pool. The ASN will be "65102" for left devices and "65202" for right devices. The interfaces will be included in the underlay routing protocol.
 3. Define a new link, with the left and right node hostname defined in AVD, along with the interface and finally assign a profile containing all required information to configure the link.
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -262,7 +262,7 @@ vlan 4094
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 | P2P_LINK_TO_DC1-SPINE1_Ethernet3 | routed | - | 10.255.255.9/31 | default | 1500 | False | - | - |
 | Ethernet2 | P2P_LINK_TO_DC1-SPINE2_Ethernet3 | routed | - | 10.255.255.11/31 | default | 1500 | False | - | - |
-| Ethernet6 | P2P_LINK_TO_dc2-leaf2a_Ethernet6 | routed | - | 172.100.100.0/31 | default | 1500 | False | - | - |
+| Ethernet6 | P2P_LINK_TO_dc2-leaf2a_Ethernet6 | routed | - | 172.16.100.0/31 | default | 1500 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -302,7 +302,7 @@ interface Ethernet6
    no shutdown
    mtu 1500
    no switchport
-   ip address 172.100.100.0/31
+   ip address 172.16.100.0/31
 !
 interface Ethernet8
    description DC1-LEAF2C_Ethernet1
@@ -671,7 +671,7 @@ ASN Notation: asplain
 | 10.255.128.15 | 65202 | default | - | Inherited from peer group EVPN-OVERLAY-CORE | Inherited from peer group EVPN-OVERLAY-CORE | - | Inherited from peer group EVPN-OVERLAY-CORE | - | - | - | - |
 | 10.255.255.8 | 65100 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.255.10 | 65100 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
-| 172.100.100.1 | 65202 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
+| 172.16.100.1 | 65202 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.1.101 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | VRF10 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 | 10.255.1.101 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | VRF11 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 
@@ -760,9 +760,9 @@ router bgp 65102
    neighbor 10.255.255.10 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.255.255.10 remote-as 65100
    neighbor 10.255.255.10 description dc1-spine2_Ethernet3
-   neighbor 172.100.100.1 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.100.100.1 remote-as 65202
-   neighbor 172.100.100.1 description dc2-leaf2a
+   neighbor 172.16.100.1 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.16.100.1 remote-as 65202
+   neighbor 172.16.100.1 description dc2-leaf2a
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 11

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -262,7 +262,7 @@ vlan 4094
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 | P2P_LINK_TO_DC1-SPINE1_Ethernet4 | routed | - | 10.255.255.13/31 | default | 1500 | False | - | - |
 | Ethernet2 | P2P_LINK_TO_DC1-SPINE2_Ethernet4 | routed | - | 10.255.255.15/31 | default | 1500 | False | - | - |
-| Ethernet6 | P2P_LINK_TO_dc2-leaf2b_Ethernet6 | routed | - | 172.100.100.2/31 | default | 1500 | False | - | - |
+| Ethernet6 | P2P_LINK_TO_dc2-leaf2b_Ethernet6 | routed | - | 172.16.100.2/31 | default | 1500 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -302,7 +302,7 @@ interface Ethernet6
    no shutdown
    mtu 1500
    no switchport
-   ip address 172.100.100.2/31
+   ip address 172.16.100.2/31
 !
 interface Ethernet8
    description DC1-LEAF2C_Ethernet2
@@ -671,7 +671,7 @@ ASN Notation: asplain
 | 10.255.128.16 | 65202 | default | - | Inherited from peer group EVPN-OVERLAY-CORE | Inherited from peer group EVPN-OVERLAY-CORE | - | Inherited from peer group EVPN-OVERLAY-CORE | - | - | - | - |
 | 10.255.255.12 | 65100 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.255.14 | 65100 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
-| 172.100.100.3 | 65202 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
+| 172.16.100.3 | 65202 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.1.100 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | VRF10 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 | 10.255.1.100 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | VRF11 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 
@@ -760,9 +760,9 @@ router bgp 65102
    neighbor 10.255.255.14 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.255.255.14 remote-as 65100
    neighbor 10.255.255.14 description dc1-spine2_Ethernet4
-   neighbor 172.100.100.3 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.100.100.3 remote-as 65202
-   neighbor 172.100.100.3 description dc2-leaf2b
+   neighbor 172.16.100.3 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.16.100.3 remote-as 65202
+   neighbor 172.16.100.3 description dc2-leaf2b
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 11

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
@@ -262,7 +262,7 @@ vlan 4094
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 | P2P_LINK_TO_DC2-SPINE1_Ethernet3 | routed | - | 10.255.255.113/31 | default | 1500 | False | - | - |
 | Ethernet2 | P2P_LINK_TO_DC2-SPINE2_Ethernet3 | routed | - | 10.255.255.115/31 | default | 1500 | False | - | - |
-| Ethernet6 | P2P_LINK_TO_dc1-leaf2a_Ethernet6 | routed | - | 172.100.100.1/31 | default | 1500 | False | - | - |
+| Ethernet6 | P2P_LINK_TO_dc1-leaf2a_Ethernet6 | routed | - | 172.16.100.1/31 | default | 1500 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -302,7 +302,7 @@ interface Ethernet6
    no shutdown
    mtu 1500
    no switchport
-   ip address 172.100.100.1/31
+   ip address 172.16.100.1/31
 !
 interface Ethernet8
    description DC2-LEAF2C_Ethernet1
@@ -671,7 +671,7 @@ ASN Notation: asplain
 | 10.255.129.121 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
 | 10.255.255.112 | 65200 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.255.114 | 65200 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
-| 172.100.100.0 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
+| 172.16.100.0 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.129.121 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | VRF10 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 | 10.255.129.121 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | VRF11 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 
@@ -760,9 +760,9 @@ router bgp 65202
    neighbor 10.255.255.114 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.255.255.114 remote-as 65200
    neighbor 10.255.255.114 description dc2-spine2_Ethernet3
-   neighbor 172.100.100.0 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.100.100.0 remote-as 65102
-   neighbor 172.100.100.0 description dc1-leaf2a
+   neighbor 172.16.100.0 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.16.100.0 remote-as 65102
+   neighbor 172.16.100.0 description dc1-leaf2a
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 11

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
@@ -262,7 +262,7 @@ vlan 4094
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 | P2P_LINK_TO_DC2-SPINE1_Ethernet4 | routed | - | 10.255.255.117/31 | default | 1500 | False | - | - |
 | Ethernet2 | P2P_LINK_TO_DC2-SPINE2_Ethernet4 | routed | - | 10.255.255.119/31 | default | 1500 | False | - | - |
-| Ethernet6 | P2P_LINK_TO_dc1-leaf2b_Ethernet6 | routed | - | 172.100.100.3/31 | default | 1500 | False | - | - |
+| Ethernet6 | P2P_LINK_TO_dc1-leaf2b_Ethernet6 | routed | - | 172.16.100.3/31 | default | 1500 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -302,7 +302,7 @@ interface Ethernet6
    no shutdown
    mtu 1500
    no switchport
-   ip address 172.100.100.3/31
+   ip address 172.16.100.3/31
 !
 interface Ethernet8
    description DC2-LEAF2C_Ethernet2
@@ -671,7 +671,7 @@ ASN Notation: asplain
 | 10.255.129.120 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
 | 10.255.255.116 | 65200 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.255.118 | 65200 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
-| 172.100.100.2 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
+| 172.16.100.2 | 65102 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.129.120 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | VRF10 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 | 10.255.129.120 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | VRF11 | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - |
 
@@ -760,9 +760,9 @@ router bgp 65202
    neighbor 10.255.255.118 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.255.255.118 remote-as 65200
    neighbor 10.255.255.118 description dc2-spine2_Ethernet4
-   neighbor 172.100.100.2 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.100.100.2 remote-as 65102
-   neighbor 172.100.100.2 description dc1-leaf2b
+   neighbor 172.16.100.2 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.16.100.2 remote-as 65102
+   neighbor 172.16.100.2 description dc1-leaf2b
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 11

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/fabric/FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/fabric/FABRIC-documentation.md
@@ -99,10 +99,10 @@
 | dc1-leaf1b | Ethernet2 | 10.255.255.7/31 | dc1-spine2 | Ethernet2 | 10.255.255.6/31 |
 | dc1-leaf2a | Ethernet1 | 10.255.255.9/31 | dc1-spine1 | Ethernet3 | 10.255.255.8/31 |
 | dc1-leaf2a | Ethernet2 | 10.255.255.11/31 | dc1-spine2 | Ethernet3 | 10.255.255.10/31 |
-| dc1-leaf2a | Ethernet6 | 172.100.100.0/31 | dc2-leaf2a | Ethernet6 | 172.100.100.1/31 |
+| dc1-leaf2a | Ethernet6 | 172.16.100.0/31 | dc2-leaf2a | Ethernet6 | 172.16.100.1/31 |
 | dc1-leaf2b | Ethernet1 | 10.255.255.13/31 | dc1-spine1 | Ethernet4 | 10.255.255.12/31 |
 | dc1-leaf2b | Ethernet2 | 10.255.255.15/31 | dc1-spine2 | Ethernet4 | 10.255.255.14/31 |
-| dc1-leaf2b | Ethernet6 | 172.100.100.2/31 | dc2-leaf2b | Ethernet6 | 172.100.100.3/31 |
+| dc1-leaf2b | Ethernet6 | 172.16.100.2/31 | dc2-leaf2b | Ethernet6 | 172.16.100.3/31 |
 | dc2-leaf1a | Ethernet1 | 10.255.255.105/31 | dc2-spine1 | Ethernet1 | 10.255.255.104/31 |
 | dc2-leaf1a | Ethernet2 | 10.255.255.107/31 | dc2-spine2 | Ethernet1 | 10.255.255.106/31 |
 | dc2-leaf1b | Ethernet1 | 10.255.255.109/31 | dc2-spine1 | Ethernet2 | 10.255.255.108/31 |

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/fabric/FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/fabric/FABRIC-p2p-links.csv
@@ -5,10 +5,10 @@ l3leaf,dc1-leaf1b,Ethernet1,10.255.255.5/31,spine,dc1-spine1,Ethernet2,10.255.25
 l3leaf,dc1-leaf1b,Ethernet2,10.255.255.7/31,spine,dc1-spine2,Ethernet2,10.255.255.6/31
 l3leaf,dc1-leaf2a,Ethernet1,10.255.255.9/31,spine,dc1-spine1,Ethernet3,10.255.255.8/31
 l3leaf,dc1-leaf2a,Ethernet2,10.255.255.11/31,spine,dc1-spine2,Ethernet3,10.255.255.10/31
-l3leaf,dc1-leaf2a,Ethernet6,172.100.100.0/31,l3leaf,dc2-leaf2a,Ethernet6,172.100.100.1/31
+l3leaf,dc1-leaf2a,Ethernet6,172.16.100.0/31,l3leaf,dc2-leaf2a,Ethernet6,172.16.100.1/31
 l3leaf,dc1-leaf2b,Ethernet1,10.255.255.13/31,spine,dc1-spine1,Ethernet4,10.255.255.12/31
 l3leaf,dc1-leaf2b,Ethernet2,10.255.255.15/31,spine,dc1-spine2,Ethernet4,10.255.255.14/31
-l3leaf,dc1-leaf2b,Ethernet6,172.100.100.2/31,l3leaf,dc2-leaf2b,Ethernet6,172.100.100.3/31
+l3leaf,dc1-leaf2b,Ethernet6,172.16.100.2/31,l3leaf,dc2-leaf2b,Ethernet6,172.16.100.3/31
 l3leaf,dc2-leaf1a,Ethernet1,10.255.255.105/31,spine,dc2-spine1,Ethernet1,10.255.255.104/31
 l3leaf,dc2-leaf1a,Ethernet2,10.255.255.107/31,spine,dc2-spine2,Ethernet1,10.255.255.106/31
 l3leaf,dc2-leaf1b,Ethernet1,10.255.255.109/31,spine,dc2-spine1,Ethernet2,10.255.255.108/31

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/FABRIC.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/group_vars/FABRIC.yml
@@ -72,7 +72,7 @@ l3_edge:
   # Define a new IP pool that will be used to assign IP addresses to L3 Edge interfaces.
   p2p_links_ip_pools:
     - name: DCI_IP_pool
-      ipv4_pool: 172.100.100.0/24
+      ipv4_pool: 172.16.100.0/24
   # Define a new link profile which will match the IP pool, the used ASNs and include the defined interface into underlay routing
   p2p_links_profiles:
     - name: DCI_profile

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -118,7 +118,7 @@ interface Ethernet6
    no shutdown
    mtu 1500
    no switchport
-   ip address 172.100.100.0/31
+   ip address 172.16.100.0/31
 !
 interface Ethernet8
    description DC1-LEAF2C_Ethernet1
@@ -298,9 +298,9 @@ router bgp 65102
    neighbor 10.255.255.10 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.255.255.10 remote-as 65100
    neighbor 10.255.255.10 description dc1-spine2_Ethernet3
-   neighbor 172.100.100.1 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.100.100.1 remote-as 65202
-   neighbor 172.100.100.1 description dc2-leaf2a
+   neighbor 172.16.100.1 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.16.100.1 remote-as 65202
+   neighbor 172.16.100.1 description dc2-leaf2a
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 11

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -118,7 +118,7 @@ interface Ethernet6
    no shutdown
    mtu 1500
    no switchport
-   ip address 172.100.100.2/31
+   ip address 172.16.100.2/31
 !
 interface Ethernet8
    description DC1-LEAF2C_Ethernet2
@@ -298,9 +298,9 @@ router bgp 65102
    neighbor 10.255.255.14 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.255.255.14 remote-as 65100
    neighbor 10.255.255.14 description dc1-spine2_Ethernet4
-   neighbor 172.100.100.3 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.100.100.3 remote-as 65202
-   neighbor 172.100.100.3 description dc2-leaf2b
+   neighbor 172.16.100.3 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.16.100.3 remote-as 65202
+   neighbor 172.16.100.3 description dc2-leaf2b
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 11

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
@@ -118,7 +118,7 @@ interface Ethernet6
    no shutdown
    mtu 1500
    no switchport
-   ip address 172.100.100.1/31
+   ip address 172.16.100.1/31
 !
 interface Ethernet8
    description DC2-LEAF2C_Ethernet1
@@ -298,9 +298,9 @@ router bgp 65202
    neighbor 10.255.255.114 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.255.255.114 remote-as 65200
    neighbor 10.255.255.114 description dc2-spine2_Ethernet3
-   neighbor 172.100.100.0 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.100.100.0 remote-as 65102
-   neighbor 172.100.100.0 description dc1-leaf2a
+   neighbor 172.16.100.0 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.16.100.0 remote-as 65102
+   neighbor 172.16.100.0 description dc1-leaf2a
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 11

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
@@ -118,7 +118,7 @@ interface Ethernet6
    no shutdown
    mtu 1500
    no switchport
-   ip address 172.100.100.3/31
+   ip address 172.16.100.3/31
 !
 interface Ethernet8
    description DC2-LEAF2C_Ethernet2
@@ -298,9 +298,9 @@ router bgp 65202
    neighbor 10.255.255.118 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.255.255.118 remote-as 65200
    neighbor 10.255.255.118 description dc2-spine2_Ethernet4
-   neighbor 172.100.100.2 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.100.100.2 remote-as 65102
-   neighbor 172.100.100.2 description dc1-leaf2b
+   neighbor 172.16.100.2 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.16.100.2 remote-as 65102
+   neighbor 172.16.100.2 description dc1-leaf2b
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 11

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -79,7 +79,7 @@ router_bgp:
     peer: dc2-leaf2a
     description: dc2-leaf2a
     remote_as: '65202'
-  - ip_address: 172.100.100.1
+  - ip_address: 172.16.100.1
     remote_as: '65202'
     peer: dc2-leaf2a
     description: dc2-leaf2a
@@ -438,7 +438,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 172.100.100.0/31
+  ip_address: 172.16.100.0/31
 - name: Ethernet5
   peer: dc1-leaf2-server1
   peer_interface: PCI1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -79,7 +79,7 @@ router_bgp:
     peer: dc2-leaf2b
     description: dc2-leaf2b
     remote_as: '65202'
-  - ip_address: 172.100.100.3
+  - ip_address: 172.16.100.3
     remote_as: '65202'
     peer: dc2-leaf2b
     description: dc2-leaf2b
@@ -438,7 +438,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 172.100.100.2/31
+  ip_address: 172.16.100.2/31
 - name: Ethernet5
   peer: dc1-leaf2-server1
   peer_interface: PCI2

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -79,7 +79,7 @@ router_bgp:
     peer: dc1-leaf2a
     description: dc1-leaf2a
     remote_as: '65102'
-  - ip_address: 172.100.100.0
+  - ip_address: 172.16.100.0
     remote_as: '65102'
     peer: dc1-leaf2a
     description: dc1-leaf2a
@@ -438,7 +438,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 172.100.100.1/31
+  ip_address: 172.16.100.1/31
 - name: Ethernet5
   peer: dc2-leaf2-server1
   peer_interface: PCI1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -79,7 +79,7 @@ router_bgp:
     peer: dc1-leaf2b
     description: dc1-leaf2b
     remote_as: '65102'
-  - ip_address: 172.100.100.2
+  - ip_address: 172.16.100.2
     remote_as: '65102'
     peer: dc1-leaf2b
     description: dc1-leaf2b
@@ -438,7 +438,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 172.100.100.3/31
+  ip_address: 172.16.100.3/31
 - name: Ethernet5
   peer: dc2-leaf2-server1
   peer_interface: PCI2

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/README.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/README.md
@@ -89,7 +89,7 @@ The drawing below shows the physical topology used in this example. The interfac
 | rr1                                                 | 172.16.1.151                |
 | rr2                                                 | 172.16.1.152                |
 | **Point-to-point links between network nodes**      | **(Underlay)**              |
-| WAN1                                                | 100.64.48.0/24              |
+| WAN1                                                | 10.255.3.0/24              |
 | **Loopback0 interfaces for router ID (p)**          | 10.255.0.0/27               |
 | **Loopback0 interfaces for overlay peering (pe)**   | 10.255.1.0/27               |
 | **Loopback0 interfaces for overlay peering (rr)**   | 10.255.2.0/27               |
@@ -430,7 +430,7 @@ A free-standing list of `core_interfaces` dictionaries and their associated prof
 core_interfaces:
   p2p_links_ip_pools:
     - name: core_pool # (1)!
-      ipv4_pool: 100.64.48.0/24
+      ipv4_pool: 10.255.3.0/24
 
   p2p_links_profiles:
     - name: core_profile # (2)!

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p1.md
@@ -167,10 +167,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 | P2P_LINK_TO_pe1_Ethernet1 | routed | - | 100.64.48.1/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_LINK_TO_pe2_Ethernet2 | routed | - | 100.64.48.7/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_LINK_TO_rr1_Ethernet3 | routed | - | 100.64.48.11/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_LINK_TO_p2_Ethernet4 | routed | - | 100.64.48.8/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_LINK_TO_pe1_Ethernet1 | routed | - | 10.255.3.1/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_LINK_TO_pe2_Ethernet2 | routed | - | 10.255.3.7/31 | default | 1500 | False | - | - |
+| Ethernet3 | P2P_LINK_TO_rr1_Ethernet3 | routed | - | 10.255.3.11/31 | default | 1500 | False | - | - |
+| Ethernet4 | P2P_LINK_TO_p2_Ethernet4 | routed | - | 10.255.3.8/31 | default | 1500 | False | - | - |
 
 ##### ISIS
 
@@ -190,7 +190,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.1/31
+   ip address 10.255.3.1/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -207,7 +207,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.7/31
+   ip address 10.255.3.7/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -224,7 +224,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.11/31
+   ip address 10.255.3.11/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -241,7 +241,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.8/31
+   ip address 10.255.3.8/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p2.md
@@ -167,10 +167,10 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 | P2P_LINK_TO_pe2_Ethernet1 | routed | - | 100.64.48.5/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_LINK_TO_pe1_Ethernet2 | routed | - | 100.64.48.3/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_LINK_TO_rr2_Ethernet3 | routed | - | 100.64.48.17/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_LINK_TO_p1_Ethernet4 | routed | - | 100.64.48.9/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_LINK_TO_pe2_Ethernet1 | routed | - | 10.255.3.5/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_LINK_TO_pe1_Ethernet2 | routed | - | 10.255.3.3/31 | default | 1500 | False | - | - |
+| Ethernet3 | P2P_LINK_TO_rr2_Ethernet3 | routed | - | 10.255.3.17/31 | default | 1500 | False | - | - |
+| Ethernet4 | P2P_LINK_TO_p1_Ethernet4 | routed | - | 10.255.3.9/31 | default | 1500 | False | - | - |
 
 ##### ISIS
 
@@ -190,7 +190,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.5/31
+   ip address 10.255.3.5/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -207,7 +207,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.3/31
+   ip address 10.255.3.3/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -224,7 +224,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.17/31
+   ip address 10.255.3.17/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -241,7 +241,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.9/31
+   ip address 10.255.3.9/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p3.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p3.md
@@ -167,9 +167,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 | P2P_LINK_TO_pe3_Ethernet1 | routed | - | 100.64.48.23/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_LINK_TO_rr1_Ethernet2 | routed | - | 100.64.48.13/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_LINK_TO_p4_Ethernet4 | routed | - | 100.64.48.20/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_LINK_TO_pe3_Ethernet1 | routed | - | 10.255.3.23/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_LINK_TO_rr1_Ethernet2 | routed | - | 10.255.3.13/31 | default | 1500 | False | - | - |
+| Ethernet4 | P2P_LINK_TO_p4_Ethernet4 | routed | - | 10.255.3.20/31 | default | 1500 | False | - | - |
 
 ##### ISIS
 
@@ -188,7 +188,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.23/31
+   ip address 10.255.3.23/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -205,7 +205,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.13/31
+   ip address 10.255.3.13/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -222,7 +222,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.20/31
+   ip address 10.255.3.20/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p4.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p4.md
@@ -167,9 +167,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet2 | P2P_LINK_TO_rr2_Ethernet2 | routed | - | 100.64.48.19/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_LINK_TO_pe3_Ethernet3 | routed | - | 100.64.48.25/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_LINK_TO_p3_Ethernet4 | routed | - | 100.64.48.21/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_LINK_TO_rr2_Ethernet2 | routed | - | 10.255.3.19/31 | default | 1500 | False | - | - |
+| Ethernet3 | P2P_LINK_TO_pe3_Ethernet3 | routed | - | 10.255.3.25/31 | default | 1500 | False | - | - |
+| Ethernet4 | P2P_LINK_TO_p3_Ethernet4 | routed | - | 10.255.3.21/31 | default | 1500 | False | - | - |
 
 ##### ISIS
 
@@ -188,7 +188,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.19/31
+   ip address 10.255.3.19/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -205,7 +205,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.25/31
+   ip address 10.255.3.25/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -222,7 +222,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.21/31
+   ip address 10.255.3.21/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe1.md
@@ -181,8 +181,8 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 | P2P_LINK_TO_p1_Ethernet1 | routed | - | 100.64.48.0/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_LINK_TO_p2_Ethernet2 | routed | - | 100.64.48.2/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_LINK_TO_p1_Ethernet1 | routed | - | 10.255.3.0/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_LINK_TO_p2_Ethernet2 | routed | - | 10.255.3.2/31 | default | 1500 | False | - | - |
 | Ethernet3.10 | C1_L3_SERVICE | l3dot1q | - | 10.0.1.1/29 | C1_VRF1 | - | False | - | - |
 | Ethernet3.20 | C2_L3_SERVICE | l3dot1q | - | 10.1.1.1/29 | C2_VRF1 | - | False | - | - |
 
@@ -202,7 +202,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.0/31
+   ip address 10.255.3.0/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -219,7 +219,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.2/31
+   ip address 10.255.3.2/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe2.md
@@ -181,8 +181,8 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 | P2P_LINK_TO_p2_Ethernet1 | routed | - | 100.64.48.4/31 | default | 1500 | False | - | - |
-| Ethernet2 | P2P_LINK_TO_p1_Ethernet2 | routed | - | 100.64.48.6/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_LINK_TO_p2_Ethernet1 | routed | - | 10.255.3.4/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_LINK_TO_p1_Ethernet2 | routed | - | 10.255.3.6/31 | default | 1500 | False | - | - |
 | Ethernet4.10 | C1_L3_SERVICE | l3dot1q | - | 10.0.1.2/29 | C1_VRF1 | - | False | - | - |
 | Ethernet4.20 | C2_L3_SERVICE | l3dot1q | - | 10.1.1.2/29 | C2_VRF1 | - | False | - | - |
 
@@ -202,7 +202,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.4/31
+   ip address 10.255.3.4/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -219,7 +219,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.6/31
+   ip address 10.255.3.6/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe3.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe3.md
@@ -174,9 +174,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet1 | P2P_LINK_TO_p3_Ethernet1 | routed | - | 100.64.48.22/31 | default | 1500 | False | - | - |
+| Ethernet1 | P2P_LINK_TO_p3_Ethernet1 | routed | - | 10.255.3.22/31 | default | 1500 | False | - | - |
 | Ethernet2 | C1_L3_SERVICE | routed | - | 10.0.1.9/30 | C1_VRF1 | - | False | - | - |
-| Ethernet3 | P2P_LINK_TO_p4_Ethernet3 | routed | - | 100.64.48.24/31 | default | 1500 | False | - | - |
+| Ethernet3 | P2P_LINK_TO_p4_Ethernet3 | routed | - | 10.255.3.24/31 | default | 1500 | False | - | - |
 | Ethernet4 | C2_L3_SERVICE | routed | - | 10.1.1.9/30 | C2_VRF1 | - | False | - | - |
 
 ##### ISIS
@@ -195,7 +195,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.22/31
+   ip address 10.255.3.22/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -220,7 +220,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.24/31
+   ip address 10.255.3.24/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr1.md
@@ -170,9 +170,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet2 | P2P_LINK_TO_p3_Ethernet2 | routed | - | 100.64.48.12/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_LINK_TO_p1_Ethernet3 | routed | - | 100.64.48.10/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_LINK_TO_rr2_Ethernet4 | routed | - | 100.64.48.14/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_LINK_TO_p3_Ethernet2 | routed | - | 10.255.3.12/31 | default | 1500 | False | - | - |
+| Ethernet3 | P2P_LINK_TO_p1_Ethernet3 | routed | - | 10.255.3.10/31 | default | 1500 | False | - | - |
+| Ethernet4 | P2P_LINK_TO_rr2_Ethernet4 | routed | - | 10.255.3.14/31 | default | 1500 | False | - | - |
 
 ##### ISIS
 
@@ -191,7 +191,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.12/31
+   ip address 10.255.3.12/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -208,7 +208,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.10/31
+   ip address 10.255.3.10/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -225,7 +225,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.14/31
+   ip address 10.255.3.14/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr2.md
@@ -170,9 +170,9 @@ vlan internal order ascending range 1006 1199
 
 | Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet2 | P2P_LINK_TO_p4_Ethernet2 | routed | - | 100.64.48.18/31 | default | 1500 | False | - | - |
-| Ethernet3 | P2P_LINK_TO_p2_Ethernet3 | routed | - | 100.64.48.16/31 | default | 1500 | False | - | - |
-| Ethernet4 | P2P_LINK_TO_rr1_Ethernet4 | routed | - | 100.64.48.15/31 | default | 1500 | False | - | - |
+| Ethernet2 | P2P_LINK_TO_p4_Ethernet2 | routed | - | 10.255.3.18/31 | default | 1500 | False | - | - |
+| Ethernet3 | P2P_LINK_TO_p2_Ethernet3 | routed | - | 10.255.3.16/31 | default | 1500 | False | - | - |
+| Ethernet4 | P2P_LINK_TO_rr1_Ethernet4 | routed | - | 10.255.3.15/31 | default | 1500 | False | - | - |
 
 ##### ISIS
 
@@ -191,7 +191,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.18/31
+   ip address 10.255.3.18/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -208,7 +208,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.16/31
+   ip address 10.255.3.16/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -225,7 +225,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.15/31
+   ip address 10.255.3.15/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/fabric/FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/fabric/FABRIC-documentation.md
@@ -64,19 +64,19 @@
 
 | Node | Node Interface | Node IP Address | Peer Node | Peer Interface | Peer IP Address |
 | ---- | -------------- | --------------- | --------- | -------------- | --------------- |
-| p1 | Ethernet1 | 100.64.48.1/31 | pe1 | Ethernet1 | 100.64.48.0/31 |
-| p1 | Ethernet2 | 100.64.48.7/31 | pe2 | Ethernet2 | 100.64.48.6/31 |
-| p1 | Ethernet3 | 100.64.48.11/31 | rr1 | Ethernet3 | 100.64.48.10/31 |
-| p1 | Ethernet4 | 100.64.48.8/31 | p2 | Ethernet4 | 100.64.48.9/31 |
-| p2 | Ethernet1 | 100.64.48.5/31 | pe2 | Ethernet1 | 100.64.48.4/31 |
-| p2 | Ethernet2 | 100.64.48.3/31 | pe1 | Ethernet2 | 100.64.48.2/31 |
-| p2 | Ethernet3 | 100.64.48.17/31 | rr2 | Ethernet3 | 100.64.48.16/31 |
-| p3 | Ethernet1 | 100.64.48.23/31 | pe3 | Ethernet1 | 100.64.48.22/31 |
-| p3 | Ethernet2 | 100.64.48.13/31 | rr1 | Ethernet2 | 100.64.48.12/31 |
-| p3 | Ethernet4 | 100.64.48.20/31 | p4 | Ethernet4 | 100.64.48.21/31 |
-| p4 | Ethernet2 | 100.64.48.19/31 | rr2 | Ethernet2 | 100.64.48.18/31 |
-| p4 | Ethernet3 | 100.64.48.25/31 | pe3 | Ethernet3 | 100.64.48.24/31 |
-| rr1 | Ethernet4 | 100.64.48.14/31 | rr2 | Ethernet4 | 100.64.48.15/31 |
+| p1 | Ethernet1 | 10.255.3.1/31 | pe1 | Ethernet1 | 10.255.3.0/31 |
+| p1 | Ethernet2 | 10.255.3.7/31 | pe2 | Ethernet2 | 10.255.3.6/31 |
+| p1 | Ethernet3 | 10.255.3.11/31 | rr1 | Ethernet3 | 10.255.3.10/31 |
+| p1 | Ethernet4 | 10.255.3.8/31 | p2 | Ethernet4 | 10.255.3.9/31 |
+| p2 | Ethernet1 | 10.255.3.5/31 | pe2 | Ethernet1 | 10.255.3.4/31 |
+| p2 | Ethernet2 | 10.255.3.3/31 | pe1 | Ethernet2 | 10.255.3.2/31 |
+| p2 | Ethernet3 | 10.255.3.17/31 | rr2 | Ethernet3 | 10.255.3.16/31 |
+| p3 | Ethernet1 | 10.255.3.23/31 | pe3 | Ethernet1 | 10.255.3.22/31 |
+| p3 | Ethernet2 | 10.255.3.13/31 | rr1 | Ethernet2 | 10.255.3.12/31 |
+| p3 | Ethernet4 | 10.255.3.20/31 | p4 | Ethernet4 | 10.255.3.21/31 |
+| p4 | Ethernet2 | 10.255.3.19/31 | rr2 | Ethernet2 | 10.255.3.18/31 |
+| p4 | Ethernet3 | 10.255.3.25/31 | pe3 | Ethernet3 | 10.255.3.24/31 |
+| rr1 | Ethernet4 | 10.255.3.14/31 | rr2 | Ethernet4 | 10.255.3.15/31 |
 
 ### Loopback Interfaces (BGP EVPN Peering)
 

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/fabric/FABRIC-p2p-links.csv
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/fabric/FABRIC-p2p-links.csv
@@ -1,14 +1,14 @@
 Type,Node,Node Interface,Leaf IP Address,Peer Type,Peer Node,Peer Interface,Peer IP Address
-p,p1,Ethernet1,100.64.48.1/31,pe,pe1,Ethernet1,100.64.48.0/31
-p,p1,Ethernet2,100.64.48.7/31,pe,pe2,Ethernet2,100.64.48.6/31
-p,p1,Ethernet3,100.64.48.11/31,rr,rr1,Ethernet3,100.64.48.10/31
-p,p1,Ethernet4,100.64.48.8/31,p,p2,Ethernet4,100.64.48.9/31
-p,p2,Ethernet1,100.64.48.5/31,pe,pe2,Ethernet1,100.64.48.4/31
-p,p2,Ethernet2,100.64.48.3/31,pe,pe1,Ethernet2,100.64.48.2/31
-p,p2,Ethernet3,100.64.48.17/31,rr,rr2,Ethernet3,100.64.48.16/31
-p,p3,Ethernet1,100.64.48.23/31,pe,pe3,Ethernet1,100.64.48.22/31
-p,p3,Ethernet2,100.64.48.13/31,rr,rr1,Ethernet2,100.64.48.12/31
-p,p3,Ethernet4,100.64.48.20/31,p,p4,Ethernet4,100.64.48.21/31
-p,p4,Ethernet2,100.64.48.19/31,rr,rr2,Ethernet2,100.64.48.18/31
-p,p4,Ethernet3,100.64.48.25/31,pe,pe3,Ethernet3,100.64.48.24/31
-rr,rr1,Ethernet4,100.64.48.14/31,rr,rr2,Ethernet4,100.64.48.15/31
+p,p1,Ethernet1,10.255.3.1/31,pe,pe1,Ethernet1,10.255.3.0/31
+p,p1,Ethernet2,10.255.3.7/31,pe,pe2,Ethernet2,10.255.3.6/31
+p,p1,Ethernet3,10.255.3.11/31,rr,rr1,Ethernet3,10.255.3.10/31
+p,p1,Ethernet4,10.255.3.8/31,p,p2,Ethernet4,10.255.3.9/31
+p,p2,Ethernet1,10.255.3.5/31,pe,pe2,Ethernet1,10.255.3.4/31
+p,p2,Ethernet2,10.255.3.3/31,pe,pe1,Ethernet2,10.255.3.2/31
+p,p2,Ethernet3,10.255.3.17/31,rr,rr2,Ethernet3,10.255.3.16/31
+p,p3,Ethernet1,10.255.3.23/31,pe,pe3,Ethernet1,10.255.3.22/31
+p,p3,Ethernet2,10.255.3.13/31,rr,rr1,Ethernet2,10.255.3.12/31
+p,p3,Ethernet4,10.255.3.20/31,p,p4,Ethernet4,10.255.3.21/31
+p,p4,Ethernet2,10.255.3.19/31,rr,rr2,Ethernet2,10.255.3.18/31
+p,p4,Ethernet3,10.255.3.25/31,pe,pe3,Ethernet3,10.255.3.24/31
+rr,rr1,Ethernet4,10.255.3.14/31,rr,rr2,Ethernet4,10.255.3.15/31

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/group_vars/WAN1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/group_vars/WAN1.yml
@@ -101,7 +101,7 @@ core_interfaces:
   # First, an IP-pool for the underlay p2p links is defined
   p2p_links_ip_pools:
     - name: core_pool
-      ipv4_pool: 100.64.48.0/24
+      ipv4_pool: 10.255.3.0/24
   p2p_links_profiles:
     - name: core_profile
       # speed: 100gfull

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p1.cfg
@@ -23,7 +23,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.1/31
+   ip address 10.255.3.1/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -40,7 +40,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.7/31
+   ip address 10.255.3.7/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -57,7 +57,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.11/31
+   ip address 10.255.3.11/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -74,7 +74,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.8/31
+   ip address 10.255.3.8/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p2.cfg
@@ -23,7 +23,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.5/31
+   ip address 10.255.3.5/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -40,7 +40,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.3/31
+   ip address 10.255.3.3/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -57,7 +57,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.17/31
+   ip address 10.255.3.17/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -74,7 +74,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.9/31
+   ip address 10.255.3.9/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p3.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p3.cfg
@@ -23,7 +23,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.23/31
+   ip address 10.255.3.23/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -40,7 +40,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.13/31
+   ip address 10.255.3.13/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -57,7 +57,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.20/31
+   ip address 10.255.3.20/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p4.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p4.cfg
@@ -23,7 +23,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.19/31
+   ip address 10.255.3.19/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -40,7 +40,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.25/31
+   ip address 10.255.3.25/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -57,7 +57,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.21/31
+   ip address 10.255.3.21/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe1.cfg
@@ -27,7 +27,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.0/31
+   ip address 10.255.3.0/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -44,7 +44,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.2/31
+   ip address 10.255.3.2/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe2.cfg
@@ -27,7 +27,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.4/31
+   ip address 10.255.3.4/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -44,7 +44,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.6/31
+   ip address 10.255.3.6/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe3.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe3.cfg
@@ -27,7 +27,7 @@ interface Ethernet1
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.22/31
+   ip address 10.255.3.22/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -52,7 +52,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.24/31
+   ip address 10.255.3.24/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr1.cfg
@@ -23,7 +23,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.12/31
+   ip address 10.255.3.12/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -40,7 +40,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.10/31
+   ip address 10.255.3.10/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -57,7 +57,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.14/31
+   ip address 10.255.3.14/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr2.cfg
@@ -23,7 +23,7 @@ interface Ethernet2
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.18/31
+   ip address 10.255.3.18/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -40,7 +40,7 @@ interface Ethernet3
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.16/31
+   ip address 10.255.3.16/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip
@@ -57,7 +57,7 @@ interface Ethernet4
    no shutdown
    mtu 1500
    no switchport
-   ip address 100.64.48.15/31
+   ip address 10.255.3.15/31
    mpls ldp igp sync
    mpls ldp interface
    mpls ip

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p1.yml
@@ -73,7 +73,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.1/31
+  ip_address: 10.255.3.1/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -94,7 +94,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.7/31
+  ip_address: 10.255.3.7/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -115,7 +115,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.8/31
+  ip_address: 10.255.3.8/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -136,7 +136,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.11/31
+  ip_address: 10.255.3.11/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p2.yml
@@ -73,7 +73,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.3/31
+  ip_address: 10.255.3.3/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -94,7 +94,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.5/31
+  ip_address: 10.255.3.5/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -115,7 +115,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.9/31
+  ip_address: 10.255.3.9/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -136,7 +136,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.17/31
+  ip_address: 10.255.3.17/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p3.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p3.yml
@@ -73,7 +73,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.13/31
+  ip_address: 10.255.3.13/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -94,7 +94,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.20/31
+  ip_address: 10.255.3.20/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -115,7 +115,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.23/31
+  ip_address: 10.255.3.23/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p4.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p4.yml
@@ -73,7 +73,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.19/31
+  ip_address: 10.255.3.19/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -94,7 +94,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.21/31
+  ip_address: 10.255.3.21/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -115,7 +115,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.25/31
+  ip_address: 10.255.3.25/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe1.yml
@@ -167,7 +167,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.0/31
+  ip_address: 10.255.3.0/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -188,7 +188,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.2/31
+  ip_address: 10.255.3.2/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe2.yml
@@ -167,7 +167,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.4/31
+  ip_address: 10.255.3.4/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -188,7 +188,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.6/31
+  ip_address: 10.255.3.6/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe3.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe3.yml
@@ -167,7 +167,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.22/31
+  ip_address: 10.255.3.22/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -188,7 +188,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.24/31
+  ip_address: 10.255.3.24/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr1.yml
@@ -143,7 +143,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.10/31
+  ip_address: 10.255.3.10/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -164,7 +164,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.12/31
+  ip_address: 10.255.3.12/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -185,7 +185,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.14/31
+  ip_address: 10.255.3.14/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr2.yml
@@ -143,7 +143,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.15/31
+  ip_address: 10.255.3.15/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -164,7 +164,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.16/31
+  ip_address: 10.255.3.16/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true
@@ -185,7 +185,7 @@ ethernet_interfaces:
   type: routed
   shutdown: false
   mtu: 1500
-  ip_address: 100.64.48.18/31
+  ip_address: 10.255.3.18/31
   isis_enable: CORE
   isis_metric: 50
   isis_network_point_to_point: true

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.105/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.105/24 | 172.100.100.1 |
 
 ##### IPv6
 
@@ -64,7 +64,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.105/24
+   ip address 172.16.100.105/24
 ```
 
 ### IP Name Servers

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF1.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.16.100.105/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.105/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -424,13 +424,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ```
 
 ## Multicast

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.106/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.106/24 | 172.100.100.1 |
 
 ##### IPv6
 
@@ -64,7 +64,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.106/24
+   ip address 172.16.100.106/24
 ```
 
 ### IP Name Servers

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF2.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.16.100.106/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.106/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -424,13 +424,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ```
 
 ## Multicast

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.107/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.107/24 | 172.100.100.1 |
 
 ##### IPv6
 
@@ -64,7 +64,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.107/24
+   ip address 172.16.100.107/24
 ```
 
 ### IP Name Servers

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF3.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.16.100.107/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.107/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -424,13 +424,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ```
 
 ## Multicast

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.16.100.108/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.108/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -424,13 +424,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ```
 
 ## Multicast

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/LEAF4.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.108/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.108/24 | 172.100.100.1 |
 
 ##### IPv6
 
@@ -64,7 +64,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.108/24
+   ip address 172.16.100.108/24
 ```
 
 ### IP Name Servers

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.16.100.101/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.101/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -455,13 +455,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ```
 
 ## Multicast

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE1.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.101/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.101/24 | 172.100.100.1 |
 
 ##### IPv6
 
@@ -64,7 +64,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.101/24
+   ip address 172.16.100.101/24
 ```
 
 ### IP Name Servers

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.16.100.102/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.102/24 | 172.16.100.1 |
 
 ##### IPv6
 
@@ -455,13 +455,13 @@ no ip routing vrf MGMT
 
 | VRF | Destination Prefix | Next Hop IP | Exit interface | Administrative Distance | Tag | Route Name | Metric |
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
-| MGMT | 0.0.0.0/0 | 172.100.100.1 | - | 1 | - | - | - |
+| MGMT | 0.0.0.0/0 | 172.16.100.1 | - | 1 | - | - | - |
 
 #### Static Routes Device Configuration
 
 ```eos
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 ```
 
 ## Multicast

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/devices/SPINE2.md
@@ -48,7 +48,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management0 | oob_management | oob | MGMT | 172.100.100.102/24 | 172.100.100.1 |
+| Management0 | oob_management | oob | MGMT | 172.16.100.102/24 | 172.100.100.1 |
 
 ##### IPv6
 
@@ -64,7 +64,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.102/24
+   ip address 172.16.100.102/24
 ```
 
 ### IP Name Servers

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/documentation/fabric/DC1_FABRIC-documentation.md
@@ -22,12 +22,12 @@
 
 | POD | Type | Node | Management IP | Platform | Provisioned in CloudVision | Serial Number |
 | --- | ---- | ---- | ------------- | -------- | -------------------------- | ------------- |
-| DC1_FABRIC | leaf | LEAF1 | 172.100.100.105/24 | cEOS-LAB | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF2 | 172.100.100.106/24 | cEOS-LAB | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF3 | 172.100.100.107/24 | cEOS-LAB | Provisioned | - |
-| DC1_FABRIC | leaf | LEAF4 | 172.100.100.108/24 | cEOS-LAB | Provisioned | - |
-| DC1_FABRIC | spine | SPINE1 | 172.100.100.101/24 | cEOS-LAB | Provisioned | - |
-| DC1_FABRIC | spine | SPINE2 | 172.100.100.102/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF1 | 172.16.100.105/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF2 | 172.16.100.106/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF3 | 172.16.100.107/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | leaf | LEAF4 | 172.16.100.108/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | SPINE1 | 172.16.100.101/24 | cEOS-LAB | Provisioned | - |
+| DC1_FABRIC | spine | SPINE2 | 172.16.100.102/24 | cEOS-LAB | Provisioned | - |
 
 > Provision status is based on Ansible inventory declaration and do not represent real status from CloudVision.
 

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/group_vars/DC1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/group_vars/DC1.yml
@@ -21,7 +21,7 @@ local_users:
     sha512_password: "$6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/."
 
 # OOB Management network default gateway
-mgmt_gateway: 172.100.100.1
+mgmt_gateway: 172.16.100.1
 mgmt_interface: Management0
 
 # dns servers.

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/group_vars/DC1_FABRIC.yml
@@ -37,10 +37,10 @@ spine:
       nodes:
         - name: SPINE1
           id: 1
-          mgmt_ip: 172.100.100.101/24
+          mgmt_ip: 172.16.100.101/24
         - name: SPINE2
           id: 2
-          mgmt_ip: 172.100.100.102/24
+          mgmt_ip: 172.16.100.102/24
 
 # Leaf Switches
 leaf:
@@ -61,11 +61,11 @@ leaf:
       nodes:
         - name: LEAF1
           id: 1
-          mgmt_ip: 172.100.100.105/24
+          mgmt_ip: 172.16.100.105/24
           uplink_switch_interfaces: [Ethernet1, Ethernet1]
         - name: LEAF2
           id: 2
-          mgmt_ip: 172.100.100.106/24
+          mgmt_ip: 172.16.100.106/24
           uplink_switch_interfaces: [Ethernet2, Ethernet2]
     - group: RACK2
       mlag: true
@@ -74,11 +74,11 @@ leaf:
       nodes:
         - name: LEAF3
           id: 3
-          mgmt_ip: 172.100.100.107/24
+          mgmt_ip: 172.16.100.107/24
           uplink_switch_interfaces: [Ethernet3, Ethernet3]
         - name: LEAF4
           id: 4
-          mgmt_ip: 172.100.100.108/24
+          mgmt_ip: 172.16.100.108/24
           uplink_switch_interfaces: [Ethernet4, Ethernet4]
 
 #### Override for vEOS/cEOS Lab Caveats ####

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
@@ -104,7 +104,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
@@ -86,7 +86,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.105/24
+   ip address 172.16.100.105/24
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
@@ -104,7 +104,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
@@ -86,7 +86,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.106/24
+   ip address 172.16.100.106/24
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
@@ -104,7 +104,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
@@ -86,7 +86,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.107/24
+   ip address 172.16.100.107/24
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
@@ -104,7 +104,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
@@ -86,7 +86,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.108/24
+   ip address 172.16.100.108/24
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
@@ -130,7 +130,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
@@ -112,7 +112,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.101/24
+   ip address 172.16.100.101/24
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
@@ -112,7 +112,7 @@ interface Management0
    description oob_management
    no shutdown
    vrf MGMT
-   ip address 172.100.100.102/24
+   ip address 172.16.100.102/24
 !
 interface Vlan4094
    description MLAG_PEER

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
@@ -130,7 +130,7 @@ mlag configuration
    reload-delay mlag 300
    reload-delay non-mlag 330
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
@@ -38,7 +38,7 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.105/24
+  ip_address: 172.16.100.105/24
   gateway: 172.100.100.1
   type: oob
 management_api_http:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 service_routing_protocols_model: multi-agent
 vlan_internal_order:
   allocation: ascending
@@ -39,7 +39,7 @@ management_interfaces:
   shutdown: false
   vrf: MGMT
   ip_address: 172.16.100.105/24
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 service_routing_protocols_model: multi-agent
 vlan_internal_order:
   allocation: ascending
@@ -39,7 +39,7 @@ management_interfaces:
   shutdown: false
   vrf: MGMT
   ip_address: 172.16.100.106/24
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
@@ -38,7 +38,7 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.106/24
+  ip_address: 172.16.100.106/24
   gateway: 172.100.100.1
   type: oob
 management_api_http:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 service_routing_protocols_model: multi-agent
 vlan_internal_order:
   allocation: ascending
@@ -39,7 +39,7 @@ management_interfaces:
   shutdown: false
   vrf: MGMT
   ip_address: 172.16.100.107/24
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
@@ -38,7 +38,7 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.107/24
+  ip_address: 172.16.100.107/24
   gateway: 172.100.100.1
   type: oob
 management_api_http:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 service_routing_protocols_model: multi-agent
 vlan_internal_order:
   allocation: ascending
@@ -39,7 +39,7 @@ management_interfaces:
   shutdown: false
   vrf: MGMT
   ip_address: 172.16.100.108/24
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
@@ -38,7 +38,7 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.108/24
+  ip_address: 172.16.100.108/24
   gateway: 172.100.100.1
   type: oob
 management_api_http:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
@@ -38,7 +38,7 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.101/24
+  ip_address: 172.16.100.101/24
   gateway: 172.100.100.1
   type: oob
 management_api_http:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 service_routing_protocols_model: multi-agent
 vlan_internal_order:
   allocation: ascending
@@ -39,7 +39,7 @@ management_interfaces:
   shutdown: false
   vrf: MGMT
   ip_address: 172.16.100.101/24
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
@@ -3,7 +3,7 @@ is_deployed: true
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
 service_routing_protocols_model: multi-agent
 vlan_internal_order:
   allocation: ascending
@@ -39,7 +39,7 @@ management_interfaces:
   shutdown: false
   vrf: MGMT
   ip_address: 172.16.100.102/24
-  gateway: 172.100.100.1
+  gateway: 172.16.100.1
   type: oob
 management_api_http:
   enable_vrfs:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
@@ -38,7 +38,7 @@ management_interfaces:
   description: oob_management
   shutdown: false
   vrf: MGMT
-  ip_address: 172.100.100.102/24
+  ip_address: 172.16.100.102/24
   gateway: 172.100.100.1
   type: oob
 management_api_http:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/inventory.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/inventory.yml
@@ -6,19 +6,19 @@ DC1:
         DC1_SPINES:
           hosts:
             SPINE1:
-              ansible_host: 172.100.100.101
+              ansible_host: 172.16.100.101
             SPINE2:
-              ansible_host: 172.100.100.102
+              ansible_host: 172.16.100.102
         DC1_LEAFS:
           hosts:
             LEAF1:
-              ansible_host: 172.100.100.105
+              ansible_host: 172.16.100.105
             LEAF2:
-              ansible_host: 172.100.100.106
+              ansible_host: 172.16.100.106
             LEAF3:
-              ansible_host: 172.100.100.107
+              ansible_host: 172.16.100.107
             LEAF4:
-              ansible_host: 172.100.100.108
+              ansible_host: 172.16.100.108
     DC1_NETWORK_SERVICES:
       children:
         DC1_LEAFS:

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/FIREWALL.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/FIREWALL.cfg
@@ -33,7 +33,7 @@ interface Ethernet2
 !
 interface Management0
    vrf MGMT
-   ip address 172.100.100.109/24
+   ip address 172.16.100.109/24
 !
 interface Vlan10
    ip address 10.10.10.1/24
@@ -47,7 +47,7 @@ interface Vlan30
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management ssh
    vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/LEAF1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/LEAF1.cfg
@@ -15,12 +15,12 @@ management api http-commands
 !
 interface Management0
    vrf MGMT
-   ip address 172.100.100.105/24
+   ip address 172.16.100.105/24
 !
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management ssh
    vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/LEAF2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/LEAF2.cfg
@@ -15,12 +15,12 @@ management api http-commands
 !
 interface Management0
    vrf MGMT
-   ip address 172.100.100.106/24
+   ip address 172.16.100.106/24
 !
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management ssh
    vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/LEAF3.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/LEAF3.cfg
@@ -15,12 +15,12 @@ management api http-commands
 !
 interface Management0
    vrf MGMT
-   ip address 172.100.100.107/24
+   ip address 172.16.100.107/24
 !
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management ssh
    vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/LEAF4.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/LEAF4.cfg
@@ -17,12 +17,12 @@ interface Ethernet48
 !
 interface Management0
    vrf MGMT
-   ip address 172.100.100.108/24
+   ip address 172.16.100.108/24
 !
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management ssh
    vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/SPINE1.cfg
@@ -15,12 +15,12 @@ management api http-commands
 !
 interface Management0
    vrf MGMT
-   ip address 172.100.100.101/24
+   ip address 172.16.100.101/24
 !
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management ssh
    vrf MGMT

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/switch-basic-configurations/SPINE2.cfg
@@ -15,12 +15,12 @@ management api http-commands
 !
 interface Management0
    vrf MGMT
-   ip address 172.100.100.102/24
+   ip address 172.16.100.102/24
 !
 ip routing
 no ip routing vrf MGMT
 !
-ip route vrf MGMT 0.0.0.0/0 172.100.100.1
+ip route vrf MGMT 0.0.0.0/0 172.16.100.1
 !
 management ssh
    vrf MGMT


### PR DESCRIPTION
## Change Summary

Remove not RFC1918 IPs from examples.

## Related Issue(s)

Fixes #3169 

## Component(s) name

`arista.avd.examples`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
