### PR TITLE
Doc: Updated the documentation for IPv4 ACL

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -583,12 +583,6 @@ roles/eos_designs/docs/tables/node-type-wan-configuration.md
 roles/eos_designs/docs/tables/node-type-ptp-configuration.md
 --8<--
 
-### IPv4 ACL Configuration
-
---8<--
-roles/eos_designs/docs/tables/ipv4-acls.md
---8<--
-
 ## Default interface settings
 
 - Set default uplink, downlink, and MLAG interfaces, which will be used if these interfaces are not defined on a device (either directly or through inheritance).
@@ -725,6 +719,12 @@ roles/eos_designs/docs/tables/bfd-settings.md
 
 --8<--
 roles/eos_designs/docs/tables/bgp-settings.md
+--8<--
+
+### IPv4 ACL Configuration
+
+--8<--
+roles/eos_designs/docs/tables/ipv4-acls.md
 --8<--
 
 ## OSPF settings

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -721,7 +721,7 @@ roles/eos_designs/docs/tables/bfd-settings.md
 roles/eos_designs/docs/tables/bgp-settings.md
 --8<--
 
-## IPv4 ACL Configuration
+## IPv4 ACL settings
 
 --8<--
 roles/eos_designs/docs/tables/ipv4-acls.md

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -721,7 +721,7 @@ roles/eos_designs/docs/tables/bfd-settings.md
 roles/eos_designs/docs/tables/bgp-settings.md
 --8<--
 
-### IPv4 ACL Configuration
+## IPv4 ACL Configuration
 
 --8<--
 roles/eos_designs/docs/tables/ipv4-acls.md

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -583,6 +583,12 @@ roles/eos_designs/docs/tables/node-type-wan-configuration.md
 roles/eos_designs/docs/tables/node-type-ptp-configuration.md
 --8<--
 
+### IPv4 ACL Configuration
+
+--8<--
+roles/eos_designs/docs/tables/ipv4-acls.md
+--8<--
+
 ## Default interface settings
 
 - Set default uplink, downlink, and MLAG interfaces, which will be used if these interfaces are not defined on a device (either directly or through inheritance).


### PR DESCRIPTION
## Change Summary

Fix the the documentation for IPv4 ACL which was only showing for SNMP setting.

## Related Issue(s)

Fixes #3897 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added the link of ipv-acls.md into input-variables.md

## How to test


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
