### PR TITLE
Fix(eos_designs): Fix missing features from LACP fallback individual

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
@@ -13,6 +13,9 @@ no aaa root
 !
 vrf instance MGMT
 !
+link tracking group LT_GROUP1
+   recovery delay 300
+!
 interface Port-Channel5
    description OLD_SW-1/5_PORT_CHANNEL_DESCRIPTION
    no shutdown
@@ -30,6 +33,13 @@ interface Port-Channel10
 !
 interface Port-Channel12
    description INDIVIDUAL_1_INDIVIDUAL_1
+   no shutdown
+   switchport
+   port-channel lacp fallback timeout 90
+   port-channel lacp fallback individual
+!
+interface Port-Channel15
+   description INDIVIDUAL_2_TRUNK_PHONE
    no shutdown
    switchport
    port-channel lacp fallback timeout 90
@@ -82,9 +92,21 @@ interface Ethernet12
    switchport trunk allowed vlan 1,2,3,4,5,6,7,123,234
    switchport mode trunk
    switchport
+   dot1x unauthorized access vlan membership egress
+   dot1x unauthorized native vlan membership egress
    channel-group 12 mode active
+   poe disabled
+   ptp enable
+   ptp sync-message interval -3
+   ptp announce interval 0
+   ptp transport ipv4
+   ptp announce timeout 3
+   ptp delay-req interval -3
+   ptp role master
+   service-profile MYQOS
    spanning-tree portfast
    spanning-tree bpdufilter enable
+   no sflow enable
 !
 interface Ethernet13
    description INDIVIDUAL_1
@@ -93,9 +115,21 @@ interface Ethernet13
    switchport trunk allowed vlan 1,2,3,4,5,6,7,123,234
    switchport mode trunk
    switchport
+   dot1x unauthorized access vlan membership egress
+   dot1x unauthorized native vlan membership egress
    channel-group 12 mode active
+   poe disabled
+   ptp enable
+   ptp sync-message interval -3
+   ptp announce interval 0
+   ptp transport ipv4
+   ptp announce timeout 3
+   ptp delay-req interval -3
+   ptp role master
+   service-profile MYQOS
    spanning-tree portfast
    spanning-tree bpdufilter enable
+   no sflow enable
 !
 interface Ethernet14
    description DOT1X_UNAUTHORIZED
@@ -106,8 +140,38 @@ interface Ethernet14
    switchport
    dot1x unauthorized access vlan membership egress
    dot1x unauthorized native vlan membership egress
+   poe disabled
+   ptp enable
+   ptp sync-message interval -3
+   ptp announce interval 0
+   ptp transport ipv4
+   ptp announce timeout 3
+   ptp delay-req interval -3
+   ptp role master
+   service-profile MYQOS
    spanning-tree portfast
    spanning-tree bpdufilter enable
+   no sflow enable
+!
+interface Ethernet15
+   description INDIVIDUAL_2_TRUNK_PHONE
+   no shutdown
+   switchport trunk native vlan 123
+   switchport phone vlan 321
+   switchport mode trunk phone
+   switchport
+   channel-group 15 mode active
+   link tracking group LT_GROUP1 downstream
+!
+interface Ethernet16
+   description INDIVIDUAL_2_TRUNK_PHONE
+   no shutdown
+   switchport trunk native vlan 123
+   switchport phone vlan 321
+   switchport mode trunk phone
+   switchport
+   channel-group 15 mode active
+   link tracking group LT_GROUP1 downstream
 no ip routing vrf MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
@@ -13,6 +13,9 @@ management_api_http:
   enable_vrfs:
   - name: MGMT
   enable_https: true
+link_tracking_groups:
+- name: LT_GROUP1
+  recovery_delay: 300
 ip_igmp_snooping:
   globally_enabled: true
 ethernet_interfaces:
@@ -97,6 +100,25 @@ ethernet_interfaces:
   native_vlan: 123
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: 'True'
+  dot1x:
+    unauthorized:
+      access_vlan_membership_egress: true
+      native_vlan_membership_egress: true
+  poe:
+    disabled: true
+  ptp:
+    announce:
+      interval: 0
+      timeout: 3
+    delay_req: -3
+    sync_message:
+      interval: -3
+    transport: ipv4
+    enable: true
+    role: master
+  service_profile: MYQOS
+  sflow:
+    enable: false
 - name: Ethernet13
   peer: INDIVIDUAL_1
   peer_type: server
@@ -112,6 +134,25 @@ ethernet_interfaces:
   native_vlan: 123
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: 'True'
+  dot1x:
+    unauthorized:
+      access_vlan_membership_egress: true
+      native_vlan_membership_egress: true
+  poe:
+    disabled: true
+  ptp:
+    announce:
+      interval: 0
+      timeout: 3
+    delay_req: -3
+    sync_message:
+      interval: -3
+    transport: ipv4
+    enable: true
+    role: master
+  service_profile: MYQOS
+  sflow:
+    enable: false
 - name: Ethernet14
   peer: DOT1X_UNAUTHORIZED
   peer_type: server
@@ -129,6 +170,53 @@ ethernet_interfaces:
     unauthorized:
       access_vlan_membership_egress: true
       native_vlan_membership_egress: true
