### PR TITLE
Feat(eos_cli_config_gen): Support additional options for IPv6 ND under SVIs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -73,6 +73,7 @@ interface Management1
 | Vlan336 | v6 attached host exports | default | - | - |
 | Vlan337 | v4 dhcp relay all-subnets | default | - | - |
 | Vlan338 | v6 dhcp relay all-subnets | default | - | - |
+| Vlan339 | v6 nd options | default | - | - |
 | Vlan501 | SVI Description | default | - | False |
 | Vlan667 | Multiple VRIDs | default | - | False |
 | Vlan1001 | SVI Description | Tenant_A | - | False |
@@ -115,8 +116,9 @@ interface Management1
 | Vlan334 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan335 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan336 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
-| Vlan337 |  default  |  16.0.2.2/25  |  -  |  -  |  -  |  -  |  -  |
+| Vlan337 |  default  |  10.0.2.2/25  |  -  |  -  |  -  |  -  |  -  |
 | Vlan338 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
+| Vlan339 |  default  |  -  |  -  |  -  |  -  |  -  |  -  |
 | Vlan501 |  default  |  10.50.26.29/27  |  -  |  -  |  -  |  -  |  -  |
 | Vlan667 |  default  |  192.0.2.2/25  |  -  |  -  |  -  |  -  |  -  |
 | Vlan1001 |  Tenant_A  |  -  |  10.1.1.1/24  |  -  |  -  |  -  |  -  |
@@ -151,34 +153,35 @@ interface Management1
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | ------------ | ---------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
-| Vlan24 | default | 1b11:3a00:22b0:6::15/64 | - | 1b11:3a00:22b0:6::1 | - | - | True | - | - |
-| Vlan25 | default | 1b11:3a00:22b0:16::16/64 | - | 1b11:3a00:22b0:16::15, 1b11:3a00:22b0:16::14 | - | - | - | - | - |
-| Vlan43 | default | a0::1/64 | - | - | - | - | - | - | - |
-| Vlan44 | default | a0::4/64 | - | - | - | - | - | - | - |
-| Vlan75 | default | 1b11:3a00:22b0:1000::15/64 | - | 1b11:3a00:22b0:1000::1 | - | - | True | - | - |
-| Vlan81 | Tenant_C | - | fc00:10:10:81::1/64, fc00:10:11:81::1/64, fc00:10:12:81::1/64 | - | - | - | - | - | - |
-| Vlan89 | default | 1b11:3a00:22b0:5200::15/64 | - | 1b11:3a00:22b0:5200::3 | - | - | True | - | - |
-| Vlan333 | default | 2001:db8::2/64 | - | - | - | - | - | - | - |
-| Vlan334 | default | 2a00:1::1/64 | - | - | - | - | - | - | - |
-| Vlan335 | default | 2a00:2::1/64 | - | - | - | - | - | - | - |
-| Vlan336 | default | 2a00:3::1/64 | - | - | - | - | - | - | - |
-| Vlan338 | default | 2a00:1::1/64 | - | - | - | - | - | - | - |
-| Vlan501 | default | 1b11:3a00:22b0:0088::207/127 | - | - | - | True | - | - | - |
-| Vlan667 | default | 2001:db8::2/64 | - | - | - | - | - | - | - |
-| Vlan1001 | Tenant_A | a1::1/64 | - | - | - | - | True | - | - |
-| Vlan1002 | Tenant_A | a2::1/64 | - | - | - | True | True | - | - |
+| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | ------------ | ---------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------------- | ----------- | ------------ |
+| Vlan24 | default | 1b11:3a00:22b0:6::15/64 | - | 1b11:3a00:22b0:6::1 | - | - | True | - | - | - |
+| Vlan25 | default | 1b11:3a00:22b0:16::16/64 | - | 1b11:3a00:22b0:16::15, 1b11:3a00:22b0:16::14 | - | - | - | - | - | - |
+| Vlan43 | default | a0::1/64 | - | - | - | - | - | - | - | - |
+| Vlan44 | default | a0::4/64 | - | - | - | - | - | - | - | - |
+| Vlan75 | default | 1b11:3a00:22b0:1000::15/64 | - | 1b11:3a00:22b0:1000::1 | - | - | True | - | - | - |
+| Vlan81 | Tenant_C | - | fc00:10:10:81::1/64, fc00:10:11:81::1/64, fc00:10:12:81::1/64 | - | - | - | - | - | - | - |
+| Vlan89 | default | 1b11:3a00:22b0:5200::15/64 | - | 1b11:3a00:22b0:5200::3 | - | - | True | - | - | - |
+| Vlan333 | default | 2001:db8:333::2/64 | - | - | - | - | - | - | - | - |
+| Vlan334 | default | 2001:db8:334::1/64 | - | - | - | - | - | - | - | - |
+| Vlan335 | default | 2001:db8:335::1/64 | - | - | - | - | - | - | - | - |
+| Vlan336 | default | 2001:db8:336::1/64 | - | - | - | - | - | - | - | - |
+| Vlan338 | default | 2001:db8:338::1/64 | - | - | - | - | - | - | - | - |
+| Vlan339 | default | 2001:db8:339::1/64 | - | - | - | - | - | True | - | - |
+| Vlan501 | default | 1b11:3a00:22b0:0088::207/127 | - | - | - | True | - | - | - | - |
+| Vlan667 | default | 2001:db8:667::2/64 | - | - | - | - | - | - | - | - |
+| Vlan1001 | Tenant_A | a1::1/64 | - | - | - | - | True | - | - | - |
+| Vlan1002 | Tenant_A | a2::1/64 | - | - | - | True | True | - | - | - |
 
 ##### VRRP Details
 
 | Interface | VRRP-ID | Priority | Advertisement Interval | Preempt | Tracked Object Name(s) | Tracked Object Action(s) | IPv4 Virtual IP | IPv4 VRRP Version | IPv6 Virtual IP |
 | --------- | ------- | -------- | ---------------------- | --------| ---------------------- | ------------------------ | --------------- | ----------------- | --------------- |
 | Vlan333 | 1 | 105 | 2 | Enabled | ID1-TrackedObjectDecrement, ID1-TrackedObjectShutdown | Decrement 5, Shutdown | 192.0.2.1 | 2 | - |
