### PR TITLE
Feat(eos_cli_config_gen): Enhance event-handlers model to accommodate other triggers with their specificities.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -77,6 +77,7 @@ event-handler trigger-on-boot
 event-handler trigger-on-counters
    trigger on-counters
       poll interval 10
+      condition bashCmd."FastCli -c 'show interface counters rates'"
    action bash echo "on-counters"
 !
 event-handler trigger-on-intf
@@ -86,6 +87,7 @@ event-handler trigger-on-intf
 event-handler trigger-on-logging
    trigger on-logging
       poll interval 10
+      regex ab*
    action bash echo "on-logging"
 !
 event-handler trigger-on-maintenance1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -44,7 +44,6 @@ interface Management1
 | Handler | Action Type | Action | Trigger |
 | ------- | ----------- | ------ | ------- |
 | CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config |
-| evpn-blacklist-recovery | bash | <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging |
 | trigger-on-boot | bash | <code>echo "on-boot"</code> | on-boot |
 | trigger-on-counters | bash | <code>echo "on-counters"</code> | on-counters |
 | trigger-on-intf | bash | <code>echo "on-intf"</code> | on-intf |
@@ -62,13 +61,6 @@ event-handler CONFIG_VERSIONING
    trigger on-startup-config
    action bash FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* | tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* | tail -n +11 | xargs -I % rm %; fi
    delay 0
-!
-event-handler evpn-blacklist-recovery
-   trigger on-logging
-      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
-   action bash FastCli -p 15 -c "clear bgp evpn host-flap"
-   delay 300
-   asynchronous
 !
 event-handler trigger-on-boot
    trigger on-boot

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -77,7 +77,8 @@ event-handler trigger-on-boot
 event-handler trigger-on-counters
    trigger on-counters
       poll interval 10
-      condition bashCmd."FastCli -c 'show interface counters rates'"
+      condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
+      granularity per-source
    action bash echo "on-counters"
 !
 event-handler trigger-on-intf

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -41,17 +41,17 @@ interface Management1
 
 #### Event Handler Summary
 
-| Handler | Action Type | Action | Trigger |
-| ------- | ----------- | ------ | ------- |
-| CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config |
-| trigger-on-boot | bash | <code>echo "on-boot"</code> | on-boot |
-| trigger-on-counters | bash | <code>echo "on-counters"</code> | on-counters |
-| trigger-on-intf | bash | <code>echo "on-intf"</code> | on-intf |
-| trigger-on-logging | bash | <code>echo "on-logging"</code> | on-logging |
-| trigger-on-maintenance1 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
-| trigger-on-maintenance2 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
-| trigger-on-maintenance3 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
-| trigger-vm-tracer | bash | <code>echo "vm-tracer vm"</code> | vm-tracer vm |
+| Handler | Action Type | Action | Trigger | Trigger Config |
+| ------- | ----------- | ------ | ------- | -------------- |
+| CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config | - |
+| trigger-on-boot | bash | <code>echo "on-boot"</code> | on-boot | - |
+| trigger-on-counters | bash | <code>echo "on-counters"</code> | on-counters | poll interval 10<br>condition( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )<br>granularity per-source |
+| trigger-on-intf | bash | <code>echo "on-intf"</code> | on-intf | trigger on-intf Ethernet4 operstatus ip ip6 |
+| trigger-on-logging | bash | <code>echo "on-logging"</code> | on-logging | poll interval 10<br>regex ab* |
+| trigger-on-maintenance1 | bash | <code>echo "on-maintenance"</code> | on-maintenance | trigger on-maintenance enter interface Management3 after stage linkdown |
+| trigger-on-maintenance2 | bash | <code>echo "on-maintenance"</code> | on-maintenance | trigger on-maintenance enter unit unit1 before stage bgp |
+| trigger-on-maintenance3 | bash | <code>echo "on-maintenance"</code> | on-maintenance | trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 all |
+| trigger-vm-tracer | bash | <code>echo "vm-tracer vm"</code> | vm-tracer vm | - |
 
 #### Event Handler Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -46,9 +46,13 @@ interface Management1
 | CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config |
 | evpn-blacklist-recovery | bash | <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging |
 | trigger-on-boot | bash | <code>echo "on-boot"</code> | on-boot |
+| trigger-on-counters | bash | <code>echo "on-counters"</code> | on-counters |
+| trigger-on-intf | bash | <code>echo "on-intf"</code> | on-intf |
+| trigger-on-logging | bash | <code>echo "on-logging"</code> | on-logging |
 | trigger-on-maintenance1 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
 | trigger-on-maintenance2 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
 | trigger-on-maintenance3 | bash | <code>echo "on-maintenance"</code> | on-maintenance |
+| trigger-vm-tracer | bash | <code>echo "vm-tracer vm"</code> | vm-tracer vm |
 
 #### Event Handler Device Configuration
 
@@ -70,6 +74,20 @@ event-handler trigger-on-boot
    trigger on-boot
    action bash echo "on-boot"
 !
+event-handler trigger-on-counters
+   trigger on-counters
+      poll interval 10
+   action bash echo "on-counters"
+!
+event-handler trigger-on-intf
+   trigger on-intf Ethernet4 operstatus ip ip6
+   action bash echo "on-intf"
+!
+event-handler trigger-on-logging
+   trigger on-logging
+      poll interval 10
+   action bash echo "on-logging"
+!
 event-handler trigger-on-maintenance1
    trigger on-maintenance enter interface Management3 after stage linkdown
    action bash echo "on-maintenance"
@@ -81,4 +99,8 @@ event-handler trigger-on-maintenance2
 event-handler trigger-on-maintenance3
    trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 all
    action bash echo "on-maintenance"
+!
+event-handler trigger-vm-tracer
+   trigger vm-tracer vm
+   action bash echo "vm-tracer vm"
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -28,6 +28,20 @@ event-handler trigger-on-boot
    trigger on-boot
    action bash echo "on-boot"
 !
+event-handler trigger-on-counters
+   trigger on-counters
+      poll interval 10
+   action bash echo "on-counters"
+!
+event-handler trigger-on-intf
+   trigger on-intf Ethernet4 operstatus ip ip6
+   action bash echo "on-intf"
+!
+event-handler trigger-on-logging
+   trigger on-logging
+      poll interval 10
+   action bash echo "on-logging"
+!
 event-handler trigger-on-maintenance1
    trigger on-maintenance enter interface Management3 after stage linkdown
    action bash echo "on-maintenance"
@@ -39,5 +53,9 @@ event-handler trigger-on-maintenance2
 event-handler trigger-on-maintenance3
    trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 all
    action bash echo "on-maintenance"
+!
+event-handler trigger-vm-tracer
+   trigger vm-tracer vm
+   action bash echo "vm-tracer vm"
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -31,7 +31,8 @@ event-handler trigger-on-boot
 event-handler trigger-on-counters
    trigger on-counters
       poll interval 10
-      condition bashCmd."FastCli -c 'show interface counters rates'"
+      condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
+      granularity per-source
    action bash echo "on-counters"
 !
 event-handler trigger-on-intf

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -17,13 +17,6 @@ event-handler CONFIG_VERSIONING
    action bash FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* | tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* | tail -n +11 | xargs -I % rm %; fi
    delay 0
 !
-event-handler evpn-blacklist-recovery
-   trigger on-logging
-      regex EVPN-3-BLACKLISTED_DUPLICATE_MAC
-   action bash FastCli -p 15 -c "clear bgp evpn host-flap"
-   delay 300
-   asynchronous
-!
 event-handler trigger-on-boot
    trigger on-boot
    action bash echo "on-boot"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -31,6 +31,7 @@ event-handler trigger-on-boot
 event-handler trigger-on-counters
    trigger on-counters
       poll interval 10
+      condition bashCmd."FastCli -c 'show interface counters rates'"
    action bash echo "on-counters"
 !
 event-handler trigger-on-intf
@@ -40,6 +41,7 @@ event-handler trigger-on-intf
 event-handler trigger-on-logging
    trigger on-logging
       poll interval 10
