### PR TITLE
CI: Remove pre-commit from Github Workflow

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -72,27 +72,6 @@ jobs:
             pyavd:
               - 'python_avd/*'
               - 'python_avd/**/*'
-  # ----------------------------------- #
-  # Pre Commit code validation
-  # ----------------------------------- #
-  pre_commit:
-    name: Run pre-commit validation hooks
-    runs-on: ubuntu-latest
-    needs: file-changes
-    if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true' || needs.file-changes.outputs.requirements == 'true'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up Python 3
-        uses: actions/setup-python@v5
-      - name: Install Python requirements
-        run: |
-          pip install -r ansible_collections/arista/avd/requirements.txt -r ansible_collections/arista/avd/requirements-dev.txt --upgrade
-      - name: Run pre-commit
-        run: |
-          pre-commit run --all-files --color always
-      # Do NOT set a name for the pre-commit-ci action. Otherwise the Github App will not pick it up.
-      - uses: pre-commit-ci/lite-action@v1.0.2
-        if: always()
 
   # ----------------------------------- #
   # Test Requirements
@@ -100,7 +79,7 @@ jobs:
   python_requirements:
     name: Test Python requirements installation
     runs-on: ubuntu-latest
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     if: needs.file-changes.outputs.requirements == 'true'
     strategy:
       fail-fast: true
@@ -139,7 +118,7 @@ jobs:
         include:
           - avd_scenario: 'eos_cli_config_gen'
             ansible_version: 'ansible-core==2.14.0'
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     if: needs.file-changes.outputs.config_gen == 'true'
     steps:
       - name: 'Set environment variables'
@@ -174,7 +153,7 @@ jobs:
       matrix:
         avd_scenario: ['dhcp_configuration', 'dhcp_provisioning']
         ansible_version: ['ansible-core<2.17.0 --upgrade']
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     if: needs.file-changes.outputs.dhcp == 'true'
     steps:
       - name: 'Set environment variables'
@@ -233,7 +212,7 @@ jobs:
             ansible_version: 'ansible-core>=2.14.0,<2.15.0 --upgrade'
           - avd_scenario: 'eos_designs_unit_tests'
             ansible_version: 'ansible-core>=2.15.0,<2.16.0 --upgrade'
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true'
     steps:
       - name: 'Set environment variables'
@@ -272,7 +251,7 @@ jobs:
         include:
           - avd_scenario: 'eos_config_deploy_cvp'
             ansible_version: 'ansible-core==2.14.0'
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     if: needs.file-changes.outputs.cloudvision == 'true'
     steps:
       - name: 'Set environment variables'
@@ -312,7 +291,7 @@ jobs:
         include:
           - avd_scenario: 'eos_validate_state'
             ansible_version: 'ansible-core==2.14.0'
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.validate_state == 'true'
     steps:
       - name: 'Set environment variables'
@@ -339,7 +318,7 @@ jobs:
   ansible_test_sanity:
     name: Run ansible-test sanity validation
     runs-on: ubuntu-latest
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     #needs: [ molecule_eos_designs, molecule_cloudvision ]
     #if: needs.cloudvision.status != 'failed' && needs.molecule_eos_designs.status != 'failed' && needs.file-changes.outputs.plugins == 'true'
     steps:
@@ -365,7 +344,7 @@ jobs:
   ansible_test_units:
     name: Run ansible-test units test cases
     runs-on: ubuntu-latest
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     steps:
       - name: 'Set environment variables'
         run: |
@@ -382,7 +361,7 @@ jobs:
   ansible_test_integration:
     name: Run ansible-test integration test cases
     runs-on: ubuntu-latest
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     steps:
       - name: 'Set environment variables'
         run: |
@@ -406,7 +385,7 @@ jobs:
   ansible_lint:
     name: Run ansible-lint test case
     runs-on: ubuntu-latest
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     steps:
       - name: 'Set environment variables'
         run: |
@@ -468,7 +447,7 @@ jobs:
   pyavd:
     name: Test pyavd
     runs-on: ubuntu-latest
-    needs: [ pre_commit ]
+    needs: [ file-changes ]
     if: |
       needs.file-changes.outputs.eos_design == 'true' ||
       needs.file-changes.outputs.config_gen == 'true' ||


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Remove pre-commit from Github Workflow

Since we have implemented the pre-commit.ci application, we no longer need to run pre-commit in the workflow.
