### PR TITLE
Refactor(eos_cli_config_gen): Modifying the data-model for management security entropy source

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -49,7 +49,7 @@ interface Management1
 
 | Settings | Value |
 | -------- | ----- |
-| Entropy source | hardware |
+| Entropy sources | hardware |
 | Common password encryption key | True |
 
 ### Management Security SSL Profiles

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -48,7 +48,7 @@ interface Management1
 
 | Settings | Value |
 | -------- | ----- |
-| Entropy source | hardware |
+| Entropy source | hardware, haveged, cpu jitter, hardware exclusive |
 | Common password encryption key | True |
 | Reversible password encryption | aes-256-gcm |
 | Minimum password length | 17 |
@@ -102,7 +102,8 @@ interface Management1
 ```eos
 !
 management security
-   entropy source hardware
+   entropy source hardware haveged cpu jitter
+   entropy source hardware exclusive
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-security.md
@@ -48,7 +48,7 @@ interface Management1
 
 | Settings | Value |
 | -------- | ----- |
-| Entropy source | hardware, haveged, cpu jitter, hardware exclusive |
+| Entropy sources | hardware, haveged, cpu jitter, hardware exclusive |
 | Common password encryption key | True |
 | Reversible password encryption | aes-256-gcm |
 | Minimum password length | 17 |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-security.cfg
@@ -13,7 +13,8 @@ interface Management1
    ip address 10.73.255.122/24
 !
 management security
-   entropy source hardware
+   entropy source hardware haveged cpu jitter
+   entropy source hardware exclusive
    password encryption-key common
    password encryption reversible aes-256-gcm
    password minimum length 17

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
@@ -33,8 +33,7 @@ mac_security:
 
 ### Mgmt sec
 management_security:
-  entropy_source:
-    hardware: true
+  entropy_source: hardware
   password:
     encryption_key_common: true
   ssl_profiles:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
@@ -33,7 +33,8 @@ mac_security:
 
 ### Mgmt sec
 management_security:
-  entropy_source: hardware
+  entropy_source:
+    hardware: true
   password:
     encryption_key_common: true
   ssl_profiles:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/mac-security-eth-po-entropy.yml
@@ -33,7 +33,8 @@ mac_security:
 
 ### Mgmt sec
 management_security:
-  entropy_source: hardware
+  entropy_sources:
+    hardware: true
   password:
     encryption_key_common: true
   ssl_profiles:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
@@ -1,6 +1,10 @@
 ### Management Security ###
 management_security:
-  entropy_source: hardware
+  entropy_source:
+    hardware: true
+    haveged: true
+    cpu_jitter: true
+    hardware_exclusive: true
   password:
     minimum_length: 17
     encryption_key_common: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-security.yml
@@ -1,6 +1,6 @@
 ### Management Security ###
 management_security:
-  entropy_source:
+  entropy_sources:
     hardware: true
     haveged: true
     cpu_jitter: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -12,6 +12,9 @@
 - [Authentication](#authentication)
   - [Local Users](#local-users)
   - [RADIUS Server](#radius-server)
+- [Management Security](#management-security)
+  - [Management Security Summary](#management-security-summary)
+  - [Management Security Device Configuration](#management-security-device-configuration)
 - [Monitoring](#monitoring)
   - [TerminAttr Daemon](#terminattr-daemon)
   - [Custom daemons](#custom-daemons)
@@ -268,6 +271,22 @@ username admin privilege 15 role network-admin nopassword
 radius-server host 10.10.10.157 vrf mgt key 7 <removed>
 radius-server host 10.10.10.249 key 7 <removed>
 radius-server host 10.10.10.158 key 7 <removed>
+```
+
+## Management Security
+
+### Management Security Summary
+
+| Settings | Value |
+| -------- | ----- |
+| Entropy source | hardware |
+
+### Management Security Device Configuration
+
+```eos
+!
+management security
+   entropy source hardware
 ```
 
 ## Monitoring

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
@@ -619,6 +619,9 @@ management api gnmi
       vrf MONITORING
    provider eos-native
 !
+management security
+   entropy source hardware
+!
 stun
    server
       local-interface Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/management-security.yml
