### PR TITLE
Revert: "Bump pre-commit-ci/lite-action from 1.0.0 to 1.0.2"

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           pre-commit run --all-files --color always
       # Do NOT set a name for the pre-commit-ci action. Otherwise the Github App will not pick it up.
-      - uses: pre-commit-ci/lite-action@v1.0.2
+      - uses: pre-commit-ci/lite-action@v1.0.0
         if: always()
 
   # ----------------------------------- #


### PR DESCRIPTION
Reverts aristanetworks/avd#3859

Currently version 1.0.2 is not allowed on our org. an HelpDesk ticket has been opened but in the meantime we need to revert until it is fixed. 