### PR TITLE
Feat(eos_cli_config_gen): Support port-only option in IP NAT pools

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
@@ -113,7 +113,6 @@ NAT profile VRF is: TEST
 | Setting | Value |
 | -------- | ----- |
 | Type | port-only |
-
 ##### Port Ranges
 
 | First Port | Last Port |
@@ -241,11 +240,11 @@ ip nat pool prefix_24 prefix-length 24
 ip nat pool prefix_32 prefix-length 32
    range 10.2.0.1 10.2.0.1 1024 65535
 ip nat pool prefix_no_type prefix-length 21
-ip nat pool prefix_16 port-only 
+ip nat pool prefix_16 port-only
    port range 1023 65534
    port range 1024 65535
    port range 1022 65525
-ip nat pool prefix_port_only port-only 
+ip nat pool prefix_port_only port-only
 ip nat synchronization
    description test sync config
    expiry-interval 60

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
@@ -108,67 +108,14 @@ NAT profile VRF is: TEST
 
 ### NAT Pools
 
-#### Pool: prefix_16
-
-| Setting | Value |
-| -------- | ----- |
-| Type | ip-port |
-| Pool Prefix Length | 16 |
-
-##### Pool Ranges
-
-| First IP Address  | Last IP Address | First Port | Last Port |
-| ----------------- | --------------- | ---------- | --------- |
-| 10.0.0.1 | 10.0.255.254 | - | - |
-| 10.1.0.0 | 10.1.255.255 | 1024 | 65535 |
-
-#### Pool: prefix_32
-
-| Setting | Value |
-| -------- | ----- |
-| Type | ip-port |
-| Pool Prefix Length | 32 |
-
-##### Pool Ranges
-
-| First IP Address  | Last IP Address | First Port | Last Port |
-| ----------------- | --------------- | ---------- | --------- |
-| 10.2.0.1 | 10.2.0.1 | 1024 | 65535 |
-| 10.2.0.2 | 10.2.0.3 | - | - |
-
-#### Pool: prefix_24
-
-| Setting | Value |
-| -------- | ----- |
-| Type | ip-port |
-| Pool Prefix Length | 24 |
-| Pool Utilization Threshold | 100 % (action: log) |
-
-#### Pool: prefix_no_type
-
-| Setting | Value |
-| -------- | ----- |
-| Type | ip-port |
-| Pool Prefix Length | 21 |
-
-#### Pool: prefix_port_only
-
-| Setting | Value |
-| -------- | ----- |
-| Type | port-only |
-
-#### Pool: prefix_17
-
-| Setting | Value |
-| -------- | ----- |
-| Type | port-only |
-
-##### Port Ranges
-
-| First Port | Last Port |
-| ---------- | --------- |
-| 10 | 15 |
-| 1024 | 65535 |
+| Pool Name | Pool Type | Prefix Length | Utilization Log Threshold | First-Last IP Addresses | First-Last Ports |
+| --------- | --------- | ------------- | ------------------------- | ----------------------- | ---------------- |
+| port_only_1 | port-only | - | - | - | - |
+| port_only_2 | port-only | - | - | - | 10 - 15,<br>1024 - 65535 |
+| prefix_16 | ip-port | 16 | 91 | 10.0.0.1 - 10.0.255.254,<br>10.1.0.0 - 10.1.255.255 |  - ,<br>1024 - 65535 |
+| prefix_21 | ip-port | 21 | - | - | - |
+| prefix_24 | ip-port | 24 | 100 | - | - |
+| prefix_32 | ip-port | 32 | - | 10.2.0.1 - 10.2.0.1,<br>10.2.0.2 - 10.2.0.3 | 1024 - 65535,<br> -  |
 
 ### NAT Synchronization
 
@@ -253,16 +200,17 @@ ip nat profile NAT-PROFILE-TEST-VRF vrf NAT-PROFILE-TEST-VRF
 ip nat pool prefix_16 prefix-length 16
    range 10.0.0.1 10.0.255.254
    range 10.1.0.0 10.1.255.255 1024 65535
+   utilization threshold 91 action log
+ip nat pool prefix_21 prefix-length 21
 ip nat pool prefix_24 prefix-length 24
    utilization threshold 100 action log
 ip nat pool prefix_32 prefix-length 32
    range 10.2.0.1 10.2.0.1 1024 65535
    range 10.2.0.2 10.2.0.3
-ip nat pool prefix_no_type prefix-length 21
-ip nat pool prefix_17 port-only
+ip nat pool port_only_1 port-only
+ip nat pool port_only_2 port-only
    port range 10 15
    port range 1024 65535
-ip nat pool prefix_port_only port-only
 ip nat synchronization
    description test sync config
    expiry-interval 60

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
@@ -112,15 +112,15 @@ NAT profile VRF is: TEST
 
 | Setting | Value |
 | -------- | ----- |
-| Type | port-only |
+| Type | ip-port |
+| Pool Prefix Length | 16 |
 
-##### Port Ranges
+##### Pool Ranges
 
-| First Port | Last Port |
-| ---------- | --------- |
-| 1023 | 65534 |
-| 1024 | 65535 |
-| 1022 | 65525 |
+| First IP Address  | Last IP Address | First Port | Last Port |
+| ----------------- | --------------- | ---------- | --------- |
+| 10.0.0.1 | 10.0.255.254 | - | - |
+| 10.1.0.0 | 10.1.255.255 | 1024 | 65535 |
 
 #### Pool: prefix_32
 
@@ -134,6 +134,7 @@ NAT profile VRF is: TEST
 | First IP Address  | Last IP Address | First Port | Last Port |
 | ----------------- | --------------- | ---------- | --------- |
 | 10.2.0.1 | 10.2.0.1 | 1024 | 65535 |
+| 10.2.0.2 | 10.2.0.3 | - | - |
 
 #### Pool: prefix_24
 
@@ -155,6 +156,19 @@ NAT profile VRF is: TEST
 | Setting | Value |
 | -------- | ----- |
 | Type | port-only |
