### PR TITLE
Feat(eos_cli_config_gen): Add capability to disable address-only for connectivity monitors

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
@@ -79,7 +79,7 @@ interface Management1
 
 ##### Host Parameters
 
-| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address Only | URL |
 | --------- | ----------- | ------------ | --------------------- | ------------ | --- |
 | server4 | server4_connectivity_monitor | 10.10.20.1 | VRF_HOST_SET | False | https://server2.local.com |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
@@ -50,13 +50,13 @@ interface Management1
 
 #### Probing Configuration
 
-| Enabled | Interval | Default Interface Set | Addres only |
-| ------- | -------- | --------------------- | ----------- |
+| Enabled | Interval | Default Interface Set | Address Only |
+| ------- | -------- | --------------------- | ------------ |
 | True | 5 | GLOBAL_SET | True |
 
 #### Host Parameters
 
-| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address Only | URL |
 | --------- | ----------- | ------------ | --------------------- | ------------ | --- |
 | server1 | server1_connectivity_monitor | 10.10.10.1 | HOST_SET | True | https://server1.local.com |
 | server2 | server2_connectivity_monitor | 10.10.10.2 | HOST_SET | True | https://server2.local.com |
@@ -64,7 +64,7 @@ interface Management1
 
 ### VRF Configuration
 
-| Name | Description | Default Interface Set | Address only |
+| Name | Description | Default Interface Set | Address Only |
 | ---- | ----------- | --------------------- | ------------ |
 | blue | - | VRF_GLOBAL_SET | False |
 | red | vrf_connectivity_monitor | VRF_GLOBAL_SET | True |
@@ -94,7 +94,7 @@ interface Management1
 
 ##### Host Parameters
 
-| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address Only | URL |
 | --------- | ----------- | ------------ | --------------------- | ------------ | --- |
 | server2 | server2_connectivity_monitor | 10.10.20.1 | VRF_HOST_SET | True | https://server2.local.com |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/monitor-connectivity.md
@@ -50,21 +50,38 @@ interface Management1
 
 #### Probing Configuration
 
-| Enabled | Interval | Default Interface Set |
-| ------- | -------- | --------------------- |
-| True | 5 | GLOBAL_SET |
+| Enabled | Interval | Default Interface Set | Addres only |
+| ------- | -------- | --------------------- | ----------- |
+| True | 5 | GLOBAL_SET | True |
 
 #### Host Parameters
 
-| Host Name | Description | IPv4 Address | Probing Interface Set | URL |
-| --------- | ----------- | ------------ | --------------------- | --- |
-| server1 | server1_connectivity_monitor | 10.10.10.1 | HOST_SET | https://server1.local.com |
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| --------- | ----------- | ------------ | --------------------- | ------------ | --- |
+| server1 | server1_connectivity_monitor | 10.10.10.1 | HOST_SET | True | https://server1.local.com |
+| server2 | server2_connectivity_monitor | 10.10.10.2 | HOST_SET | True | https://server2.local.com |
+| server3 | server3_connectivity_monitor | 10.10.10.3 | HOST_SET | False | - |
 
 ### VRF Configuration
 
-| Name | Description | Default Interface Set |
-| ---- | ----------- | --------------------- |
-| red | vrf_connectivity_monitor | VRF_GLOBAL_SET |
+| Name | Description | Default Interface Set | Address only |
+| ---- | ----------- | --------------------- | ------------ |
+| blue | - | VRF_GLOBAL_SET | False |
+| red | vrf_connectivity_monitor | VRF_GLOBAL_SET | True |
+
+#### Vrf blue Configuration
+
+##### Interface Sets
+
+| Name | Interfaces |
+| ---- | ---------- |
+| VRF_GLOBAL_SET | Vlan21-24, Vlan29-32 |
+
+##### Host Parameters
+
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| --------- | ----------- | ------------ | --------------------- | ------------ | --- |
+| server4 | server4_connectivity_monitor | 10.10.20.1 | VRF_HOST_SET | False | https://server2.local.com |
 
 #### Vrf red Configuration
 
