### PR TITLE
Feat(eos_cli_config_gen): Support activity polling-interval for router multicast.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-multicast.md
@@ -71,9 +71,13 @@ router multicast
       rpf route 10.10.10.1/32 Ethernet1 1
       rpf route 10.10.10.2/32 Ethernet2
       counters rate period decay 300 seconds
+      activity polling-interval 10
       routing
       multipath deterministic router-id
       software-forwarding sfe
+   !
+   ipv6
+      activity polling-interval 20
    !
    vrf MCAST_VRF1
       ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-multicast.cfg
@@ -18,9 +18,13 @@ router multicast
       rpf route 10.10.10.1/32 Ethernet1 1
       rpf route 10.10.10.2/32 Ethernet2
       counters rate period decay 300 seconds
+      activity polling-interval 10
       routing
       multipath deterministic router-id
       software-forwarding sfe
+   !
+   ipv6
+      activity polling-interval 20
    !
    vrf MCAST_VRF1
       ipv4

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-multicast.yml
@@ -2,6 +2,7 @@
 
 router_multicast:
   ipv4:
+    activity_polling_interval: 10
     rpf:
       routes:
         - source_prefix: 10.10.10.1/32
@@ -18,6 +19,8 @@ router_multicast:
     routing: true
     multipath: "deterministic router-id"
     software_forwarding: sfe
+  ipv6:
+    activity_polling_interval: 20
   vrfs:
     - name: MCAST_VRF1
       ipv4:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-multicast.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-multicast.md