-| Vlan333 | 2 | - | - | Enabled | ID2-TrackedObjectDecrement, ID2-TrackedObjectShutdown | Decrement 10, Shutdown | - | 2 | 2001:db8::1 |
+| Vlan333 | 2 | - | - | Enabled | ID2-TrackedObjectDecrement, ID2-TrackedObjectShutdown | Decrement 10, Shutdown | - | 2 | 2001:db8:333::1 |
 | Vlan333 | 3 | - | - | Disabled | - | - | 100.64.0.1 | 3 | - |
 | Vlan667 | 1 | 105 | 2 | Enabled | - | - | 192.0.2.1 | 2 | - |
-| Vlan667 | 2 | - | - | Enabled | - | - | - | 2 | 2001:db8::1 |
+| Vlan667 | 2 | - | - | Enabled | - | - | - | 2 | 2001:db8:667::1 |
 
 ##### ISIS
 
@@ -380,7 +383,7 @@ interface Vlan333
    arp aging timeout 180
    ip address 192.0.2.2/25
    ipv6 enable
-   ipv6 address 2001:db8::2/64
+   ipv6 address 2001:db8:333::2/64
    ipv6 address fe80::2/64 link-local
    vrrp 1 priority-level 105
    vrrp 1 advertisement interval 2
@@ -388,7 +391,7 @@ interface Vlan333
    vrrp 1 ipv4 192.0.2.1
    vrrp 1 tracked-object ID1-TrackedObjectDecrement decrement 5
    vrrp 1 tracked-object ID1-TrackedObjectShutdown shutdown
-   vrrp 2 ipv6 2001:db8::1
+   vrrp 2 ipv6 2001:db8:333::1
    vrrp 2 tracked-object ID2-TrackedObjectDecrement decrement 10
    vrrp 2 tracked-object ID2-TrackedObjectShutdown shutdown
    no vrrp 3 preempt