@@ -77,9 +94,9 @@ interface Management1
 
 ##### Host Parameters
 
-| Host Name | Description | IPv4 Address | Probing Interface Set | URL |
-| --------- | ----------- | ------------ | --------------------- | --- |
-| server2 | server2_connectivity_monitor | 10.10.20.1 | VRF_HOST_SET | https://server2.local.com |
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| --------- | ----------- | ------------ | --------------------- | ------------ | --- |
+| server2 | server2_connectivity_monitor | 10.10.20.1 | VRF_HOST_SET | True | https://server2.local.com |
 
 ### Monitor Connectivity Device Configuration
 
@@ -98,6 +115,29 @@ monitor connectivity
       local-interfaces HOST_SET address-only
       ip 10.10.10.1
       url https://server1.local.com
+   !
+   host server2
+      description
+      server2_connectivity_monitor
+      local-interfaces HOST_SET address-only
+      ip 10.10.10.2
+      url https://server2.local.com
+   !
+   host server3
+      description
+      server3_connectivity_monitor
+      local-interfaces HOST_SET
+      ip 10.10.10.3
+   vrf blue
+      interface set VRF_GLOBAL_SET Vlan21-24, Vlan29-32
+      local-interfaces VRF_GLOBAL_SET default
+      !
+      host server4
+         description
+         server4_connectivity_monitor
+         local-interfaces VRF_HOST_SET
+         ip 10.10.20.1
+         url https://server2.local.com
    vrf red
       interface set VRF_GLOBAL_SET Vlan21-24, Vlan29-32
       interface set VRF_HOST_SET Loopback12-14, 19-23

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/monitor-connectivity.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/monitor-connectivity.cfg
@@ -25,6 +25,29 @@ monitor connectivity
       local-interfaces HOST_SET address-only
       ip 10.10.10.1
       url https://server1.local.com
+   !
+   host server2
+      description
+      server2_connectivity_monitor
+      local-interfaces HOST_SET address-only
+      ip 10.10.10.2
+      url https://server2.local.com
+   !
+   host server3
+      description
+      server3_connectivity_monitor
+      local-interfaces HOST_SET
+      ip 10.10.10.3
+   vrf blue
+      interface set VRF_GLOBAL_SET Vlan21-24, Vlan29-32
+      local-interfaces VRF_GLOBAL_SET default
+      !
+      host server4
+         description
+         server4_connectivity_monitor
+         local-interfaces VRF_HOST_SET
+         ip 10.10.20.1
+         url https://server2.local.com
    vrf red
       interface set VRF_GLOBAL_SET Vlan21-24, Vlan29-32
       interface set VRF_HOST_SET Loopback12-14, 19-23

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/monitor-connectivity.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/monitor-connectivity.yml
@@ -13,7 +13,20 @@ monitor_connectivity:
       description: server1_connectivity_monitor
       ip: 10.10.10.1
       local_interfaces: HOST_SET
+      address_only: true
       url: https://server1.local.com
+    - name: server2
+      description: server2_connectivity_monitor
+      ip: 10.10.10.2
+      local_interfaces: HOST_SET
+      # This is default in AVD 4.x
+      # address_only: true
+      url: https://server2.local.com
+    - name: server3
+      description: server3_connectivity_monitor
+      ip: 10.10.10.3
+      local_interfaces: HOST_SET
+      address_only: false
   vrfs:
     - name: red
       description: vrf_connectivity_monitor
@@ -27,5 +40,18 @@ monitor_connectivity:
         - name: server2
           description: server2_connectivity_monitor
           ip: 10.10.20.1