+      regex ab*
    action bash echo "on-logging"
 !
 event-handler trigger-on-maintenance1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -53,7 +53,8 @@ event_handlers:
     trigger: on-counters
     trigger_on_counters:
       poll_interval: 10
-      condition: bashCmd."FastCli -c 'show interface counters rates'"
+      condition: ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
+      granularity_per_source: true
     action_type: bash
     action: echo "on-counters"
   - name: trigger-on-intf
@@ -69,4 +70,3 @@ event_handlers:
     trigger: "vm-tracer vm"
     action_type: bash
     action: echo "vm-tracer vm"
-  

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -42,3 +42,29 @@ event_handlers:
       action: all
     action_type: bash
     action: echo "on-maintenance"
+  - name: trigger-on-logging
+    trigger: on-logging
+    trigger_on_logging:
+      poll_interval: 10
+    action_type: bash
+    action: echo "on-logging"
+  - name: trigger-on-counters
+    trigger: on-counters
+    trigger_on_counters:
+      poll_interval: 10
+    action_type: bash
+    action: echo "on-counters"
+  - name: trigger-on-intf
+    trigger: on-intf
+    trigger_on_intf:
+      interface: Ethernet4
+      ip: true
+      ip6: true
+      operstatus: true
+    action_type: bash
+    action: echo "on-intf"
+  - name: trigger-vm-tracer
+    trigger: "vm-tracer vm"
+    action_type: bash
+    action: echo "vm-tracer vm"
+  

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -46,12 +46,14 @@ event_handlers:
     trigger: on-logging
     trigger_on_logging:
       poll_interval: 10
+      regex: "ab*"
     action_type: bash
     action: echo "on-logging"
   - name: trigger-on-counters
     trigger: on-counters
     trigger_on_counters:
       poll_interval: 10
+      condition: bashCmd."FastCli -c 'show interface counters rates'"
     action_type: bash
     action: echo "on-counters"
   - name: trigger-on-intf

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -1,11 +1,4 @@
 event_handlers:
-  - name: evpn-blacklist-recovery
-    action_type: bash
-    action: FastCli -p 15 -c "clear bgp evpn host-flap"
-    delay: 300
-    trigger: on-logging
-    regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
-    asynchronous: true
   - name: CONFIG_VERSIONING
     action_type: bash
     action: FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* | tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* | tail -n +11 | xargs -I % rm %; fi

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -55,7 +55,7 @@ event_handlers:
     trigger_on_intf:
       interface: Ethernet4
       ip: true
-      ip6: true
+      ipv6: true
       operstatus: true
     action_type: bash
     action: echo "on-intf"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -450,10 +450,10 @@ vmtracer session session_2
 
 #### Event Handler Summary
 
-| Handler | Action Type | Action | Trigger |
-| ------- | ----------- | ------ | ------- |
-| CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config |
-| evpn-blacklist-recovery | bash | <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging |
+| Handler | Action Type | Action | Trigger | Trigger Config |
+| ------- | ----------- | ------ | ------- | -------------- |
+| CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config | - |
+| evpn-blacklist-recovery | bash | <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging | - |
 
 #### Event Handler Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/event-handlers.yml
@@ -8,6 +8,7 @@ event_handlers:
     action: FastCli -p 15 -c "clear bgp evpn host-flap"
     delay: 300
     trigger: on-logging
+    # Testing regex key which is deprecared and will be removed in 5.0.0
     regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
     asynchronous: true
   CONFIG_VERSIONING:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -12,7 +12,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;conditon</samp>](## "event_handlers.[].trigger_on_counters.conditon") | String |  |  |  | Set the counters condition expression. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].trigger_on_logging.regex") | String |  |  |  | Regular expression to use for searching log messages. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_intf.interface") | String | Required |  |  | Interface name.<br>Example - Ethernet4<br>          Loopback4-6<br>          Port-channel4,7 |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "event_handlers.[].trigger_on_intf.ip") | Boolean |  |  |  | Action is triggered upon changes to interface IP address assignment. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip6</samp>](## "event_handlers.[].trigger_on_intf.ip6") | Boolean |  |  |  | Action is triggered upon changes to interface ip6 address assignment. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operstatus</samp>](## "event_handlers.[].trigger_on_intf.operstatus") | Boolean |  |  |  | Action is triggered upon changes to interface operStatus. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp_peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name.<br>Trigger condition occurs on maintenance operation of specified BGP peer. |
@@ -43,7 +54,37 @@
         delay: <int>
 
         # Configure event trigger condition.
-        trigger: <str; "on-boot" | "on-logging" | "on-startup-config" | "on-maintenance">
+        trigger: <str; "on-boot" | "on-counters" | "on-intf" | "on-logging" | "on-maintenance" | "on-startup-config" | "vm-tracer vm">
+        trigger_on_counters:
+
+          # Set the counters condition expression.
+          conditon: <str>
+
+          # Set the polling interval in seconds.
+          poll_interval: <int>
+        trigger_on_logging:
+
+          # Set the polling interval in seconds.
+          poll_interval: <int>
+
+          # Regular expression to use for searching log messages.
+          regex: <str>
+        trigger_on_intf:
+
+          # Interface name.
+          # Example - Ethernet4
+          #           Loopback4-6
+          #           Port-channel4,7
+          interface: <str; required>
+
+          # Action is triggered upon changes to interface IP address assignment.
+          ip: <bool>
+
+          # Action is triggered upon changes to interface ip6 address assignment.
+          ip6: <bool>
+
+          # Action is triggered upon changes to interface operStatus.
+          operstatus: <bool>
 
         # Settings required for trigger 'on-maintenance'.
         trigger_on_maintenance:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -15,6 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;condition</samp>](## "event_handlers.[].trigger_on_counters.condition") | String |  |  |  | Set the counters condition expression. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;granularity_per_source</samp>](## "event_handlers.[].trigger_on_counters.granularity_per_source") | Boolean |  |  |  | Set the granularity of event counting for a wildcarded condition.<br>Example -<br>  condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )<br>  [* wildcard is used here] |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
@@ -59,6 +60,12 @@
 
           # Set the counters condition expression.
           condition: <str>
+
+          # Set the granularity of event counting for a wildcarded condition.
+          # Example -
+          #   condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
+          #   [* wildcard is used here]
+          granularity_per_source: <bool>
 
           # Set the polling interval in seconds.
           poll_interval: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -33,7 +33,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp_peer" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") <span style="color:red">deprecated</span> | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.trigger_on_logging.regex</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking.<br> |
 
 === "YAML"
@@ -120,6 +120,9 @@
           unit: <str>
 
         # Regular expression to use for searching log messages. Required for on-logging trigger.
+        # This key is deprecated.
+        # Support will be removed in AVD version 5.0.0.
+        # Use <samp>event_handlers.trigger_on_logging.regex</samp> instead.
         regex: <str>
 
         # Set the action to be non-blocking.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -14,7 +14,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;conditon</samp>](## "event_handlers.[].trigger_on_counters.conditon") | String |  |  |  | Set the counters condition expression. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;condition</samp>](## "event_handlers.[].trigger_on_counters.condition") | String |  |  |  | Set the counters condition expression. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
@@ -58,7 +58,7 @@
         trigger_on_counters:
 
           # Set the counters condition expression.