@@ -400,29 +403,38 @@ interface Vlan334
    description v6 attached host exports
    ipv6 attached-host route export 19
    ipv6 enable
-   ipv6 address 2a00:1::1/64
+   ipv6 address 2001:db8:334::1/64
 !
 interface Vlan335
    description v6 attached host exports
    ipv6 attached-host route export prefix-length 64
    ipv6 enable
-   ipv6 address 2a00:2::1/64
+   ipv6 address 2001:db8:335::1/64
 !
 interface Vlan336
    description v6 attached host exports
    ipv6 attached-host route export 18 prefix-length 64
    ipv6 enable
-   ipv6 address 2a00:3::1/64
+   ipv6 address 2001:db8:336::1/64
 !
 interface Vlan337
    description v4 dhcp relay all-subnets
-   ip address 16.0.2.2/25
+   ip address 10.0.2.2/25
    ip dhcp relay all-subnets
 !
 interface Vlan338
    description v6 dhcp relay all-subnets
    ipv6 dhcp relay all-subnets
-   ipv6 address 2a00:1::1/64
+   ipv6 address 2001:db8:338::1/64
+!
+interface Vlan339
+   description v6 nd options
+   ipv6 nd cache expire 250
+   ipv6 nd cache dynamic capacity 900
+   ipv6 nd cache refresh always
+   ipv6 enable
+   ipv6 address 2001:db8:339::1/64
+   ipv6 nd other-config-flag
 !
 interface Vlan501
    description SVI Description
@@ -437,13 +449,13 @@ interface Vlan667
    arp aging timeout 180
    ip address 192.0.2.2/25
    ipv6 enable
-   ipv6 address 2001:db8::2/64
+   ipv6 address 2001:db8:667::2/64
    ipv6 address fe80::2/64 link-local
    vrrp 1 priority-level 105
    vrrp 1 advertisement interval 2
    vrrp 1 preempt delay minimum 30 reload 800
    vrrp 1 ipv4 192.0.2.1
-   vrrp 2 ipv6 2001:db8::1
+   vrrp 2 ipv6 2001:db8:667::1
 !
 interface Vlan1001
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -191,7 +191,7 @@ interface Vlan333
    arp aging timeout 180
    ip address 192.0.2.2/25
    ipv6 enable
-   ipv6 address 2001:db8::2/64
+   ipv6 address 2001:db8:333::2/64
    ipv6 address fe80::2/64 link-local
    vrrp 1 priority-level 105
    vrrp 1 advertisement interval 2
@@ -199,7 +199,7 @@ interface Vlan333
    vrrp 1 ipv4 192.0.2.1
    vrrp 1 tracked-object ID1-TrackedObjectDecrement decrement 5
    vrrp 1 tracked-object ID1-TrackedObjectShutdown shutdown
-   vrrp 2 ipv6 2001:db8::1
+   vrrp 2 ipv6 2001:db8:333::1
    vrrp 2 tracked-object ID2-TrackedObjectDecrement decrement 10
    vrrp 2 tracked-object ID2-TrackedObjectShutdown shutdown
    no vrrp 3 preempt
@@ -211,29 +211,38 @@ interface Vlan334
    description v6 attached host exports
    ipv6 attached-host route export 19
    ipv6 enable
-   ipv6 address 2a00:1::1/64
+   ipv6 address 2001:db8:334::1/64
 !
 interface Vlan335
    description v6 attached host exports
    ipv6 attached-host route export prefix-length 64
    ipv6 enable
-   ipv6 address 2a00:2::1/64
+   ipv6 address 2001:db8:335::1/64
 !
 interface Vlan336
    description v6 attached host exports
    ipv6 attached-host route export 18 prefix-length 64
    ipv6 enable
-   ipv6 address 2a00:3::1/64
+   ipv6 address 2001:db8:336::1/64
 !
 interface Vlan337
    description v4 dhcp relay all-subnets
