### PR TITLE
Feat(eos_cli_config_gen): Support SA lifetime for IP sec

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -54,11 +54,11 @@ interface Management1
 
 ### Security Association policies
 
-| Policy name | ESP Integrity | ESP Encryption | PFS DH Group |
-| ----------- | ------------- | -------------- | ------------ |
-| SA-1 | - | aes128 | 14 |
-| SA-2 | - | aes128 | 14 |
-| SA-3 | disabled | disabled | 17 |
+| Policy name | ESP Integrity | ESP Encryption | Lifetime | PFS DH Group |
+| ----------- | ------------- | -------------- | -------- | ------------ |
+| SA-1 | - | aes128 | - | 14 |
+| SA-2 | - | aes128 | 42 gigabytes | 14 |
+| SA-3 | disabled | disabled | 8 hours | 17 |
 
 ### IPSec profiles
 
@@ -100,11 +100,13 @@ ip security
    !
    sa policy SA-2
       esp encryption aes128
+      sa lifetime 42 gigabytes
       pfs dh-group 14
    !
    sa policy SA-3
       esp integrity null
       esp encryption null
+      sa lifetime 8 hours
       pfs dh-group 17
    !
    profile Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -29,11 +29,13 @@ ip security
    !
    sa policy SA-2
       esp encryption aes128
+      sa lifetime 42 gigabytes
       pfs dh-group 14
    !
    sa policy SA-3
       esp integrity null
       esp encryption null
+      sa lifetime 8 hours
       pfs dh-group 17
    !
    profile Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -21,11 +21,17 @@ ip_security:
     - name: SA-2
       esp:
         encryption: aes128
+      sa_lifetime:
+        value: 42
+        unit: gigabytes
       pfs_dh_group: 14
     - name: SA-3
       esp:
         integrity: disabled
         encryption: disabled
