### PR TITLE
Feat(eos_cli_config_gen): Add IPsec and NAT options to tunnel_interfaces.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/tunnel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/tunnel-interfaces.md
@@ -41,12 +41,12 @@ interface Management1
 
 #### Tunnel Interfaces Summary
 
-| Interface | Description | VRF | MTU | Shutdown | Source Interface | Destination | PMTU-Discovery |
-| --------- | ----------- | --- | --- | -------- | ---------------- | ----------- | -------------- |
-| Tunnel1 | test ipv4 only | Tunnel-VRF | 1500 | False | Ethernet42 | 6.6.6.6 | True |
-| Tunnel2 | test ipv6 only | default | - | True | Ethernet42 | dead:beef::1 | False |
-| Tunnel3 | test dual stack | default | 1500 | - | Ethernet42 | 1.1.1.1 | - |
-| Tunnel4 | test no tcp_mss | default | 1500 | - | Ethernet42 | 1.1.1.1 | - |
+| Interface | Description | VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
+| --------- | ----------- | --- | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
+| Tunnel1 | test ipv4 only | Tunnel-VRF | 1500 | False | - | ipsec | Ethernet42 | 6.6.6.6 | True | - |
+| Tunnel2 | test ipv6 only | default | - | True | NAT-PROFILE-NO-VRF-2 | gre | Ethernet42 | dead:beef::1 | False | - |
+| Tunnel3 | test dual stack | default | 1500 | - | - | ipsec | Ethernet42 | 1.1.1.1 | - | Profile-3 |
+| Tunnel4 | test no tcp_mss | default | 1500 | - | NAT-PROFILE-NO-VRF-1 | - | Ethernet42 | 1.1.1.1 | - | - |
 
 ##### IPv4
 
@@ -77,6 +77,7 @@ interface Tunnel1
    ip access-group test-in in
    ip access-group test-out out
    tcp mss ceiling ipv4 666 ingress
+   tunnel mode ipsec
    tunnel source interface Ethernet42
    tunnel destination 6.6.6.6
    tunnel path-mtu-discovery
@@ -93,6 +94,8 @@ interface Tunnel2
    ipv6 access-group test-in in
    ipv6 access-group test-out out
    tcp mss ceiling ipv6 666 egress
+   ip nat service-profile NAT-PROFILE-NO-VRF-2
+   tunnel mode gre
    tunnel source interface Ethernet42
    tunnel destination dead:beef::1
 !
@@ -103,8 +106,10 @@ interface Tunnel3
    ipv6 enable
    ipv6 address beef::64/64
    tcp mss ceiling ipv4 666 ipv6 666
+   tunnel mode ipsec
    tunnel source interface Ethernet42
    tunnel destination 1.1.1.1
+   tunnel ipsec profile Profile-3
 !
 interface Tunnel4
    description test no tcp_mss
@@ -112,6 +117,7 @@ interface Tunnel4
    ip address 64.64.64.64/24
    ipv6 enable
    ipv6 address beef::64/64
+   ip nat service-profile NAT-PROFILE-NO-VRF-1
    tunnel source interface Ethernet42
    tunnel destination 1.1.1.1
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/tunnel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/tunnel-interfaces.md
@@ -44,7 +44,7 @@ interface Management1
 | Interface | Description | VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
 | --------- | ----------- | --- | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
 | Tunnel1 | test ipv4 only | Tunnel-VRF | 1500 | False | - | ipsec | Ethernet42 | 6.6.6.6 | True | - |
-| Tunnel2 | test ipv6 only | default | - | True | NAT-PROFILE-NO-VRF-2 | gre | Ethernet42 | dead:beef::1 | False | - |
+| Tunnel2 | test ipv6 only | default | - | True | NAT-PROFILE-NO-VRF-2 | gre | Ethernet42 | dead:beef::1 | False | Profile-2 |
 | Tunnel3 | test dual stack | default | 1500 | - | - | ipsec | Ethernet42 | 1.1.1.1 | - | Profile-3 |
 | Tunnel4 | test no tcp_mss | default | 1500 | - | NAT-PROFILE-NO-VRF-1 | - | Ethernet42 | 1.1.1.1 | - | - |
 