+          local_interfaces: VRF_HOST_SET
+          url: https://server2.local.com
+    - name: blue
+      local_interfaces: VRF_GLOBAL_SET
+      address_only: false
+      interface_sets:
+        - name: VRF_GLOBAL_SET
+          interfaces: Vlan21-24, Vlan29-32
+      hosts:
+        - name: server4
+          description: server4_connectivity_monitor
+          ip: 10.10.20.1
+          address_only: false
           local_interfaces: VRF_HOST_SET
           url: https://server2.local.com

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/monitor-connectivity.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/monitor-connectivity.md
@@ -14,11 +14,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "monitor_connectivity.interface_sets.[].name") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "monitor_connectivity.interface_sets.[].interfaces") | String |  |  |  | Interface range(s) should be of same type, Ethernet, Loopback, Management etc.<br>Multiple interface ranges can be specified separated by ","<br> |
     | [<samp>&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.local_interfaces") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;address_only</samp>](## "monitor_connectivity.address_only") | Boolean |  | `True` |  | PREVIEW: This key is in preview.<br>When address-only is configured, the source IP of the packet is set to the interface<br>IP but the packet may exit the device via a different interface.<br>When set to `false`, the probe uses the interface to exit the device.<br>Not supported yet in EOS. |
     | [<samp>&nbsp;&nbsp;hosts</samp>](## "monitor_connectivity.hosts") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "monitor_connectivity.hosts.[].name") | String |  |  |  | Host Name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "monitor_connectivity.hosts.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "monitor_connectivity.hosts.[].ip") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.hosts.[].local_interfaces") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_only</samp>](## "monitor_connectivity.hosts.[].address_only") | Boolean |  | `True` |  | PREVIEW: This key is in preview.<br>When address-only is configured, the source IP of the packet is set to the interface<br>IP but the packet may exit the device via a different interface.<br>When set to `false`, the probe uses the interface to exit the device.<br>Not supported yet in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;url</samp>](## "monitor_connectivity.hosts.[].url") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "monitor_connectivity.vrfs") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "monitor_connectivity.vrfs.[].name") | String | Required, Unique |  |  | VRF Name |
@@ -27,11 +29,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "monitor_connectivity.vrfs.[].interface_sets.[].name") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "monitor_connectivity.vrfs.[].interface_sets.[].interfaces") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.vrfs.[].local_interfaces") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_only</samp>](## "monitor_connectivity.vrfs.[].address_only") | Boolean |  | `True` |  | PREVIEW: This key is in preview.<br>When address-only is configured, the source IP of the packet is set to the interface<br>IP but the packet may exit the device via a different interface.<br>When set to `false`, the probe uses the interface to exit the device.<br>Not supported yet in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hosts</samp>](## "monitor_connectivity.vrfs.[].hosts") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "monitor_connectivity.vrfs.[].hosts.[].name") | String |  |  |  | Host name |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "monitor_connectivity.vrfs.[].hosts.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "monitor_connectivity.vrfs.[].hosts.[].ip") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.vrfs.[].hosts.[].local_interfaces") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_only</samp>](## "monitor_connectivity.vrfs.[].hosts.[].address_only") | Boolean |  | `True` |  | PREVIEW: This key is in preview.<br>When address-only is configured, the source IP of the packet is set to the interface<br>IP but the packet may exit the device via a different interface.<br>When set to `false`, the probe uses the interface to exit the device.<br>Not supported yet in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;url</samp>](## "monitor_connectivity.vrfs.[].hosts.[].url") | String |  |  |  |  |
 
 === "YAML"
@@ -47,6 +51,13 @@
           # Multiple interface ranges can be specified separated by ","
           interfaces: <str>
       local_interfaces: <str>
+
+      # PREVIEW: This key is in preview.
+      # When address-only is configured, the source IP of the packet is set to the interface
+      # IP but the packet may exit the device via a different interface.
+      # When set to `false`, the probe uses the interface to exit the device.
+      # Not supported yet in EOS.
+      address_only: <bool; default=True>
       hosts:
 
           # Host Name
@@ -54,6 +65,13 @@
           description: <str>
           ip: <str>
           local_interfaces: <str>
