### PR TITLE
Fix(eos_cli_config_gen): Don't render 'vrf default' on 'router ospf'

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -153,6 +153,7 @@ interface Vlan24
 | 400 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
 | 500 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
 | 600 | - | disabled |- | disabled | default | disabled | disabled | - | - | - | - |
+| 602 | 1.0.1.1 | enabled |- | disabled | default | disabled | disabled | - | - | - | - |
 
 #### Router OSPF Distance
 
@@ -307,4 +308,8 @@ router ospf 600
    area 0.0.20.25 nssa default-information-originate metric-type 1
    area 0.0.20.26 nssa no-summary
    area 0.0.20.26 nssa default-information-originate metric 50 metric-type 1 nssa-only
+!
+router ospf 602
+   router-id 1.0.1.1
+   passive-interface default
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -116,4 +116,8 @@ router ospf 600
    area 0.0.20.26 nssa no-summary
    area 0.0.20.26 nssa default-information-originate metric 50 metric-type 1 nssa-only
 !
+router ospf 602
+   router-id 1.0.1.1
+   passive-interface default
+!
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -159,7 +159,11 @@ router_ospf:
           default_information_originate:
             metric: 50
             metric_type: 1
-
+    # squash rendering the default vrf
+    - id: 602
+      vrf: default
+      passive_interface_default: true
+      router_id: 1.0.1.1
 
 ethernet_interfaces:
   - name: Ethernet1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-ospf.j2
@@ -6,7 +6,7 @@
 {# eos - router ospf #}
 {% for process_id in router_ospf.process_ids | arista.avd.natural_sort('id') %}
 !
-{%     if process_id.vrf is arista.avd.defined %}
+{%     if process_id.vrf is arista.avd.defined and process_id.vrf != 'default' %}
 router ospf {{ process_id.id }} vrf {{ process_id.vrf }}
 {%     else %}
 router ospf {{ process_id.id }}


### PR DESCRIPTION
## Change Summary

This change changes the rendering of `router ospf <x> vrf default` to `router ospf <x>`

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
added test for default vrf

## How to test
tested with molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
