### PR TITLE
CI: Move offline links checker to daily scheduled workflow

### DIFF
--- a/.github/workflows/offline-links-check.yml
+++ b/.github/workflows/offline-links-check.yml
@@ -1,0 +1,48 @@
+---
+name: "Check links offline for dead targets"
+
+on:
+  # schedule every day at 3 AM on devel
+  schedule:
+    - cron: "0 3 * * *"
+  # Allow for manual trigger on the selected branch in UI
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  offline_link_check:
+    name: 'Validate mkdoc content'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v3
+      - name: 'Start docker-compose stack'
+        run: |
+          docker-compose -f development/docker-compose.yml up -d webdoc_avd
+          docker-compose -f development/docker-compose.yml ps
+      - name: 'Test connectivity to mkdoc server'
+        run: |
+          bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1:8000)" != "200" ]]; do sleep 5; done'
+      - name: Check links for 404
+        run: |
+          docker run --network container:webdoc_avd raviqqe/muffet:2.10.1 http://127.0.0.1:8000/ -f \
+            --buffer-size 8192 \
+            --exclude ".*fonts.googleapis.com.*" \
+            --exclude ".*fonts.gstatic.com.*" \
+            --exclude ".*tools.ietf.org.*" \
+            --exclude ".*edit.*" \
+            --exclude ".*docs.github.com.*" \
+            --exclude "twitter.com" \
+            --exclude "www.docker.com" \
+            --exclude "hub.docker.com" \
+            --exclude "tech-library.arista.com" \
+            --max-connections-per-host 30 \
+            --max-redirections 3 \
+            --rate-limit 1 \
+            --timeout 30
+      - name: 'Stop docker-compose stack'
+        run: |
+          docker-compose -f development/docker-compose.yml down

--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -93,44 +93,6 @@ jobs:
       # Do NOT set a name for the pre-commit-ci action. Otherwise the Github App will not pick it up.
       - uses: pre-commit-ci/lite-action@v1.0.0
         if: always()
-  # ----------------------------------- #
-  # Check Links  offline for dead target
-  # ----------------------------------- #
-  offline_link_check:
-    name: 'Validate mkdoc content'
-    runs-on: ubuntu-latest
-    needs: [ file-changes ]
-    if: needs.file-changes.outputs.docs == 'true'
-    timeout-minutes: 15
-    steps:
-      - uses: actions/checkout@v3
-      - name: 'Start docker-compose stack'
-        run: |
-          docker-compose -f development/docker-compose.yml up -d webdoc_avd
-          docker-compose -f development/docker-compose.yml ps
-      - name: 'Test connectivity to mkdoc server'
-        run: |
-          bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1:8000)" != "200" ]]; do sleep 5; done'
-      - name: Check links for 404
-        run: |
-          docker run --network container:webdoc_avd raviqqe/muffet:2.10.1 http://127.0.0.1:8000/ -f \
-            --buffer-size 8192 \
-            --exclude ".*fonts.googleapis.com.*" \
-            --exclude ".*fonts.gstatic.com.*" \
-            --exclude ".*tools.ietf.org.*" \
-            --exclude ".*edit.*" \
-            --exclude ".*docs.github.com.*" \
-            --exclude "twitter.com" \
-            --exclude "www.docker.com" \
-            --exclude "hub.docker.com" \
-            --exclude "tech-library.arista.com" \
-            --max-connections-per-host 30 \
-            --max-redirections 3 \
-            --rate-limit 1 \
-            --timeout 30
-      - name: 'Stop docker-compose stack'
-        run: |
-          docker-compose -f development/docker-compose.yml down
 
   # ----------------------------------- #
   # Test Requirements


### PR DESCRIPTION
## Change Summary

Move the job to check for dead links in `pull-request-management.yml` to a separate workflow scheduled to run every day at 3 AM.
The workflow can also be triggered manually (`workflow_dispatch`) on any branch.

## Component(s) name

`ci`

## How to test

Need to merge in devel

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