+
+          # PREVIEW: This key is in preview.
+          # When address-only is configured, the source IP of the packet is set to the interface
+          # IP but the packet may exit the device via a different interface.
+          # When set to `false`, the probe uses the interface to exit the device.
+          # Not supported yet in EOS.
+          address_only: <bool; default=True>
           url: <str>
       vrfs:
 
@@ -64,6 +82,13 @@
             - name: <str>
               interfaces: <str>
           local_interfaces: <str>
+
+          # PREVIEW: This key is in preview.
+          # When address-only is configured, the source IP of the packet is set to the interface
+          # IP but the packet may exit the device via a different interface.
+          # When set to `false`, the probe uses the interface to exit the device.
+          # Not supported yet in EOS.
+          address_only: <bool; default=True>
           hosts:
 
               # Host name
@@ -71,5 +96,12 @@
               description: <str>
               ip: <str>
               local_interfaces: <str>
+
+              # PREVIEW: This key is in preview.
+              # When address-only is configured, the source IP of the packet is set to the interface
+              # IP but the packet may exit the device via a different interface.
+              # When set to `false`, the probe uses the interface to exit the device.
+              # Not supported yet in EOS.
+              address_only: <bool; default=True>
               url: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -11349,6 +11349,12 @@
           "type": "string",
           "title": "Local Interfaces"
         },
