### PR TITLE
Fix(eos_designs): Fix code error for monitor_sessions for network_ports

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-monitor-sessions-mismatch-direction.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-monitor-sessions-mismatch-direction.yml
@@ -1,0 +1,43 @@
+---
+loopback_ipv4_pool: 192.168.0.0/24
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    - name: connected-endpoints-monitor-sessions-mismatch-direction
+
+servers:
+  # conflicting direction for monitor-session for port-channel 44
+  - name: INDIVIDUAL_1
+    adapters:
+      - switches: [connected-endpoints-monitor-sessions-mismatch-direction]
+        switch_ports: [Ethernet14]
+        description: Monitor port-channel 44
+        port_channel:
+          channel_id: 44
+          mode: active
+        monitor_sessions:
+          - name: DMF
+            role: source
+            source_settings:
+              direction: rx
+      - switches: [connected-endpoints-monitor-sessions-mismatch-direction]
+        switch_ports: [Ethernet15]
+        description: Monitor port-channel 44
+        port_channel:
+          channel_id: 44
+          mode: active
+        monitor_sessions:
+          - name: DMF
+            role: source
+            source_settings:
+              direction: both
+      - switches: [connected-endpoints-monitor-sessions-mismatch-direction]
+        switch_ports: [Ethernet16]
+        description: Destination
+        monitor_sessions:
+          - name: DMF
+            role: destination
+
+expected_error_message: "Found duplicate objects with conflicting data while generating configuration for Monitor session defined under connected_endpoints. {'name': 'Port-Channel44', 'direction': 'both'} conflicts with {'name': 'Port-Channel44', 'direction': 'rx'}."

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -59,6 +59,7 @@ all:
         connected-endpoints-wrong-profile-lacp-fallback:
         connected-endpoints-phone-vlan-mode:
         connected-endpoints-phone-vlan-vlans:
+        connected-endpoints-monitor-sessions-mismatch-direction:
         duplicate-vlans-l2vlans:
         duplicate-vlans-svi-id:
         duplicate-vrfs-duplicate-svi-name-conflict:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -586,7 +586,7 @@ interface Ethernet16
    channel-group 44 mode active
 !
 interface Ethernet17
-   description monitor sessions destination
+   description Monitor sessions destination
    no shutdown
    switchport
 !
@@ -607,7 +607,6 @@ interface Vlan4094
 no ip routing vrf MGMT
 !
 monitor session DMF source Ethernet14 both
-monitor session DMF source Port-Channel44 both
 monitor session DMF source Port-Channel44 both
 monitor session DMF destination Ethernet17
 monitor session DMF encapsulation gre metadata tx

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -54,6 +54,12 @@ interface Port-Channel43
    switchport
    mlag 43
 !
+interface Port-Channel44
+   description Checking monitor sessions on port-channels
+   no shutdown
+   switchport
+   mlag 44
+!
 interface Port-Channel101
    description MLAG_PEER_network-ports-tests.1_Po101
    no shutdown
@@ -564,6 +570,26 @@ interface Ethernet12
    switchport mode trunk phone
    switchport
 !
+interface Ethernet14
+   description Checking monitor sessions on single interface
+   no shutdown
+   switchport
+!
+interface Ethernet15
+   description Checking monitor sessions on port-channels
+   no shutdown
+   channel-group 44 mode active
+!
+interface Ethernet16
+   description Checking monitor sessions on port-channels
+   no shutdown
+   channel-group 44 mode active
+!
+interface Ethernet17
+   description monitor sessions destination
+   no shutdown
+   switchport
+!
 interface Ethernet51
    no shutdown
    channel-group 43 mode active
@@ -579,6 +605,12 @@ interface Vlan4094
    no autostate
    ip address 10.255.252.1/31
 no ip routing vrf MGMT
+!
+monitor session DMF source Ethernet14 both
+monitor session DMF source Port-Channel44 both
+monitor session DMF source Port-Channel44 both
+monitor session DMF destination Ethernet17
+monitor session DMF encapsulation gre metadata tx
 !
 mlag configuration
    domain-id mlag

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -69,6 +69,11 @@ port_channel_interfaces:
   type: switched
   shutdown: false
   mlag: 42
