### PR TITLE
Doc(eos_validate_state): Add link for OSX fork issue

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
@@ -260,3 +260,7 @@ When specifying a group, it must be a group from the Ansible inventory. The cust
         # To save catalogs
         save_catalog: true
 ```
+
+## Known issues
+
+* `[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.` This issue affects OSX users only and is covered in Ansible documentation: https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#running-on-macos-as-a-control-node.

--- a/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/ANTA-Preview.md
@@ -263,4 +263,4 @@ When specifying a group, it must be a group from the Ansible inventory. The cust
 
 ## Known issues
 
-* `[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.` This issue affects OSX users only and is covered in Ansible documentation: https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#running-on-macos-as-a-control-node.
+- `[__NSCFConstantString initialize] may have been in progress in another thread when fork() was called.` This issue affects OSX users only and is covered in Ansible documentation: https://docs.ansible.com/ansible/latest/reference_appendices/faq.html#running-on-macos-as-a-control-node.


### PR DESCRIPTION
## Change Summary

Add known issue regarding Ansible forks on OSX.

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes

cf summary

## How to test

not needed

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