@@ -98,6 +98,7 @@ interface Tunnel2
    tunnel mode gre
    tunnel source interface Ethernet42
    tunnel destination dead:beef::1
+   tunnel ipsec profile Profile-2
 !
 interface Tunnel3
    description test dual stack

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/tunnel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/tunnel-interfaces.cfg
@@ -42,6 +42,7 @@ interface Tunnel2
    tunnel mode gre
    tunnel source interface Ethernet42
    tunnel destination dead:beef::1
+   tunnel ipsec profile Profile-2
 !
 interface Tunnel3
    description test dual stack

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/tunnel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/tunnel-interfaces.cfg
@@ -21,6 +21,7 @@ interface Tunnel1
    ip access-group test-in in
    ip access-group test-out out
    tcp mss ceiling ipv4 666 ingress
+   tunnel mode ipsec
    tunnel source interface Ethernet42
    tunnel destination 6.6.6.6
    tunnel path-mtu-discovery
@@ -37,6 +38,8 @@ interface Tunnel2
    ipv6 access-group test-in in
    ipv6 access-group test-out out
    tcp mss ceiling ipv6 666 egress
+   ip nat service-profile NAT-PROFILE-NO-VRF-2
+   tunnel mode gre
    tunnel source interface Ethernet42
    tunnel destination dead:beef::1
 !
@@ -47,8 +50,10 @@ interface Tunnel3
    ipv6 enable
    ipv6 address beef::64/64
    tcp mss ceiling ipv4 666 ipv6 666
+   tunnel mode ipsec
    tunnel source interface Ethernet42
    tunnel destination 1.1.1.1
+   tunnel ipsec profile Profile-3
 !
 interface Tunnel4
    description test no tcp_mss
@@ -56,6 +61,7 @@ interface Tunnel4
    ip address 64.64.64.64/24
    ipv6 enable
    ipv6 address beef::64/64
+   ip nat service-profile NAT-PROFILE-NO-VRF-1
    tunnel source interface Ethernet42
    tunnel destination 1.1.1.1
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/tunnel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/tunnel-interfaces.yml
@@ -12,6 +12,7 @@ tunnel_interfaces:
     tcp_mss_ceiling:
       ipv4: 666
       direction: ingress
+    tunnel_mode: ipsec
     source_interface: Ethernet42
     destination: 6.6.6.6
     path_mtu_discovery: true
@@ -29,9 +30,12 @@ tunnel_interfaces:
     tcp_mss_ceiling:
       ipv6: 666
       direction: egress
+    tunnel_mode: gre
     source_interface: Ethernet42
     destination: dead:beef::1
     path_mtu_discovery: false
+    ipsec_profile: Profile-2
+    nat_profile: NAT-PROFILE-NO-VRF-2
 
   - name: Tunnel3
     description: test dual stack
@@ -40,11 +44,13 @@ tunnel_interfaces:
     ipv6_enable: true
     ipv6_address: beef::64/64
     # no direction this time
+    tunnel_mode: ipsec
     tcp_mss_ceiling:
       ipv4: 666
       ipv6: 666
     source_interface: Ethernet42
     destination: 1.1.1.1
+    ipsec_profile: Profile-3
     # no PMTU
 
   - name: Tunnel4
@@ -54,5 +60,6 @@ tunnel_interfaces:
     ipv6_enable: true
     ipv6_address: beef::64/64
     # no tcp_mss_ceiling
+    nat_profile: NAT-PROFILE-NO-VRF-1
     source_interface: Ethernet42
     destination: 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -785,10 +785,10 @@ interface Loopback1
 
 #### Tunnel Interfaces Summary
 