+- name: Port-Channel44
+  description: Checking monitor sessions on port-channels
+  type: switched
+  shutdown: false
+  mlag: 44
 - name: Port-Channel43
   type: switched
   shutdown: false
@@ -714,6 +719,36 @@ ethernet_interfaces:
   channel_group:
     id: 42
     mode: active
+- name: Ethernet14
+  peer: Checking monitor sessions on single interface
+  peer_type: network_port
+  description: Checking monitor sessions on single interface
+  shutdown: false
+  type: switched
+- name: Ethernet15
+  peer: Checking monitor sessions on port-channels
+  peer_type: network_port
+  description: Checking monitor sessions on port-channels
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 44
+    mode: active
+- name: Ethernet16
+  peer: Checking monitor sessions on port-channels
+  peer_type: network_port
+  description: Checking monitor sessions on port-channels
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 44
+    mode: active
+- name: Ethernet17
+  peer: monitor sessions destination
+  peer_type: network_port
+  description: monitor sessions destination
+  shutdown: false
+  type: switched
 - name: Ethernet51
   peer_type: network_port
   shutdown: false
@@ -737,3 +772,15 @@ mlag_configuration:
   reload_delay_non_mlag: '330'
 ip_igmp_snooping:
   globally_enabled: true
+monitor_sessions:
+- name: DMF
+  sources:
+  - name: Ethernet14
+    direction: both
+  - name: Port-Channel44
+    direction: both
+  - name: Port-Channel44
+    direction: both
+  destinations:
+  - Ethernet17
+  encapsulation_gre_metadata_tx: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -744,9 +744,9 @@ ethernet_interfaces:
     id: 44
     mode: active
 - name: Ethernet17
-  peer: monitor sessions destination
+  peer: Monitor sessions destination
   peer_type: network_port
-  description: monitor sessions destination
+  description: Monitor sessions destination
   shutdown: false
   type: switched
 - name: Ethernet51
@@ -776,8 +776,6 @@ monitor_sessions:
 - name: DMF
   sources:
   - name: Ethernet14
-    direction: both
-  - name: Port-Channel44
     direction: both
   - name: Port-Channel44
     direction: both

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -76,7 +76,7 @@ network_ports:
       - network-ports-tests.2
     switch_ports:
       - Ethernet14
-    description: "Checking monitor sessions on single interface"
+    description: Checking monitor sessions on single interface
     monitor_sessions:
       - name: DMF
         role: "source"
@@ -88,7 +88,7 @@ network_ports:
       - network-ports-tests.2
     switch_ports:
       - Ethernet15-16
-    description: "Checking monitor sessions on port-channels"
+    description: Checking monitor sessions on port-channels
     port_channel:
       channel_id: 44
       mode: "active"
@@ -103,10 +103,10 @@ network_ports:
       - network-ports-tests.2
     switch_ports:
       - Ethernet17
-    description: "monitor sessions destination"
+    description: Monitor sessions destination
     monitor_sessions:
       - name: DMF
-        role: "destination"
+        role: destination
         session_settings:
           encapsulation_gre_metadata_tx: true
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -71,6 +71,45 @@ network_ports:
       channel_id: 42
       mode: "active"
 
+  # Tests for issue #3816
+  - switches:
+      - network-ports-tests.2
+    switch_ports:
+      - Ethernet14
+    description: "Checking monitor sessions on single interface"
+    monitor_sessions:
+      - name: DMF
+        role: "source"
+        source_settings:
+          direction: "both"
+        session_settings:
+          encapsulation_gre_metadata_tx: true
+  - switches:
+      - network-ports-tests.2
+    switch_ports:
+      - Ethernet15-16
+    description: "Checking monitor sessions on port-channels"
+    port_channel:
+      channel_id: 44
+      mode: "active"
+    monitor_sessions:
+      - name: DMF
+        role: source
+        source_settings:
+          direction: both
+        session_settings:
+          encapsulation_gre_metadata_tx: true
+  - switches:
+      - network-ports-tests.2
+    switch_ports:
+      - Ethernet17
+    description: "monitor sessions destination"
+    monitor_sessions:
+      - name: DMF
+        role: "destination"
+        session_settings:
+          encapsulation_gre_metadata_tx: true
+
   # The next entries are used to test the duplicate check feature together with the
   # CONNECTED_ENDPOINT_OVERWRITING_NETWORK_PORT below.
   - switches:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/monitor_sessions.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/monitor_sessions.py
