### PR TITLE
Fix(eos_designs): Wrong IPsec profile name for Zscaler

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/duplicate-tunnel-interface-internet-exit.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/duplicate-tunnel-interface-internet-exit.yml
@@ -139,6 +139,6 @@ zscaler_endpoints:
 
 expected_error_message: >-
   Found duplicate objects with conflicting data while generating configuration for Tunnel interface for Internet Exit policy.
-  {'name': 'Tunnel100', 'description': 'Internet Exit ZSCALER-EXIT-POLICY-2 PRI', 'ip_address': 'unnumbered Ethernet2', 'source_interface': 'Ethernet2'}
+  {'name': 'Tunnel100', 'description': 'Internet Exit ZSCALER-EXIT-POLICY-2 PRI', 'ip_address': 'unnumbered Ethernet2', 'ipsec_profile': 'IE-ZSCALER-EXIT-POLICY-2-PROFILE', 'source_interface': 'Ethernet2'}
   conflicts with
-  {'name': 'Tunnel100', 'description': 'Internet Exit ZSCALER-EXIT-POLICY-1 PRI', 'ip_address': 'unnumbered Ethernet1', 'source_interface': 'Ethernet1'}.
+  {'name': 'Tunnel100', 'description': 'Internet Exit ZSCALER-EXIT-POLICY-1 PRI', 'ip_address': 'unnumbered Ethernet1', 'ipsec_profile': 'IE-ZSCALER-EXIT-POLICY-1-PROFILE', 'source_interface': 'Ethernet1'}.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -345,7 +345,7 @@ interface Tunnel100
    tunnel mode ipsec
    tunnel source interface Ethernet3
    tunnel destination 10.37.121.1
-   tunnel ipsec profile ZSCALER-IPSEC-PROFILE
+   tunnel ipsec profile IE-ZSCALER-EXIT-POLICY-1-PROFILE
 !
 interface Tunnel101
    description Internet Exit ZSCALER-EXIT-POLICY-1 SEC
@@ -355,7 +355,7 @@ interface Tunnel101
    tunnel mode ipsec
    tunnel source interface Ethernet3
    tunnel destination 10.39.77.1
-   tunnel ipsec profile ZSCALER-IPSEC-PROFILE
+   tunnel ipsec profile IE-ZSCALER-EXIT-POLICY-1-PROFILE
 !
 interface Tunnel102
    description Internet Exit ZSCALER-EXIT-POLICY-1 TER
@@ -365,7 +365,7 @@ interface Tunnel102
    tunnel mode ipsec
    tunnel source interface Ethernet3
    tunnel destination 10.50.9.1
-   tunnel ipsec profile ZSCALER-IPSEC-PROFILE
+   tunnel ipsec profile IE-ZSCALER-EXIT-POLICY-1-PROFILE
 !
 interface Vxlan1
    description cv-pathfinder-edge_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -366,7 +366,7 @@ interface Tunnel100
    tunnel mode ipsec
    tunnel source interface Ethernet3
    tunnel destination 10.37.121.1
-   tunnel ipsec profile ZSCALER-IPSEC-PROFILE
+   tunnel ipsec profile IE-ZSCALER-EXIT-POLICY-1-PROFILE
 !
 interface Tunnel101
    description Internet Exit ZSCALER-EXIT-POLICY-1 SEC
@@ -376,7 +376,7 @@ interface Tunnel101
    tunnel mode ipsec
    tunnel source interface Ethernet3
    tunnel destination 10.39.77.1
-   tunnel ipsec profile ZSCALER-IPSEC-PROFILE
+   tunnel ipsec profile IE-ZSCALER-EXIT-POLICY-1-PROFILE
 !
 interface Tunnel102
    description Internet Exit ZSCALER-EXIT-POLICY-1 TER
@@ -386,7 +386,7 @@ interface Tunnel102
    tunnel mode ipsec
    tunnel source interface Ethernet3
    tunnel destination 10.50.9.1
-   tunnel ipsec profile ZSCALER-IPSEC-PROFILE
+   tunnel ipsec profile IE-ZSCALER-EXIT-POLICY-1-PROFILE
 !
 interface Tunnel110
    description Internet Exit ZSCALER-EXIT-POLICY-2 PRI