-| Interface | Description | VRF | MTU | Shutdown | Source Interface | Destination | PMTU-Discovery |
-| --------- | ----------- | --- | --- | -------- | ---------------- | ----------- | -------------- |
-| Tunnel3 | test dual stack | default | 1500 | - | Ethernet42 | 1.1.1.1 | - |
-| Tunnel4 | test no tcp_mss | default | 1500 | - | Ethernet42 | 1.1.1.1 | - |
+| Interface | Description | VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
+| --------- | ----------- | --- | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
+| Tunnel3 | test dual stack | default | 1500 | - | - | - | Ethernet42 | 1.1.1.1 | - | - |
+| Tunnel4 | test no tcp_mss | default | 1500 | - | - | - | Ethernet42 | 1.1.1.1 | - | - |
 
 ##### IPv4
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tunnel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tunnel-interfaces.md
@@ -24,9 +24,12 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "tunnel_interfaces.[].tcp_mss_ceiling.ipv4") | Integer |  |  | Min: 64<br>Max: 65495 | Segment Size for IPv4 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "tunnel_interfaces.[].tcp_mss_ceiling.ipv6") | Integer |  |  | Min: 64<br>Max: 65475 | Segment Size for IPv6 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "tunnel_interfaces.[].tcp_mss_ceiling.direction") | String |  |  | Valid Values:<br>- <code>ingress</code><br>- <code>egress</code> | Optional direction ('ingress', 'egress')  for tcp mss ceiling<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tunnel_mode</samp>](## "tunnel_interfaces.[].tunnel_mode") | String |  |  | Valid Values:<br>- <code>gre</code><br>- <code>ipsec</code> | Tunnel encapsulation method.<br>gre: Generic route encapsulation protocol,<br>ipsec: IPsec-over-IP encapsulation.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "tunnel_interfaces.[].source_interface") | String |  |  |  | Tunnel Source Interface Name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "tunnel_interfaces.[].destination") | String |  |  |  | IPv4 or IPv6 Address Tunnel Destination |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;path_mtu_discovery</samp>](## "tunnel_interfaces.[].path_mtu_discovery") | Boolean |  |  |  | Enable Path MTU Discovery On Tunnel |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipsec_profile</samp>](## "tunnel_interfaces.[].ipsec_profile") | String |  |  |  | Used only when tunnel_mode is set to ipsec.<br>It must target a defined IPsec profile.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;nat_profile</samp>](## "tunnel_interfaces.[].nat_profile") | String |  |  |  | It must target a defined NAT profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "tunnel_interfaces.[].eos_cli") | String |  |  |  | Multiline String with EOS CLI rendered directly on the Tunnel interface in the final EOS configuration.<br> |
 
 === "YAML"
@@ -72,6 +75,11 @@
           # Optional direction ('ingress', 'egress')  for tcp mss ceiling
           direction: <str; "ingress" | "egress">
 
+        # Tunnel encapsulation method.
+        # gre: Generic route encapsulation protocol,
+        # ipsec: IPsec-over-IP encapsulation.
+        tunnel_mode: <str; "gre" | "ipsec">
+
         # Tunnel Source Interface Name
         source_interface: <str>
 
@@ -80,6 +88,13 @@
 
         # Enable Path MTU Discovery On Tunnel
         path_mtu_discovery: <bool>
+
+        # Used only when tunnel_mode is set to ipsec.
+        # It must target a defined IPsec profile.
+        ipsec_profile: <str>
+
+        # It must target a defined NAT profile.
+        nat_profile: <str>
 
         # Multiline String with EOS CLI rendered directly on the Tunnel interface in the final EOS configuration.
         eos_cli: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tunnel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tunnel-interfaces.md
@@ -29,7 +29,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "tunnel_interfaces.[].destination") | String |  |  |  | IPv4 or IPv6 Address Tunnel Destination |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;path_mtu_discovery</samp>](## "tunnel_interfaces.[].path_mtu_discovery") | Boolean |  |  |  | Enable Path MTU Discovery On Tunnel |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipsec_profile</samp>](## "tunnel_interfaces.[].ipsec_profile") | String |  |  |  | Used only when tunnel_mode is set to ipsec.<br>It must target a defined IPsec profile.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;nat_profile</samp>](## "tunnel_interfaces.[].nat_profile") | String |  |  |  | It must target a defined NAT profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;nat_profile</samp>](## "tunnel_interfaces.[].nat_profile") | String |  |  |  | NAT interface profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "tunnel_interfaces.[].eos_cli") | String |  |  |  | Multiline String with EOS CLI rendered directly on the Tunnel interface in the final EOS configuration.<br> |
 
 === "YAML"
@@ -93,7 +93,7 @@
         # It must target a defined IPsec profile.
         ipsec_profile: <str>
 
-        # It must target a defined NAT profile.
+        # NAT interface profile.
         nat_profile: <str>
 
         # Multiline String with EOS CLI rendered directly on the Tunnel interface in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tunnel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tunnel-interfaces.md
@@ -24,11 +24,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "tunnel_interfaces.[].tcp_mss_ceiling.ipv4") | Integer |  |  | Min: 64<br>Max: 65495 | Segment Size for IPv4 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "tunnel_interfaces.[].tcp_mss_ceiling.ipv6") | Integer |  |  | Min: 64<br>Max: 65475 | Segment Size for IPv6 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "tunnel_interfaces.[].tcp_mss_ceiling.direction") | String |  |  | Valid Values:<br>- <code>ingress</code><br>- <code>egress</code> | Optional direction ('ingress', 'egress')  for tcp mss ceiling<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tunnel_mode</samp>](## "tunnel_interfaces.[].tunnel_mode") | String |  |  | Valid Values:<br>- <code>gre</code><br>- <code>ipsec</code> | Tunnel encapsulation method.<br>gre: Generic route encapsulation protocol,<br>ipsec: IPsec-over-IP encapsulation.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tunnel_mode</samp>](## "tunnel_interfaces.[].tunnel_mode") | String |  |  | Valid Values:<br>- <code>gre</code><br>- <code>ipsec</code> | Tunnel encapsulation method.<br>`gre`: Generic route encapsulation protocol,<br>`ipsec`: IPsec-over-IP encapsulation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "tunnel_interfaces.[].source_interface") | String |  |  |  | Tunnel Source Interface Name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "tunnel_interfaces.[].destination") | String |  |  |  | IPv4 or IPv6 Address Tunnel Destination |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;path_mtu_discovery</samp>](## "tunnel_interfaces.[].path_mtu_discovery") | Boolean |  |  |  | Enable Path MTU Discovery On Tunnel |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipsec_profile</samp>](## "tunnel_interfaces.[].ipsec_profile") | String |  |  |  | Used only when tunnel_mode is set to ipsec.<br>It must target a defined IPsec profile.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipsec_profile</samp>](## "tunnel_interfaces.[].ipsec_profile") | String |  |  |  | Used only when `tunnel_mode` is set to `ipsec`.<br>It must target a defined IPsec profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;nat_profile</samp>](## "tunnel_interfaces.[].nat_profile") | String |  |  |  | NAT interface profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "tunnel_interfaces.[].eos_cli") | String |  |  |  | Multiline String with EOS CLI rendered directly on the Tunnel interface in the final EOS configuration.<br> |
 
@@ -76,8 +76,8 @@
           direction: <str; "ingress" | "egress">
 
         # Tunnel encapsulation method.
-        # gre: Generic route encapsulation protocol,
-        # ipsec: IPsec-over-IP encapsulation.
+        # `gre`: Generic route encapsulation protocol,
+        # `ipsec`: IPsec-over-IP encapsulation.
         tunnel_mode: <str; "gre" | "ipsec">
 
         # Tunnel Source Interface Name
@@ -89,7 +89,7 @@
         # Enable Path MTU Discovery On Tunnel
         path_mtu_discovery: <bool>
 
-        # Used only when tunnel_mode is set to ipsec.
+        # Used only when `tunnel_mode` is set to `ipsec`.
         # It must target a defined IPsec profile.
         ipsec_profile: <str>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -26390,7 +26390,7 @@
           },
           "nat_profile": {
             "type": "string",
-            "description": "It must target a defined NAT profile.",
+            "description": "NAT interface profile.",
             "title": "Nat Profile"
           },
           "eos_cli": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -26359,6 +26359,15 @@
             },
             "title": "TCP Mss Ceiling"
           },