-   ip address 16.0.2.2/25
+   ip address 10.0.2.2/25
    ip dhcp relay all-subnets
 !
 interface Vlan338
    description v6 dhcp relay all-subnets
    ipv6 dhcp relay all-subnets
-   ipv6 address 2a00:1::1/64
+   ipv6 address 2001:db8:338::1/64
+!
+interface Vlan339
+   description v6 nd options
+   ipv6 nd cache expire 250
+   ipv6 nd cache dynamic capacity 900
+   ipv6 nd cache refresh always
+   ipv6 enable
+   ipv6 address 2001:db8:339::1/64
+   ipv6 nd other-config-flag
 !
 interface Vlan501
    description SVI Description
@@ -248,13 +257,13 @@ interface Vlan667
    arp aging timeout 180
    ip address 192.0.2.2/25
    ipv6 enable
-   ipv6 address 2001:db8::2/64
+   ipv6 address 2001:db8:667::2/64
    ipv6 address fe80::2/64 link-local
    vrrp 1 priority-level 105
    vrrp 1 advertisement interval 2
    vrrp 1 preempt delay minimum 30 reload 800
    vrrp 1 ipv4 192.0.2.1
-   vrrp 2 ipv6 2001:db8::1
+   vrrp 2 ipv6 2001:db8:667::1
 !
 interface Vlan1001
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -349,7 +349,7 @@ vlan_interfaces:
     arp_aging_timeout: 180
     ip_address: 192.0.2.2/25
     ipv6_enable: true
-    ipv6_address: 2001:db8::2/64
+    ipv6_address: 2001:db8:667::2/64
     ipv6_address_link_local: fe80::2/64
     vrrp_ids:
       - id: 1
@@ -368,7 +368,7 @@ vlan_interfaces:
           enabled: true
           delay:
         ipv6:
-          address: 2001:db8::1
+          address: 2001:db8:667::1
 
   - name: Vlan333
     description: Multiple VRIDs and tracking
@@ -376,7 +376,7 @@ vlan_interfaces:
     arp_aging_timeout: 180
     ip_address: 192.0.2.2/25
     ipv6_enable: true
-    ipv6_address: 2001:db8::2/64
+    ipv6_address: 2001:db8:333::2/64
     ipv6_address_link_local: fe80::2/64
     vrrp_ids:
       - id: 1
@@ -400,7 +400,7 @@ vlan_interfaces:
           enabled: true
           delay:
         ipv6:
-          address: 2001:db8::1
+          address: 2001:db8:333::1
         tracked_object:
           - name: ID2-TrackedObjectDecrement
             decrement: 10
@@ -419,7 +419,7 @@ vlan_interfaces:
   - name: Vlan334
     description: v6 attached host exports
     ipv6_enable: true
-    ipv6_address: 2a00:1::1/64
+    ipv6_address: 2001:db8:334::1/64
     ipv6_attached_host_route_export:
       enabled: true
       distance: 19
@@ -427,7 +427,7 @@ vlan_interfaces:
   - name: Vlan335
     description: v6 attached host exports
     ipv6_enable: true
-    ipv6_address: 2a00:2::1/64
+    ipv6_address: 2001:db8:335::1/64
     ipv6_attached_host_route_export:
       enabled: true
       prefix_length: 64
@@ -435,7 +435,7 @@ vlan_interfaces:
   - name: Vlan336
     description: v6 attached host exports
     ipv6_enable: true
-    ipv6_address: 2a00:3::1/64
+    ipv6_address: 2001:db8:336::1/64
     ipv6_attached_host_route_export:
       enabled: true
       distance: 18
@@ -443,10 +443,20 @@ vlan_interfaces:
 
   - name: Vlan337
     description: v4 dhcp relay all-subnets
-    ip_address: 16.0.2.2/25
+    ip_address: 10.0.2.2/25
     ip_dhcp_relay_all_subnets: true
 
   - name: Vlan338
     description: v6 dhcp relay all-subnets
-    ipv6_address: 2a00:1::1/64
+    ipv6_address: 2001:db8:338::1/64
     ipv6_dhcp_relay_all_subnets: true