@@ -396,7 +396,7 @@ interface Tunnel110
    tunnel mode ipsec
    tunnel source interface Ethernet3
    tunnel destination 10.37.121.1
-   tunnel ipsec profile ZSCALER-IPSEC-PROFILE
+   tunnel ipsec profile IE-ZSCALER-EXIT-POLICY-2-PROFILE
 !
 interface Tunnel111
    description Internet Exit ZSCALER-EXIT-POLICY-2 SEC
@@ -406,7 +406,7 @@ interface Tunnel111
    tunnel mode ipsec
    tunnel source interface Ethernet3
    tunnel destination 10.39.77.1
-   tunnel ipsec profile ZSCALER-IPSEC-PROFILE
+   tunnel ipsec profile IE-ZSCALER-EXIT-POLICY-2-PROFILE
 !
 interface Tunnel112
    description Internet Exit ZSCALER-EXIT-POLICY-2 TER
@@ -416,7 +416,7 @@ interface Tunnel112
    tunnel mode ipsec
    tunnel source interface Ethernet3
    tunnel destination 10.50.9.1
-   tunnel ipsec profile ZSCALER-IPSEC-PROFILE
+   tunnel ipsec profile IE-ZSCALER-EXIT-POLICY-2-PROFILE
 !
 interface Vxlan1
    description cv-pathfinder-edge1_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -728,7 +728,7 @@ tunnel_interfaces:
   tunnel_mode: ipsec
   source_interface: Ethernet3
   destination: 10.37.121.1
-  ipsec_profile: ZSCALER-IPSEC-PROFILE
+  ipsec_profile: IE-ZSCALER-EXIT-POLICY-1-PROFILE
   nat_profile: VRF-AWARE-NAT
 - name: Tunnel101
   description: Internet Exit ZSCALER-EXIT-POLICY-1 SEC
@@ -737,7 +737,7 @@ tunnel_interfaces:
   tunnel_mode: ipsec
   source_interface: Ethernet3
   destination: 10.39.77.1
-  ipsec_profile: ZSCALER-IPSEC-PROFILE
+  ipsec_profile: IE-ZSCALER-EXIT-POLICY-1-PROFILE
   nat_profile: VRF-AWARE-NAT
 - name: Tunnel102
   description: Internet Exit ZSCALER-EXIT-POLICY-1 TER
@@ -746,7 +746,7 @@ tunnel_interfaces:
   tunnel_mode: ipsec
   source_interface: Ethernet3
   destination: 10.50.9.1
-  ipsec_profile: ZSCALER-IPSEC-PROFILE
+  ipsec_profile: IE-ZSCALER-EXIT-POLICY-1-PROFILE
   nat_profile: VRF-AWARE-NAT
 monitor_connectivity:
   interface_sets:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -722,7 +722,7 @@ tunnel_interfaces:
   tunnel_mode: ipsec
   source_interface: Ethernet3
   destination: 10.37.121.1
-  ipsec_profile: ZSCALER-IPSEC-PROFILE
+  ipsec_profile: IE-ZSCALER-EXIT-POLICY-1-PROFILE
   nat_profile: VRF-AWARE-NAT
 - name: Tunnel101
   description: Internet Exit ZSCALER-EXIT-POLICY-1 SEC
@@ -731,7 +731,7 @@ tunnel_interfaces:
   tunnel_mode: ipsec
   source_interface: Ethernet3
   destination: 10.39.77.1
-  ipsec_profile: ZSCALER-IPSEC-PROFILE
+  ipsec_profile: IE-ZSCALER-EXIT-POLICY-1-PROFILE
   nat_profile: VRF-AWARE-NAT
 - name: Tunnel102
   description: Internet Exit ZSCALER-EXIT-POLICY-1 TER
@@ -740,7 +740,7 @@ tunnel_interfaces:
   tunnel_mode: ipsec
   source_interface: Ethernet3
   destination: 10.50.9.1
-  ipsec_profile: ZSCALER-IPSEC-PROFILE
+  ipsec_profile: IE-ZSCALER-EXIT-POLICY-1-PROFILE
   nat_profile: VRF-AWARE-NAT
 - name: Tunnel110
   description: Internet Exit ZSCALER-EXIT-POLICY-2 PRI
