### PR TITLE
Fix(pyavd): Remove accidental requirement for PyYAML

### DIFF
--- a/python-avd/Makefile
+++ b/python-avd/Makefile
@@ -71,7 +71,9 @@ copy-libs: ## Copy files from Ansible AVD collection
 .PHONY: fix-libs
 fix-libs: ## Fix/remove various Ansible specifics things from python files
 	rm -f $(VENDOR_DIR)/schema/avdschematools.py
-
+	rm -f $(VENDOR_DIR)/utils/yaml_dumper.py
+	rm -f $(VENDOR_DIR)/utils/yaml_loader.py
+	sed -i -e '/Yaml/d' $(VENDOR_DIR)/utils/__init__.py
 	find $(PACKAGE_DIR) -name '__pycache__' -exec rm -rf {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/^from __future__ import.*/from __future__ import annotations/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e '/^__metaclass__ = type/d' {} +


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove accidental requirement for PyYAML

## Related Issue(s)

Fixes #3834 

## Component(s) name

`PyAVD`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

PyAVD vendors in code from ansible-avd, including all utilities, even if they are not being used in PyAVD.
This resulted in getting some YAML related utils into PyAVD, which in turn leads to failures when PyYAML is not installed.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