+  poe:
+    disabled: true
+  ptp:
+    announce:
+      interval: 0
+      timeout: 3
+    delay_req: -3
+    sync_message:
+      interval: -3
+    transport: ipv4
+    enable: true
+    role: master
+  service_profile: MYQOS
+  sflow:
+    enable: false
+- name: Ethernet15
+  peer: INDIVIDUAL_2_TRUNK_PHONE
+  peer_type: server
+  description: INDIVIDUAL_2_TRUNK_PHONE
+  shutdown: false
+  type: switched
+  channel_group:
+    id: 15
+    mode: active
+  mode: trunk phone
+  native_vlan: 123
+  phone:
+    vlan: 321
+  link_tracking_groups:
+  - name: LT_GROUP1
+    direction: downstream
+- name: Ethernet16
+  peer: INDIVIDUAL_2_TRUNK_PHONE
+  peer_type: server
+  description: INDIVIDUAL_2_TRUNK_PHONE
+  shutdown: false
+  type: switched
+  channel_group:
+    id: 15
+    mode: active
+  mode: trunk phone
+  native_vlan: 123
+  phone:
+    vlan: 321
+  link_tracking_groups:
+  - name: LT_GROUP1
+    direction: downstream
 port_channel_interfaces:
 - name: Port-Channel5
   description: OLD_SW-1/5_PORT_CHANNEL_DESCRIPTION
@@ -148,3 +236,11 @@ port_channel_interfaces:
   shutdown: false
   lacp_fallback_mode: individual
   lacp_fallback_timeout: 90
+- name: Port-Channel15
+  description: INDIVIDUAL_2_TRUNK_PHONE
+  type: switched
+  shutdown: false
+  lacp_fallback_mode: individual
+  lacp_fallback_timeout: 90
+metadata:
+  platform: 720XP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
@@ -5,6 +5,9 @@ l2leaf:
   defaults:
   nodes:
     - name: connected_endpoints
+      platform: 720XP
+      link_tracking:
+        enabled: true
 
 servers:
   # single port override physical port description
@@ -63,7 +66,16 @@ servers:
       - switches: [connected_endpoints]
         switch_ports: [Ethernet14]
         profile: INDIVIDUAL_TRUNK
-
+  - name: INDIVIDUAL_2_TRUNK_PHONE
+    adapters:
+      - switches: [connected_endpoints, connected_endpoints]
+        switch_ports: [Ethernet15, Ethernet16]
+        port_channel:
+          mode: "active"
+          lacp_fallback:
+            mode: individual
+            individual:
+              profile: INDIVIDUAL_TRUNK_PHONE
 port_profiles:
   - profile: INDIVIDUAL_TRUNK
     mode: trunk
@@ -76,3 +88,16 @@ port_profiles:
       unauthorized:
         access_vlan_membership_egress: True
         native_vlan_membership_egress: True
+    qos_profile: MYQOS
+    poe:
+      disabled: true
+    ptp:
+      enabled: true
+    sflow: false
+
+  - profile: INDIVIDUAL_TRUNK_PHONE
+    mode: trunk phone
+    native_vlan: 123
+    phone_vlan: 321
+    link_tracking:
+      enabled: true

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/ethernet_interfaces.py
@@ -94,6 +94,13 @@ class EthernetInterfacesMixin(UtilsMixin):
                 "spanning_tree_bpdufilter": adapter.get("spanning_tree_bpdufilter"),
                 "spanning_tree_bpduguard": adapter.get("spanning_tree_bpduguard"),
                 "storm_control": self._get_adapter_storm_control(adapter),
+                "dot1x": adapter.get("dot1x"),
+                "phone": self._get_adapter_phone(adapter, connected_endpoint),
+                "poe": self._get_adapter_poe(adapter),
+                "ptp": self._get_adapter_ptp(adapter),
+                "service_profile": adapter.get("qos_profile"),
+                "sflow": self._get_adapter_sflow(adapter),
+                "link_tracking_groups": self._get_adapter_link_tracking_groups(adapter),
             }
         )
         return ethernet_interface
@@ -190,19 +197,8 @@ class EthernetInterfacesMixin(UtilsMixin):
         # NOT a port-channel member
         else:
             ethernet_interface = self._update_ethernet_interface_cfg(adapter, ethernet_interface, connected_endpoint)
-            ethernet_interface.update(
-                {
-                    "dot1x": adapter.get("dot1x"),
-                    "phone": self._get_adapter_phone(adapter, connected_endpoint),
-                    "poe": self._get_adapter_poe(adapter),
-                    "ptp": self._get_adapter_ptp(adapter),
-                    "service_profile": adapter.get("qos_profile"),
-                    "sflow": self._get_adapter_sflow(adapter),
-                    "evpn_ethernet_segment": self._get_adapter_evpn_ethernet_segment_cfg(
-                        adapter, short_esi, node_index, connected_endpoint, "auto", "single-active"
-                    ),
-                    "link_tracking_groups": self._get_adapter_link_tracking_groups(adapter),
-                }
+            ethernet_interface["evpn_ethernet_segment"] = self._get_adapter_evpn_ethernet_segment_cfg(
+                adapter, short_esi, node_index, connected_endpoint, "auto", "single-active"
             )
 
         # More common ethernet_interface settings


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix missing features from LACP fallback individual

## Related Issue(s)

Fixes #3822 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Fix and add testing for missing features under LACP fallback individual:

- dot1x
- phone
- poe
- ptp
- qos profile
- sflow
- link-tracking

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added molecule coverage.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
