### PR TITLE
Add optional dependency ansible to pyavd

### DIFF
--- a/ansible_collections/arista/avd/docs/pyavd.md
+++ b/ansible_collections/arista/avd/docs/pyavd.md
@@ -86,6 +86,13 @@ Optional `md-toc` requirement (automatically installed with above command):
 md-toc>=8.1.8
 ```
 
+To install ansible [avd collection additional python requirements](installation/collection-installation.md#additional-python-libraries-required) install with extra `ansible`:
+
+```sh
+pip3 install pyavd[ansible]
+```
+
+
 ## Reference
 
 ::: pyavd.validate_inputs

--- a/ansible_collections/arista/avd/docs/pyavd.md
+++ b/ansible_collections/arista/avd/docs/pyavd.md
@@ -92,7 +92,6 @@ To install ansible [avd collection additional python requirements](installation/
 pip3 install pyavd[ansible]
 ```
 
-
 ## Reference
 
 ::: pyavd.validate_inputs

--- a/python-avd/.gitignore
+++ b/python-avd/.gitignore
@@ -12,3 +12,5 @@ __pycache__/
 /pyavd/version.py
 *.prof
 /site/
+
+requirements-ansible-avd.txt

--- a/python-avd/Makefile
+++ b/python-avd/Makefile
@@ -68,6 +68,8 @@ copy-libs: ## Copy files from Ansible AVD collection
 	cp -r $(ANSIBLE_AVD_DIR)/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.pickle $(SCHEMAS_DIR)/
 	cp -r $(ANSIBLE_AVD_DIR)/ansible_collections/arista/avd/plugins/plugin_utils/schema/avd_meta_schema.pickle $(SCHEMAS_DIR)/
 
+	cp $(ANSIBLE_AVD_DIR)/ansible_collections/arista/avd/requirements.txt requirements-ansible-avd.txt
+
 .PHONY: fix-libs
 fix-libs: ## Fix/remove various Ansible specifics things from python files
 	rm -f $(VENDOR_DIR)/schema/avdschematools.py

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -55,7 +55,7 @@ exclude = ["vendor_overrides*"]
 [tool.setuptools.dynamic]
 version = {attr = "pyavd.__version__"}
 dependencies = {file = ["requirements.txt"]}
-optional-dependencies = {"mdtoc" = { file = ["requirements-mdtoc.txt"] }}
+optional-dependencies = {"mdtoc" = { file = ["requirements-mdtoc.txt"] }, "ansible" = { file = ["requirements-ansible-avd.txt"] } }
 
 [tool.black]
 line-length = 160


### PR DESCRIPTION
## Change Summary
Added optional dependency ansible to pyavd that requires ansible avd collection python requirements.

## How to test
Build pyavd package
pip install pyavd-path-to-wheel[ansible] should install all requirements listed at ansible_collections/arista/avd/requirements.txt

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