+      sa_lifetime:
+        value: 8
+        # default unit is hours
       pfs_dh_group: 17
   profiles:
     - name: Profile-1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -18,7 +18,7 @@
     | [<samp>&nbsp;&nbsp;sa_policies</samp>](## "ip_security.sa_policies") | List, items: Dictionary |  |  |  | Security Association policies. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sa_lifetime</samp>](## "ip_security.sa_policies.[].sa_lifetime") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "ip_security.sa_policies.[].sa_lifetime.value") | Integer |  |  |  | Lifetime value for this SA.<br>Valid range depends on the unit. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "ip_security.sa_policies.[].sa_lifetime.value") | Integer |  |  |  | Lifetime value for this SA.<br>Valid range depends on the unit.<br><1-24>       Lifetime in hours ( default )<br><1-4000000>  Packet limit in thousands<br><1-6000>     Byte limit in GB ( 1024 MB )<br><1-6144000>  Byte limit in MB ( 1024 KB ) |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ip_security.sa_policies.[].sa_lifetime.unit") | String |  | `hours` | Valid Values:<br>- <code>gigabytes</code><br>- <code>hours</code><br>- <code>megabytes</code><br>- <code>thousand-packets</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;esp</samp>](## "ip_security.sa_policies.[].esp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.sa_policies.[].esp.integrity") | String |  |  | Valid Values:<br>- <code>disabled</code><br>- <code>sha1</code><br>- <code>sha256</code><br>- <code>null</code> |  |
@@ -78,6 +78,10 @@
 
             # Lifetime value for this SA.
             # Valid range depends on the unit.
+            # <1-24>       Lifetime in hours ( default )
+            # <1-4000000>  Packet limit in thousands
+            # <1-6000>     Byte limit in GB ( 1024 MB )
+            # <1-6144000>  Byte limit in MB ( 1024 KB )
             value: <int>
             unit: <str; "gigabytes" | "hours" | "megabytes" | "thousand-packets"; default="hours">
           esp:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -17,6 +17,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dh_group</samp>](## "ip_security.ike_policies.[].dh_group") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>5</code><br>- <code>14</code><br>- <code>15</code><br>- <code>16</code><br>- <code>17</code><br>- <code>20</code><br>- <code>21</code><br>- <code>24</code> | Diffie-Hellman group for the key exchange. |
     | [<samp>&nbsp;&nbsp;sa_policies</samp>](## "ip_security.sa_policies") | List, items: Dictionary |  |  |  | Security Association policies. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0 |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sa_lifetime</samp>](## "ip_security.sa_policies.[].sa_lifetime") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "ip_security.sa_policies.[].sa_lifetime.value") | Integer |  |  |  | Lifetime value for this SA.<br>Valid range depends on the unit. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ip_security.sa_policies.[].sa_lifetime.unit") | String |  | `hours` | Valid Values:<br>- <code>gigabytes</code><br>- <code>hours</code><br>- <code>megabytes</code><br>- <code>thousand-packets</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;esp</samp>](## "ip_security.sa_policies.[].esp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.sa_policies.[].esp.integrity") | String |  |  | Valid Values:<br>- <code>disabled</code><br>- <code>sha1</code><br>- <code>sha256</code><br>- <code>null</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.sa_policies.[].esp.encryption") | String |  |  | Valid Values:<br>- <code>disabled</code><br>- <code>aes128</code><br>- <code>aes128gcm128</code><br>- <code>aes128gcm64</code><br>- <code>aes256</code><br>- <code>aes256gcm128</code><br>- <code>null</code> |  |
@@ -71,6 +74,12 @@
 
           # Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0
         - name: <str; required; unique>
+          sa_lifetime:
+
+            # Lifetime value for this SA.
+            # Valid range depends on the unit.
+            value: <int>
+            unit: <str; "gigabytes" | "hours" | "megabytes" | "thousand-packets"; default="hours">
           esp:
             integrity: <str; "disabled" | "sha1" | "sha256" | "null">
             encryption: <str; "disabled" | "aes128" | "aes128gcm128" | "aes128gcm64" | "aes256" | "aes256gcm128" | "null">

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7803,7 +7803,7 @@
                 "properties": {
                   "value": {
                     "type": "integer",
-                    "description": "Lifetime value for this SA.\nValid range depends on the unit.",
+                    "description": "Lifetime value for this SA.\nValid range depends on the unit.\n<1-24>       Lifetime in hours ( default )\n<1-4000000>  Packet limit in thousands\n<1-6000>     Byte limit in GB ( 1024 MB )\n<1-6144000>  Byte limit in MB ( 1024 KB )",
                     "title": "Value"
                   },
                   "unit": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -7798,6 +7798,32 @@
                 "description": "Name of the SA policy. The \"null\" value is deprecated and will be removed in AVD 5.0.0",
                 "title": "Name"
               },
+              "sa_lifetime": {
+                "type": "object",
+                "properties": {
+                  "value": {
+                    "type": "integer",
+                    "description": "Lifetime value for this SA.\nValid range depends on the unit.",
+                    "title": "Value"
+                  },
+                  "unit": {
+                    "type": "string",
+                    "enum": [
+                      "gigabytes",
+                      "hours",
+                      "megabytes",
+                      "thousand-packets"
+                    ],
+                    "default": "hours",
+                    "title": "Unit"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Sa Lifetime"
+              },
               "esp": {
                 "type": "object",
                 "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4656,6 +4656,22 @@ keys:
               type: str
               description: Name of the SA policy. The "null" value is deprecated and
                 will be removed in AVD 5.0.0
+            sa_lifetime:
+              type: dict
+              keys:
+                value:
+                  type: int
+                  description: 'Lifetime value for this SA.
+
+                    Valid range depends on the unit.'
+                unit:
+                  type: str
+                  valid_values:
+                  - gigabytes
+                  - hours
+                  - megabytes
+                  - thousand-packets
+                  default: hours
             esp:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -4663,7 +4663,15 @@ keys:
                   type: int
                   description: 'Lifetime value for this SA.
 
-                    Valid range depends on the unit.'
+                    Valid range depends on the unit.
+
+                    <1-24>       Lifetime in hours ( default )
+
+                    <1-4000000>  Packet limit in thousands
+
+                    <1-6000>     Byte limit in GB ( 1024 MB )
+
+                    <1-6144000>  Byte limit in MB ( 1024 KB )'
                 unit:
                   type: str
                   valid_values:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
@@ -60,6 +60,22 @@ keys:
             name:
               type: str
               description: Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0
+            sa_lifetime:
+              type: dict
+              keys:
+                value:
+                  type: int
+                  description: |-
+                    Lifetime value for this SA.
+                    Valid range depends on the unit.
+                unit:
+                  type: str
+                  valid_values:
+                    - gigabytes
+                    - hours
+                    - megabytes
+                    - thousand-packets
+                  default: hours
             esp:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ip_security.schema.yml
@@ -68,6 +68,10 @@ keys:
                   description: |-
                     Lifetime value for this SA.
                     Valid range depends on the unit.
+                    <1-24>       Lifetime in hours ( default )
+                    <1-4000000>  Packet limit in thousands
+                    <1-6000>     Byte limit in GB ( 1024 MB )
+                    <1-6144000>  Byte limit in MB ( 1024 KB )
                 unit:
                   type: str
                   valid_values:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ip-security.j2
@@ -25,10 +25,13 @@
 
 ### Security Association policies
 
-| Policy name | ESP Integrity | ESP Encryption | PFS DH Group |
-| ----------- | ------------- | -------------- | ------------ |
+| Policy name | ESP Integrity | ESP Encryption | Lifetime | PFS DH Group |
+| ----------- | ------------- | -------------- | -------- | ------------ |
 {%         for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
-| {{ sa_policy.name }} | {{ sa_policy.esp.integrity | arista.avd.default("-") }} | {{ sa_policy.esp.encryption | arista.avd.default("-") }} | {{ sa_policy.pfs_dh_group | arista.avd.default("-") }} |
+{%             if sa_policy.sa_lifetime.value is arista.avd.defined %}
+{%                 set lifetime = sa_policy.sa_lifetime.value ~ " " ~ sa_policy.sa_lifetime.unit | arista.avd.default("hours") %}
+{%             endif %}
+| {{ sa_policy.name }} | {{ sa_policy.esp.integrity | arista.avd.default("-") }} | {{ sa_policy.esp.encryption | arista.avd.default("-") }} | {{ lifetime | arista.avd.default("-") }} | {{ sa_policy.pfs_dh_group | arista.avd.default("-") }} |
 {%         endfor %}
 {%     endif %}
 {%     if ip_security.profiles is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ip-security.j2
@@ -42,6 +42,9 @@ ip security
       esp encryption {{ sa_policy.esp.encryption }}
 {%             endif %}
 {%         endif %}
+{%         if sa_policy.sa_lifetime.value is arista.avd.defined %}
+      sa lifetime {{ sa_policy.sa_lifetime.value }} {{ sa_policy.sa_lifetime.unit | arista.avd.default("hours") }}
+{%         endif %}
 {%         if sa_policy.pfs_dh_group is arista.avd.defined %}
       pfs dh-group {{ sa_policy.pfs_dh_group }}
 {%         endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -23547,7 +23547,7 @@
                           "properties": {
                             "value": {
                               "type": "integer",
-                              "description": "Lifetime value for this SA.\nValid range depends on the unit.",
+                              "description": "Lifetime value for this SA.\nValid range depends on the unit.\n<1-24>       Lifetime in hours ( default )\n<1-4000000>  Packet limit in thousands\n<1-6000>     Byte limit in GB ( 1024 MB )\n<1-6144000>  Byte limit in MB ( 1024 KB )",
                               "title": "Value"
                             },
                             "unit": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -23542,6 +23542,32 @@
                           "description": "Name of the SA policy. The \"null\" value is deprecated and will be removed in AVD 5.0.0",
                           "title": "Name"
                         },
+                        "sa_lifetime": {
+                          "type": "object",
+                          "properties": {
+                            "value": {
+                              "type": "integer",
+                              "description": "Lifetime value for this SA.\nValid range depends on the unit.",
+                              "title": "Value"
+                            },
+                            "unit": {
+                              "type": "string",
+                              "enum": [
+                                "gigabytes",
+                                "hours",
+                                "megabytes",
+                                "thousand-packets"
+                              ],
+                              "default": "hours",
+                              "title": "Unit"
+                            }
+                          },
+                          "additionalProperties": false,
+                          "patternProperties": {
+                            "^_.+$": {}
+                          },
+                          "title": "Sa Lifetime"
+                        },
                         "esp": {
                           "type": "object",
                           "properties": {


### PR DESCRIPTION
## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```
edge4B(config-ipsec-sa)#show cli commands | grep lifetime
[no|default] sa lifetime <byteLimit> gigabytes
[no|default] sa lifetime <byteLimit> megabytes
[no|default] sa lifetime <packetLimit> thousand-packets
[no|default] sa lifetime <time> [ hours ]

edge4B(config-ipsec-sa)#sa lifetime ?
  <1-24>       Lifetime in hours ( default )
  <1-4000000>  Packet limit in thousands
  <1-6000>     Byte limit in GB ( 1024 MB )
  <1-6144000>  Byte limit in MB ( 1024 KB )

edge4B(config-ipsec-sa)#sa lifetime 5 ?
  gigabytes         Byte limit in GB ( 1024 MB )
  hours             Lifetime in hours ( default )
  megabytes         Byte limit in MB ( 1024 KB )
  thousand-packets  Packet limit in thousands
  <cr>

```

Proposed schema

```
         - name: <str; required; unique>
+          sa_lifetime:
+
+            # Lifetime value for this SA.
+            # Valid range depends on the unit.
+            value: <int>
+            unit: <str; "gigabytes" | "hours" | "megabytes" | "thousand-packets"; default="hours">
```

## How to test
molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
