### PR TITLE
Doc: Fix examples for connected endpoints using deprecated data-model in input-varaibles.md

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -52,7 +52,7 @@ See the following examples using the `l3ls-evpn` design:
 
 ### 5-stage clos topology support (Super Spine)
 
-- The **eos_designs** role support lager deployments with super-spines (5-stage Clos) and optionally, with dedicated overlay controllers.
+- The **eos_designs** role support larger deployments with super-spines (5-stage Clos) and optionally, with dedicated overlay controllers.
 - 5 stage Clos fabric can be represented as multiple leaf-spine structures (called PODs - Point of Delivery) interconnected by super-spines.
 - The logic to deploy every leaf-spine POD fabric remains unchanged.
 - Super-spines can be deployed as a single plane (typically chassis switches) or multiple planes.
@@ -1055,6 +1055,7 @@ Both data models support variable inheritance from profiles defined under [`port
             port_channel:
               description: PortChanne1
               mode: active
+            ethernet_segment:
               short_esi: 0303:0202:0101
     ```
 


### PR DESCRIPTION
## Change Summary

Fix examples for connected endpoints using deprecated data-model in input-varaibles.md

## Related Issue(s)

Fixes #3905

## Component(s) name

`arista.avd.eos_designs`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