+        "address_only": {
+          "type": "boolean",
+          "description": "PREVIEW: This key is in preview.\nWhen address-only is configured, the source IP of the packet is set to the interface\nIP but the packet may exit the device via a different interface.\nWhen set to `false`, the probe uses the interface to exit the device.\nNot supported yet in EOS.",
+          "default": true,
+          "title": "Address Only"
+        },
         "hosts": {
           "type": "array",
           "items": {
@@ -11370,6 +11376,12 @@
               "local_interfaces": {
                 "type": "string",
                 "title": "Local Interfaces"
+              },
+              "address_only": {
+                "type": "boolean",
+                "description": "PREVIEW: This key is in preview.\nWhen address-only is configured, the source IP of the packet is set to the interface\nIP but the packet may exit the device via a different interface.\nWhen set to `false`, the probe uses the interface to exit the device.\nNot supported yet in EOS.",
+                "default": true,
+                "title": "Address Only"
               },
               "url": {
                 "type": "string",
@@ -11422,6 +11434,12 @@
                 "type": "string",
                 "title": "Local Interfaces"
               },
+              "address_only": {
+                "type": "boolean",
+                "description": "PREVIEW: This key is in preview.\nWhen address-only is configured, the source IP of the packet is set to the interface\nIP but the packet may exit the device via a different interface.\nWhen set to `false`, the probe uses the interface to exit the device.\nNot supported yet in EOS.",
+                "default": true,
+                "title": "Address Only"
+              },
               "hosts": {
                 "type": "array",
                 "items": {
@@ -11443,6 +11461,12 @@
                     "local_interfaces": {
                       "type": "string",
                       "title": "Local Interfaces"
+                    },
+                    "address_only": {
+                      "type": "boolean",
+                      "description": "PREVIEW: This key is in preview.\nWhen address-only is configured, the source IP of the packet is set to the interface\nIP but the packet may exit the device via a different interface.\nWhen set to `false`, the probe uses the interface to exit the device.\nNot supported yet in EOS.",
+                      "default": true,
+                      "title": "Address Only"
                     },
                     "url": {
                       "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -6697,6 +6697,19 @@ keys:
                 '
       local_interfaces:
         type: str
+      address_only:
+        type: bool
+        description: 'PREVIEW: This key is in preview.
+
+          When address-only is configured, the source IP of the packet is set to the
+          interface
+
+          IP but the packet may exit the device via a different interface.
+
+          When set to `false`, the probe uses the interface to exit the device.
+
+          Not supported yet in EOS.'
+        default: true
       hosts:
         type: list
         items:
@@ -6711,6 +6724,19 @@ keys:
               type: str
             local_interfaces:
               type: str
+            address_only:
+              type: bool
+              description: 'PREVIEW: This key is in preview.
+
+                When address-only is configured, the source IP of the packet is set
+                to the interface
+
+                IP but the packet may exit the device via a different interface.
+
+                When set to `false`, the probe uses the interface to exit the device.
+
+                Not supported yet in EOS.'
+              default: true
             url:
               type: str
       vrfs:
@@ -6737,6 +6763,19 @@ keys:
                     type: str
             local_interfaces:
               type: str
+            address_only:
+              type: bool
+              description: 'PREVIEW: This key is in preview.
+
+                When address-only is configured, the source IP of the packet is set
+                to the interface
+
+                IP but the packet may exit the device via a different interface.
+
+                When set to `false`, the probe uses the interface to exit the device.
+
+                Not supported yet in EOS.'
+              default: true
             hosts:
               type: list
               items:
@@ -6751,6 +6790,20 @@ keys:
                     type: str
                   local_interfaces:
                     type: str
+                  address_only:
+                    type: bool
+                    description: 'PREVIEW: This key is in preview.
+
+                      When address-only is configured, the source IP of the packet
+                      is set to the interface
+
+                      IP but the packet may exit the device via a different interface.
+
+                      When set to `false`, the probe uses the interface to exit the
+                      device.
+
+                      Not supported yet in EOS.'
+                    default: true
                   url:
                     type: str
   monitor_layer1:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_connectivity.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/monitor_connectivity.schema.yml
@@ -29,6 +29,15 @@ keys:
                 Multiple interface ranges can be specified separated by ","
       local_interfaces:
         type: str
+      address_only:
+        type: bool
+        description: |-
+          PREVIEW: This key is in preview.
+          When address-only is configured, the source IP of the packet is set to the interface
+          IP but the packet may exit the device via a different interface.
+          When set to `false`, the probe uses the interface to exit the device.
+          Not supported yet in EOS.
+        default: true
       hosts:
         type: list
         items:
@@ -43,6 +52,15 @@ keys:
               type: str
             local_interfaces:
               type: str
+            address_only:
+              type: bool
+              description: |-
+                PREVIEW: This key is in preview.
+                When address-only is configured, the source IP of the packet is set to the interface
+                IP but the packet may exit the device via a different interface.
+                When set to `false`, the probe uses the interface to exit the device.
+                Not supported yet in EOS.
+              default: true
             url:
               type: str
       vrfs:
@@ -69,6 +87,15 @@ keys:
                     type: str
             local_interfaces:
               type: str
+            address_only:
+              type: bool
+              description: |-
+                PREVIEW: This key is in preview.
+                When address-only is configured, the source IP of the packet is set to the interface
+                IP but the packet may exit the device via a different interface.
+                When set to `false`, the probe uses the interface to exit the device.
+                Not supported yet in EOS.
+              default: true
             hosts:
               type: list
               items:
@@ -83,5 +110,14 @@ keys:
                     type: str
                   local_interfaces:
                     type: str
+                  address_only:
+                    type: bool
+                    description: |-
+                      PREVIEW: This key is in preview.
+                      When address-only is configured, the source IP of the packet is set to the interface
+                      IP but the packet may exit the device via a different interface.
+                      When set to `false`, the probe uses the interface to exit the device.
+                      Not supported yet in EOS.
+                    default: true
                   url:
                     type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/monitor-connectivity.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/monitor-connectivity.j2
@@ -24,18 +24,18 @@
 
 #### Probing Configuration
 
-| Enabled | Interval | Default Interface Set |
-| ------- | -------- | --------------------- |
-| {{ not monitor_connectivity.shutdown | arista.avd.default(true) }} | {{ monitor_connectivity.interval | arista.avd.default('-') }} | {{ monitor_connectivity.local_interfaces | arista.avd.default('-') }} |
+| Enabled | Interval | Default Interface Set | Addres only |
+| ------- | -------- | --------------------- | ----------- |
+| {{ not monitor_connectivity.shutdown | arista.avd.default(true) }} | {{ monitor_connectivity.interval | arista.avd.default('-') }} | {{ monitor_connectivity.local_interfaces | arista.avd.default('-') }} | {{ monitor_connectivity.address_only | arista.avd.default(true) }} |
 {%     if monitor_connectivity.hosts is arista.avd.defined %}
 
 #### Host Parameters
 
-| Host Name | Description | IPv4 Address | Probing Interface Set | URL |
-| --------- | ----------- | ------------ | --------------------- | --- |
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| --------- | ----------- | ------------ | --------------------- | ------------ | --- |
 {%         for host in monitor_connectivity.hosts | arista.avd.natural_sort('name') %}
 {%             if host.name is arista.avd.defined %}
-| {{ host.name }} | {{ host.description | arista.avd.default('-') }} | {{ host.ip | arista.avd.default('-') }} | {{ host.local_interfaces | arista.avd.default('-') }} | {{ host.url | arista.avd.default('-') }} |
+| {{ host.name }} | {{ host.description | arista.avd.default('-') }} | {{ host.ip | arista.avd.default('-') }} | {{ host.local_interfaces | arista.avd.default('-') }} | {{ host.address_only | arista.avd.default(true) }} | {{ host.url | arista.avd.default('-') }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}
@@ -43,11 +43,11 @@
 
 ### VRF Configuration
 
-| Name | Description | Default Interface Set |
-| ---- | ----------- | --------------------- |
+| Name | Description | Default Interface Set | Address only |
+| ---- | ----------- | --------------------- | ------------ |
 {%         for vrf in monitor_connectivity.vrfs | arista.avd.natural_sort('name') %}
 {%             if vrf.name is arista.avd.defined %}
-| {{ vrf.name }} | {{ vrf.description | arista.avd.default('-') }} | {{ vrf.local_interfaces | arista.avd.default('-') }} |
+| {{ vrf.name }} | {{ vrf.description | arista.avd.default('-') }} | {{ vrf.local_interfaces | arista.avd.default('-') }} | {{ vrf.address_only | arista.avd.default(true) }} |
 {%             endif %}
 {%         endfor %}
 {%         for vrf in monitor_connectivity.vrfs | arista.avd.natural_sort('name') %}
@@ -70,11 +70,11 @@
 
 ##### Host Parameters
 
-| Host Name | Description | IPv4 Address | Probing Interface Set | URL |
-| --------- | ----------- | ------------ | --------------------- | --- |
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| --------- | ----------- | ------------ | --------------------- | ------------ | --- |
 {%                     for host in vrf.hosts | arista.avd.natural_sort('name') %}
 {%                         if host.name is arista.avd.defined %}
-| {{ host.name }} | {{ host.description | arista.avd.default('-') }} | {{ host.ip | arista.avd.default('-') }} | {{ host.local_interfaces | arista.avd.default('-') }} | {{ host.url | arista.avd.default('-') }} |
+| {{ host.name }} | {{ host.description | arista.avd.default('-') }} | {{ host.ip | arista.avd.default('-') }} | {{ host.local_interfaces | arista.avd.default('-') }} | {{ host.address_only | arista.avd.default(true) }} | {{ host.url | arista.avd.default('-') }} |
 {%                         endif %}
 {%                     endfor %}
 {%                 endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/monitor-connectivity.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/monitor-connectivity.j2
@@ -24,14 +24,14 @@
 
 #### Probing Configuration
 
-| Enabled | Interval | Default Interface Set | Addres only |
-| ------- | -------- | --------------------- | ----------- |
+| Enabled | Interval | Default Interface Set | Address Only |
+| ------- | -------- | --------------------- | ------------ |
 | {{ not monitor_connectivity.shutdown | arista.avd.default(true) }} | {{ monitor_connectivity.interval | arista.avd.default('-') }} | {{ monitor_connectivity.local_interfaces | arista.avd.default('-') }} | {{ monitor_connectivity.address_only | arista.avd.default(true) }} |
 {%     if monitor_connectivity.hosts is arista.avd.defined %}
 
 #### Host Parameters
 
-| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address Only | URL |
 | --------- | ----------- | ------------ | --------------------- | ------------ | --- |
 {%         for host in monitor_connectivity.hosts | arista.avd.natural_sort('name') %}
 {%             if host.name is arista.avd.defined %}
@@ -43,7 +43,7 @@
 
 ### VRF Configuration
 
-| Name | Description | Default Interface Set | Address only |
+| Name | Description | Default Interface Set | Address Only |
 | ---- | ----------- | --------------------- | ------------ |
 {%         for vrf in monitor_connectivity.vrfs | arista.avd.natural_sort('name') %}
 {%             if vrf.name is arista.avd.defined %}
@@ -70,7 +70,7 @@
 
 ##### Host Parameters
 
-| Host Name | Description | IPv4 Address | Probing Interface Set | Address only | URL |
+| Host Name | Description | IPv4 Address | Probing Interface Set | Address Only | URL |
 | --------- | ----------- | ------------ | --------------------- | ------------ | --- |
 {%                     for host in vrf.hosts | arista.avd.natural_sort('name') %}
 {%                         if host.name is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/monitor-connectivity.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/monitor-connectivity.j2
@@ -21,7 +21,12 @@ monitor connectivity
 {%         endif %}
 {%     endfor %}
 {%     if monitor_connectivity.local_interfaces is arista.avd.defined %}
-   local-interfaces {{ monitor_connectivity.local_interfaces }} address-only default
+{%         set local_interfaces_cli = "local-interfaces " ~ monitor_connectivity.local_interfaces %}
+{# In AVD 4.x address_only default is true - TODO reevaluate for AVD 5.0.0 #}
+{%         if monitor_connectivity.address_only | arista.avd.default(true) %}
+{%             set local_interfaces_cli = local_interfaces_cli ~ " address-only" %}
+{%         endif %}
+   {{ local_interfaces_cli }} default
 {%     endif %}
 {%     for host in monitor_connectivity.hosts | arista.avd.natural_sort('name') %}
 {%         if host.name is arista.avd.defined %}
@@ -32,7 +37,12 @@ monitor connectivity
       {{ host.description }}
 {%             endif %}
 {%             if host.local_interfaces is arista.avd.defined %}
-      local-interfaces {{ host.local_interfaces }} address-only
+{%                 set local_interfaces_cli = "local-interfaces " ~ host.local_interfaces %}
+{# In AVD 4.x address_only default is true - TODO reevaluate for AVD 5.0.0 #}
+{%                 if host.address_only | arista.avd.default(true) %}
+{%                     set local_interfaces_cli = local_interfaces_cli ~ " address-only" %}
+{%                 endif %}
+      {{ local_interfaces_cli }}
 {%             endif %}
 {%             if host.ip is arista.avd.defined %}
       ip {{ host.ip }}
@@ -51,7 +61,12 @@ monitor connectivity
 {%                 endif %}
 {%             endfor %}
 {%             if vrf.local_interfaces is arista.avd.defined %}
-      local-interfaces {{ vrf.local_interfaces }} address-only default
+{%                 set local_interfaces_cli = "local-interfaces " ~ vrf.local_interfaces %}
+{# In AVD 4.x address_only default is true - TODO reevaluate for AVD 5.0.0 #}
+{%                 if vrf.address_only | arista.avd.default(true) %}
+{%                     set local_interfaces_cli = local_interfaces_cli ~ " address-only" %}
+{%                 endif %}
+      {{ local_interfaces_cli }} default
 {%             endif %}
 {%             if vrf.description is arista.avd.defined %}
       description
@@ -66,7 +81,12 @@ monitor connectivity
          {{ host.description }}
 {%                     endif %}
 {%                     if host.local_interfaces is arista.avd.defined %}
-         local-interfaces {{ host.local_interfaces }} address-only
+{%                         set local_interfaces_cli = "local-interfaces " ~ host.local_interfaces %}
+{# In AVD 4.x address_only default is true - TODO reevaluate for AVD 5.0.0 #}
+{%                         if host.address_only | arista.avd.default(true) %}
+{%                             set local_interfaces_cli = local_interfaces_cli ~ " address-only" %}
+{%                         endif %}
+         {{ local_interfaces_cli }}
 {%                     endif %}
 {%                     if host.ip is arista.avd.defined %}
          ip {{ host.ip }}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -27026,6 +27026,12 @@
                     "type": "string",
                     "title": "Local Interfaces"
                   },
+                  "address_only": {
+                    "type": "boolean",
+                    "description": "PREVIEW: This key is in preview.\nWhen address-only is configured, the source IP of the packet is set to the interface\nIP but the packet may exit the device via a different interface.\nWhen set to `false`, the probe uses the interface to exit the device.\nNot supported yet in EOS.",
+                    "default": true,
+                    "title": "Address Only"
+                  },
                   "hosts": {
                     "type": "array",
                     "items": {
@@ -27047,6 +27053,12 @@
                         "local_interfaces": {
                           "type": "string",
                           "title": "Local Interfaces"
+                        },
+                        "address_only": {
+                          "type": "boolean",
+                          "description": "PREVIEW: This key is in preview.\nWhen address-only is configured, the source IP of the packet is set to the interface\nIP but the packet may exit the device via a different interface.\nWhen set to `false`, the probe uses the interface to exit the device.\nNot supported yet in EOS.",
+                          "default": true,
+                          "title": "Address Only"
                         },
                         "url": {
                           "type": "string",
@@ -27099,6 +27111,12 @@
                           "type": "string",
                           "title": "Local Interfaces"
                         },
+                        "address_only": {
+                          "type": "boolean",
+                          "description": "PREVIEW: This key is in preview.\nWhen address-only is configured, the source IP of the packet is set to the interface\nIP but the packet may exit the device via a different interface.\nWhen set to `false`, the probe uses the interface to exit the device.\nNot supported yet in EOS.",
+                          "default": true,
+                          "title": "Address Only"
+                        },
                         "hosts": {
                           "type": "array",
                           "items": {
@@ -27120,6 +27138,12 @@
                               "local_interfaces": {
                                 "type": "string",
                                 "title": "Local Interfaces"
+                              },
+                              "address_only": {
+                                "type": "boolean",
+                                "description": "PREVIEW: This key is in preview.\nWhen address-only is configured, the source IP of the packet is set to the interface\nIP but the packet may exit the device via a different interface.\nWhen set to `false`, the probe uses the interface to exit the device.\nNot supported yet in EOS.",
+                                "default": true,
+                                "title": "Address Only"
                               },
                               "url": {
                                 "type": "string",


### PR DESCRIPTION
## Change Summary

> [!IMPORTANT]  
> You need a very recent engineering version of EOS to test - this is not yet released.

This PR is required for WAN Internet Exit configuration towards SWG

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

* Add a boolean `address_only` in the four places where it can now be disabled
* Set the boolean to `true` by default to be backward compatible
    * In AVD 5.0 we may decide to make it default False -> **this needs to be tracked as a 5.0 issue if we decide so** 
* Exercise the new knob in 3 of the four places - can make it work as well in the last one but requires an extra host in `eos_cli_config_gen` molecule.

## How to test

molecule

## Checklist

### Reviewer Checklist

- [ ] For documentation, rather than adding a template we could decide to add `(address-only)` in the local interfaces cell when this is configured and nothing otherwise, if the reviewer feels strongly about this, we can change that.
 
### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