+
+#### Pool: prefix_17
+
+| Setting | Value |
+| -------- | ----- |
+| Type | port-only |
+
+##### Port Ranges
+
+| First Port | Last Port |
+| ---------- | --------- |
+| 10 | 15 |
+| 1024 | 65535 |
 
 ### NAT Synchronization
 
@@ -236,15 +250,18 @@ ip nat profile NAT-PROFILE-NO-VRF-2
 !
 ip nat profile NAT-PROFILE-TEST-VRF vrf NAT-PROFILE-TEST-VRF
 !
+ip nat pool prefix_16 prefix-length 16
+   range 10.0.0.1 10.0.255.254
+   range 10.1.0.0 10.1.255.255 1024 65535
 ip nat pool prefix_24 prefix-length 24
    utilization threshold 100 action log
 ip nat pool prefix_32 prefix-length 32
    range 10.2.0.1 10.2.0.1 1024 65535
+   range 10.2.0.2 10.2.0.3
 ip nat pool prefix_no_type prefix-length 21
-ip nat pool prefix_16 port-only
-   port range 1023 65534
+ip nat pool prefix_17 port-only
+   port range 10 15
    port range 1024 65535
-   port range 1022 65525
 ip nat pool prefix_port_only port-only
 ip nat synchronization
    description test sync config

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
@@ -112,41 +112,49 @@ NAT profile VRF is: TEST
 
 | Setting | Value |
 | -------- | ----- |
-| Pool Prefix Length | 16 |
-| Pool Utilization Threshold | 1 % (action: log) |
+| Type | port-only |
 
-##### Pool Ranges
+##### Port Ranges
 
-| First IP Address  | Last IP Address | First Port | Last Port |
-| ----------------- | --------------- | ---------- | --------- |
-| 10.0.0.1 | 10.0.255.254 | - | - |
-| 10.1.0.0 | 10.1.255.255 | 1024 | 65535 |
+| First Port | Last Port |
+| ---------- | --------- |
+| 1023 | 65534 |
+| 1024 | 65535 |
+| 1022 | 65525 |
 
 #### Pool: prefix_32
 
 | Setting | Value |
 | -------- | ----- |
+| Type | ip-port |
 | Pool Prefix Length | 32 |
 
 ##### Pool Ranges
 
 | First IP Address  | Last IP Address | First Port | Last Port |
 | ----------------- | --------------- | ---------- | --------- |
-| 10.2.0.1 | 10.2.0.1 | - | - |
+| 10.2.0.1 | 10.2.0.1 | 1024 | 65535 |
 
 #### Pool: prefix_24
 
 | Setting | Value |
 | -------- | ----- |
+| Type | ip-port |
 | Pool Prefix Length | 24 |
 | Pool Utilization Threshold | 100 % (action: log) |
 
-##### Pool Ranges
+#### Pool: prefix_no_type
 
-| First IP Address  | Last IP Address | First Port | Last Port |
-| ----------------- | --------------- | ---------- | --------- |
-| 10.3.0.1 | 10.3.0.254 | - | - |
-| 10.3.1.0 | 10.3.1.255 | 1024 | 65535 |
+| Setting | Value |
+| -------- | ----- |
+| Type | ip-port |
+| Pool Prefix Length | 21 |
+
+#### Pool: prefix_port_only
+
+| Setting | Value |
+| -------- | ----- |
+| Type | port-only |
 
 ### NAT Synchronization
 
@@ -228,16 +236,16 @@ ip nat profile NAT-PROFILE-NO-VRF-2
 !
 ip nat profile NAT-PROFILE-TEST-VRF vrf NAT-PROFILE-TEST-VRF
 !
-ip nat pool prefix_16 prefix-length 16
-   range 10.0.0.1 10.0.255.254
-   range 10.1.0.0 10.1.255.255 1024 65535
-   utilization threshold 1 action log
-ip nat pool prefix_32 prefix-length 32
-   range 10.2.0.1 10.2.0.1
 ip nat pool prefix_24 prefix-length 24
-   range 10.3.0.1 10.3.0.254
-   range 10.3.1.0 10.3.1.255 1024 65535
    utilization threshold 100 action log
+ip nat pool prefix_32 prefix-length 32
+   range 10.2.0.1 10.2.0.1 1024 65535
+ip nat pool prefix_no_type prefix-length 21
+ip nat pool prefix_16 port-only 
+   port range 1023 65534
+   port range 1024 65535
+   port range 1022 65525
+ip nat pool prefix_port_only port-only 
 ip nat synchronization
    description test sync config
    expiry-interval 60

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
@@ -111,11 +111,11 @@ NAT profile VRF is: TEST
 | Pool Name | Pool Type | Prefix Length | Utilization Log Threshold | First-Last IP Addresses | First-Last Ports |
 | --------- | --------- | ------------- | ------------------------- | ----------------------- | ---------------- |
 | port_only_1 | port-only | - | - | - | - |
-| port_only_2 | port-only | - | - | - | 10 - 15,<br>1024 - 65535 |
-| prefix_16 | ip-port | 16 | 91 | 10.0.0.1 - 10.0.255.254,<br>10.1.0.0 - 10.1.255.255 |  - ,<br>1024 - 65535 |
+| port_only_2 | port-only | - | - | - | 10-15<br>1024-65535 |
+| prefix_16 | ip-port | 16 | 91 | 10.0.0.1-10.0.255.254<br>10.1.0.0-10.1.255.255 | -<br>1024-65535 |
 | prefix_21 | ip-port | 21 | - | - | - |
 | prefix_24 | ip-port | 24 | 100 | - | - |
-| prefix_32 | ip-port | 32 | - | 10.2.0.1 - 10.2.0.1,<br>10.2.0.2 - 10.2.0.3 | 1024 - 65535,<br> -  |
+| prefix_32 | ip-port | 32 | - | 10.2.0.1-10.2.0.1<br>10.2.0.2-10.2.0.3 | 1024-65535<br>- |
 
 ### NAT Synchronization
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
@@ -113,6 +113,7 @@ NAT profile VRF is: TEST
 | Setting | Value |
 | -------- | ----- |
 | Type | port-only |
