### PR TITLE
Fix(plugins): Handle md-toc v9

### DIFF
--- a/ansible_collections/arista/avd/plugins/filter/add_md_toc.py
+++ b/ansible_collections/arista/avd/plugins/filter/add_md_toc.py
@@ -118,7 +118,12 @@ def add_md_toc(md_input, skip_lines=0, toc_levels=3, toc_marker="<!-- toc -->"):
     with StringIO(md_input) as md:
         stdin = sys.stdin
         sys.stdin = md
-        toc = md_toc.build_toc("-", keep_header_levels=toc_levels, skip_lines=skip_lines).rstrip()
+        try:
+            # Try using new md_toc api when md-toc>=9.0.0.
+            toc = md_toc.api.build_toc("-", keep_header_levels=toc_levels, skip_lines=skip_lines).rstrip()
+        except AttributeError:
+            # If that fails, use the previous version md-toc>=7.1.0,<9.0.0
+            toc = md_toc.build_toc("-", keep_header_levels=toc_levels, skip_lines=skip_lines).rstrip()
         sys.stdin = stdin
 
     # Insert TOC between markers

--- a/ansible_collections/arista/avd/tests/unit/filters/test_add_md_toc.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_add_md_toc.py
@@ -40,7 +40,12 @@ class TestAddMdTocFilter:
             toc_output = m.search(resp).group(2)
 
             # Generate TOC for input file
-            toc_input = md_toc.build_toc(MD_INPUT, list_marker="-", keep_header_levels=TOC_LEVEL, skip_lines=SKIP_LINES)
+            try:
+                # Try using new md_toc api when md-toc>=9.0.0.
+                toc_input = md_toc.api.build_toc(MD_INPUT, list_marker="-", keep_header_levels=TOC_LEVEL, skip_lines=SKIP_LINES)
+            except AttributeError:
+                # If that fails, use the previous version md-toc>=7.1.0,<9.0.0
+                toc_input = md_toc.build_toc(MD_INPUT, list_marker="-", keep_header_levels=TOC_LEVEL, skip_lines=SKIP_LINES)
 
             assert toc_output.strip() == toc_input.strip()
 


### PR DESCRIPTION
## Change Summary

The new version of md-toc 9.0.0 has breaking API changes and  `md_toc.build_toc` becomes `md_toc.api.build_toc`.
Handle both new and old versions of md-toc in `arista.avd.add_md_toc` plugin.

## Related Issue(s)

Fixes #3835 

## Component(s) name

`arista.avd.add_md_toc`

## Proposed changes
Add try expect block in `arista.avd.add_md_toc` to handle both new and old version of md-toc

## How to test

CI Passes all tests
Test eos_cli_config_gen documentation with both new md-toc 9.0.0 and old md-toc 8.2.3.