+          "tunnel_mode": {
+            "type": "string",
+            "enum": [
+              "gre",
+              "ipsec"
+            ],
+            "description": "Tunnel encapsulation method.\ngre: Generic route encapsulation protocol,\nipsec: IPsec-over-IP encapsulation.\n",
+            "title": "Tunnel Mode"
+          },
           "source_interface": {
             "type": "string",
             "description": "Tunnel Source Interface Name",
@@ -26373,6 +26382,16 @@
             "type": "boolean",
             "description": "Enable Path MTU Discovery On Tunnel",
             "title": "Path MTU Discovery"
+          },
+          "ipsec_profile": {
+            "type": "string",
+            "description": "Used only when tunnel_mode is set to ipsec.\nIt must target a defined IPsec profile.\n",
+            "title": "Ipsec Profile"
+          },
+          "nat_profile": {
+            "type": "string",
+            "description": "It must target a defined NAT profile.",
+            "title": "Nat Profile"
           },
           "eos_cli": {
             "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -26365,7 +26365,7 @@
               "gre",
               "ipsec"
             ],
-            "description": "Tunnel encapsulation method.\ngre: Generic route encapsulation protocol,\nipsec: IPsec-over-IP encapsulation.\n",
+            "description": "Tunnel encapsulation method.\n`gre`: Generic route encapsulation protocol,\n`ipsec`: IPsec-over-IP encapsulation.",
             "title": "Tunnel Mode"
           },
           "source_interface": {
@@ -26385,7 +26385,7 @@
           },
           "ipsec_profile": {
             "type": "string",
-            "description": "Used only when tunnel_mode is set to ipsec.\nIt must target a defined IPsec profile.\n",
+            "description": "Used only when `tunnel_mode` is set to `ipsec`.\nIt must target a defined IPsec profile.",
             "title": "Ipsec Profile"
           },
           "nat_profile": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -15229,11 +15229,9 @@ keys:
           - ipsec
           description: 'Tunnel encapsulation method.
 
