### PR TITLE
Feat(eos_designs): Add sample rate to sflow settings in eos_designs.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf1.cfg
@@ -8,6 +8,7 @@ service routing protocols model multi-agent
 !
 hostname sflow-tests-l2-leaf1
 !
+sflow sample 10
 sflow vrf MGMT destination 10.10.10.12
 sflow vrf MGMT source-interface Management1
 sflow destination 10.10.10.10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf2.cfg
@@ -8,6 +8,7 @@ service routing protocols model multi-agent
 !
 hostname sflow-tests-l2-leaf2
 !
+sflow sample 10
 sflow vrf MGMT destination 10.10.10.12
 sflow vrf MGMT source-interface Management1
 sflow destination 10.10.10.10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
@@ -75,6 +75,7 @@ vlan_interfaces:
   type: inband_mgmt
 sflow:
   run: true
+  sample: 10
   destinations:
   - destination: 10.10.10.10
   - destination: 10.10.10.11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
@@ -75,6 +75,7 @@ vlan_interfaces:
   type: inband_mgmt
 sflow:
   run: true
+  sample: 10
   destinations:
   - destination: 10.10.10.10
   - destination: 10.10.10.11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SFLOW_TESTS_L2_LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SFLOW_TESTS_L2_LEAFS.yml
@@ -4,6 +4,7 @@ type: l2leaf
 default_mgmt_method: inband
 
 sflow_settings:
+  sample: 10
   destinations:
     - destination: 10.10.10.10
       vrf: use_inband_mgmt_vrf

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SFLOW_TESTS_L2_LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/SFLOW_TESTS_L2_LEAFS.yml
@@ -4,7 +4,8 @@ type: l2leaf
 default_mgmt_method: inband
 
 sflow_settings:
-  sample: 10
+  sample:
+    rate: 10
   destinations:
     - destination: 10.10.10.10
       vrf: use_inband_mgmt_vrf

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-sflow-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-sflow-settings.md
@@ -15,7 +15,8 @@
     | [<samp>&nbsp;&nbsp;core_interfaces</samp>](## "fabric_sflow.core_interfaces") | Boolean |  |  |  | Enable sFlow on all p2p_links defined under core_interfaces. |
     | [<samp>&nbsp;&nbsp;mlag_interfaces</samp>](## "fabric_sflow.mlag_interfaces") | Boolean |  |  |  | Enable sFlow on all MLAG peer interfaces. |
     | [<samp>sflow_settings</samp>](## "sflow_settings") | Dictionary |  |  |  | sFlow settings.<br>The sFlow process will only be configured if any interface is enabled for sFlow.<br>For default enabling of sFlow for various interface types across the fabric see `fabric_sflow`. |
-    | [<samp>&nbsp;&nbsp;sample</samp>](## "sflow_settings.sample") | Integer |  |  | Min: 1<br>Max: 4294967295 | Sample rate. |
+    | [<samp>&nbsp;&nbsp;sample</samp>](## "sflow_settings.sample") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rate</samp>](## "sflow_settings.sample.rate") | Integer |  |  | Min: 1<br>Max: 4294967295 | Packet sampling rate that defines the average number of ingress packets that pass through an interface for every packet that is sampled.<br>A rate of 16384 corresponds to an average sample of one per 16384 packets. |
     | [<samp>&nbsp;&nbsp;destinations</samp>](## "sflow_settings.destinations") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;destination</samp>](## "sflow_settings.destinations.[].destination") | String | Required |  |  | sFlow destination name or IP address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow_settings.destinations.[].port") | Integer |  |  | Min: 1<br>Max: 65535 | UDP Port number. The default port number for sFlow is 6343. |
@@ -54,9 +55,11 @@
     # The sFlow process will only be configured if any interface is enabled for sFlow.
     # For default enabling of sFlow for various interface types across the fabric see `fabric_sflow`.
     sflow_settings:
+      sample:
 
-      # Sample rate.
-      sample: <int; 1-4294967295>
+        # Packet sampling rate that defines the average number of ingress packets that pass through an interface for every packet that is sampled.
+        # A rate of 16384 corresponds to an average sample of one per 16384 packets.
+        rate: <int; 1-4294967295>
       destinations:
 
           # sFlow destination name or IP address.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-sflow-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-sflow-settings.md
@@ -15,6 +15,7 @@
     | [<samp>&nbsp;&nbsp;core_interfaces</samp>](## "fabric_sflow.core_interfaces") | Boolean |  |  |  | Enable sFlow on all p2p_links defined under core_interfaces. |
     | [<samp>&nbsp;&nbsp;mlag_interfaces</samp>](## "fabric_sflow.mlag_interfaces") | Boolean |  |  |  | Enable sFlow on all MLAG peer interfaces. |
     | [<samp>sflow_settings</samp>](## "sflow_settings") | Dictionary |  |  |  | sFlow settings.<br>The sFlow process will only be configured if any interface is enabled for sFlow.<br>For default enabling of sFlow for various interface types across the fabric see `fabric_sflow`. |
+    | [<samp>&nbsp;&nbsp;sample</samp>](## "sflow_settings.sample") | Integer |  |  | Min: 1<br>Max: 4294967295 | Sample rate. |
     | [<samp>&nbsp;&nbsp;destinations</samp>](## "sflow_settings.destinations") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;destination</samp>](## "sflow_settings.destinations.[].destination") | String | Required |  |  | sFlow destination name or IP address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;port</samp>](## "sflow_settings.destinations.[].port") | Integer |  |  | Min: 1<br>Max: 65535 | UDP Port number. The default port number for sFlow is 6343. |
@@ -53,6 +54,9 @@
     # The sFlow process will only be configured if any interface is enabled for sFlow.
     # For default enabling of sFlow for various interface types across the fabric see `fabric_sflow`.
     sflow_settings:
+
+      # Sample rate.
+      sample: <int; 1-4294967295>
       destinations:
 
           # sFlow destination name or IP address.

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/flows/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/flows/avdstructuredconfig.py
@@ -45,10 +45,10 @@ class AvdStructuredConfigFlows(AvdFacts):
 
         # At this point we have at least one interface with sFlow enabled
         # and at least one destination.
-        sflow = {"run": True}
-
-        # Add the packet sampling rate.
-        sflow["sample"] = get(self._hostvars, "sflow_settings.sample", default=None)
+        sflow = {
+            "run": True,
+            "sample": get(self._hostvars, "sflow_settings.sample.rate"),
+        }
 
         # Using a temporary dict for VRFs
         sflow_vrfs = {}

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/flows/avdstructuredconfig.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/flows/avdstructuredconfig.py
@@ -47,6 +47,9 @@ class AvdStructuredConfigFlows(AvdFacts):
         # and at least one destination.
         sflow = {"run": True}
 
+        # Add the packet sampling rate.
+        sflow["sample"] = get(self._hostvars, "sflow_settings.sample", default=None)
+
         # Using a temporary dict for VRFs
         sflow_vrfs = {}
 

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -51550,10 +51550,20 @@
       "description": "sFlow settings.\nThe sFlow process will only be configured if any interface is enabled for sFlow.\nFor default enabling of sFlow for various interface types across the fabric see `fabric_sflow`.",
       "properties": {
         "sample": {
-          "type": "integer",
-          "minimum": 1,
-          "maximum": 4294967295,
-          "description": "Sample rate.",
+          "type": "object",
+          "properties": {
+            "rate": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 4294967295,
+              "description": "Packet sampling rate that defines the average number of ingress packets that pass through an interface for every packet that is sampled.\nA rate of 16384 corresponds to an average sample of one per 16384 packets.",
+              "title": "Rate"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
           "title": "Sample"
         },
         "destinations": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -51549,6 +51549,13 @@
       "type": "object",
       "description": "sFlow settings.\nThe sFlow process will only be configured if any interface is enabled for sFlow.\nFor default enabling of sFlow for various interface types across the fabric see `fabric_sflow`.",
       "properties": {
+        "sample": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 4294967295,
+          "description": "Sample rate.",
+          "title": "Sample"
+        },
         "destinations": {
           "type": "array",
           "items": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3263,6 +3263,13 @@ keys:
       For default enabling of sFlow for various interface types across the fabric
       see `fabric_sflow`.'
     keys:
+      sample:
+        type: int
+        convert_types:
+        - str
+        min: 1
+        max: 4294967295
+        description: Sample rate.
       destinations:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -3264,12 +3264,19 @@ keys:
       see `fabric_sflow`.'
     keys:
       sample:
-        type: int
-        convert_types:
-        - str
-        min: 1
-        max: 4294967295
-        description: Sample rate.
+        type: dict
+        keys:
+          rate:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 4294967295
+            description: 'Packet sampling rate that defines the average number of
+              ingress packets that pass through an interface for every packet that
+              is sampled.
+
+              A rate of 16384 corresponds to an average sample of one per 16384 packets.'
       destinations:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/sflow_settings.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/sflow_settings.schema.yml
@@ -15,6 +15,13 @@ keys:
       The sFlow process will only be configured if any interface is enabled for sFlow.
       For default enabling of sFlow for various interface types across the fabric see `fabric_sflow`.
     keys:
+      sample:
+        type: int
+        convert_types:
+          - str
+        min: 1
+        max: 4294967295
+        description: Sample rate.
       destinations:
         type: list
         items:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/sflow_settings.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/sflow_settings.schema.yml
@@ -16,12 +16,17 @@ keys:
       For default enabling of sFlow for various interface types across the fabric see `fabric_sflow`.
     keys:
       sample:
-        type: int
-        convert_types:
-          - str
-        min: 1
-        max: 4294967295
-        description: Sample rate.
+        type: dict
+        keys:
+          rate:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 4294967295
+            description: |-
+              Packet sampling rate that defines the average number of ingress packets that pass through an interface for every packet that is sampled.
+              A rate of 16384 corresponds to an average sample of one per 16384 packets.
       destinations:
         type: list
         items:


### PR DESCRIPTION
## Change Summary

 Add sample rate to sflow settings in eos_designs.

## Related Issue(s)

Fixes #3802 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Adding `sample` key to `sflow_settings` data-model in eos_designs
```

sflow_settings:
     sample:
          rate: <int; 1-4294967295>
```

## How to test

Test written in molecule scenario `eos_designs_unit_tests`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