+
+  - name: Vlan339
+    description: v6 nd options
+    ipv6_enable: true
+    ipv6_address: 2001:db8:339::1/64
+    ipv6_nd_other_config_flag: true
+    ipv6_nd_cache:
+      dynamic_capacity: 900
+      expire: 250
+      refresh_always: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -868,11 +868,11 @@ interface Tunnel4
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | ------------ | ---------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
-| Vlan1 | default | - | fc00:10:10:1::1/64 | - | - | - | - | - | - |
-| Vlan2 | default | 1b11:3a00:22b0:5200::15/64 | fc00:10:10:2::1/64, fc00:10:11:2::1/64, fc00:10:12:2::1/64 | - | - | - | True | - | - |
-| Vlan3 | default | 1b11:3a00:22b3:5200::15/64 | - | fc00:10:10:3::1/64 | - | - | - | - | - |
+| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | ------------ | ---------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------------- | ----------- | ------------ |
+| Vlan1 | default | - | fc00:10:10:1::1/64 | - | - | - | - | - | - | - |
+| Vlan2 | default | 1b11:3a00:22b0:5200::15/64 | fc00:10:10:2::1/64, fc00:10:11:2::1/64, fc00:10:12:2::1/64 | - | - | - | True | - | - | - |
+| Vlan3 | default | 1b11:3a00:22b3:5200::15/64 | - | fc00:10:10:3::1/64 | - | - | - | - | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -96,6 +96,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "vlan_interfaces.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6 address or IPv6_address/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_ra_disabled</samp>](## "vlan_interfaces.[].ipv6_nd_ra_disabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_managed_config_flag</samp>](## "vlan_interfaces.[].ipv6_nd_managed_config_flag") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_other_config_flag</samp>](## "vlan_interfaces.[].ipv6_nd_other_config_flag") | Boolean |  |  |  | Set the "other stateful configuration" flag in IPv6 router advertisements. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_cache</samp>](## "vlan_interfaces.[].ipv6_nd_cache") | Dictionary |  |  |  | IPv6 neighbor cache options. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic_capacity</samp>](## "vlan_interfaces.[].ipv6_nd_cache.dynamic_capacity") | Integer |  |  | Min: 0<br>Max: 4294967295 | Capacity of dynamic cache entries. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;expire</samp>](## "vlan_interfaces.[].ipv6_nd_cache.expire") | Integer |  |  | Min: 1<br>Max: 65535 | Cache entries expirery in seconds. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;refresh_always</samp>](## "vlan_interfaces.[].ipv6_nd_cache.refresh_always") | Boolean |  |  |  | Force refresh on cache expiry. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_nd_prefixes</samp>](## "vlan_interfaces.[].ipv6_nd_prefixes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ipv6_prefix</samp>](## "vlan_interfaces.[].ipv6_nd_prefixes.[].ipv6_prefix") | String | Required, Unique |  |  | IPv6_address/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;valid_lifetime</samp>](## "vlan_interfaces.[].ipv6_nd_prefixes.[].valid_lifetime") | String |  |  |  | In seconds <0-4294967295> or infinite. |
@@ -393,6 +398,21 @@
           - <str>
         ipv6_nd_ra_disabled: <bool>
         ipv6_nd_managed_config_flag: <bool>
+
+        # Set the "other stateful configuration" flag in IPv6 router advertisements.
+        ipv6_nd_other_config_flag: <bool>
+
+        # IPv6 neighbor cache options.
+        ipv6_nd_cache:
+
+          # Capacity of dynamic cache entries.
+          dynamic_capacity: <int; 0-4294967295>
+
+          # Cache entries expirery in seconds.
+          expire: <int; 1-65535>
+
+          # Force refresh on cache expiry.
+          refresh_always: <bool>
         ipv6_nd_prefixes:
 
             # IPv6_address/Mask.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -28260,6 +28260,41 @@
             "type": "boolean",
             "title": "IPv6 ND Managed Config Flag"
           },