-            gre: Generic route encapsulation protocol,
+            `gre`: Generic route encapsulation protocol,
 
-            ipsec: IPsec-over-IP encapsulation.
-
-            '
+            `ipsec`: IPsec-over-IP encapsulation.'
         source_interface:
           type: str
           description: Tunnel Source Interface Name
@@ -15245,11 +15243,9 @@ keys:
           description: Enable Path MTU Discovery On Tunnel
         ipsec_profile:
           type: str
-          description: 'Used only when tunnel_mode is set to ipsec.
+          description: 'Used only when `tunnel_mode` is set to `ipsec`.
 
-            It must target a defined IPsec profile.
-
-            '
+            It must target a defined IPsec profile.'
         nat_profile:
           type: str
           description: NAT interface profile.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -15222,6 +15222,18 @@ keys:
                 mss ceiling
 
                 '
+        tunnel_mode:
+          type: str
+          valid_values:
+          - gre
+          - ipsec
+          description: 'Tunnel encapsulation method.
+
+            gre: Generic route encapsulation protocol,
+
+            ipsec: IPsec-over-IP encapsulation.
+
+            '
         source_interface:
           type: str
           description: Tunnel Source Interface Name
@@ -15231,6 +15243,16 @@ keys:
         path_mtu_discovery:
           type: bool
           description: Enable Path MTU Discovery On Tunnel
+        ipsec_profile:
+          type: str
+          description: 'Used only when tunnel_mode is set to ipsec.
+
+            It must target a defined IPsec profile.
+
+            '
+        nat_profile:
+          type: str
+          description: It must target a defined NAT profile.
         eos_cli:
           type: str
           description: 'Multiline String with EOS CLI rendered directly on the Tunnel

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -15252,7 +15252,7 @@ keys:
             '
         nat_profile:
           type: str
-          description: It must target a defined NAT profile.
+          description: NAT interface profile.
         eos_cli:
           type: str
           description: 'Multiline String with EOS CLI rendered directly on the Tunnel

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tunnel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tunnel_interfaces.schema.yml
@@ -79,10 +79,10 @@ keys:
         tunnel_mode:
           type: str
           valid_values: ["gre", "ipsec"]
-          description: |
+          description: |-
             Tunnel encapsulation method.