@@ -749,7 +749,7 @@ tunnel_interfaces:
   tunnel_mode: ipsec
   source_interface: Ethernet3
   destination: 10.37.121.1
-  ipsec_profile: ZSCALER-IPSEC-PROFILE
+  ipsec_profile: IE-ZSCALER-EXIT-POLICY-2-PROFILE
   nat_profile: VRF-AWARE-NAT
 - name: Tunnel111
   description: Internet Exit ZSCALER-EXIT-POLICY-2 SEC
@@ -758,7 +758,7 @@ tunnel_interfaces:
   tunnel_mode: ipsec
   source_interface: Ethernet3
   destination: 10.39.77.1
-  ipsec_profile: ZSCALER-IPSEC-PROFILE
+  ipsec_profile: IE-ZSCALER-EXIT-POLICY-2-PROFILE
   nat_profile: VRF-AWARE-NAT
 - name: Tunnel112
   description: Internet Exit ZSCALER-EXIT-POLICY-2 TER
@@ -767,7 +767,7 @@ tunnel_interfaces:
   tunnel_mode: ipsec
   source_interface: Ethernet3
   destination: 10.50.9.1
-  ipsec_profile: ZSCALER-IPSEC-PROFILE
+  ipsec_profile: IE-ZSCALER-EXIT-POLICY-2-PROFILE
   nat_profile: VRF-AWARE-NAT
 monitor_connectivity:
   interface_sets:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -665,8 +665,9 @@ class UtilsMixin:
 
         These are useful for easy creation of connectivity-monitor, service-intersion connections, exit-groups, tunnels etc.
         """
-        # Only supporting Zscaler for now
         policy_name = internet_exit_policy["name"]
+
+        # Only supporting Zscaler for now
         if get(internet_exit_policy, "type") != "zscaler":
             raise AristaAvdError(f"Unsupported type '{internet_exit_policy['type']}' found in cv_pathfinder_internet_exit[name={policy_name}].")
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/network_services/utils.py
@@ -666,10 +666,9 @@ class UtilsMixin:
         These are useful for easy creation of connectivity-monitor, service-intersion connections, exit-groups, tunnels etc.
         """
         # Only supporting Zscaler for now
+        policy_name = internet_exit_policy["name"]
         if get(internet_exit_policy, "type") != "zscaler":
-            raise AristaAvdError(
-                f"Unsupported type '{internet_exit_policy['type']}' found in cv_pathfinder_internet_exit[name={internet_exit_policy['name']}]."
-            )
+            raise AristaAvdError(f"Unsupported type '{internet_exit_policy['type']}' found in cv_pathfinder_internet_exit[name={policy_name}].")
 
         cloud_name = get(internet_exit_policy, "zscaler.cloud_name", required=True)
         connections = []
@@ -684,7 +683,6 @@ class UtilsMixin:
                 "type": "tunnel",
                 "source_interface": wan_interface["name"],
                 "monitor_url": f"http://gateway.{cloud_name}.net/vpntest",
-                "ipsec_profile": "ZSCALER-IPSEC-PROFILE",
             }
 
             tunnel_id_range = range_expand(get(interface_policy_config, "tunnel_interface_numbers", required=True))
@@ -709,8 +707,9 @@ class UtilsMixin:
                         "tunnel_id": tunnel_id,
                         "tunnel_ip_address": f"unnumbered {wan_interface['name']}",
                         "tunnel_destination_ip": destination_ip,
-                        "description": f"Internet Exit {internet_exit_policy['name']} {suffix}",
-                        "exit_group": f"{internet_exit_policy['name']}_{suffix}",
+                        "ipsec_profile": f"IE-{policy_name}-PROFILE",
+                        "description": f"Internet Exit {policy_name} {suffix}",
+                        "exit_group": f"{policy_name}_{suffix}",
                         "preference": zscaler_endpoint_key,
                     }
                 )


### PR DESCRIPTION
## Change Summary

Fix the wrong name of IPsec profile

## Related Issue(s)

Fixes #3947 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Replace static name with proper dynamic name

## How to test
molecule

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