@@ -9,6 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>router_multicast</samp>](## "router_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;ipv4</samp>](## "router_multicast.ipv4") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;activity_polling_interval</samp>](## "router_multicast.ipv4.activity_polling_interval") | Integer |  |  | Min: 1<br>Max: 60 | MFIB entry activity polling interval. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters</samp>](## "router_multicast.ipv4.counters") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rate_period_decay</samp>](## "router_multicast.ipv4.counters.rate_period_decay") | Integer |  |  | Min: 0<br>Max: 600 | Rate in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;routing</samp>](## "router_multicast.ipv4.routing") | Boolean |  |  |  |  |
@@ -20,6 +21,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destinations</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations") | List, items: Dictionary | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;nexthop</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].nexthop") | String | Required |  |  | Next-hop IP address or interface name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "router_multicast.ipv4.rpf.routes.[].destinations.[].distance") | Integer |  |  | Min: 1<br>Max: 255 | Administrative distance for this route. |
+    | [<samp>&nbsp;&nbsp;ipv6</samp>](## "router_multicast.ipv6") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;activity_polling_interval</samp>](## "router_multicast.ipv6.activity_polling_interval") | Integer |  |  | Min: 1<br>Max: 60 | MFIB entry activity polling interval. |
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "router_multicast.vrfs") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_multicast.vrfs.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_multicast.vrfs.[].ipv4") | Dictionary |  |  |  |  |
@@ -30,6 +33,9 @@
     ```yaml
     router_multicast:
       ipv4:
+
+        # MFIB entry activity polling interval.
+        activity_polling_interval: <int; 1-60>
         counters:
 
           # Rate in seconds.
@@ -49,6 +55,10 @@
 
                   # Administrative distance for this route.
                   distance: <int; 1-255>
+      ipv6:
+
+        # MFIB entry activity polling interval.
+        activity_polling_interval: <int; 1-60>
       vrfs:
         - name: <str; required; unique>
           ipv4:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -23219,6 +23219,13 @@
         "ipv4": {
           "type": "object",
           "properties": {
+            "activity_polling_interval": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 60,
+              "description": "MFIB entry activity polling interval.",
+              "title": "Activity Polling Interval"
+            },
             "counters": {
               "type": "object",
               "properties": {
@@ -23324,6 +23331,23 @@
             "^_.+$": {}
           },
           "title": "IPv4"
+        },
+        "ipv6": {
+          "type": "object",
+          "properties": {
+            "activity_polling_interval": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 60,
+              "description": "MFIB entry activity polling interval.",
+              "title": "Activity Polling Interval"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "IPv6"
         },
         "vrfs": {
           "type": "array",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -13360,6 +13360,13 @@ keys:
       ipv4:
         type: dict
         keys:
+          activity_polling_interval:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 60
+            description: MFIB entry activity polling interval.
           counters:
             type: dict
             keys:
@@ -13413,6 +13420,16 @@ keys:
                             max: 255
                             convert_types:
                             - str
+      ipv6:
+        type: dict
+        keys:
+          activity_polling_interval:
+            type: int
+            convert_types:
+            - str
+            min: 1
+            max: 60
+            description: MFIB entry activity polling interval.
       vrfs:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_multicast.schema.yml
@@ -12,6 +12,13 @@ keys:
       ipv4:
         type: dict
         keys:
+          activity_polling_interval:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 60
+            description: MFIB entry activity polling interval.
           counters:
             type: dict
             keys:
@@ -59,6 +66,16 @@ keys:
                             max: 255
                             convert_types:
                               - str
+      ipv6:
+        type: dict
+        keys:
+          activity_polling_interval:
+            type: int
+            convert_types:
+              - str
+            min: 1
+            max: 60
+            description: MFIB entry activity polling interval.
       vrfs:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-multicast.j2
@@ -21,6 +21,9 @@ router multicast
 {%         if router_multicast.ipv4.counters.rate_period_decay is arista.avd.defined %}
       counters rate period decay {{ router_multicast.ipv4.counters.rate_period_decay }} seconds
 {%         endif %}
+{%         if router_multicast.ipv4.activity_polling_interval is arista.avd.defined %}
+      activity polling-interval {{ router_multicast.ipv4.activity_polling_interval }}
+{%         endif %}
 {%         if router_multicast.ipv4.routing is arista.avd.defined(true) %}
       routing
 {%         endif %}
@@ -29,6 +32,13 @@ router multicast
 {%         endif %}
 {%         if router_multicast.ipv4.software_forwarding is arista.avd.defined %}
       software-forwarding {{ router_multicast.ipv4.software_forwarding }}
+{%         endif %}
+{%     endif %}
+{%     if router_multicast.ipv6 is arista.avd.defined %}
+   !
+   ipv6
+{%         if router_multicast.ipv6.activity_polling_interval is arista.avd.defined %}
+      activity polling-interval {{ router_multicast.ipv6.activity_polling_interval }}
 {%         endif %}
 {%     endif %}
 {%     for vrf in router_multicast.vrfs | arista.avd.natural_sort('name') %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -39761,6 +39761,13 @@
                   "ipv4": {
                     "type": "object",
                     "properties": {
+                      "activity_polling_interval": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 60,
+                        "description": "MFIB entry activity polling interval.",
+                        "title": "Activity Polling Interval"
+                      },
                       "counters": {
                         "type": "object",
                         "properties": {
@@ -39866,6 +39873,23 @@
                       "^_.+$": {}
                     },
                     "title": "IPv4"
+                  },
+                  "ipv6": {
+                    "type": "object",
+                    "properties": {
+                      "activity_polling_interval": {
+                        "type": "integer",
+                        "minimum": 1,
+                        "maximum": 60,
+                        "description": "MFIB entry activity polling interval.",
+                        "title": "Activity Polling Interval"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "IPv6"
                   },
                   "vrfs": {
                     "type": "array",


### PR DESCRIPTION
## Change Summary

Add support  for `activity polling-interval` in router multicast ipv4/ipv6.

## Related Issue(s)

Fixes #3879 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Insert a new key in `router_multicast` data-model for IPv4 and IPv6 - 

```
router_multicast:
      ipv4:
        # MFIB entry activity polling interval.
        activity_polling_interval: <int; 1-60>

      ipv6:
        # MFIB entry activity polling interval.
        activity_polling_interval: <int; 1-60>
```


## How to test

Added test in molecule scenario and check in EOS CLI.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