+
 ##### Port Ranges
 
 | First Port | Last Port |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
@@ -61,16 +61,16 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
-ip nat pool prefix_16 prefix-length 16
-   range 10.0.0.1 10.0.255.254
-   range 10.1.0.0 10.1.255.255 1024 65535
-   utilization threshold 1 action log
-ip nat pool prefix_32 prefix-length 32
-   range 10.2.0.1 10.2.0.1
 ip nat pool prefix_24 prefix-length 24
-   range 10.3.0.1 10.3.0.254
-   range 10.3.1.0 10.3.1.255 1024 65535
    utilization threshold 100 action log
+ip nat pool prefix_32 prefix-length 32
+   range 10.2.0.1 10.2.0.1 1024 65535
+ip nat pool prefix_no_type prefix-length 21
+ip nat pool prefix_16 port-only 
+   port range 1023 65534
+   port range 1024 65535
+   port range 1022 65525
+ip nat pool prefix_port_only port-only 
 ip nat synchronization
    description test sync config
    expiry-interval 60

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
@@ -66,11 +66,11 @@ ip nat pool prefix_24 prefix-length 24
 ip nat pool prefix_32 prefix-length 32
    range 10.2.0.1 10.2.0.1 1024 65535
 ip nat pool prefix_no_type prefix-length 21
-ip nat pool prefix_16 port-only 
+ip nat pool prefix_16 port-only
    port range 1023 65534
    port range 1024 65535
    port range 1022 65525
-ip nat pool prefix_port_only port-only 
+ip nat pool prefix_port_only port-only
 ip nat synchronization
    description test sync config
    expiry-interval 60

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
@@ -64,16 +64,17 @@ interface Management1
 ip nat pool prefix_16 prefix-length 16
    range 10.0.0.1 10.0.255.254
    range 10.1.0.0 10.1.255.255 1024 65535
+   utilization threshold 91 action log
+ip nat pool prefix_21 prefix-length 21
 ip nat pool prefix_24 prefix-length 24
    utilization threshold 100 action log
 ip nat pool prefix_32 prefix-length 32
    range 10.2.0.1 10.2.0.1 1024 65535
    range 10.2.0.2 10.2.0.3
-ip nat pool prefix_no_type prefix-length 21
-ip nat pool prefix_17 port-only
+ip nat pool port_only_1 port-only
+ip nat pool port_only_2 port-only
    port range 10 15
    port range 1024 65535
-ip nat pool prefix_port_only port-only
 ip nat synchronization
    description test sync config
    expiry-interval 60

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
@@ -61,15 +61,18 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
+ip nat pool prefix_16 prefix-length 16
+   range 10.0.0.1 10.0.255.254
+   range 10.1.0.0 10.1.255.255 1024 65535
 ip nat pool prefix_24 prefix-length 24
    utilization threshold 100 action log
 ip nat pool prefix_32 prefix-length 32
    range 10.2.0.1 10.2.0.1 1024 65535
+   range 10.2.0.2 10.2.0.3
 ip nat pool prefix_no_type prefix-length 21
-ip nat pool prefix_16 port-only
-   port range 1023 65534
+ip nat pool prefix_17 port-only
+   port range 10 15
    port range 1024 65535
-   port range 1022 65525
 ip nat pool prefix_port_only port-only
 ip nat synchronization
    description test sync config

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-nat.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-nat.yml
@@ -3,18 +3,15 @@ ip_nat:
   kernel_buffer_size: 64
   pools:
     - name: prefix_16
-      type: port-only
+      type: ip-port
       prefix_length: 16
       ranges:
-        - first_port: 1023
-          last_port: 65534
+        - first_ip: 10.0.0.1
+          last_ip: 10.0.255.254
         - first_ip: 10.1.0.0
           last_ip: 10.1.255.255
           first_port: 1024
           last_port: 65535
-        - first_ip: 10.0.0.1
-          first_port: 1022
-          last_port: 65525
     - name: prefix_32
       type: ip-port
       prefix_length: 32
@@ -23,6 +20,8 @@ ip_nat:
           last_ip: 10.2.0.1
           first_port: 1024
           last_port: 65535
+        - first_ip: 10.2.0.2
+          last_ip: 10.2.0.3
     - name: prefix_24
       prefix_length: 24
       utilization_log_threshold: 100
@@ -30,6 +29,15 @@ ip_nat:
       prefix_length: 21
     - name: prefix_port_only
       type: port-only
+    - name: prefix_17
+      type: port-only
+      ranges:
+        - first_port: 10
+          last_port: 15
+        - first_ip: 10.1.0.0 # first_ip and last_ip will be ignored for port-only.
+          last_ip: 10.1.255.255
+          first_port: 1024
+          last_port: 65535
   synchronization:
     description: 'test sync config'
     expiry_interval: 60

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-nat.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-nat.yml
@@ -12,6 +12,7 @@ ip_nat:
           last_ip: 10.1.255.255
           first_port: 1024
           last_port: 65535
+      utilization_log_threshold: 91
     - name: prefix_32
       type: ip-port
       prefix_length: 32
@@ -25,11 +26,11 @@ ip_nat:
     - name: prefix_24
       prefix_length: 24
       utilization_log_threshold: 100
-    - name: prefix_no_type
+    - name: prefix_21
       prefix_length: 21
-    - name: prefix_port_only
+    - name: port_only_1
       type: port-only
-    - name: prefix_17
+    - name: port_only_2
       type: port-only
       ranges:
         - first_port: 10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-nat.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-nat.yml
@@ -3,30 +3,33 @@ ip_nat:
   kernel_buffer_size: 64
   pools:
     - name: prefix_16
+      type: port-only
       prefix_length: 16
       ranges:
-        - first_ip: 10.0.0.1
-          last_ip: 10.0.255.254
+        - first_port: 1023
+          last_port: 65534
         - first_ip: 10.1.0.0
           last_ip: 10.1.255.255
           first_port: 1024
           last_port: 65535
-      utilization_log_threshold: 1
+        - first_ip: 10.0.0.1
+          first_port: 1022
+          last_port: 65525
     - name: prefix_32
+      type: ip-port
       prefix_length: 32
       ranges:
         - first_ip: 10.2.0.1
           last_ip: 10.2.0.1
-    - name: prefix_24
-      prefix_length: 24
-      ranges:
-        - first_ip: 10.3.0.1
-          last_ip: 10.3.0.254
-        - first_ip: 10.3.1.0
-          last_ip: 10.3.1.255
           first_port: 1024
           last_port: 65535
+    - name: prefix_24
+      prefix_length: 24
       utilization_log_threshold: 100
+    - name: prefix_no_type
+      prefix_length: 21
+    - name: prefix_port_only
+      type: port-only
   synchronization:
     description: 'test sync config'
     expiry_interval: 60

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-nat.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-nat.md
@@ -49,12 +49,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;translated_port</samp>](## "ip_nat.profiles.[].source.static.[].translated_port") | Integer |  |  | Min: 1<br>Max: 65535 | requires 'original_port' |
     | [<samp>&nbsp;&nbsp;pools</samp>](## "ip_nat.pools") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_nat.pools.[].name") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_length</samp>](## "ip_nat.pools.[].prefix_length") | Integer | Required |  | Min: 16<br>Max: 32 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "ip_nat.pools.[].type") | String |  | `ip-port` | Valid Values:<br>- <code>ip-port</code><br>- <code>port-only</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_length</samp>](## "ip_nat.pools.[].prefix_length") | Integer |  |  | Min: 16<br>Max: 32 | It is only used and required when `type` is `ip-port`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ranges</samp>](## "ip_nat.pools.[].ranges") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;first_ip</samp>](## "ip_nat.pools.[].ranges.[].first_ip") | String | Required |  |  | IPv4 address |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;last_ip</samp>](## "ip_nat.pools.[].ranges.[].last_ip") | String | Required |  |  | IPv4 address |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;first_ip</samp>](## "ip_nat.pools.[].ranges.[].first_ip") | String |  |  |  | IPv4 address.<br>Required when `type` is `ip-port` and ignored otherwise. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;last_ip</samp>](## "ip_nat.pools.[].ranges.[].last_ip") | String |  |  |  | IPv4 address.<br>Required when `type` is `ip-port` and ignored otherwise. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;first_port</samp>](## "ip_nat.pools.[].ranges.[].first_port") | Integer |  |  | Min: 1<br>Max: 65535 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;last_port</samp>](## "ip_nat.pools.[].ranges.[].last_port") | Integer |  |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;last_port</samp>](## "ip_nat.pools.[].ranges.[].last_port") | Integer |  |  | Min: 1<br>Max: 65535 | Required when `first_port` is set. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;utilization_log_threshold</samp>](## "ip_nat.pools.[].utilization_log_threshold") | Integer |  |  | Min: 1<br>Max: 100 |  |
     | [<samp>&nbsp;&nbsp;synchronization</samp>](## "ip_nat.synchronization") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "ip_nat.synchronization.description") | String |  |  |  |  |
@@ -162,15 +163,22 @@
                 translated_port: <int; 1-65535>
       pools:
         - name: <str; required; unique>
-          prefix_length: <int; 16-32; required>
+          type: <str; "ip-port" | "port-only"; default="ip-port">
+
+          # It is only used and required when `type` is `ip-port`.
+          prefix_length: <int; 16-32>
           ranges:
 
-              # IPv4 address
-            - first_ip: <str; required>
+              # IPv4 address.
+              # Required when `type` is `ip-port` and ignored otherwise.
+            - first_ip: <str>
 
-              # IPv4 address
-              last_ip: <str; required>
+              # IPv4 address.
+              # Required when `type` is `ip-port` and ignored otherwise.
+              last_ip: <str>
               first_port: <int; 1-65535>
+
+              # Required when `first_port` is set.
               last_port: <int; 1-65535>
           utilization_log_threshold: <int; 1-100>
       synchronization:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-nat.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-nat.md
@@ -53,9 +53,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_length</samp>](## "ip_nat.pools.[].prefix_length") | Integer |  |  | Min: 16<br>Max: 32 | It is only used and required when `type` is `ip-port`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ranges</samp>](## "ip_nat.pools.[].ranges") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;first_ip</samp>](## "ip_nat.pools.[].ranges.[].first_ip") | String |  |  |  | IPv4 address.<br>Required when `type` is `ip-port` and ignored otherwise. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;last_ip</samp>](## "ip_nat.pools.[].ranges.[].last_ip") | String |  |  |  | IPv4 address.<br>Required when `type` is `ip-port` and ignored otherwise. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;last_ip</samp>](## "ip_nat.pools.[].ranges.[].last_ip") | String |  |  |  | IPv4 address.<br>Required when `type` is `ip-port` and ignored otherwise.<br>`first_ip` and `last_ip` ip addresses should lie in same subnet. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;first_port</samp>](## "ip_nat.pools.[].ranges.[].first_port") | Integer |  |  | Min: 1<br>Max: 65535 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;last_port</samp>](## "ip_nat.pools.[].ranges.[].last_port") | Integer |  |  | Min: 1<br>Max: 65535 | Required when `first_port` is set. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;last_port</samp>](## "ip_nat.pools.[].ranges.[].last_port") | Integer |  |  | Min: 1<br>Max: 65535 | Required when `first_port` is set.<br>`last_port` must be greater than or equal to `first_port`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;utilization_log_threshold</samp>](## "ip_nat.pools.[].utilization_log_threshold") | Integer |  |  | Min: 1<br>Max: 100 |  |
     | [<samp>&nbsp;&nbsp;synchronization</samp>](## "ip_nat.synchronization") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "ip_nat.synchronization.description") | String |  |  |  |  |
@@ -175,10 +175,12 @@
 
               # IPv4 address.
               # Required when `type` is `ip-port` and ignored otherwise.
+              # `first_ip` and `last_ip` ip addresses should lie in same subnet.
               last_ip: <str>
               first_port: <int; 1-65535>
 
               # Required when `first_port` is set.
+              # `last_port` must be greater than or equal to `first_port`.
               last_port: <int; 1-65535>
           utilization_log_threshold: <int; 1-100>
       synchronization:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7439,7 +7439,7 @@
                     },
                     "last_ip": {
                       "type": "string",
-                      "description": "IPv4 address.\nRequired when `type` is `ip-port` and ignored otherwise.",
+                      "description": "IPv4 address.\nRequired when `type` is `ip-port` and ignored otherwise.\n`first_ip` and `last_ip` ip addresses should lie in same subnet.",
                       "title": "Last IP"
                     },
                     "first_port": {
@@ -7452,7 +7452,7 @@
                       "type": "integer",
                       "minimum": 1,
                       "maximum": 65535,
-                      "description": "Required when `first_port` is set.",
+                      "description": "Required when `first_port` is set.\n`last_port` must be greater than or equal to `first_port`.",
                       "title": "Last Port"
                     }
                   },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7411,10 +7411,20 @@
                 "type": "string",
                 "title": "Name"
               },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "ip-port",
+                  "port-only"
+                ],
+                "default": "ip-port",
+                "title": "Type"
+              },
               "prefix_length": {
                 "type": "integer",
                 "minimum": 16,
                 "maximum": 32,
+                "description": "It is only used and required when `type` is `ip-port`.",
                 "title": "Prefix Length"
               },
               "ranges": {
@@ -7424,12 +7434,12 @@
                   "properties": {
                     "first_ip": {
                       "type": "string",
-                      "description": "IPv4 address",
+                      "description": "IPv4 address.\nRequired when `type` is `ip-port` and ignored otherwise.",
                       "title": "First IP"
                     },
                     "last_ip": {
                       "type": "string",
-                      "description": "IPv4 address",
+                      "description": "IPv4 address.\nRequired when `type` is `ip-port` and ignored otherwise.",
                       "title": "Last IP"
                     },
                     "first_port": {
@@ -7442,13 +7452,10 @@
                       "type": "integer",
                       "minimum": 1,
                       "maximum": 65535,
+                      "description": "Required when `first_port` is set.",
                       "title": "Last Port"
                     }
                   },
-                  "required": [
-                    "first_ip",
-                    "last_ip"
-                  ],
                   "additionalProperties": false,
                   "patternProperties": {
                     "^_.+$": {}
@@ -7463,14 +7470,13 @@
                 "title": "Utilization Log Threshold"
               }
             },