-          conditon: <str>
+          condition: <str>
 
           # Set the polling interval in seconds.
           poll_interval: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -20,10 +20,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  | Min: 1<br>Max: 1000000 | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].trigger_on_logging.regex") | String |  |  |  | Regular expression to use for searching log messages. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  | Trigger condition occurs on specified interface changes.<br>Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface` |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  | Trigger condition occurs on specified interface changes.<br>Note: Any one of the `ip`, `ipv6` and `operstatus` key needs to be defined along with the `interface`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_intf.interface") | String | Required |  |  | Interface name.<br>Example - Ethernet4<br>          Loopback4-6<br>          Port-channel4,7 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "event_handlers.[].trigger_on_intf.ip") | Boolean |  |  |  | Action is triggered upon changes to interface IP address assignment. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip6</samp>](## "event_handlers.[].trigger_on_intf.ip6") | Boolean |  |  |  | Action is triggered upon changes to interface ip6 address assignment. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "event_handlers.[].trigger_on_intf.ipv6") | Boolean |  |  |  | Action is triggered upon changes to interface ipv6 address assignment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operstatus</samp>](## "event_handlers.[].trigger_on_intf.operstatus") | Boolean |  |  |  | Action is triggered upon changes to interface operStatus. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
@@ -78,7 +78,7 @@
           regex: <str>
 
         # Trigger condition occurs on specified interface changes.
-        # Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`
+        # Note: Any one of the `ip`, `ipv6` and `operstatus` key needs to be defined along with the `interface`.
         trigger_on_intf:
 
           # Interface name.
@@ -90,8 +90,8 @@
           # Action is triggered upon changes to interface IP address assignment.
           ip: <bool>
 
-          # Action is triggered upon changes to interface ip6 address assignment.
-          ip6: <bool>
+          # Action is triggered upon changes to interface ipv6 address assignment.
+          ipv6: <bool>
 
           # Action is triggered upon changes to interface operStatus.
           operstatus: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -14,13 +14,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;condition</samp>](## "event_handlers.[].trigger_on_counters.condition") | String |  |  |  | Set the counters condition expression. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;condition</samp>](## "event_handlers.[].trigger_on_counters.condition") | String |  |  |  | Set the logical expression to evaluate. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;granularity_per_source</samp>](## "event_handlers.[].trigger_on_counters.granularity_per_source") | Boolean |  |  |  | Set the granularity of event counting for a wildcarded condition.<br>Example -<br>  condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )<br>  [* wildcard is used here] |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  | Min: 1<br>Max: 1000000 | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  | Min: 1<br>Max: 1000000 | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].trigger_on_logging.regex") | String |  |  |  | Regular expression to use for searching log messages. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  | Trigger condition occurs on specified interface changes.<br>Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface` |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_intf.interface") | String | Required |  |  | Interface name.<br>Example - Ethernet4<br>          Loopback4-6<br>          Port-channel4,7 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "event_handlers.[].trigger_on_intf.ip") | Boolean |  |  |  | Action is triggered upon changes to interface IP address assignment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip6</samp>](## "event_handlers.[].trigger_on_intf.ip6") | Boolean |  |  |  | Action is triggered upon changes to interface ip6 address assignment. |
@@ -58,7 +58,7 @@
         trigger: <str; "on-boot" | "on-counters" | "on-intf" | "on-logging" | "on-maintenance" | "on-startup-config" | "vm-tracer vm">
         trigger_on_counters:
 
-          # Set the counters condition expression.
+          # Set the logical expression to evaluate.
           condition: <str>
 
           # Set the granularity of event counting for a wildcarded condition.
@@ -68,14 +68,17 @@
           granularity_per_source: <bool>
 
           # Set the polling interval in seconds.
-          poll_interval: <int>
+          poll_interval: <int; 1-1000000>
         trigger_on_logging:
 
           # Set the polling interval in seconds.
-          poll_interval: <int>
+          poll_interval: <int; 1-1000000>
 
           # Regular expression to use for searching log messages.
           regex: <str>
+
+        # Trigger condition occurs on specified interface changes.
+        # Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`
         trigger_on_intf:
 
           # Interface name.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5596,7 +5596,7 @@
           },
           "trigger_on_intf": {
             "type": "object",
-            "description": "Trigger condition occurs on specified interface changes.\nNote: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`",
+            "description": "Trigger condition occurs on specified interface changes.\nNote: Any one of the `ip`, `ipv6` and `operstatus` key needs to be defined along with the `interface`.",
             "properties": {
               "interface": {
                 "type": "string",
@@ -5608,10 +5608,10 @@
                 "description": "Action is triggered upon changes to interface IP address assignment.",
                 "title": "IP"
               },
-              "ip6": {
+              "ipv6": {
                 "type": "boolean",
-                "description": "Action is triggered upon changes to interface ip6 address assignment.",
-                "title": "Ip6"
+                "description": "Action is triggered upon changes to interface ipv6 address assignment.",
+                "title": "IPv6"
               },
               "operstatus": {
                 "type": "boolean",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5536,11 +5536,87 @@
             "description": "Configure event trigger condition.\n",
             "enum": [
               "on-boot",
+              "on-counters",
+              "on-intf",
               "on-logging",
+              "on-maintenance",
               "on-startup-config",
-              "on-maintenance"
+              "vm-tracer vm"
             ],
             "title": "Trigger"
+          },
+          "trigger_on_counters": {
+            "type": "object",
+            "properties": {
+              "conditon": {
+                "type": "string",
+                "description": "Set the counters condition expression.",
+                "title": "Conditon"
+              },
+              "poll_interval": {
+                "type": "integer",
+                "description": "Set the polling interval in seconds.",
+                "title": "Poll Interval"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Trigger On Counters"
+          },
+          "trigger_on_logging": {
+            "type": "object",
+            "properties": {
+              "poll_interval": {
+                "type": "integer",
+                "description": "Set the polling interval in seconds.",
+                "title": "Poll Interval"
+              },
+              "regex": {
+                "type": "string",
+                "description": "Regular expression to use for searching log messages.",
+                "title": "Regex"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Trigger On Logging"
+          },
+          "trigger_on_intf": {
+            "type": "object",
+            "properties": {
+              "interface": {
+                "type": "string",
+                "description": "Interface name.\nExample - Ethernet4\n          Loopback4-6\n          Port-channel4,7",
+                "title": "Interface"
+              },
+              "ip": {
+                "type": "boolean",
+                "description": "Action is triggered upon changes to interface IP address assignment.",
+                "title": "IP"
+              },
+              "ip6": {
+                "type": "boolean",
+                "description": "Action is triggered upon changes to interface ip6 address assignment.",
+                "title": "Ip6"
+              },
+              "operstatus": {
+                "type": "boolean",
+                "description": "Action is triggered upon changes to interface operStatus.",
+                "title": "Operstatus"
+              }
+            },
+            "required": [
+              "interface"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Trigger On Intf"
           },
           "trigger_on_maintenance": {
             "description": "Settings required for trigger 'on-maintenance'.",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5548,10 +5548,10 @@
           "trigger_on_counters": {
             "type": "object",
             "properties": {
-              "conditon": {
+              "condition": {
                 "type": "string",
                 "description": "Set the counters condition expression.",
-                "title": "Conditon"
+                "title": "Condition"
               },
               "poll_interval": {
                 "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5550,7 +5550,7 @@
             "properties": {
               "condition": {
                 "type": "string",
-                "description": "Set the counters condition expression.",
+                "description": "Set the logical expression to evaluate.",
                 "title": "Condition"
               },
               "granularity_per_source": {
@@ -5560,6 +5560,8 @@
               },
               "poll_interval": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": 1000000,
                 "description": "Set the polling interval in seconds.",
                 "title": "Poll Interval"
               }
@@ -5575,6 +5577,8 @@
             "properties": {
               "poll_interval": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": 1000000,
                 "description": "Set the polling interval in seconds.",
                 "title": "Poll Interval"
               },
@@ -5592,6 +5596,7 @@
           },
           "trigger_on_intf": {
             "type": "object",
+            "description": "Trigger condition occurs on specified interface changes.\nNote: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`",
             "properties": {
               "interface": {
                 "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5553,6 +5553,11 @@
                 "description": "Set the counters condition expression.",
                 "title": "Condition"
               },
+              "granularity_per_source": {
+                "type": "boolean",
+                "description": "Set the granularity of event counting for a wildcarded condition.\nExample -\n  condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )\n  [* wildcard is used here]",
+                "title": "Granularity Per Source"
+              },
               "poll_interval": {
                 "type": "integer",
                 "description": "Set the polling interval in seconds.",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5696,7 +5696,8 @@
           },
           "regex": {
             "type": "string",
-            "description": "Regular expression to use for searching log messages. Required for on-logging trigger.\n",
+            "description": "Regular expression to use for searching log messages. Required for on-logging trigger.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.trigger_on_logging.regex</samp> instead.",
+            "deprecated": true,
             "title": "Regex"
           },
           "asynchronous": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3319,9 +3319,51 @@ keys:
             '
           valid_values:
           - on-boot
+          - on-counters
+          - on-intf
           - on-logging
-          - on-startup-config
           - on-maintenance
+          - on-startup-config
+          - vm-tracer vm
+        trigger_on_counters:
+          type: dict
+          keys:
+            conditon:
+              type: str
+              description: Set the counters condition expression.
+            poll_interval:
+              type: int
+              description: Set the polling interval in seconds.
+        trigger_on_logging:
+          type: dict
+          keys:
+            poll_interval:
+              type: int
+              convert_types:
+              - str
+              description: Set the polling interval in seconds.
+            regex:
+              type: str
+              description: Regular expression to use for searching log messages.
+        trigger_on_intf:
+          type: dict
+          keys:
+            interface:
+              type: str
+              required: true
+              description: "Interface name.\nExample - Ethernet4\n          Loopback4-6\n
+                \         Port-channel4,7"
+            ip:
+              type: bool
+              description: Action is triggered upon changes to interface IP address
+                assignment.
+            ip6:
+              type: bool
+              description: Action is triggered upon changes to interface ip6 address
+                assignment.
+            operstatus:
+              type: bool
+              description: Action is triggered upon changes to interface operStatus.
         trigger_on_maintenance:
           description: Settings required for trigger 'on-maintenance'.
           type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3328,7 +3328,7 @@ keys:
         trigger_on_counters:
           type: dict
           keys:
-            conditon:
+            condition:
               type: str
               description: Set the counters condition expression.
             poll_interval:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3427,6 +3427,11 @@ keys:
                 of specified unit
         regex:
           type: str
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 5.0.0
+            new_key: event_handlers.trigger_on_logging.regex
           description: 'Regular expression to use for searching log messages. Required
             for on-logging trigger.
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3330,7 +3330,7 @@ keys:
           keys:
             condition:
               type: str
-              description: Set the counters condition expression.
+              description: Set the logical expression to evaluate.
             granularity_per_source:
               type: bool
               description: "Set the granularity of event counting for a wildcarded
@@ -3339,6 +3339,10 @@ keys:
                 here]"
             poll_interval:
               type: int
+              convert_types:
+              - str
+              min: 1
+              max: 1000000
               description: Set the polling interval in seconds.
         trigger_on_logging:
           type: dict
@@ -3347,12 +3351,18 @@ keys:
               type: int
               convert_types:
               - str
+              min: 1
+              max: 1000000
               description: Set the polling interval in seconds.
             regex:
               type: str
               description: Regular expression to use for searching log messages.
         trigger_on_intf:
           type: dict
+          description: 'Trigger condition occurs on specified interface changes.
+
+            Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined
+            with the `interface`'
           keys:
             interface:
               type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3331,6 +3331,12 @@ keys:
             condition:
               type: str
               description: Set the counters condition expression.
+            granularity_per_source:
+              type: bool
+              description: "Set the granularity of event counting for a wildcarded
+                condition.\nExample -\n  condition ( Arad*.IptCrcErrCnt.delta > 100
+                ) and ( Arad*.UcFifoFullDrop.delta > 100 )\n  [* wildcard is used
+                here]"
             poll_interval:
               type: int
               description: Set the polling interval in seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3361,8 +3361,8 @@ keys:
           type: dict
           description: 'Trigger condition occurs on specified interface changes.
 
-            Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined
-            with the `interface`'
+            Note: Any one of the `ip`, `ipv6` and `operstatus` key needs to be defined
+            along with the `interface`.'
           keys:
             interface:
               type: str
@@ -3373,9 +3373,9 @@ keys:
               type: bool
               description: Action is triggered upon changes to interface IP address
                 assignment.
-            ip6:
+            ipv6:
               type: bool
-              description: Action is triggered upon changes to interface ip6 address
+              description: Action is triggered upon changes to interface ipv6 address
                 assignment.
             operstatus:
               type: bool

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -52,9 +52,13 @@ keys:
             condition:
               type: str
               description: Set the counters condition expression.
-            # granularity_per_source:
-            #   type: bool
-            #   description: Set the granularity of event counting for a wildcarded condition.
+            granularity_per_source:
+              type: bool
+              description: |-
+                Set the granularity of event counting for a wildcarded condition.
+                Example -
+                  condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
+                  [* wildcard is used here]
             poll_interval:
               type: int
               description: Set the polling interval in seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -83,7 +83,7 @@ keys:
           type: dict
           description: |-
             Trigger condition occurs on specified interface changes.
-            Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`
+            Note: Any one of the `ip`, `ipv6` and `operstatus` key needs to be defined along with the `interface`.
           keys:
             interface:
               type: str
@@ -96,9 +96,9 @@ keys:
             ip:
               type: bool
               description: Action is triggered upon changes to interface IP address assignment.
-            ip6:
+            ipv6:
               type: bool
-              description: Action is triggered upon changes to interface ip6 address assignment.
+              description: Action is triggered upon changes to interface ipv6 address assignment.
             operstatus:
               type: bool
               description: Action is triggered upon changes to interface operStatus.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -49,7 +49,7 @@ keys:
         trigger_on_counters:
           type: dict
           keys:
-            conditon:
+            condition:
               type: str
               description: Set the counters condition expression.
             # granularity_per_source:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -146,6 +146,11 @@ keys:
               description: Name of unit. Trigger condition occurs on maintenance operation of specified unit
         regex:
           type: str
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 5.0.0
+            new_key: event_handlers.trigger_on_logging.regex
           description: |
             Regular expression to use for searching log messages. Required for on-logging trigger.
         asynchronous:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -51,7 +51,7 @@ keys:
           keys:
             condition:
               type: str
-              description: Set the counters condition expression.
+              description: Set the logical expression to evaluate.
             granularity_per_source:
               type: bool
               description: |-
@@ -61,6 +61,10 @@ keys:
                   [* wildcard is used here]
             poll_interval:
               type: int
+              convert_types:
+              - str
+              min: 1
+              max: 1000000
               description: Set the polling interval in seconds.
         trigger_on_logging:
           type: dict
@@ -68,13 +72,18 @@ keys:
             poll_interval:
               type: int
               convert_types:
-              - "str"
+              - str
+              min: 1
+              max: 1000000
               description: Set the polling interval in seconds.
             regex:
               type: str
               description: Regular expression to use for searching log messages.
         trigger_on_intf:
           type: dict
+          description: |-
+            Trigger condition occurs on specified interface changes.
+            Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`
           keys:
             interface:
               type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -39,10 +39,56 @@ keys:
           description: |
             Configure event trigger condition.
           valid_values:
-          - on-boot
-          - on-logging
-          - on-startup-config
-          - on-maintenance
+          - "on-boot"
+          - "on-counters"
+          - "on-intf"
+          - "on-logging"
+          - "on-maintenance"
+          - "on-startup-config"
+          - "vm-tracer vm"
+        trigger_on_counters:
+          type: dict
+          keys:
+            conditon:
+              type: str
+              description: Set the counters condition expression.
+            # granularity_per_source:
+            #   type: bool
+            #   description: Set the granularity of event counting for a wildcarded condition.
+            poll_interval:
+              type: int
+              description: Set the polling interval in seconds.
+        trigger_on_logging:
+          type: dict
+          keys:
+            poll_interval:
+              type: int
+              convert_types:
+              - "str"
+              description: Set the polling interval in seconds.
+            regex:
+              type: str
+              description: Regular expression to use for searching log messages.
+        trigger_on_intf:
+          type: dict
+          keys:
+            interface:
+              type: str
+              required: True
+              description: |-
+                Interface name.
+                Example - Ethernet4
+                          Loopback4-6
+                          Port-channel4,7
+            ip:
+              type: bool
+              description: Action is triggered upon changes to interface IP address assignment.
+            ip6:
+              type: bool
+              description: Action is triggered upon changes to interface ip6 address assignment.
+            operstatus:
+              type: bool
+              description: Action is triggered upon changes to interface operStatus.
         trigger_on_maintenance:
           description: Settings required for trigger 'on-maintenance'.
           type: dict

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
@@ -10,14 +10,70 @@
 
 #### Event Handler Summary
 
-| Handler | Action Type | Action | Trigger |
-| ------- | ----------- | ------ | ------- |
+| Handler | Action Type | Action | Trigger | Trigger Config |
+| ------- | ----------- | ------ | ------- | -------------- |
 {%     for handler in event_handlers | arista.avd.natural_sort('name') %}
 {%         set action = handler.action | replace('|', '\|') %}
 {%         if handler.action_type == 'bash' %}
 {%             set action = '<code>' ~ action ~ '</code>' %}
 {%         endif %}
-| {{ handler.name }} | {{ handler.action_type }} | {{ action }} | {{ handler.trigger }} |
+{%         if handler.trigger is arista.avd.defined("on-maintenance")
+            and handler.trigger_on_maintenance.operation is arista.avd.defined
+            and handler.trigger_on_maintenance.action is arista.avd.defined %}
+{%             set trigger_config =  "trigger " ~ handler.trigger ~ " " ~ handler.trigger_on_maintenance.operation %}
+{%             if handler.trigger_on_maintenance.bgp_peer is arista.avd.defined %}
+{%                 set trigger_config = trigger_config ~ " bgp " ~ handler.trigger_on_maintenance.bgp_peer %}
+{%                 if handler.trigger_on_maintenance.vrf is arista.avd.defined %}
+{%                     set trigger_config = trigger_config ~ " vrf " ~ handler.trigger_on_maintenance.vrf %}
+{%                 endif %}
+{%             elif handler.trigger_on_maintenance.interface is arista.avd.defined %}
+{%                 set trigger_config = trigger_config ~ " interface " ~ handler.trigger_on_maintenance.interface %}
+{%             elif handler.trigger_on_maintenance.unit is arista.avd.defined %}
+{%                 set trigger_config = trigger_config ~ " unit " ~ handler.trigger_on_maintenance.unit %}
+{%             endif %}
+{%             if handler.trigger_on_maintenance.action is arista.avd.defined("after") or handler.trigger_on_maintenance.action is arista.avd.defined("before") %}
+{%                 set trigger_config = trigger_config ~ " " ~ handler.trigger_on_maintenance.action ~ " stage " ~ handler.trigger_on_maintenance.stage %}
+{%             elif handler.trigger_on_maintenance.action is arista.avd.defined("all") %}
+{%                 set trigger_config = trigger_config ~ " all" %}
+{%             elif handler.trigger_on_maintenance.action is arista.avd.defined("begin") %}
+{%                 set trigger_config = trigger_config ~ " begin" %}
+{%             elif handler.trigger_on_maintenance.action is arista.avd.defined("end") %}
+{%                 set trigger_config = trigger_config ~ " end" %}
+{%             endif %}
+{%         elif handler.trigger is arista.avd.defined("on-counters") %}
+{%             if handler.trigger_on_counters.poll_interval is arista.avd.defined %}
+{%                 set trigger_config = "poll interval " ~ handler.trigger_on_counters.poll_interval %}
+{%             endif %}
+{%             if handler.trigger_on_counters.condition is arista.avd.defined %}
+{%                 set trigger_config = trigger_config ~ "<br>condition" ~ handler.trigger_on_counters.condition %}
+{%             endif %}
+{%             if handler.trigger_on_counters.granularity_per_source is arista.avd.defined(true) %}
+{%                 set trigger_config = trigger_config ~ "<br>granularity per-source" %}
+{%             endif %}
+{%         elif handler.trigger is arista.avd.defined("on-logging") %}
+{%             if handler.trigger_on_logging.poll_interval is arista.avd.defined %}
+{%                 set trigger_config = "poll interval " ~ handler.trigger_on_logging.poll_interval %}
+{%             endif %}
+{%             if handler.trigger_on_logging.regex is arista.avd.defined %}
+{%                 set trigger_config = trigger_config ~ "<br>regex " ~ handler.trigger_on_logging.regex %}
+{%             endif %}
+{%         elif handler.trigger is arista.avd.defined("on-intf") and handler.trigger_on_intf.interface is arista.avd.defined %}
+{%             if handler.trigger_on_intf.ip is arista.avd.defined(true) or
+                handler.trigger_on_intf.ipv6 is arista.avd.defined(true) or
+                handler.trigger_on_intf.operstatus is arista.avd.defined(true) %}
+{%                 set trigger_config = "trigger on-intf " ~ handler.trigger_on_intf.interface %}
+{%                 if handler.trigger_on_intf.operstatus is arista.avd.defined(true) %}
+{%                     set trigger_config = trigger_config ~ " operstatus" %}
+{%                 endif %}
+{%                 if handler.trigger_on_intf.ip is arista.avd.defined(true) %}
+{%                     set trigger_config = trigger_config ~ " ip" %}
+{%                 endif %}
+{%                 if handler.trigger_on_intf.ipv6 is arista.avd.defined(true) %}
+{%                     set trigger_config = trigger_config ~ " ip6" %}
+{%                 endif %}
+{%             endif %}
+{%         endif %}
+| {{ handler.name }} | {{ handler.action_type }} | {{ action }} | {{ handler.trigger }} | {{ trigger_config | arista.avd.default("-") }} |
 {%     endfor %}
 
 #### Event Handler Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -54,7 +54,7 @@ event-handler {{ handler.name }}
 {%                 endif %}
 {%             elif handler.trigger is arista.avd.defined("on-intf") and handler.trigger_on_intf.interface is arista.avd.defined %}
 {%                 if handler.trigger_on_intf.ip is arista.avd.defined(true) or
-                     handler.trigger_on_intf.ip6 is arista.avd.defined(true) or
+                     handler.trigger_on_intf.ipv6 is arista.avd.defined(true) or
                      handler.trigger_on_intf.operstatus is arista.avd.defined(true) %}
 {%                     set trigger_on_intf_cli = "trigger on-intf " ~ handler.trigger_on_intf.interface %}
 {%                     if handler.trigger_on_intf.operstatus is arista.avd.defined(true) %}
@@ -63,7 +63,7 @@ event-handler {{ handler.name }}
 {%                     if handler.trigger_on_intf.ip is arista.avd.defined(true) %}
 {%                         set trigger_on_intf_cli = trigger_on_intf_cli ~ " ip" %}
 {%                     endif %}
-{%                     if handler.trigger_on_intf.ip6 is arista.avd.defined(true) %}
+{%                     if handler.trigger_on_intf.ipv6 is arista.avd.defined(true) %}
 {%                         set trigger_on_intf_cli = trigger_on_intf_cli ~ " ip6" %}
 {%                     endif %}
    {{ trigger_on_intf_cli }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -39,7 +39,7 @@ event-handler {{ handler.name }}
       poll interval {{ handler.trigger_on_counters.poll_interval }}
 {%                 endif %}
 {%                 if handler.trigger_on_counters.condition is arista.avd.defined %}
-      condition {{ handler.trigger_on_counters.regex }}
+      condition {{ handler.trigger_on_counters.condition }}
 {%                 endif %}
 {%             elif handler.trigger is arista.avd.defined("on-logging") %}
    trigger on-logging

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -33,6 +33,38 @@ event-handler {{ handler.name }}
 {%                     set trigger_on_manitenance_cli = trigger_on_manitenance_cli ~ " end" %}
 {%                 endif %}
    {{ trigger_on_manitenance_cli }}
+{%             elif handler.trigger is arista.avd.defined("on-counters") %}
+   trigger on-counters
+{%                 if handler.trigger_on_counters.poll_interval is arista.avd.defined %}
+      poll interval {{ handler.trigger_on_counters.poll_interval }}
+{%                 endif %}
+{%                 if handler.trigger_on_counters.condition is arista.avd.defined %}
+      condition {{ handler.trigger_on_counters.regex }}
+{%                 endif %}
+{%             elif handler.trigger is arista.avd.defined("on-logging") %}
+   trigger on-logging
+{%                 if handler.trigger_on_logging.poll_interval is arista.avd.defined %}
+      poll interval {{ handler.trigger_on_logging.poll_interval }}
+{%                 endif %}
+{%                 if handler.trigger_on_logging.regex is arista.avd.defined %}
+      regex {{ handler.trigger_on_logging.regex }}
+{%                 endif %}
+{%             elif handler.trigger is arista.avd.defined("on-intf") and handler.trigger_on_intf.interface is arista.avd.defined %}
+{%                 if handler.trigger_on_intf.ip is arista.avd.defined(true) or
+                     handler.trigger_on_intf.ip6 is arista.avd.defined(true) or
+                     handler.trigger_on_intf.operstatus is arista.avd.defined(true) %}
+{%                     set trigger_on_intf_cli = "trigger on-intf " ~ handler.trigger_on_intf.interface %}
+{%                     if handler.trigger_on_intf.operstatus is arista.avd.defined(true) %}
+{%                         set trigger_on_intf_cli = trigger_on_intf_cli ~ " operstatus" %}
+{%                     endif %}
+{%                     if handler.trigger_on_intf.ip is arista.avd.defined(true) %}
+{%                         set trigger_on_intf_cli = trigger_on_intf_cli ~ " ip" %}
+{%                     endif %}
+{%                     if handler.trigger_on_intf.ip6 is arista.avd.defined(true) %}
+{%                         set trigger_on_intf_cli = trigger_on_intf_cli ~ " ip6" %}
+{%                     endif %}
+   {{ trigger_on_intf_cli }}
+{%                 endif %}
 {%             else %}
    trigger {{ handler.trigger }}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -41,6 +41,9 @@ event-handler {{ handler.name }}
 {%                 if handler.trigger_on_counters.condition is arista.avd.defined %}
       condition {{ handler.trigger_on_counters.condition }}
 {%                 endif %}
+{%                 if handler.trigger_on_counters.granularity_per_source is arista.avd.defined(true) %}
+      granularity per-source
+{%                 endif %}
 {%             elif handler.trigger is arista.avd.defined("on-logging") %}
    trigger on-logging
 {%                 if handler.trigger_on_logging.poll_interval is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -20,10 +20,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  | Min: 1<br>Max: 1000000 | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].trigger_on_logging.regex") | String |  |  |  | Regular expression to use for searching log messages. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  | Trigger condition occurs on specified interface changes.<br>Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface` |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  | Trigger condition occurs on specified interface changes.<br>Note: Any one of the `ip`, `ipv6` and `operstatus` key needs to be defined along with the `interface`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_intf.interface") | String | Required |  |  | Interface name.<br>Example - Ethernet4<br>          Loopback4-6<br>          Port-channel4,7 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "event_handlers.[].trigger_on_intf.ip") | Boolean |  |  |  | Action is triggered upon changes to interface IP address assignment. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip6</samp>](## "event_handlers.[].trigger_on_intf.ip6") | Boolean |  |  |  | Action is triggered upon changes to interface ip6 address assignment. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "event_handlers.[].trigger_on_intf.ipv6") | Boolean |  |  |  | Action is triggered upon changes to interface ipv6 address assignment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operstatus</samp>](## "event_handlers.[].trigger_on_intf.operstatus") | Boolean |  |  |  | Action is triggered upon changes to interface operStatus. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
@@ -116,7 +116,7 @@
           regex: <str>
 
         # Trigger condition occurs on specified interface changes.
-        # Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`
+        # Note: Any one of the `ip`, `ipv6` and `operstatus` key needs to be defined along with the `interface`.
         trigger_on_intf:
 
           # Interface name.
@@ -128,8 +128,8 @@
           # Action is triggered upon changes to interface IP address assignment.
           ip: <bool>
 
-          # Action is triggered upon changes to interface ip6 address assignment.
-          ip6: <bool>
+          # Action is triggered upon changes to interface ipv6 address assignment.
+          ipv6: <bool>
 
           # Action is triggered upon changes to interface operStatus.
           operstatus: <bool>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -33,7 +33,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "event_handlers.[].trigger_on_maintenance.vrf") | String |  |  |  | VRF name. VRF can be defined for "bgp_peer" only. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_maintenance.interface") | String |  |  |  | Trigger condition occurs on maintenance operation of specified interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "event_handlers.[].trigger_on_maintenance.unit") | String |  |  |  | Name of unit. Trigger condition occurs on maintenance operation of specified unit |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].regex") <span style="color:red">deprecated</span> | String |  |  |  | Regular expression to use for searching log messages. Required for on-logging trigger.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.trigger_on_logging.regex</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;asynchronous</samp>](## "event_handlers.[].asynchronous") | Boolean |  | `False` |  | Set the action to be non-blocking.<br> |
     | [<samp>ipv6_mgmt_destination_networks</samp>](## "ipv6_mgmt_destination_networks") | List, items: String |  |  |  | List of IPv6 prefixes to configure as static routes towards the OOB IPv6 Management interface gateway.<br>Replaces the default route.<br> |
     | [<samp>&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "ipv6_mgmt_destination_networks.[]") | String |  |  |  | IPv6_network/Mask. |
@@ -158,6 +158,9 @@
           unit: <str>
 
         # Regular expression to use for searching log messages. Required for on-logging trigger.
+        # This key is deprecated.
+        # Support will be removed in AVD version 5.0.0.
+        # Use <samp>event_handlers.trigger_on_logging.regex</samp> instead.
         regex: <str>
 
         # Set the action to be non-blocking.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -12,7 +12,18 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-logging</code><br>- <code>on-startup-config</code><br>- <code>on-maintenance</code> | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;conditon</samp>](## "event_handlers.[].trigger_on_counters.conditon") | String |  |  |  | Set the counters condition expression. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].trigger_on_logging.regex") | String |  |  |  | Regular expression to use for searching log messages. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_intf.interface") | String | Required |  |  | Interface name.<br>Example - Ethernet4<br>          Loopback4-6<br>          Port-channel4,7 |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "event_handlers.[].trigger_on_intf.ip") | Boolean |  |  |  | Action is triggered upon changes to interface IP address assignment. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip6</samp>](## "event_handlers.[].trigger_on_intf.ip6") | Boolean |  |  |  | Action is triggered upon changes to interface ip6 address assignment. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operstatus</samp>](## "event_handlers.[].trigger_on_intf.operstatus") | Boolean |  |  |  | Action is triggered upon changes to interface operStatus. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_maintenance</samp>](## "event_handlers.[].trigger_on_maintenance") | Dictionary |  |  |  | Settings required for trigger 'on-maintenance'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;operation</samp>](## "event_handlers.[].trigger_on_maintenance.operation") | String | Required |  | Valid Values:<br>- <code>enter</code><br>- <code>exit</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_peer</samp>](## "event_handlers.[].trigger_on_maintenance.bgp_peer") | String |  |  |  | Ipv4/Ipv6 address or peer group name.<br>Trigger condition occurs on maintenance operation of specified BGP peer. |
@@ -81,7 +92,37 @@
         delay: <int>
 
         # Configure event trigger condition.
-        trigger: <str; "on-boot" | "on-logging" | "on-startup-config" | "on-maintenance">
+        trigger: <str; "on-boot" | "on-counters" | "on-intf" | "on-logging" | "on-maintenance" | "on-startup-config" | "vm-tracer vm">
+        trigger_on_counters:
+
+          # Set the counters condition expression.
+          conditon: <str>
+
+          # Set the polling interval in seconds.
+          poll_interval: <int>
+        trigger_on_logging:
+
+          # Set the polling interval in seconds.
+          poll_interval: <int>
+
+          # Regular expression to use for searching log messages.
+          regex: <str>
+        trigger_on_intf:
+
+          # Interface name.
+          # Example - Ethernet4
+          #           Loopback4-6
+          #           Port-channel4,7
+          interface: <str; required>
+
+          # Action is triggered upon changes to interface IP address assignment.
+          ip: <bool>
+
+          # Action is triggered upon changes to interface ip6 address assignment.
+          ip6: <bool>
+
+          # Action is triggered upon changes to interface operStatus.
+          operstatus: <bool>
 
         # Settings required for trigger 'on-maintenance'.
         trigger_on_maintenance:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -14,7 +14,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;conditon</samp>](## "event_handlers.[].trigger_on_counters.conditon") | String |  |  |  | Set the counters condition expression. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;condition</samp>](## "event_handlers.[].trigger_on_counters.condition") | String |  |  |  | Set the counters condition expression. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
@@ -96,7 +96,7 @@
         trigger_on_counters:
 
           # Set the counters condition expression.
-          conditon: <str>
+          condition: <str>
 
           # Set the polling interval in seconds.
           poll_interval: <int>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -14,13 +14,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;condition</samp>](## "event_handlers.[].trigger_on_counters.condition") | String |  |  |  | Set the counters condition expression. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;condition</samp>](## "event_handlers.[].trigger_on_counters.condition") | String |  |  |  | Set the logical expression to evaluate. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;granularity_per_source</samp>](## "event_handlers.[].trigger_on_counters.granularity_per_source") | Boolean |  |  |  | Set the granularity of event counting for a wildcarded condition.<br>Example -<br>  condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )<br>  [* wildcard is used here] |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  | Min: 1<br>Max: 1000000 | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  | Min: 1<br>Max: 1000000 | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;regex</samp>](## "event_handlers.[].trigger_on_logging.regex") | String |  |  |  | Regular expression to use for searching log messages. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_intf</samp>](## "event_handlers.[].trigger_on_intf") | Dictionary |  |  |  | Trigger condition occurs on specified interface changes.<br>Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface` |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "event_handlers.[].trigger_on_intf.interface") | String | Required |  |  | Interface name.<br>Example - Ethernet4<br>          Loopback4-6<br>          Port-channel4,7 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "event_handlers.[].trigger_on_intf.ip") | Boolean |  |  |  | Action is triggered upon changes to interface IP address assignment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip6</samp>](## "event_handlers.[].trigger_on_intf.ip6") | Boolean |  |  |  | Action is triggered upon changes to interface ip6 address assignment. |
@@ -96,7 +96,7 @@
         trigger: <str; "on-boot" | "on-counters" | "on-intf" | "on-logging" | "on-maintenance" | "on-startup-config" | "vm-tracer vm">
         trigger_on_counters:
 
-          # Set the counters condition expression.
+          # Set the logical expression to evaluate.
           condition: <str>
 
           # Set the granularity of event counting for a wildcarded condition.
@@ -106,14 +106,17 @@
           granularity_per_source: <bool>
 
           # Set the polling interval in seconds.
-          poll_interval: <int>
+          poll_interval: <int; 1-1000000>
         trigger_on_logging:
 
           # Set the polling interval in seconds.
-          poll_interval: <int>
+          poll_interval: <int; 1-1000000>
 
           # Regular expression to use for searching log messages.
           regex: <str>
+
+        # Trigger condition occurs on specified interface changes.
+        # Note: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`
         trigger_on_intf:
 
           # Interface name.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -15,6 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;condition</samp>](## "event_handlers.[].trigger_on_counters.condition") | String |  |  |  | Set the counters condition expression. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;granularity_per_source</samp>](## "event_handlers.[].trigger_on_counters.granularity_per_source") | Boolean |  |  |  | Set the granularity of event counting for a wildcarded condition.<br>Example -<br>  condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )<br>  [* wildcard is used here] |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_counters.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_logging</samp>](## "event_handlers.[].trigger_on_logging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;poll_interval</samp>](## "event_handlers.[].trigger_on_logging.poll_interval") | Integer |  |  |  | Set the polling interval in seconds. |
@@ -97,6 +98,12 @@
 
           # Set the counters condition expression.
           condition: <str>
+
+          # Set the granularity of event counting for a wildcarded condition.
+          # Example -
+          #   condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
+          #   [* wildcard is used here]
+          granularity_per_source: <bool>
 
           # Set the polling interval in seconds.
           poll_interval: <int>

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5087,11 +5087,87 @@
             "description": "Configure event trigger condition.\n",
             "enum": [
               "on-boot",
+              "on-counters",
+              "on-intf",
               "on-logging",
+              "on-maintenance",
               "on-startup-config",
-              "on-maintenance"
+              "vm-tracer vm"
             ],
             "title": "Trigger"
+          },
+          "trigger_on_counters": {
+            "type": "object",
+            "properties": {
+              "conditon": {
+                "type": "string",
+                "description": "Set the counters condition expression.",
+                "title": "Conditon"
+              },
+              "poll_interval": {
+                "type": "integer",
+                "description": "Set the polling interval in seconds.",
+                "title": "Poll Interval"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Trigger On Counters"
+          },
+          "trigger_on_logging": {
+            "type": "object",
+            "properties": {
+              "poll_interval": {
+                "type": "integer",
+                "description": "Set the polling interval in seconds.",
+                "title": "Poll Interval"
+              },
+              "regex": {
+                "type": "string",
+                "description": "Regular expression to use for searching log messages.",
+                "title": "Regex"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Trigger On Logging"
+          },
+          "trigger_on_intf": {
+            "type": "object",
+            "properties": {
+              "interface": {
+                "type": "string",
+                "description": "Interface name.\nExample - Ethernet4\n          Loopback4-6\n          Port-channel4,7",
+                "title": "Interface"
+              },
+              "ip": {
+                "type": "boolean",
+                "description": "Action is triggered upon changes to interface IP address assignment.",
+                "title": "IP"
+              },
+              "ip6": {
+                "type": "boolean",
+                "description": "Action is triggered upon changes to interface ip6 address assignment.",
+                "title": "Ip6"
+              },
+              "operstatus": {
+                "type": "boolean",
+                "description": "Action is triggered upon changes to interface operStatus.",
+                "title": "Operstatus"
+              }
+            },
+            "required": [
+              "interface"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Trigger On Intf"
           },
           "trigger_on_maintenance": {
             "description": "Settings required for trigger 'on-maintenance'.",
@@ -22109,11 +22185,87 @@
                       "description": "Configure event trigger condition.\n",
                       "enum": [
                         "on-boot",
+                        "on-counters",
+                        "on-intf",
                         "on-logging",
+                        "on-maintenance",
                         "on-startup-config",
-                        "on-maintenance"
+                        "vm-tracer vm"
                       ],
                       "title": "Trigger"
+                    },
+                    "trigger_on_counters": {
+                      "type": "object",
+                      "properties": {
+                        "conditon": {
+                          "type": "string",
+                          "description": "Set the counters condition expression.",
+                          "title": "Conditon"
+                        },
+                        "poll_interval": {
+                          "type": "integer",
+                          "description": "Set the polling interval in seconds.",
+                          "title": "Poll Interval"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Trigger On Counters"
+                    },
+                    "trigger_on_logging": {
+                      "type": "object",
+                      "properties": {
+                        "poll_interval": {
+                          "type": "integer",
+                          "description": "Set the polling interval in seconds.",
+                          "title": "Poll Interval"
+                        },
+                        "regex": {
+                          "type": "string",
+                          "description": "Regular expression to use for searching log messages.",
+                          "title": "Regex"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Trigger On Logging"
+                    },
+                    "trigger_on_intf": {
+                      "type": "object",
+                      "properties": {
+                        "interface": {
+                          "type": "string",
+                          "description": "Interface name.\nExample - Ethernet4\n          Loopback4-6\n          Port-channel4,7",
+                          "title": "Interface"
+                        },
+                        "ip": {
+                          "type": "boolean",
+                          "description": "Action is triggered upon changes to interface IP address assignment.",
+                          "title": "IP"
+                        },
+                        "ip6": {
+                          "type": "boolean",
+                          "description": "Action is triggered upon changes to interface ip6 address assignment.",
+                          "title": "Ip6"
+                        },
+                        "operstatus": {
+                          "type": "boolean",
+                          "description": "Action is triggered upon changes to interface operStatus.",
+                          "title": "Operstatus"
+                        }
+                      },
+                      "required": [
+                        "interface"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Trigger On Intf"
                     },
                     "trigger_on_maintenance": {
                       "description": "Settings required for trigger 'on-maintenance'.",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5104,6 +5104,11 @@
                 "description": "Set the counters condition expression.",
                 "title": "Condition"
               },
+              "granularity_per_source": {
+                "type": "boolean",
+                "description": "Set the granularity of event counting for a wildcarded condition.\nExample -\n  condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )\n  [* wildcard is used here]",
+                "title": "Granularity Per Source"
+              },
               "poll_interval": {
                 "type": "integer",
                 "description": "Set the polling interval in seconds.",
@@ -22201,6 +22206,11 @@
                           "type": "string",
                           "description": "Set the counters condition expression.",
                           "title": "Condition"
+                        },
+                        "granularity_per_source": {
+                          "type": "boolean",
+                          "description": "Set the granularity of event counting for a wildcarded condition.\nExample -\n  condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )\n  [* wildcard is used here]",
+                          "title": "Granularity Per Source"
                         },
                         "poll_interval": {
                           "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5147,7 +5147,7 @@
           },
           "trigger_on_intf": {
             "type": "object",
-            "description": "Trigger condition occurs on specified interface changes.\nNote: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`",
+            "description": "Trigger condition occurs on specified interface changes.\nNote: Any one of the `ip`, `ipv6` and `operstatus` key needs to be defined along with the `interface`.",
             "properties": {
               "interface": {
                 "type": "string",
@@ -5159,10 +5159,10 @@
                 "description": "Action is triggered upon changes to interface IP address assignment.",
                 "title": "IP"
               },
-              "ip6": {
+              "ipv6": {
                 "type": "boolean",
-                "description": "Action is triggered upon changes to interface ip6 address assignment.",
-                "title": "Ip6"
+                "description": "Action is triggered upon changes to interface ipv6 address assignment.",
+                "title": "IPv6"
               },
               "operstatus": {
                 "type": "boolean",
@@ -22256,7 +22256,7 @@
                     },
                     "trigger_on_intf": {
                       "type": "object",
-                      "description": "Trigger condition occurs on specified interface changes.\nNote: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`",
+                      "description": "Trigger condition occurs on specified interface changes.\nNote: Any one of the `ip`, `ipv6` and `operstatus` key needs to be defined along with the `interface`.",
                       "properties": {
                         "interface": {
                           "type": "string",
@@ -22268,10 +22268,10 @@
                           "description": "Action is triggered upon changes to interface IP address assignment.",
                           "title": "IP"
                         },
-                        "ip6": {
+                        "ipv6": {
                           "type": "boolean",
-                          "description": "Action is triggered upon changes to interface ip6 address assignment.",
-                          "title": "Ip6"
+                          "description": "Action is triggered upon changes to interface ipv6 address assignment.",
+                          "title": "IPv6"
                         },
                         "operstatus": {
                           "type": "boolean",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5101,7 +5101,7 @@
             "properties": {
               "condition": {
                 "type": "string",
-                "description": "Set the counters condition expression.",
+                "description": "Set the logical expression to evaluate.",
                 "title": "Condition"
               },
               "granularity_per_source": {
@@ -5111,6 +5111,8 @@
               },
               "poll_interval": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": 1000000,
                 "description": "Set the polling interval in seconds.",
                 "title": "Poll Interval"
               }
@@ -5126,6 +5128,8 @@
             "properties": {
               "poll_interval": {
                 "type": "integer",
+                "minimum": 1,
+                "maximum": 1000000,
                 "description": "Set the polling interval in seconds.",
                 "title": "Poll Interval"
               },
@@ -5143,6 +5147,7 @@
           },
           "trigger_on_intf": {
             "type": "object",
+            "description": "Trigger condition occurs on specified interface changes.\nNote: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`",
             "properties": {
               "interface": {
                 "type": "string",
@@ -22204,7 +22209,7 @@
                       "properties": {
                         "condition": {
                           "type": "string",
-                          "description": "Set the counters condition expression.",
+                          "description": "Set the logical expression to evaluate.",
                           "title": "Condition"
                         },
                         "granularity_per_source": {
@@ -22214,6 +22219,8 @@
                         },
                         "poll_interval": {
                           "type": "integer",
+                          "minimum": 1,
+                          "maximum": 1000000,
                           "description": "Set the polling interval in seconds.",
                           "title": "Poll Interval"
                         }
@@ -22229,6 +22236,8 @@
                       "properties": {
                         "poll_interval": {
                           "type": "integer",
+                          "minimum": 1,
+                          "maximum": 1000000,
                           "description": "Set the polling interval in seconds.",
                           "title": "Poll Interval"
                         },
@@ -22246,6 +22255,7 @@
                     },
                     "trigger_on_intf": {
                       "type": "object",
+                      "description": "Trigger condition occurs on specified interface changes.\nNote: Any one of the `ip`, `ip6` and `operstatus` key needs to be defined with the `interface`",
                       "properties": {
                         "interface": {
                           "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5099,10 +5099,10 @@
           "trigger_on_counters": {
             "type": "object",
             "properties": {
-              "conditon": {
+              "condition": {
                 "type": "string",
                 "description": "Set the counters condition expression.",
-                "title": "Conditon"
+                "title": "Condition"
               },
               "poll_interval": {
                 "type": "integer",
@@ -22197,10 +22197,10 @@
                     "trigger_on_counters": {
                       "type": "object",
                       "properties": {
-                        "conditon": {
+                        "condition": {
                           "type": "string",
                           "description": "Set the counters condition expression.",
-                          "title": "Conditon"
+                          "title": "Condition"
                         },
                         "poll_interval": {
                           "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5247,7 +5247,8 @@
           },
           "regex": {
             "type": "string",
-            "description": "Regular expression to use for searching log messages. Required for on-logging trigger.\n",
+            "description": "Regular expression to use for searching log messages. Required for on-logging trigger.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.trigger_on_logging.regex</samp> instead.",
+            "deprecated": true,
             "title": "Regex"
           },
           "asynchronous": {
@@ -22355,7 +22356,8 @@
                     },
                     "regex": {
                       "type": "string",
-                      "description": "Regular expression to use for searching log messages. Required for on-logging trigger.\n",
+                      "description": "Regular expression to use for searching log messages. Required for on-logging trigger.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.trigger_on_logging.regex</samp> instead.",
+                      "deprecated": true,
                       "title": "Regex"
                     },
                     "asynchronous": {


### PR DESCRIPTION
## Change Summary

Refactor event-handlers model to accommodate other triggers with their specificities

## Related Issue(s)

Fixes #3267 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adding a dict with extra settings per trigger type.
```
        trigger: <str; "on-boot" | "on-counters" | "on-intf" | "on-logging" | "on-maintenance" | "on-startup-config" | "vm- 
                      tracer vm">
        trigger_on_counters:

          # Set the counters condition expression.
          condition: <str>

          # Set the granularity of event counting for a wildcarded condition.
          # Example -
          #   condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
          #   [* wildcard is used here]
          granularity_per_source: <bool>

          # Set the polling interval in seconds.
          poll_interval: <int>
        trigger_on_logging:

          # Set the polling interval in seconds.
          poll_interval: <int>

          # Regular expression to use for searching log messages.
          regex: <str>
        trigger_on_intf:

          # Interface name.
          # Example - Ethernet4
          #           Loopback4-6
          #           Port-channel4,7
          interface: <str; required>

          # Action is triggered upon changes to interface IP address assignment.
          ip: <bool>

          # Action is triggered upon changes to interface ip6 address assignment.
          ip6: <bool>

          # Action is triggered upon changes to interface operStatus.
          operstatus: <bool>
```


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
