### PR TITLE
Fix(eos_designs): Make WAN RRs route-reflector clients of each other

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr1.cfg
@@ -174,6 +174,7 @@ router bgp 65000
    neighbor WAN-RR-OVERLAY-PEERS peer group
    neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
    neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS route-reflector-client
    neighbor WAN-RR-OVERLAY-PEERS bfd
    neighbor WAN-RR-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
    neighbor WAN-RR-OVERLAY-PEERS ttl maximum-hops 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/autovpn-rr2.cfg
@@ -175,6 +175,7 @@ router bgp 65000
    neighbor WAN-RR-OVERLAY-PEERS peer group
    neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
    neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS route-reflector-client
    neighbor WAN-RR-OVERLAY-PEERS bfd
    neighbor WAN-RR-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
    neighbor WAN-RR-OVERLAY-PEERS ttl maximum-hops 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
@@ -265,6 +265,7 @@ router bgp 65000
    neighbor WAN-RR-OVERLAY-PEERS peer group
    neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
    neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS route-reflector-client
    neighbor WAN-RR-OVERLAY-PEERS bfd
    neighbor WAN-RR-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
    neighbor WAN-RR-OVERLAY-PEERS ttl maximum-hops 1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -355,6 +355,7 @@ router bgp 65000
    neighbor WAN-RR-OVERLAY-PEERS peer group
    neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
    neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS route-reflector-client
    neighbor WAN-RR-OVERLAY-PEERS bfd
    neighbor WAN-RR-OVERLAY-PEERS bfd interval 2020 min-rx 2000 multiplier 3
    neighbor WAN-RR-OVERLAY-PEERS ttl maximum-hops 42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -368,6 +368,7 @@ router bgp 65000
    neighbor WAN-RR-OVERLAY-PEERS peer group
    neighbor WAN-RR-OVERLAY-PEERS remote-as 65000
    neighbor WAN-RR-OVERLAY-PEERS update-source Dps1
+   neighbor WAN-RR-OVERLAY-PEERS route-reflector-client
    neighbor WAN-RR-OVERLAY-PEERS bfd
    neighbor WAN-RR-OVERLAY-PEERS bfd interval 2020 min-rx 2000 multiplier 3
    neighbor WAN-RR-OVERLAY-PEERS ttl maximum-hops 42

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr1.yml
@@ -45,6 +45,7 @@ router_bgp:
       interval: 1000
       min_rx: 1000
       multiplier: 10
+    route_reflector_client: true
   address_family_evpn:
     peer_groups:
     - name: WAN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -45,6 +45,7 @@ router_bgp:
       interval: 1000
       min_rx: 1000
       multiplier: 10
+    route_reflector_client: true
   address_family_evpn:
     peer_groups:
     - name: WAN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
@@ -43,6 +43,7 @@ router_bgp:
       interval: 1000
       min_rx: 1000
       multiplier: 10
+    route_reflector_client: true
   address_family_ipv4:
     peer_groups:
     - name: IPv4-UNDERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -43,6 +43,7 @@ router_bgp:
       interval: 2020
       min_rx: 2000
       multiplier: 3
+    route_reflector_client: true
   address_family_ipv4:
     peer_groups:
     - name: IPv4-UNDERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -43,6 +43,7 @@ router_bgp:
       interval: 2020
       min_rx: 2000
       multiplier: 3
+    route_reflector_client: true
   address_family_ipv4:
     peer_groups:
     - name: IPv4-UNDERLAY-PEERS

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/router_bgp.py
@@ -150,9 +150,13 @@ class RouterBgpMixin(UtilsMixin):
             if self._is_wan_server_with_peers:
                 wan_rr_overlay_peer_group = self._generate_base_peer_group("wan", "wan_rr_overlay_peers", update_source=self.shared_utils.vtep_loopback)
                 wan_rr_overlay_peer_group.update(
-                    {"remote_as": self.shared_utils.bgp_as, "ttl_maximum_hops": self.shared_utils.bgp_peer_groups["wan_rr_overlay_peers"]["ttl_maximum_hops"]}
+                    {
+                        "remote_as": self.shared_utils.bgp_as,
+                        "ttl_maximum_hops": self.shared_utils.bgp_peer_groups["wan_rr_overlay_peers"]["ttl_maximum_hops"],
+                        "bfd_timers": get(self.shared_utils.bgp_peer_groups["wan_rr_overlay_peers"], "bfd_timers"),
+                        "route_reflector_client": True,
+                    }
                 )
-                wan_rr_overlay_peer_group["bfd_timers"] = get(self.shared_utils.bgp_peer_groups["wan_rr_overlay_peers"], "bfd_timers")
                 peer_groups.append(wan_rr_overlay_peer_group)
 
         # same for ebgp and ibgp


### PR DESCRIPTION
## Change Summary

This was missed during initial implementation. Confirmed with engineering.

## Related Issue(s)

Issue from field

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Automatically inject `neighbor WAN-RR-OVERLAY-PEERS route-reflector-client` for the peer group

## How to test

molecule shows the fix working

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
