### PR TITLE
Fix(eos_cli_config_gen): Missing variable protection in Jinja Templates.

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
@@ -20,7 +20,7 @@ mac security
       cipher {{ profile.cipher }}
 {%         endif %}
 {%         for connection_key in profile.connection_keys | arista.avd.natural_sort('id') %}
-{%             if connection_key.encrypted_key is arista.avd.defined and connection_key.id is arista.avd.defined %}
+{%             if connection_key.encrypted_key is arista.avd.defined %}
 {%                 set key_cli = "key " ~ connection_key.id ~ " 7 " ~ connection_key.encrypted_key | arista.avd.hide_passwords(hide_passwords) %}
 {%                 if connection_key.fallback is arista.avd.defined(true) %}
 {%                     set key_cli = key_cli ~ " fallback" %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/mac-security.j2
@@ -20,7 +20,7 @@ mac security
       cipher {{ profile.cipher }}
 {%         endif %}
 {%         for connection_key in profile.connection_keys | arista.avd.natural_sort('id') %}
-{%             if connection_key.encrypted_key is arista.avd.defined %}
+{%             if connection_key.encrypted_key is arista.avd.defined and connection_key.id is arista.avd.defined %}
 {%                 set key_cli = "key " ~ connection_key.id ~ " 7 " ~ connection_key.encrypted_key | arista.avd.hide_passwords(hide_passwords) %}
 {%                 if connection_key.fallback is arista.avd.defined(true) %}
 {%                     set key_cli = key_cli ~ " fallback" %}
@@ -37,10 +37,10 @@ mac security
 {%         if profile.sci is arista.avd.defined(true) %}
       sci
 {%         endif %}
-{%         if profile.l2_protocols.ethernet_flow_control is arista.avd.defined %}
+{%         if profile.l2_protocols.ethernet_flow_control.mode is arista.avd.defined %}
       l2-protocol ethernet-flow-control {{ profile.l2_protocols.ethernet_flow_control.mode }}
 {%         endif %}
-{%         if profile.l2_protocols.lldp is arista.avd.defined %}
+{%         if profile.l2_protocols.lldp.mode is arista.avd.defined %}
       l2-protocol lldp {{ profile.l2_protocols.lldp.mode }}
 {%         endif %}
 {%     endfor %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/port-channel-interfaces.j2
@@ -64,7 +64,7 @@ interface {{ port_channel_interface.name }}
 {%     elif port_channel_interface.type | arista.avd.default("switched") == 'switched' %}
    switchport
 {%     endif %}
-{%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode in ["access", "dot1q-tunnel"] %}
+{%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined and port_channel_interface.mode in ["access", "dot1q-tunnel"] %}
    switchport access vlan {{ port_channel_interface.vlans }}
 {%     endif %}
 {%     if port_channel_interface.vlans is arista.avd.defined and port_channel_interface.mode is arista.avd.defined("trunk") %}


### PR DESCRIPTION
## Change Summary

Missing variable protection in Jinja Template

## Related Issue(s)

Fixes #3996

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