-            "required": [
-              "prefix_length",
-              "name"
-            ],
             "additionalProperties": false,
             "patternProperties": {
               "^_.+$": {}
-            }
+            },
+            "required": [
+              "name"
+            ]
           },
           "title": "Pools"
         },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4402,13 +4402,19 @@ keys:
           keys:
             name:
               type: str
+            type:
+              type: str
+              valid_values:
+              - ip-port
+              - port-only
+              default: ip-port
             prefix_length:
               type: int
-              required: true
               convert_types:
               - str
               min: 16
               max: 32
+              description: It is only used and required when `type` is `ip-port`.
             ranges:
               type: list
               items:
@@ -4416,12 +4422,14 @@ keys:
                 keys:
                   first_ip:
                     type: str
-                    required: true
-                    description: IPv4 address
+                    description: 'IPv4 address.
+
+                      Required when `type` is `ip-port` and ignored otherwise.'
                   last_ip:
                     type: str
-                    required: true
-                    description: IPv4 address
+                    description: 'IPv4 address.
+
+                      Required when `type` is `ip-port` and ignored otherwise.'
                   first_port:
                     type: int
                     convert_types:
@@ -4434,6 +4442,7 @@ keys:
                     - str
                     min: 1
                     max: 65535
+                    description: Required when `first_port` is set.
             utilization_log_threshold:
               type: int
               convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4429,7 +4429,9 @@ keys:
                     type: str
                     description: 'IPv4 address.
 
-                      Required when `type` is `ip-port` and ignored otherwise.'
+                      Required when `type` is `ip-port` and ignored otherwise.
+
+                      `first_ip` and `last_ip` ip addresses should lie in same subnet.'
                   first_port:
                     type: int
                     convert_types:
@@ -4442,7 +4444,9 @@ keys:
                     - str
                     min: 1
                     max: 65535
-                    description: Required when `first_port` is set.
+                    description: 'Required when `first_port` is set.
+
+                      `last_port` must be greater than or equal to `first_port`.'
             utilization_log_threshold:
               type: int
               convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_nat.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_nat.schema.yml
@@ -64,6 +64,7 @@ keys:
                     description: |-
                       IPv4 address.
                       Required when `type` is `ip-port` and ignored otherwise.
+                      `first_ip` and `last_ip` ip addresses should lie in same subnet.
                   first_port:
                     type: int
                     convert_types:
@@ -76,7 +77,9 @@ keys:
                       - str
                     min: 1
                     max: 65535
-                    description: Required when `first_port` is set.
+                    description: |-
+                      Required when `first_port` is set.
+                      `last_port` must be greater than or equal to `first_port`.
             utilization_log_threshold:
               type: int
               convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_nat.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_nat.schema.yml
@@ -38,13 +38,17 @@ keys:
           keys:
             name:
               type: str
+            type:
+              type: str
+              valid_values: ["ip-port", "port-only"]
+              default: "ip-port"
             prefix_length:
               type: int
-              required: true
               convert_types:
                 - str
               min: 16
               max: 32
