### PR TITLE
Doc(eos_cli_config_gen): Add missing switchport port security table to documentation

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -363,10 +363,16 @@ roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
 roles/eos_cli_config_gen/docs/tables/switchport-default.md
 --8<--
 
+### Switchport port security
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/switchport-port-security.md
+--8<--
+
 ### Transceiver QSFP default mode 4x10
 
 --8<--
-transceiver-qsfp-default-mode-4x10.md
+roles/eos_cli_config_gen/docs/tables/transceiver-qsfp-default-mode-4x10.md
 --8<--
 
 ### Tunnel interfaces


### PR DESCRIPTION
## Change Summary

Add missing switchport port security table to input variables documentation.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add the missing tables!
- add table Switchport port security
- fix path for Transceiver QSFP default mode 4x10 table