@@ -52,12 +52,12 @@ class MonitorSessionsMixin(UtilsMixin):
                         "priority": access_group.get("priority"),
                     }
                 append_if_not_duplicate(
-                        list_of_dicts=monitor_session["sources"],
-                        primary_key="name",
-                        new_dict=source,
-                        context="Monitor session defined under connected_endpoints",
-                        context_keys=["name"],
-                    )
+                    list_of_dicts=monitor_session["sources"],
+                    primary_key="name",
+                    new_dict=source,
+                    context="Monitor session defined under connected_endpoints",
+                    context_keys=["name"],
+                )
 
             if (session_settings := merged_settings.get("session_settings")) is not None:
                 monitor_session.update(session_settings)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/monitor_sessions.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/monitor_sessions.py
@@ -9,7 +9,7 @@ from functools import cached_property
 from ansible_collections.arista.avd.plugins.filter.range_expand import range_expand
 from ansible_collections.arista.avd.plugins.plugin_utils.merge import merge
 from ansible_collections.arista.avd.plugins.plugin_utils.strip_empties import strip_null_from_data
-from ansible_collections.arista.avd.plugins.plugin_utils.utils import get, groupby
+from ansible_collections.arista.avd.plugins.plugin_utils.utils import append_if_not_duplicate, get, groupby
 
 from .utils import UtilsMixin
 
@@ -51,7 +51,13 @@ class MonitorSessionsMixin(UtilsMixin):
                         "name": access_group.get("name"),
                         "priority": access_group.get("priority"),
                     }
-                monitor_session["sources"].append(source)
+                append_if_not_duplicate(
+                        list_of_dicts=monitor_session["sources"],
+                        primary_key="name",
+                        new_dict=source,
+                        context="Monitor session defined under connected_endpoints",
+                        context_keys=["name"],
+                    )
 
             if (session_settings := merged_settings.get("session_settings")) is not None:
                 monitor_session.update(session_settings)

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/monitor_sessions.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/monitor_sessions.py
@@ -99,6 +99,7 @@ class MonitorSessionsMixin(UtilsMixin):
             if "monitor_sessions" not in network_port:
                 continue
 
+
             for ethernet_interface_name in range_expand(network_port["switch_ports"]):
                 # Monitor session on Port-channel interface
                 if get(network_port, "port_channel.mode") is not None:
@@ -107,13 +108,13 @@ class MonitorSessionsMixin(UtilsMixin):
 
                     port_channel_interface_name = f"Port-Channel{channel_group_id}"
                     monitor_session_configs.extend(
-                        [dict(monitor_session, interface=port_channel_interface_name) for monitor_session in adapter["monitor_sessions"]],
+                        [dict(monitor_session, interface=port_channel_interface_name) for monitor_session in network_port["monitor_sessions"]],
                     )
                     continue
 
                 # Monitor session on Ethernet interface
                 monitor_session_configs.extend(
-                    [dict(monitor_session, interface=ethernet_interface_name) for monitor_session in adapter["monitor_sessions"]],
+                    [dict(monitor_session, interface=ethernet_interface_name) for monitor_session in network_port["monitor_sessions"]],
                 )
 
         return monitor_session_configs

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/monitor_sessions.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/monitor_sessions.py
@@ -99,7 +99,6 @@ class MonitorSessionsMixin(UtilsMixin):
             if "monitor_sessions" not in network_port:
                 continue
 
-
             for ethernet_interface_name in range_expand(network_port["switch_ports"]):
                 # Monitor session on Port-channel interface
                 if get(network_port, "port_channel.mode") is not None:


### PR DESCRIPTION
## Change Summary

Fix wrong python object access for network_ports.
no molecule test existed for this so it never worked probably or has not been for a while

## Related Issue(s)

Fixes #3816

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Fix python typo

## How to test

molecule

## Checklist

### User Checklist

- [ ] Need reviewer to check the port-channel output, it looks redundant.

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