@@ -1,0 +1,6 @@
+### Management Security
+
+management_security:
+  # Testing entropy source as string
+  # String type is deprecated. To be removed in 5.0.0
+  entropy_source: hardware

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -8,7 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>management_security</samp>](## "management_security") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") <span style="color:red">deprecated</span> | String |  |  |  | <span style="color:red">This key is deprecated. Use <samp>entropy_sources</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") <span style="color:red">deprecated</span> | String |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version v5.0.0. Use <samp>entropy_sources</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;entropy_sources</samp>](## "management_security.entropy_sources") | Dictionary |  |  |  | Source of entropy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware</samp>](## "management_security.entropy_sources.hardware") | Boolean |  |  |  | Use a hardware based source. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;haveged</samp>](## "management_security.entropy_sources.haveged") | Boolean |  |  |  | Use the HAVEGE algorithm. |
@@ -58,6 +58,7 @@
     ```yaml
     management_security:
       # This key is deprecated.
+      # Support will be removed in AVD version v5.0.0.
       # Use <samp>entropy_sources</samp> instead.
       entropy_source: <str>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -8,7 +8,11 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>management_security</samp>](## "management_security") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") | Dictionary |  |  |  | Source of entropy. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware</samp>](## "management_security.entropy_source.hardware") | Boolean |  |  |  | Use a hardware based source. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;haveged</samp>](## "management_security.entropy_source.haveged") | Boolean |  |  |  | Use the HAVEGE algorithm. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cpu_jitter</samp>](## "management_security.entropy_source.cpu_jitter") | Boolean |  |  |  | Use the Jitter RNG algorithm of a CPU based source. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_exclusive</samp>](## "management_security.entropy_source.hardware_exclusive") | Boolean |  |  |  | Only use entropy from the hardware source. |
     | [<samp>&nbsp;&nbsp;password</samp>](## "management_security.password") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;minimum_length</samp>](## "management_security.password.minimum_length") | Integer |  |  | Min: 1<br>Max: 32 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_key_common</samp>](## "management_security.password.encryption_key_common") | Boolean |  |  |  |  |
@@ -52,7 +56,21 @@
 
     ```yaml
     management_security:
-      entropy_source: <str>
+
+      # Source of entropy.
+      entropy_source:
+
+        # Use a hardware based source.
+        hardware: <bool>
+
+        # Use the HAVEGE algorithm.
+        haveged: <bool>
+
+        # Use the Jitter RNG algorithm of a CPU based source.
+        cpu_jitter: <bool>
+
+        # Only use entropy from the hardware source.
+        hardware_exclusive: <bool>
       password:
         minimum_length: <int; 1-32>
         encryption_key_common: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -8,11 +8,12 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>management_security</samp>](## "management_security") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") | Dictionary |  |  |  | Source of entropy. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware</samp>](## "management_security.entropy_source.hardware") | Boolean |  |  |  | Use a hardware based source. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;haveged</samp>](## "management_security.entropy_source.haveged") | Boolean |  |  |  | Use the HAVEGE algorithm. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cpu_jitter</samp>](## "management_security.entropy_source.cpu_jitter") | Boolean |  |  |  | Use the Jitter RNG algorithm of a CPU based source. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_exclusive</samp>](## "management_security.entropy_source.hardware_exclusive") | Boolean |  |  |  | Only use entropy from the hardware source. |
+    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") <span style="color:red">deprecated</span> | String |  |  |  | <span style="color:red">This key is deprecated. Use <samp>entropy_sources</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;entropy_sources</samp>](## "management_security.entropy_sources") | Dictionary |  |  |  | Source of entropy. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware</samp>](## "management_security.entropy_sources.hardware") | Boolean |  |  |  | Use a hardware based source. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;haveged</samp>](## "management_security.entropy_sources.haveged") | Boolean |  |  |  | Use the HAVEGE algorithm. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cpu_jitter</samp>](## "management_security.entropy_sources.cpu_jitter") | Boolean |  |  |  | Use the Jitter RNG algorithm of a CPU based source. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_exclusive</samp>](## "management_security.entropy_sources.hardware_exclusive") | Boolean |  |  |  | Only use entropy from the hardware source. |
     | [<samp>&nbsp;&nbsp;password</samp>](## "management_security.password") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;minimum_length</samp>](## "management_security.password.minimum_length") | Integer |  |  | Min: 1<br>Max: 32 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encryption_key_common</samp>](## "management_security.password.encryption_key_common") | Boolean |  |  |  |  |
@@ -56,9 +57,12 @@
 
     ```yaml
     management_security:
+      # This key is deprecated.
+      # Use <samp>entropy_sources</samp> instead.
+      entropy_source: <str>
 
       # Source of entropy.
-      entropy_source:
+      entropy_sources:
 
         # Use a hardware based source.
         hardware: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10216,7 +10216,34 @@
       "type": "object",
       "properties": {
         "entropy_source": {
-          "type": "string",
+          "type": "object",
+          "description": "Source of entropy.",
+          "properties": {
+            "hardware": {
+              "type": "boolean",
+              "description": "Use a hardware based source.",
+              "title": "Hardware"
+            },
+            "haveged": {
+              "type": "boolean",
+              "description": "Use the HAVEGE algorithm.",
+              "title": "Haveged"
+            },
+            "cpu_jitter": {
+              "type": "boolean",
+              "description": "Use the Jitter RNG algorithm of a CPU based source.",
+              "title": "CPU Jitter"
+            },
+            "hardware_exclusive": {
+              "type": "boolean",
+              "description": "Only use entropy from the hardware source.",
+              "title": "Hardware Exclusive"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
           "title": "Entropy Source"
         },
         "password": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -10216,6 +10216,10 @@
       "type": "object",
       "properties": {
         "entropy_source": {
+          "type": "string",
+          "title": "Entropy Source"
+        },
+        "entropy_sources": {
           "type": "object",
           "description": "Source of entropy.",
           "properties": {
@@ -10244,7 +10248,7 @@
           "patternProperties": {
             "^_.+$": {}
           },
-          "title": "Entropy Source"
+          "title": "Entropy Sources"
         },
         "password": {
           "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6101,7 +6101,21 @@ keys:
     type: dict
     keys:
       entropy_source:
-        type: str
+        type: dict
+        description: Source of entropy.
+        keys:
+          hardware:
+            type: bool
+            description: Use a hardware based source.
+          haveged:
+            type: bool
+            description: Use the HAVEGE algorithm.
+          cpu_jitter:
+            type: bool
+            description: Use the Jitter RNG algorithm of a CPU based source.
+          hardware_exclusive:
+            type: bool
+            description: Only use entropy from the hardware source.
       password:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6101,6 +6101,12 @@ keys:
     type: dict
     keys:
       entropy_source:
+        type: str
+        deprecation:
+          warning: true
+          removed: false
+          new_key: entropy_sources
+      entropy_sources:
         type: dict
         description: Source of entropy.
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6104,7 +6104,7 @@ keys:
         type: str
         deprecation:
           warning: true
-          removed: false
+          remove_in_version: v5.0.0
           new_key: entropy_sources
       entropy_sources:
         type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -10,6 +10,12 @@ keys:
     type: dict
     keys:
       entropy_source:
+        type: str
+        deprecation:
+          warning: true
+          removed: false
+          new_key: entropy_sources
+      entropy_sources:
         type: dict
         description: Source of entropy.
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -10,7 +10,21 @@ keys:
     type: dict
     keys:
       entropy_source:
-        type: str
+        type: dict
+        description: Source of entropy.
+        keys:
+          hardware:
+            type: bool
+            description: Use a hardware based source.
+          haveged:
+            type: bool
+            description: Use the HAVEGE algorithm.
+          cpu_jitter:
+            type: bool
+            description: Use the Jitter RNG algorithm of a CPU based source.
+          hardware_exclusive:
+            type: bool
+            description: Only use entropy from the hardware source.
       password:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/management_security.schema.yml
@@ -13,7 +13,7 @@ keys:
         type: str
         deprecation:
           warning: true
-          removed: false
+          remove_in_version: v5.0.0
           new_key: entropy_sources
       entropy_sources:
         type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -19,7 +19,7 @@
 {%         set entropy_sources = [] %}
 {%         for source in ['hardware', 'haveged', 'cpu_jitter', 'hardware_exclusive'] %}
 {%             if management_security.entropy_sources[source] is arista.avd.defined(true) %}
-{%                 set _ = entropy_sources.append(source.replace("_", " ")) %}
+{%                 do entropy_sources.append(source.replace("_", " ")) %}
 {%             endif %}
 {%         endfor %}
 | Entropy sources | {{ entropy_sources | join(", ") }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -13,7 +13,13 @@
 | Settings | Value |
 | -------- | ----- |
 {%     if management_security.entropy_source is arista.avd.defined %}
-| Entropy source | {{ management_security.entropy_source }} |
+{%         set entropy_sources = [] %}
+{%         for source in ['hardware', 'haveged', 'cpu_jitter', 'hardware_exclusive'] %}
+{%             if management_security.entropy_source[source] is arista.avd.defined(true) %}
+{%                 set _ = entropy_sources.append(source.replace("_", " ")) %}
+{%             endif %}
+{%         endfor %}
+| Entropy source | {{ entropy_sources | join(", ") }} |
 {%     endif %}
 {%     if management_security.password.encryption_key_common is arista.avd.defined %}
 | Common password encryption key | {{ management_security.password.encryption_key_common }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/management-security.j2
@@ -13,13 +13,16 @@
 | Settings | Value |
 | -------- | ----- |
 {%     if management_security.entropy_source is arista.avd.defined %}
+| Entropy source | {{ management_security.entropy_source }} |
+{%     endif %}
+{%     if management_security.entropy_sources is arista.avd.defined %}
 {%         set entropy_sources = [] %}
 {%         for source in ['hardware', 'haveged', 'cpu_jitter', 'hardware_exclusive'] %}
-{%             if management_security.entropy_source[source] is arista.avd.defined(true) %}
+{%             if management_security.entropy_sources[source] is arista.avd.defined(true) %}
 {%                 set _ = entropy_sources.append(source.replace("_", " ")) %}
 {%             endif %}
 {%         endfor %}
-| Entropy source | {{ entropy_sources | join(", ") }} |
+| Entropy sources | {{ entropy_sources | join(", ") }} |
 {%     endif %}
 {%     if management_security.password.encryption_key_common is arista.avd.defined %}
 | Common password encryption key | {{ management_security.password.encryption_key_common }} |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -8,16 +8,19 @@
 !
 management security
 {%     if management_security.entropy_source is arista.avd.defined %}
+   entropy source {{ management_security.entropy_source }}
+{%     endif %}
+{%     if management_security.entropy_sources is arista.avd.defined %}
 {%         set entropy_sources = [] %}
 {%         for source in ['hardware', 'haveged', 'cpu_jitter'] %}
-{%             if management_security.entropy_source[source] is arista.avd.defined(true) %}
+{%             if management_security.entropy_sources[source] is arista.avd.defined(true) %}
 {%                 set _ = entropy_sources.append(source.replace("_", " ")) %}
 {%             endif %}
 {%         endfor %}
 {%         if entropy_sources %}
    entropy source {{ entropy_sources | join(" ") }}
 {%         endif %}
-{%         if management_security.entropy_source.hardware_exclusive is arista.avd.defined(true) %}
+{%         if management_security.entropy_sources.hardware_exclusive is arista.avd.defined(true) %}
    entropy source hardware exclusive
 {%         endif %}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -14,7 +14,7 @@ management security
 {%         set entropy_sources = [] %}
 {%         for source in ['hardware', 'haveged', 'cpu_jitter'] %}
 {%             if management_security.entropy_sources[source] is arista.avd.defined(true) %}
-{%                 set _ = entropy_sources.append(source.replace("_", " ")) %}
+{%                 do entropy_sources.append(source.replace("_", " ")) %}
 {%             endif %}
 {%         endfor %}
 {%         if entropy_sources %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/management-security.j2
@@ -8,7 +8,18 @@
 !
 management security
 {%     if management_security.entropy_source is arista.avd.defined %}
-   entropy source {{ management_security.entropy_source }}
+{%         set entropy_sources = [] %}
+{%         for source in ['hardware', 'haveged', 'cpu_jitter'] %}
+{%             if management_security.entropy_source[source] is arista.avd.defined(true) %}
+{%                 set _ = entropy_sources.append(source.replace("_", " ")) %}
+{%             endif %}
+{%         endfor %}
+{%         if entropy_sources %}
+   entropy source {{ entropy_sources | join(" ") }}
+{%         endif %}
+{%         if management_security.entropy_source.hardware_exclusive is arista.avd.defined(true) %}
+   entropy source hardware exclusive
+{%         endif %}
 {%     endif %}
 {%     if management_security.password.encryption_key_common is arista.avd.defined(true) %}
    password encryption-key common

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -25960,7 +25960,34 @@
                 "type": "object",
                 "properties": {
                   "entropy_source": {
-                    "type": "string",
+                    "type": "object",
+                    "description": "Source of entropy.",
+                    "properties": {
+                      "hardware": {
+                        "type": "boolean",
+                        "description": "Use a hardware based source.",
+                        "title": "Hardware"
+                      },
+                      "haveged": {
+                        "type": "boolean",
+                        "description": "Use the HAVEGE algorithm.",
+                        "title": "Haveged"
+                      },
+                      "cpu_jitter": {
+                        "type": "boolean",
+                        "description": "Use the Jitter RNG algorithm of a CPU based source.",
+                        "title": "CPU Jitter"
+                      },
+                      "hardware_exclusive": {
+                        "type": "boolean",
+                        "description": "Only use entropy from the hardware source.",
+                        "title": "Hardware Exclusive"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
                     "title": "Entropy Source"
                   },
                   "password": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -25960,6 +25960,10 @@
                 "type": "object",
                 "properties": {
                   "entropy_source": {
+                    "type": "string",
+                    "title": "Entropy Source"
+                  },
+                  "entropy_sources": {
                     "type": "object",
                     "description": "Source of entropy.",
                     "properties": {
@@ -25988,7 +25992,7 @@
                     "patternProperties": {
                       "^_.+$": {}
                     },
-                    "title": "Entropy Source"
+                    "title": "Entropy Sources"
                   },
                   "password": {
                     "type": "object",


### PR DESCRIPTION
## Change Summary

Modifying the data-model for management security entropy source

## Related Issue(s)

In favour of #1226 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Expanding the data-model for entropy source to -
```
management_security:

      # Source of entropy.
      entropy_source:

        # Use a hardware based source.
        hardware: <bool>

        # Use the HAVEGE algorithm.
        haveged: <bool>

        # Use the Jitter RNG algorithm of a CPU based source.
        cpu_jitter: <bool>

        # Only use entropy from the hardware source.
        hardware_exclusive: <bool>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
