### PR TITLE
CI: updated the version for ansible-lint

### DIFF
--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,5 +1,5 @@
 ansible-core>=2.14.0,<2.17.0
-ansible-lint>=6.21.0
+ansible-lint>=6.21.0,<24.5.0
 codespell>=2.2.6
 pycodestyle
 flake8

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,5 +1,5 @@
 ansible-core>=2.14.0,<2.17.0
-ansible-lint>=6.21.0,<24.5.0
+ansible-lint==24.2.3
 codespell>=2.2.6
 pycodestyle
 flake8

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,5 +1,5 @@
 ansible-core>=2.14.0,<2.17.0
-ansible-lint==24.2.3
+ansible-lint>=6.21.0,<24.5.0
 codespell>=2.2.6
 pycodestyle
 flake8


### PR DESCRIPTION
## Change Summary

Updated the ansible-lint version in requirements-dev.txt to overcome the name[casing] issue.

## Component(s) name

CI /ansible-lint

## Proposed changes

Capped ansible-lint>=6.21.0,<24.5.0 in requirements-dev.txt.

## How to test

CI Must Pass

