### PR TITLE
Fix: Fixing event-handlers in eos_designs_unit_tests molecule scenario.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -322,7 +322,8 @@ event_handlers:
   action: FastCli -p 15 -c "clear bgp evpn host-flap"
   delay: 300
   trigger: on-logging
-  regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
+  trigger_on_logging:
+    regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
   asynchronous: true
 ip_name_servers:
 - ip_address: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
@@ -25,7 +25,8 @@ event_handlers:
     action: FastCli -p 15 -c "clear bgp evpn host-flap"
     delay: 300
     trigger: on-logging
-    regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
+    trigger_on_logging:
+      regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
     asynchronous: true
 
 # Testing with inline jinja - targeting base.py loaded in eos_designs_structured_config.


### PR DESCRIPTION
## Change Summary

Fixing event-handlers in `eos_designs_unit_tests` molecule scenario.

## Proposed changes
Updating the input for event-handlers as per the new data-model in eos_cli_config_gen.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