-            gre: Generic route encapsulation protocol,
-            ipsec: IPsec-over-IP encapsulation.
+            `gre`: Generic route encapsulation protocol,
+            `ipsec`: IPsec-over-IP encapsulation.
         source_interface:
           type: str
           description: Tunnel Source Interface Name
@@ -94,8 +94,8 @@ keys:
           description: Enable Path MTU Discovery On Tunnel
         ipsec_profile:
           type: str
-          description: |
-            Used only when tunnel_mode is set to ipsec.
+          description: |-
+            Used only when `tunnel_mode` is set to `ipsec`.
             It must target a defined IPsec profile.
         nat_profile:
           type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tunnel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tunnel_interfaces.schema.yml
@@ -76,6 +76,13 @@ keys:
               valid_values: ["ingress", "egress"]
               description: |
                 Optional direction ('ingress', 'egress')  for tcp mss ceiling
+        tunnel_mode:
+          type: str
+          valid_values: ["gre", "ipsec"]
+          description: |
+            Tunnel encapsulation method.
+            gre: Generic route encapsulation protocol,
+            ipsec: IPsec-over-IP encapsulation.
         source_interface:
           type: str
           description: Tunnel Source Interface Name
@@ -85,6 +92,14 @@ keys:
         path_mtu_discovery:
           type: bool
           description: Enable Path MTU Discovery On Tunnel
+        ipsec_profile:
+          type: str
+          description: |
+            Used only when tunnel_mode is set to ipsec.
+            It must target a defined IPsec profile.
+        nat_profile:
+          type: str
+          description: It must target a defined NAT profile.
         eos_cli:
           type: str
           description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tunnel_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/tunnel_interfaces.schema.yml
@@ -99,7 +99,7 @@ keys:
             It must target a defined IPsec profile.
         nat_profile:
           type: str
-          description: It must target a defined NAT profile.
+          description: NAT interface profile.
         eos_cli:
           type: str
           description: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tunnel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tunnel-interfaces.j2
@@ -30,7 +30,6 @@
 {%         set row_source_interface = tunnel_interface.source_interface | arista.avd.default("-") %}
 {%         set row_destination = tunnel_interface.destination | arista.avd.default("-") %}
 {%         set row_pmtu = tunnel_interface.path_mtu_discovery | arista.avd.default("-") %}
-{%         set ipsec_profile = "-" %}
 {%         set ipsec_profile = tunnel_interface.ipsec_profile | arista.avd.default("-") %}
 | {{ tunnel_interface.name }} | {{ description }} | {{ vrf }} | {{ mtu }} | {{ shutdown }} | {{ nat_profile }} | {{ tunnel_mode }} | {{ row_source_interface }} | {{ row_destination }} | {{ row_pmtu }} | {{ ipsec_profile }} |
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tunnel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tunnel-interfaces.j2
@@ -12,8 +12,8 @@
 
 {%     set tunnel_interfaces_ipv4 = [] %}
 {%     set tunnel_interfaces_ipv6 = [] %}
-| Interface | Description | VRF | MTU | Shutdown | Source Interface | Destination | PMTU-Discovery |
-| --------- | ----------- | --- | --- | -------- | ---------------- | ----------- | -------------- |
+| Interface | Description | VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
+| --------- | ----------- | --- | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
 {%     for tunnel_interface in tunnel_interfaces | arista.avd.natural_sort('name') %}
 {%         if tunnel_interface.ipv6_address is arista.avd.defined %}
 {%             do tunnel_interfaces_ipv6.append(tunnel_interface) %}
@@ -25,10 +25,16 @@
 {%         set vrf = tunnel_interface.vrf | arista.avd.default('default') %}
 {%         set mtu = tunnel_interface.mtu | arista.avd.default('-') %}
 {%         set shutdown = tunnel_interface.shutdown | arista.avd.default('-') %}
+{%         set nat_profile = tunnel_interface.nat_profile | arista.avd.default('-') %}
+{%         set tunnel_mode = tunnel_interface.tunnel_mode | arista.avd.default("-") %}
 {%         set row_source_interface = tunnel_interface.source_interface | arista.avd.default("-") %}
 {%         set row_destination = tunnel_interface.destination | arista.avd.default("-") %}
 {%         set row_pmtu = tunnel_interface.path_mtu_discovery | arista.avd.default("-") %}
