### PR TITLE
CI: Change label for dependabot PRs to 'type: dependencies'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     reviewers:
       - "aristanetworks/avd-maintainers"
     labels:
-      - 'dependencies'
+      - 'dependabot'
     pull-request-branch-name:
       separator: "/"
     commit-message:
@@ -29,7 +29,7 @@ updates:
     reviewers:
       - "aristanetworks/avd-maintainers"
     labels:
-      - 'dependencies'
+      - 'dependabot'
     pull-request-branch-name:
       separator: "/"
     commit-message:
@@ -46,7 +46,7 @@ updates:
     reviewers:
       - "aristanetworks/avd-maintainers"
     labels:
-      - 'CI'
+      - 'dependabot'
     commit-message:
       prefix: "CI: "
     open-pull-requests-limit: 10

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     reviewers:
       - "aristanetworks/avd-maintainers"
     labels:
-      - 'dependabot'
+      - 'type: dependencies'
     pull-request-branch-name:
       separator: "/"
     commit-message:
@@ -29,7 +29,7 @@ updates:
     reviewers:
       - "aristanetworks/avd-maintainers"
     labels:
-      - 'dependabot'
+      - 'type: dependencies'
     pull-request-branch-name:
       separator: "/"
     commit-message:
@@ -46,7 +46,7 @@ updates:
     reviewers:
       - "aristanetworks/avd-maintainers"
     labels:
-      - 'dependabot'
+      - 'type: dependencies'
     commit-message:
       prefix: "CI: "
     open-pull-requests-limit: 10


### PR DESCRIPTION
## Change Summary

cf title

## Component(s) name

`ci`

## Proposed changes

Changing the previous labels (which don't exist and would be confusing)

~If PR is approved, need to create the `dependabot` label~

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