+              description: It is only used and required when `type` is `ip-port`.
             ranges:
               type: list
               items:
@@ -52,12 +56,14 @@ keys:
                 keys:
                   first_ip:
                     type: str
-                    required: true
-                    description: IPv4 address
+                    description: |-
+                      IPv4 address.
+                      Required when `type` is `ip-port` and ignored otherwise.
                   last_ip:
                     type: str
-                    required: true
-                    description: IPv4 address
+                    description: |-
+                      IPv4 address.
+                      Required when `type` is `ip-port` and ignored otherwise.
                   first_port:
                     type: int
                     convert_types:
@@ -70,6 +76,7 @@ keys:
                       - str
                     min: 1
                     max: 65535
+                    description: Required when `first_port` is set.
             utilization_log_threshold:
               type: int
               convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
@@ -133,6 +133,7 @@ NAT profile VRF is: {{ profile.vrf }}
 {%         for pool in ip_nat.pools %}
 
 #### Pool: {{ pool.name }}
+
 {%             set pool_type = pool.type | arista.avd.default('ip-port') %}
 | Setting | Value |
 | -------- | ----- |
@@ -145,7 +146,9 @@ NAT profile VRF is: {{ profile.vrf }}
 | Pool Utilization Threshold | {{ pool.utilization_log_threshold }} % (action: log) |
 {%                 endif %}
 {%                 if pool.ranges is arista.avd.defined() %}
+
 ##### Pool Ranges
+
 | First IP Address  | Last IP Address | First Port | Last Port |
 | ----------------- | --------------- | ---------- | --------- |
 {%                     for range in pool.ranges | arista.avd.default([]) %}
@@ -155,7 +158,9 @@ NAT profile VRF is: {{ profile.vrf }}
 {%             endif %}
 {%             if pool_type == "port-only" %}
 {%                 if pool.ranges is arista.avd.defined() %}
+
 ##### Port Ranges