-| {{ tunnel_interface.name }} | {{ description }} | {{ vrf }} | {{ mtu }} | {{ shutdown }} | {{ row_source_interface }} | {{ row_destination }} | {{ row_pmtu }} |
+{%         set ipsec_profile = "-" %}
+{%         if tunnel_mode == "ipsec" %}
+{%             set ipsec_profile = tunnel_interface.ipsec_profile | arista.avd.default("-") %}
+{%         endif %}
+| {{ tunnel_interface.name }} | {{ description }} | {{ vrf }} | {{ mtu }} | {{ shutdown }} | {{ nat_profile }} | {{ tunnel_mode }} | {{ row_source_interface }} | {{ row_destination }} | {{ row_pmtu }} | {{ ipsec_profile }} |
 {%     endfor %}
 {# IPv4 #}
 {%     if tunnel_interfaces_ipv4 | length > 0 %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tunnel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/tunnel-interfaces.j2
@@ -31,9 +31,7 @@
 {%         set row_destination = tunnel_interface.destination | arista.avd.default("-") %}
 {%         set row_pmtu = tunnel_interface.path_mtu_discovery | arista.avd.default("-") %}
 {%         set ipsec_profile = "-" %}
-{%         if tunnel_mode == "ipsec" %}
-{%             set ipsec_profile = tunnel_interface.ipsec_profile | arista.avd.default("-") %}
-{%         endif %}
+{%         set ipsec_profile = tunnel_interface.ipsec_profile | arista.avd.default("-") %}
 | {{ tunnel_interface.name }} | {{ description }} | {{ vrf }} | {{ mtu }} | {{ shutdown }} | {{ nat_profile }} | {{ tunnel_mode }} | {{ row_source_interface }} | {{ row_destination }} | {{ row_pmtu }} | {{ ipsec_profile }} |
 {%     endfor %}
 {# IPv4 #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tunnel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tunnel-interfaces.j2
@@ -55,6 +55,12 @@ interface {{ tunnel_interface.name }}
 {%         endif %}
    {{ tcp_mss_ceiling_cli }}
 {%     endif %}
+{%     if tunnel_interface.nat_profile is arista.avd.defined %}
+   ip nat service-profile {{ tunnel_interface.nat_profile }}
+{%     endif %}
+{%     if tunnel_interface.tunnel_mode is arista.avd.defined %}
+   tunnel mode {{ tunnel_interface.tunnel_mode }}
+{%     endif %}
 {%     if tunnel_interface.source_interface is arista.avd.defined %}
    tunnel source interface {{ tunnel_interface.source_interface }}
 {%     endif %}
@@ -63,6 +69,9 @@ interface {{ tunnel_interface.name }}
 {%     endif %}
 {%     if tunnel_interface.path_mtu_discovery is arista.avd.defined(true) %}
    tunnel path-mtu-discovery
+{%     endif %}
+{%     if tunnel_interface.ipsec_profile is arista.avd.defined and tunnel_interface.tunnel_mode == "ipsec" %}
+   tunnel ipsec profile {{ tunnel_interface.ipsec_profile }}
 {%     endif %}
 {%     if tunnel_interface.eos_cli is arista.avd.defined %}
    {{ tunnel_interface.eos_cli | indent(3, false) }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tunnel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/tunnel-interfaces.j2
@@ -70,7 +70,7 @@ interface {{ tunnel_interface.name }}
 {%     if tunnel_interface.path_mtu_discovery is arista.avd.defined(true) %}
    tunnel path-mtu-discovery
 {%     endif %}
-{%     if tunnel_interface.ipsec_profile is arista.avd.defined and tunnel_interface.tunnel_mode == "ipsec" %}
+{%     if tunnel_interface.ipsec_profile is arista.avd.defined %}
    tunnel ipsec profile {{ tunnel_interface.ipsec_profile }}
 {%     endif %}
 {%     if tunnel_interface.eos_cli is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Add ip nat service-profile, tunnel mode and tunnel ipsec profile to tunnel interfaces.

## Related Issue(s)

Fixes #3824 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
