### PR TITLE
Fix(eos_designs): Sanitize interface name in STUN profile name

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -87,7 +87,7 @@ router path-selection
    path-group MPLS id 100
       !
       local interface Ethernet2
-         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       !
       peer dynamic
       !
@@ -300,7 +300,7 @@ stun
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
          ssl profile STUN-DTLS
-      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
          ip address 172.16.0.1
          ssl profile STUN-DTLS
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -81,7 +81,7 @@ router path-selection
       ipsec profile CP-PROFILE
       !
       local interface Ethernet2
-         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       !
       peer dynamic
          ipsec disabled
@@ -299,7 +299,7 @@ stun
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
          ssl profile STUN-DTLS
-      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
          ip address 172.16.0.1
          ssl profile STUN-DTLS
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -158,7 +158,7 @@ router path-selection
       keepalive interval 300 milliseconds failure-threshold 5 intervals
       !
       local interface Ethernet2
-         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       !
       peer dynamic
          ipsec disabled
@@ -611,7 +611,7 @@ stun
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
          ssl profile profileA
-      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
          ip address 172.16.0.1
          ssl profile profileA
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -128,7 +128,7 @@ router path-selection
       keepalive interval 300 milliseconds failure-threshold 5 intervals
       !
       local interface Ethernet2
-         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       !
       peer dynamic
          ipsec disabled
@@ -536,7 +536,7 @@ management security
 !
 stun
    client
-      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
          ip address 172.16.0.1
          ssl profile profileA
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -145,7 +145,7 @@ router path-selection
    path-group MPLS id 100
       keepalive interval 300 milliseconds failure-threshold 5 intervals
       !
-      local interface Ethernet2
+      local interface Ethernet2/2
    !
    path-group Satellite id 104
    !
@@ -248,7 +248,7 @@ interface Ethernet1
    no switchport
    ip address 10.7.7.7/31
 !
-interface Ethernet2
+interface Ethernet2/2
    description Colt_10000
    no shutdown
    no switchport
@@ -410,7 +410,7 @@ management security
 stun
    server
       local-interface Ethernet1
-      local-interface Ethernet2
+      local-interface Ethernet2/2
       local-interface Ethernet3
       ssl profile profileA
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -156,7 +156,7 @@ router path-selection
       keepalive interval 300 milliseconds failure-threshold 5 intervals
       !
       local interface Ethernet2.42
-         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       !
       peer dynamic
          ipsec disabled
@@ -571,7 +571,7 @@ stun
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
          ssl profile profileA
-      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
          ip address 172.16.0.1
          ssl profile profileA
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -156,7 +156,7 @@ router path-selection
       keepalive interval 300 milliseconds failure-threshold 5 intervals
       !
       local interface Ethernet2.42
-         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+         stun server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       !
       peer dynamic
          ipsec disabled
@@ -571,7 +571,7 @@ stun
       server-profile INET-cv-pathfinder-pathfinder-Ethernet3
          ip address 10.9.9.9
          ssl profile profileA
-      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2
+      server-profile MPLS-cv-pathfinder-pathfinder-Ethernet2_2
          ip address 172.16.0.1
          ssl profile profileA
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -300,7 +300,7 @@ router_path_selection:
     - name: Ethernet2
       stun:
         server_profiles:
-        - MPLS-cv-pathfinder-pathfinder-Ethernet2
+        - MPLS-cv-pathfinder-pathfinder-Ethernet2_2
     dynamic_peers:
       enabled: true
     static_peers:
@@ -340,7 +340,7 @@ stun:
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
       ssl_profile: STUN-DTLS
-    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
+    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       ip_address: 172.16.0.1
       ssl_profile: STUN-DTLS
 application_traffic_recognition:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -312,7 +312,7 @@ router_path_selection:
     - name: Ethernet2
       stun:
         server_profiles:
-        - MPLS-cv-pathfinder-pathfinder-Ethernet2
+        - MPLS-cv-pathfinder-pathfinder-Ethernet2_2
     dynamic_peers:
       enabled: true
       ipsec: false
@@ -350,7 +350,7 @@ stun:
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
       ssl_profile: STUN-DTLS
-    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
+    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       ip_address: 172.16.0.1
       ssl_profile: STUN-DTLS
 application_traffic_recognition:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -514,7 +514,7 @@ router_path_selection:
     - name: Ethernet2
       stun:
         server_profiles:
-        - MPLS-cv-pathfinder-pathfinder-Ethernet2
+        - MPLS-cv-pathfinder-pathfinder-Ethernet2_2
     dynamic_peers:
       enabled: true
       ipsec: false
@@ -587,7 +587,7 @@ stun:
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
       ssl_profile: profileA