+
 | First Port | Last Port |
 | ---------- | --------- |
 {%                     for range in pool.ranges | arista.avd.default([]) %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
@@ -144,9 +144,9 @@ NAT profile VRF is: {{ profile.vrf }}
 {%             set first_last_port = [] %}
 {%             for range in pool.ranges | arista.avd.default([]) %}
 {%                 if pool_type == 'ip-port' %}
-{%                     do first_last_ip.append( range.first_ip | arista.avd.default('') ~ ' - ' ~ range.last_ip | arista.avd.default('') ) %}
+{%                     do first_last_ip.append(range.first_ip | arista.avd.default('') ~ '-' ~ range.last_ip | arista.avd.default('')) %}
 {%                 endif %}
-{%                 do first_last_port.append( range.first_port | arista.avd.default('') ~ ' - ' ~ range.last_port | arista.avd.default('') ) %}
+{%                 do first_last_port.append(range.first_port | arista.avd.default('') ~ '-' ~ range.last_port | arista.avd.default('')) %}
 {%             endfor %}
 {%             if first_last_ip == [] %}
 {%                 set first_last_ip = '-' %}
@@ -154,7 +154,7 @@ NAT profile VRF is: {{ profile.vrf }}
 {%             if first_last_port == [] %}
 {%                 set first_last_port = '-' %}
 {%             endif %}
-| {{ pool_name }} | {{ pool_type }} | {{ prefix_length | arista.avd.default('-') }} | {{ utilization_log_threshold | arista.avd.default('-') }} | {{ first_last_ip | join(',<br>') }} | {{ first_last_port | join(',<br>') }} |
+| {{ pool_name }} | {{ pool_type }} | {{ prefix_length | arista.avd.default('-') }} | {{ utilization_log_threshold | arista.avd.default('-') }} | {{ first_last_ip | join('<br>') }} | {{ first_last_port | join('<br>') }} |
 {%         endfor %}
 
 ### NAT Synchronization

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
@@ -130,45 +130,32 @@ NAT profile VRF is: {{ profile.vrf }}
 {%     if ip_nat.pools is arista.avd.defined %}
 
 ### NAT Pools
-{%         for pool in ip_nat.pools %}
-#### Pool: {{ pool.name }}
+
+| Pool Name | Pool Type | Prefix Length | Utilization Log Threshold | First-Last IP Addresses | First-Last Ports |
+| --------- | --------- | ------------- | ------------------------- | ----------------------- | ---------------- |
+{%         for pool in ip_nat.pools | arista.avd.natural_sort('name') %}
+{%             set pool_name = pool.name %}
 {%             set pool_type = pool.type | arista.avd.default('ip-port') %}
-| Setting | Value |
-| -------- | ----- |
-| Type | {{ pool_type }} |
 {%             if pool_type == 'ip-port' %}
-{%                 if pool.prefix_length is arista.avd.defined %}
-| Pool Prefix Length | {{ pool.prefix_length }} |
-{%                 endif %}
-{%                 if pool.utilization_log_threshold is arista.avd.defined %}
-| Pool Utilization Threshold | {{ pool.utilization_log_threshold }} % (action: log) |
-{%                 endif %}
-
-{%                 if pool.ranges is arista.avd.defined %}
-##### Pool Ranges
-
-| First IP Address  | Last IP Address | First Port | Last Port |
-| ----------------- | --------------- | ---------- | --------- |
-{%                     for range in pool.ranges | arista.avd.default([]) %}
-| {{ range.first_ip | arista.avd.default('-') }} | {{ range.last_ip | arista.avd.default('-') }} | {{ range.first_port | arista.avd.default('-') }} | {{ range.last_port | arista.avd.default('-') }} |
-{%                     endfor %}
-{%                 endif %}
+{%                 set prefix_length = pool.prefix_length | arista.avd.default('-') %}
+{%                 set utilization_log_threshold = pool.utilization_log_threshold | arista.avd.default('-') %}
 {%             endif %}
-
-{%             if pool_type == "port-only" %}
-{%                 if pool.ranges is arista.avd.defined %}
-##### Port Ranges
-
-| First Port | Last Port |
-| ---------- | --------- |
-{%                     for range in pool.ranges | arista.avd.default([]) %}
-| {{ range.first_port | arista.avd.default('-') }} | {{ range.last_port | arista.avd.default('-') }} |
-{%                     endfor %}
+{%             set first_last_ip = [] %}
+{%             set first_last_port = [] %}
+{%             for range in pool.ranges | arista.avd.default([]) %}
+{%                 if pool_type == 'ip-port' %}
+{%                     do first_last_ip.append( range.first_ip | arista.avd.default('') ~ ' - ' ~ range.last_ip | arista.avd.default('') ) %}
 {%                 endif %}
+{%                 do first_last_port.append( range.first_port | arista.avd.default('') ~ ' - ' ~ range.last_port | arista.avd.default('') ) %}
+{%             endfor %}
+{%             if first_last_ip == [] %}
+{%                 set first_last_ip = '-' %}
 {%             endif %}
+{%             if first_last_port == [] %}
+{%                 set first_last_port = '-' %}
+{%             endif %}
+| {{ pool_name }} | {{ pool_type }} | {{ prefix_length | arista.avd.default('-') }} | {{ utilization_log_threshold | arista.avd.default('-') }} | {{ first_last_ip | join(',<br>') }} | {{ first_last_port | join(',<br>') }} |
 {%         endfor %}
-{%     endif %}
-{%     if ip_nat.synchronization is arista.avd.defined %}
 
 ### NAT Synchronization
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
@@ -131,9 +131,7 @@ NAT profile VRF is: {{ profile.vrf }}
 
 ### NAT Pools
 {%         for pool in ip_nat.pools %}
-
 #### Pool: {{ pool.name }}
-
 {%             set pool_type = pool.type | arista.avd.default('ip-port') %}
 | Setting | Value |
 | -------- | ----- |
@@ -145,8 +143,8 @@ NAT profile VRF is: {{ profile.vrf }}
 {%                 if pool.utilization_log_threshold is arista.avd.defined %}
 | Pool Utilization Threshold | {{ pool.utilization_log_threshold }} % (action: log) |
 {%                 endif %}
-{%                 if pool.ranges is arista.avd.defined() %}
 
+{%                 if pool.ranges is arista.avd.defined %}
 ##### Pool Ranges
 
 | First IP Address  | Last IP Address | First Port | Last Port |
@@ -156,9 +154,9 @@ NAT profile VRF is: {{ profile.vrf }}
 {%                     endfor %}
 {%                 endif %}
 {%             endif %}
-{%             if pool_type == "port-only" %}
-{%                 if pool.ranges is arista.avd.defined() %}
 
+{%             if pool_type == "port-only" %}
+{%                 if pool.ranges is arista.avd.defined %}
 ##### Port Ranges
 
 | First Port | Last Port |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-nat.j2
@@ -133,21 +133,36 @@ NAT profile VRF is: {{ profile.vrf }}
 {%         for pool in ip_nat.pools %}
 
 #### Pool: {{ pool.name }}
-
+{%             set pool_type = pool.type | arista.avd.default('ip-port') %}
 | Setting | Value |
 | -------- | ----- |
+| Type | {{ pool_type }} |
+{%             if pool_type == 'ip-port' %}
+{%                 if pool.prefix_length is arista.avd.defined %}
 | Pool Prefix Length | {{ pool.prefix_length }} |
-{%             if pool.utilization_log_threshold is arista.avd.defined %}
+{%                 endif %}
+{%                 if pool.utilization_log_threshold is arista.avd.defined %}
 | Pool Utilization Threshold | {{ pool.utilization_log_threshold }} % (action: log) |
-{%             endif %}
-
+{%                 endif %}
+{%                 if pool.ranges is arista.avd.defined() %}
 ##### Pool Ranges
-
 | First IP Address  | Last IP Address | First Port | Last Port |
 | ----------------- | --------------- | ---------- | --------- |
-{%             for range in pool.ranges | arista.avd.default([]) %}
-| {{ range.first_ip }} | {{ range.last_ip }} | {{ range.first_port | arista.avd.default('-') }} | {{ range.last_port | arista.avd.default('-') }} |
-{%             endfor %}
+{%                     for range in pool.ranges | arista.avd.default([]) %}
+| {{ range.first_ip | arista.avd.default('-') }} | {{ range.last_ip | arista.avd.default('-') }} | {{ range.first_port | arista.avd.default('-') }} | {{ range.last_port | arista.avd.default('-') }} |
+{%                     endfor %}
+{%                 endif %}
+{%             endif %}
+{%             if pool_type == "port-only" %}
+{%                 if pool.ranges is arista.avd.defined() %}
+##### Port Ranges
+| First Port | Last Port |
+| ---------- | --------- |
+{%                     for range in pool.ranges | arista.avd.default([]) %}
+| {{ range.first_port | arista.avd.default('-') }} | {{ range.last_port | arista.avd.default('-') }} |
+{%                     endfor %}
+{%                 endif %}
+{%             endif %}
 {%         endfor %}
 {%     endif %}
 {%     if ip_nat.synchronization is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-nat-part2.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-nat-part2.j2
@@ -6,18 +6,34 @@
 {# eos - ip nat part 2 (pools, synchronization) #}
 {% if ip_nat is arista.avd.defined %}
 !
-{%     for pool in ip_nat.pools | arista.avd.default([]) %}
-{%         if pool.name is arista.avd.defined and pool.prefix_length is arista.avd.defined %}
+{%     for pool in ip_nat.pools | arista.avd.natural_sort('name') %}
+{%         set pool_type = pool.type | arista.avd.default('ip-port') %}
+{%         if pool_type == 'ip-port' %}
+{%             if pool.name is arista.avd.defined and pool.prefix_length is arista.avd.defined %}
 ip nat pool {{ pool.name }} prefix-length {{ pool.prefix_length }}
-{%             for range in pool.ranges | arista.avd.default([]) %}
-{%                 set range_cli = 'range ' ~ range.first_ip ~ ' ' ~ range.last_ip %}
-{%                 if range.first_port is arista.avd.defined and range.last_port is arista.avd.defined %}
-{%                     set range_cli = range_cli ~ ' ' ~ range.first_port ~ ' ' ~ range.last_port %}
-{%                 endif %}
+{%                 for range in pool.ranges | arista.avd.default([]) %}
+{%                     if range.first_ip is arista.avd.defined and range.last_ip is arista.avd.defined and range.first_port is arista.avd.defined and range.last_port is arista.avd.defined %}
+{%                         set range_cli = 'range ' ~ range.first_ip ~ ' ' ~ range.last_ip ~ ' ' ~ range.first_port ~ ' ' ~ range.last_port %}
    {{ range_cli }}
-{%             endfor %}
-{%             if pool.utilization_log_threshold is arista.avd.defined %}
+{%                     endif %}
+{%                 endfor %}
+{%                 if pool.utilization_log_threshold is arista.avd.defined %}
    utilization threshold {{ pool.utilization_log_threshold }} action log
+{%                 endif %}
+{%             endif %}
+{%         endif %}
+{%     endfor %}
+{%     for pool in ip_nat.pools | arista.avd.natural_sort('name') %}
+{%         set pool_type = pool.type | arista.avd.default('ip-port') %}
+{%         if pool_type == 'port-only' %}
+{%             if pool.name is arista.avd.defined %}
+ip nat pool {{ pool.name }} port-only
+{%                 for range in pool.ranges | arista.avd.default([]) %}
+{%                     if range.first_port is arista.avd.defined and range.last_port is arista.avd.defined %}
+{%                         set range_cli = 'port range ' ~ range.first_port ~ ' ' ~ range.last_port %}
+   {{ range_cli }}
+{%                     endif %}
+{%                 endfor %}
 {%             endif %}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-nat-part2.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-nat-part2.j2
@@ -12,8 +12,11 @@
 {%             if pool.name is arista.avd.defined and pool.prefix_length is arista.avd.defined %}
 ip nat pool {{ pool.name }} prefix-length {{ pool.prefix_length }}
 {%                 for range in pool.ranges | arista.avd.default([]) %}
-{%                     if range.first_ip is arista.avd.defined and range.last_ip is arista.avd.defined and range.first_port is arista.avd.defined and range.last_port is arista.avd.defined %}
-{%                         set range_cli = 'range ' ~ range.first_ip ~ ' ' ~ range.last_ip ~ ' ' ~ range.first_port ~ ' ' ~ range.last_port %}
+{%                     if range.first_ip is arista.avd.defined and range.last_ip is arista.avd.defined %}
+{%                         set range_cli = 'range ' ~ range.first_ip ~ ' ' ~ range.last_ip %}
+{%                         if range.first_port is arista.avd.defined and range.last_port is arista.avd.defined %}
+{%                             set range_cli = range_cli ~ ' ' ~ range.first_port ~ ' ' ~ range.last_port %}
+{%                         endif %}
    {{ range_cli }}
 {%                     endif %}
 {%                 endfor %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -23155,10 +23155,20 @@
                           "type": "string",
                           "title": "Name"
                         },
+                        "type": {
+                          "type": "string",
+                          "enum": [
+                            "ip-port",
+                            "port-only"
+                          ],
+                          "default": "ip-port",
+                          "title": "Type"
+                        },
                         "prefix_length": {
                           "type": "integer",
                           "minimum": 16,
                           "maximum": 32,
+                          "description": "It is only used and required when `type` is `ip-port`.",
                           "title": "Prefix Length"
                         },
                         "ranges": {
@@ -23168,12 +23178,12 @@
                             "properties": {
                               "first_ip": {
                                 "type": "string",
-                                "description": "IPv4 address",
+                                "description": "IPv4 address.\nRequired when `type` is `ip-port` and ignored otherwise.",
                                 "title": "First IP"
                               },
                               "last_ip": {
                                 "type": "string",
-                                "description": "IPv4 address",
+                                "description": "IPv4 address.\nRequired when `type` is `ip-port` and ignored otherwise.",
                                 "title": "Last IP"
                               },
                               "first_port": {
@@ -23186,13 +23196,10 @@
                                 "type": "integer",
                                 "minimum": 1,
                                 "maximum": 65535,
+                                "description": "Required when `first_port` is set.",
                                 "title": "Last Port"
                               }
                             },
-                            "required": [
-                              "first_ip",
-                              "last_ip"
-                            ],
                             "additionalProperties": false,
                             "patternProperties": {
                               "^_.+$": {}
@@ -23207,14 +23214,13 @@
                           "title": "Utilization Log Threshold"
                         }
                       },
-                      "required": [
-                        "prefix_length",
-                        "name"
-                      ],
                       "additionalProperties": false,
                       "patternProperties": {
                         "^_.+$": {}
-                      }
+                      },
+                      "required": [
+                        "name"
+                      ]
                     },
                     "title": "Pools"
                   },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -23183,7 +23183,7 @@
                               },
                               "last_ip": {
                                 "type": "string",
-                                "description": "IPv4 address.\nRequired when `type` is `ip-port` and ignored otherwise.",
+                                "description": "IPv4 address.\nRequired when `type` is `ip-port` and ignored otherwise.\n`first_ip` and `last_ip` ip addresses should lie in same subnet.",
                                 "title": "Last IP"
                               },
                               "first_port": {
@@ -23196,7 +23196,7 @@
                                 "type": "integer",
                                 "minimum": 1,
                                 "maximum": 65535,
-                                "description": "Required when `first_port` is set.",
+                                "description": "Required when `first_port` is set.\n`last_port` must be greater than or equal to `first_port`.",
                                 "title": "Last Port"
                               }
                             },


### PR DESCRIPTION
## Change Summary

Support port-only option in IP NAT pools

## Related Issue(s)

Fixes #3825 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