+          "ipv6_nd_other_config_flag": {
+            "type": "boolean",
+            "description": "Set the \"other stateful configuration\" flag in IPv6 router advertisements.",
+            "title": "IPv6 ND Other Config Flag"
+          },
+          "ipv6_nd_cache": {
+            "type": "object",
+            "description": "IPv6 neighbor cache options.",
+            "properties": {
+              "dynamic_capacity": {
+                "type": "integer",
+                "description": "Capacity of dynamic cache entries.",
+                "minimum": 0,
+                "maximum": 4294967295,
+                "title": "Dynamic Capacity"
+              },
+              "expire": {
+                "type": "integer",
+                "description": "Cache entries expirery in seconds.",
+                "minimum": 1,
+                "maximum": 65535,
+                "title": "Expire"
+              },
+              "refresh_always": {
+                "type": "boolean",
+                "description": "Force refresh on cache expiry.",
+                "title": "Refresh Always"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "IPv6 ND Cache"
+          },
           "ipv6_nd_prefixes": {
             "type": "array",
             "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -16293,6 +16293,31 @@ keys:
           type: bool
         ipv6_nd_managed_config_flag:
           type: bool
+        ipv6_nd_other_config_flag:
+          type: bool
+          description: Set the "other stateful configuration" flag in IPv6 router
+            advertisements.
+        ipv6_nd_cache:
+          type: dict
+          description: IPv6 neighbor cache options.
+          keys:
+            dynamic_capacity:
+              type: int
+              description: Capacity of dynamic cache entries.
+              convert_types:
+              - str
+              min: 0
+              max: 4294967295
+            expire:
+              type: int
+              description: Cache entries expirery in seconds.
+              convert_types:
+              - str
+              min: 1
+              max: 65535
+            refresh_always:
+              type: bool
+              description: Force refresh on cache expiry.
         ipv6_nd_prefixes:
           type: list
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/vlan_interfaces.schema.yml
@@ -212,6 +212,30 @@ keys:
           type: bool
         ipv6_nd_managed_config_flag:
           type: bool
+        ipv6_nd_other_config_flag:
+          type: bool
+          description: Set the "other stateful configuration" flag in IPv6 router advertisements.
+        ipv6_nd_cache:
+          type: dict
+          description: IPv6 neighbor cache options.
+          keys:
+            dynamic_capacity:
+              type: int
+              description: Capacity of dynamic cache entries.
+              convert_types:
+                - str
+              min: 0
+              max: 4294967295
+            expire:
+              type: int
+              description: Cache entries expirery in seconds.
+              convert_types:
+                - str
+              min: 1
+              max: 65535
+            refresh_always:
+              type: bool
+              description: Force refresh on cache expiry.
         ipv6_nd_prefixes:
           type: list
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/vlan-interfaces.j2
@@ -69,8 +69,8 @@
 
 ##### IPv6
 
-| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | IPv6 ACL In | IPv6 ACL Out |
-| --------- | --- | ------------ | ---------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------- | ------------ |
+| Interface | VRF | IPv6 Address | IPv6 Virtual Addresses | Virtual Router Address | VRRP | ND RA Disabled | Managed Config Flag | Other Config Flag | IPv6 ACL In | IPv6 ACL Out |
+| --------- | --- | ------------ | ---------------------- | ---------------------- | ---- | -------------- | ------------------- | ----------------- | ----------- | ------------ |
 {%         for vlan_interface in vlan_interfaces_ipv6 | arista.avd.natural_sort('name') %}
 {%             set row_vrf = vlan_interface.vrf | arista.avd.default('default') %}
 {%             set row_ip_addr = vlan_interface.ipv6_address | arista.avd.default('-') %}
@@ -87,9 +87,10 @@
 {%             set row_vrrp = vlan_interface.vrrp.ipv6 | arista.avd.default('-') %}
 {%             set row_nd_ra_disabled = vlan_interface.ipv6_nd_ra_disabled | arista.avd.default('-') %}
 {%             set row_nd_man_cfg = vlan_interface.ipv6_nd_managed_config_flag | arista.avd.default('-') %}
+{%             set row_nd_oth_cfg = vlan_interface.ipv6_nd_other_config_flag | arista.avd.default('-') %}
 {%             set row_acl_in = vlan_interface.ipv6_access_group_in | arista.avd.default('-') %}
 {%             set row_acl_out = vlan_interface.ipv6_access_group_out | arista.avd.default('-') %}
-| {{ vlan_interface.name }} | {{ row_vrf }} | {{ row_ip_addr }} | {{ row_ip_vaddr }} | {{ row_varp }} | {{ row_vrrp }} | {{ row_nd_ra_disabled }} | {{ row_nd_man_cfg }} | {{ row_acl_in }} | {{ row_acl_out }} |
+| {{ vlan_interface.name }} | {{ row_vrf }} | {{ row_ip_addr }} | {{ row_ip_vaddr }} | {{ row_varp }} | {{ row_vrrp }} | {{ row_nd_ra_disabled }} | {{ row_nd_man_cfg }} | {{ row_nd_oth_cfg }} | {{ row_acl_in }} | {{ row_acl_out }} |
 {%         endfor %}
 {%     endif %}
 {# VRRP #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/vlan-interfaces.j2
@@ -41,6 +41,17 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.arp_cache_dynamic_capacity is arista.avd.defined %}
    arp cache dynamic capacity {{ vlan_interface.arp_cache_dynamic_capacity }}
 {%     endif %}
+{%     if vlan_interface.ipv6_nd_cache is arista.avd.defined() %}
+{%         if vlan_interface.ipv6_nd_cache.expire is arista.avd.defined() %}
+   ipv6 nd cache expire {{ vlan_interface.ipv6_nd_cache.expire }}
+{%         endif %}
+{%         if vlan_interface.ipv6_nd_cache.dynamic_capacity is arista.avd.defined() %}
+   ipv6 nd cache dynamic capacity {{ vlan_interface.ipv6_nd_cache.dynamic_capacity }}
+{%         endif %}
+{%         if vlan_interface.ipv6_nd_cache.refresh_always is arista.avd.defined(true) %}
+   ipv6 nd cache refresh always
+{%         endif %}
+{%     endif %}
 {%     if vlan_interface.ip_proxy_arp is arista.avd.defined(true) %}
    ip proxy-arp
 {%     endif %}
@@ -158,6 +169,9 @@ interface {{ vlan_interface.name }}
 {%     endif %}
 {%     if vlan_interface.ipv6_nd_managed_config_flag is arista.avd.defined(true) %}
    ipv6 nd managed-config-flag
+{%     endif %}
+{%     if vlan_interface.ipv6_nd_other_config_flag is arista.avd.defined(true) %}
+   ipv6 nd other-config-flag
 {%     endif %}
 {%     if vlan_interface.ipv6_nd_prefixes is arista.avd.defined %}
 {%         for prefix in vlan_interface.ipv6_nd_prefixes %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -44954,6 +44954,41 @@
                       "type": "boolean",
                       "title": "IPv6 ND Managed Config Flag"
                     },
+                    "ipv6_nd_other_config_flag": {
+                      "type": "boolean",
+                      "description": "Set the \"other stateful configuration\" flag in IPv6 router advertisements.",
+                      "title": "IPv6 ND Other Config Flag"
+                    },
+                    "ipv6_nd_cache": {
+                      "type": "object",
+                      "description": "IPv6 neighbor cache options.",
+                      "properties": {
+                        "dynamic_capacity": {
+                          "type": "integer",
+                          "description": "Capacity of dynamic cache entries.",
+                          "minimum": 0,
+                          "maximum": 4294967295,
+                          "title": "Dynamic Capacity"
+                        },
+                        "expire": {
+                          "type": "integer",
+                          "description": "Cache entries expirery in seconds.",
+                          "minimum": 1,
+                          "maximum": 65535,
+                          "title": "Expire"
+                        },
+                        "refresh_always": {
+                          "type": "boolean",
+                          "description": "Force refresh on cache expiry.",
+                          "title": "Refresh Always"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "IPv6 ND Cache"
+                    },
                     "ipv6_nd_prefixes": {
                       "type": "array",
                       "items": {
@@ -54024,6 +54059,41 @@
                       "type": "boolean",
                       "title": "IPv6 ND Managed Config Flag"
                     },
+                    "ipv6_nd_other_config_flag": {
+                      "type": "boolean",
+                      "description": "Set the \"other stateful configuration\" flag in IPv6 router advertisements.",
+                      "title": "IPv6 ND Other Config Flag"
+                    },
+                    "ipv6_nd_cache": {
+                      "type": "object",
+                      "description": "IPv6 neighbor cache options.",
+                      "properties": {
+                        "dynamic_capacity": {
+                          "type": "integer",
+                          "description": "Capacity of dynamic cache entries.",
+                          "minimum": 0,
+                          "maximum": 4294967295,
+                          "title": "Dynamic Capacity"
+                        },
+                        "expire": {
+                          "type": "integer",
+                          "description": "Cache entries expirery in seconds.",
+                          "minimum": 1,
+                          "maximum": 65535,
+                          "title": "Expire"
+                        },
+                        "refresh_always": {
+                          "type": "boolean",
+                          "description": "Force refresh on cache expiry.",
+                          "title": "Refresh Always"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "IPv6 ND Cache"
+                    },
                     "ipv6_nd_prefixes": {
                       "type": "array",
                       "items": {
@@ -55886,6 +55956,41 @@
               "ipv6_nd_managed_config_flag": {
                 "type": "boolean",
                 "title": "IPv6 ND Managed Config Flag"
+              },
+              "ipv6_nd_other_config_flag": {
+                "type": "boolean",
+                "description": "Set the \"other stateful configuration\" flag in IPv6 router advertisements.",
+                "title": "IPv6 ND Other Config Flag"
+              },
+              "ipv6_nd_cache": {
+                "type": "object",
+                "description": "IPv6 neighbor cache options.",
+                "properties": {
+                  "dynamic_capacity": {
+                    "type": "integer",
+                    "description": "Capacity of dynamic cache entries.",
+                    "minimum": 0,
+                    "maximum": 4294967295,
+                    "title": "Dynamic Capacity"
+                  },
+                  "expire": {
+                    "type": "integer",
+                    "description": "Cache entries expirery in seconds.",
+                    "minimum": 1,
+                    "maximum": 65535,
+                    "title": "Expire"
+                  },
+                  "refresh_always": {
+                    "type": "boolean",
+                    "description": "Force refresh on cache expiry.",
+                    "title": "Refresh Always"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "IPv6 ND Cache"
               },
               "ipv6_nd_prefixes": {
                 "type": "array",


### PR DESCRIPTION
## Change Summary

Under SVIs, added the options for:

ipv6 nd other-config-flag
ipv6 nd cache ...

## Related Issue(s)

Fixes #3933 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
for the SVI the following was added:


```
        ipv6_nd_other_config_flag:
          type: bool
          description: Set the "other stateful configuration" flag in IPv6 router advertisements.
        ipv6_nd_cache:
          type: dict
          description: IPv6 neighbor cache options.
          keys:
            dynamic_capacity:
              type: int
              description: Capacity of dynamic cache entries.
              convert_types:
                - str
              min: 0
              max: 4294967295
            expire:
              type: int
              description: Cache entries expirery in seconds.
              convert_types:
                - str
              min: 1
              max: 65535
            refresh_always:
              type: bool
              description: Force refresh on cache expiry.
```

## How to test

```
tenants:
  - name: BLA
    vlan_aware_bundle_number_base: 300
    mac_vrf_vni_base: 20000
    vrfs:
      - name: BLA_VRF
        vrf_vni: 789654
        svis:
          - id: 4088
            name: SVI_1
            enabled: true
            evpn_vlan_bundle: bundle3
            ip_address: 1.1.1.1/24
            ipv6_address_virtuals: [ 2002:a:1::22/64 ]
            structured_config:
              ipv6_nd_other_config_flag: true
              ipv6_nd_cache:
                dynamic_capacity: 900
                expire: 250
                refresh_always: true
```

## Checklist

### User Checklist

- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