-    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
+    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       ip_address: 172.16.0.1
       ssl_profile: profileA
 application_traffic_recognition:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -544,7 +544,7 @@ router_path_selection:
     - name: Ethernet2
       stun:
         server_profiles:
-        - MPLS-cv-pathfinder-pathfinder-Ethernet2
+        - MPLS-cv-pathfinder-pathfinder-Ethernet2_2
     dynamic_peers:
       enabled: true
       ipsec: false
@@ -612,7 +612,7 @@ router_traffic_engineering:
 stun:
   client:
     server_profiles:
-    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
+    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       ip_address: 172.16.0.1
       ssl_profile: profileA
 application_traffic_recognition:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -112,7 +112,7 @@ ethernet_interfaces:
   shutdown: false
   type: routed
   description: Bouygues_Telecom_777
-- name: Ethernet2
+- name: Ethernet2/2
   peer_type: l3_interface
   ip_address: 172.16.0.1/31
   shutdown: false
@@ -302,7 +302,7 @@ router_path_selection:
   - name: MPLS
     id: 100
     local_interfaces:
-    - name: Ethernet2
+    - name: Ethernet2/2
     keepalive:
       interval: 300
       failure_threshold: 5
@@ -403,7 +403,7 @@ stun:
   server:
     local_interfaces:
     - Ethernet1
-    - Ethernet2
+    - Ethernet2/2
     - Ethernet3
     ssl_profile: profileA
 application_traffic_recognition:
@@ -513,7 +513,7 @@ metadata:
         value: Bouygues_Telecom
       - name: Circuit
         value: '777'
-    - interface: Ethernet2
+    - interface: Ethernet2/2
       tags:
       - name: Type
         value: wan
@@ -541,7 +541,7 @@ metadata:
       circuit_id: '777'
       pathgroup: INET
       public_ip: 172.17.7.7
-    - name: Ethernet2
+    - name: Ethernet2/2
       carrier: Colt
       circuit_id: '10000'
       pathgroup: MPLS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -553,7 +553,7 @@ router_path_selection:
     - name: Ethernet2.42
       stun:
         server_profiles:
-        - MPLS-cv-pathfinder-pathfinder-Ethernet2
+        - MPLS-cv-pathfinder-pathfinder-Ethernet2_2
     dynamic_peers:
       enabled: true
       ipsec: false
@@ -645,7 +645,7 @@ stun:
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
       ssl_profile: profileA
-    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
+    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       ip_address: 172.16.0.1
       ssl_profile: profileA
 application_traffic_recognition:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -553,7 +553,7 @@ router_path_selection:
     - name: Ethernet2.42
       stun:
         server_profiles:
-        - MPLS-cv-pathfinder-pathfinder-Ethernet2
+        - MPLS-cv-pathfinder-pathfinder-Ethernet2_2
     dynamic_peers:
       enabled: true
       ipsec: false
@@ -645,7 +645,7 @@ stun:
     - name: INET-cv-pathfinder-pathfinder-Ethernet3
       ip_address: 10.9.9.9
       ssl_profile: profileA
-    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2
+    - name: MPLS-cv-pathfinder-pathfinder-Ethernet2_2
       ip_address: 172.16.0.1
       ssl_profile: profileA
 application_traffic_recognition:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_MULTI_RR_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_MULTI_RR_TESTS.yml
@@ -27,7 +27,7 @@ wan_route_servers:
             public_ip: 172.17.17.17
       - name: INET
         interfaces:
-          - name: Ethernet2
+          - name: Ethernet2/1
             public_ip: 10.50.50.50
 
 # Overwriting TTL

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -245,7 +245,7 @@ wan_rr:
           ip_address: 10.7.7.7/31
           public_ip: 172.17.7.7
           peer_ip: 10.7.7.6
-        - name: Ethernet2
+        - name: Ethernet2/2
           wan_carrier: Colt
           wan_circuit_id: 10000
           ip_address: 172.16.0.1/31

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/overlay/utils.py
@@ -265,8 +265,12 @@ class UtilsMixin:
     def _stun_server_profile_name(self, wan_route_server_name: str, path_group_name: str, interface_name: str) -> str:
         """
         Return a string to use as the name of the stun server_profile
+
+        `/` are not allowed, `.` are allowed so
+        Ethernet1/1.1 is transformed into Ethernet1_1.1
         """
-        return f"{path_group_name}-{wan_route_server_name}-{interface_name}"
+        sanitized_interface_name = interface_name.replace("/", "_")
+        return f"{path_group_name}-{wan_route_server_name}-{sanitized_interface_name}"
 
     @cached_property
     def _stun_server_profiles(self) -> list:


### PR DESCRIPTION
## Change Summary

Sanitize the STUN profile name generated by AVD by replacing `/` by `_` when using interface name.
Checked that `.` is accepted.

## Related Issue(s)

Fixes #3940

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

change the funciton generating the name1

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
