### PR TITLE
Fix(eos_cli_config_gen): Fix the schema and template for action in event-handler.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -41,17 +41,17 @@ interface Management1
 
 #### Event Handler Summary
 
-| Handler | Action Type | Action | Trigger | Trigger Config |
-| ------- | ----------- | ------ | ------- | -------------- |
-| CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config | - |
-| trigger-on-boot | - | - | on-boot | - |
-| trigger-on-counters | bash | <code>echo "on-counters"</code> | on-counters | poll interval 10<br>condition( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )<br>granularity per-source |
-| trigger-on-intf | bash | <code>echo "on-intf"</code> | on-intf | trigger on-intf Ethernet4 operstatus ip ip6 |
-| trigger-on-logging | bash | <code>echo "on-logging"</code> | on-logging | poll interval 10<br>regex ab* |
-| trigger-on-maintenance1 | bash | <code>echo "on-maintenance"</code> | on-maintenance | trigger on-maintenance enter interface Management3 after stage linkdown |
-| trigger-on-maintenance2 | bash | <code>echo "on-maintenance"</code> | on-maintenance | trigger on-maintenance enter unit unit1 before stage bgp |
-| trigger-on-maintenance3 | bash | <code>echo "on-maintenance"</code> | on-maintenance | trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 all |
-| trigger-vm-tracer | bash | <code>echo "vm-tracer vm"</code> | vm-tracer vm | - |
+| Handler | Actions | Trigger | Trigger Config |
+| ------- | ------- | ------- | -------------- |
+| CONFIG_VERSIONING | bash <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config | - |
+| trigger-on-boot | bash <code>if [ 15 -gt 10 ]\nthen\n  echo "a is greater than 10"\nfi </code><br>increment device health metric Metric1 | on-boot | - |
+| trigger-on-counters | log | on-counters | poll interval 10<br>condition( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )<br>granularity per-source |
+| trigger-on-intf | - | on-intf | trigger on-intf Ethernet4 operstatus ip ip6 |
+| trigger-on-logging | increment device health metric Metric2 | on-logging | poll interval 10<br>regex ab* |
+| trigger-on-maintenance1 | - | on-maintenance | trigger on-maintenance enter interface Management3 after stage linkdown |
+| trigger-on-maintenance2 | bash <code>echo "on-maintenance"</code> | on-maintenance | trigger on-maintenance enter unit unit1 before stage bgp |
+| trigger-on-maintenance3 | bash <code>echo "on-maintenance"</code> | on-maintenance | trigger on-maintenance enter bgp 10.0.0.2 vrf vrf1 all |
+| trigger-vm-tracer | bash <code>echo "vm-tracer vm"</code> | vm-tracer vm | - |
 
 #### Event Handler Device Configuration
 
@@ -65,30 +65,31 @@ event-handler CONFIG_VERSIONING
 event-handler trigger-on-boot
    trigger on-boot
    action bash
-      echo "shivani\n"
-      hello
+      if [ 15 -gt 10 ]
+      then
+        echo "a is greater than 10"
+      fi
       EOF
+   action increment device-health metric Metric1
 !
 event-handler trigger-on-counters
    trigger on-counters
       poll interval 10
       condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
       granularity per-source
-   action bash echo "on-counters"
+   action log
 !
 event-handler trigger-on-intf
    trigger on-intf Ethernet4 operstatus ip ip6
-   action bash echo "on-intf"
 !
 event-handler trigger-on-logging
    trigger on-logging
       poll interval 10
       regex ab*
-   action bash echo "on-logging"
+   action increment device-health metric Metric2
 !
 event-handler trigger-on-maintenance1
    trigger on-maintenance enter interface Management3 after stage linkdown
-   action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance2
    trigger on-maintenance enter unit unit1 before stage bgp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -44,7 +44,7 @@ interface Management1
 | Handler | Action Type | Action | Trigger | Trigger Config |
 | ------- | ----------- | ------ | ------- | -------------- |
 | CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config | - |
-| trigger-on-boot | bash | <code>echo "on-boot"</code> | on-boot | - |
+| trigger-on-boot | - | - | on-boot | - |
 | trigger-on-counters | bash | <code>echo "on-counters"</code> | on-counters | poll interval 10<br>condition( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )<br>granularity per-source |
 | trigger-on-intf | bash | <code>echo "on-intf"</code> | on-intf | trigger on-intf Ethernet4 operstatus ip ip6 |
 | trigger-on-logging | bash | <code>echo "on-logging"</code> | on-logging | poll interval 10<br>regex ab* |
@@ -64,7 +64,10 @@ event-handler CONFIG_VERSIONING
 !
 event-handler trigger-on-boot
    trigger on-boot
-   action bash echo "on-boot"
+   action bash
+      echo "shivani\n"
+      hello
+      EOF
 !
 event-handler trigger-on-counters
    trigger on-counters

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/event-handlers.md
@@ -44,7 +44,7 @@ interface Management1
 | Handler | Actions | Trigger | Trigger Config |
 | ------- | ------- | ------- | -------------- |
 | CONFIG_VERSIONING | bash <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config | - |
-| trigger-on-boot | bash <code>if [ 15 -gt 10 ]\nthen\n  echo "a is greater than 10"\nfi </code><br>increment device health metric Metric1 | on-boot | - |
+| trigger-on-boot | bash <code>if [ 15 -gt 10 ]\nthen\n  echo "a is greater than 10"\nfi</code><br>increment device health metric Metric1 | on-boot | - |
 | trigger-on-counters | log | on-counters | poll interval 10<br>condition( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )<br>granularity per-source |
 | trigger-on-intf | - | on-intf | trigger on-intf Ethernet4 operstatus ip ip6 |
 | trigger-on-logging | increment device health metric Metric2 | on-logging | poll interval 10<br>regex ab* |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -19,7 +19,10 @@ event-handler CONFIG_VERSIONING
 !
 event-handler trigger-on-boot
    trigger on-boot
-   action bash echo "on-boot"
+   action bash
+      echo "shivani\n"
+      hello
+      EOF
 !
 event-handler trigger-on-counters
    trigger on-counters

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/event-handlers.cfg
@@ -20,30 +20,31 @@ event-handler CONFIG_VERSIONING
 event-handler trigger-on-boot
    trigger on-boot
    action bash
-      echo "shivani\n"
-      hello
+      if [ 15 -gt 10 ]
+      then
+        echo "a is greater than 10"
+      fi
       EOF
+   action increment device-health metric Metric1
 !
 event-handler trigger-on-counters
    trigger on-counters
       poll interval 10
       condition ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
       granularity per-source
-   action bash echo "on-counters"
+   action log
 !
 event-handler trigger-on-intf
    trigger on-intf Ethernet4 operstatus ip ip6
-   action bash echo "on-intf"
 !
 event-handler trigger-on-logging
    trigger on-logging
       poll interval 10
       regex ab*
-   action bash echo "on-logging"
+   action increment device-health metric Metric2
 !
 event-handler trigger-on-maintenance1
    trigger on-maintenance enter interface Management3 after stage linkdown
-   action bash echo "on-maintenance"
 !
 event-handler trigger-on-maintenance2
    trigger on-maintenance enter unit unit1 before stage bgp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -1,15 +1,18 @@
 event_handlers:
   - name: CONFIG_VERSIONING
-    action_type: bash
-    action: FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* | tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* | tail -n +11 | xargs -I % rm %; fi
+    actions:
+      bash_command: FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* | tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* | tail -n +11 | xargs -I % rm %; fi
     delay: 0
     trigger: on-startup-config
   - name: trigger-on-boot
     trigger: on-boot
-    event_handler_action:
-      bash_command: |
-        echo "shivani\n"
-        hello
+    actions:
+      bash_command: |-
+        if [ 15 -gt 10 ]
+        then
+          echo "a is greater than 10"
+        fi 
+      increment_device_health_metric: Metric1
   - name: trigger-on-maintenance1
     trigger: on-maintenance
     trigger_on_maintenance:
@@ -17,8 +20,6 @@ event_handlers:
       interface: Management3
       action: after
       stage: linkdown
-    action_type: bash
-    action: echo "on-maintenance"
   - name: trigger-on-maintenance2
     trigger: on-maintenance
     trigger_on_maintenance:
@@ -26,8 +27,8 @@ event_handlers:
       unit: unit1
       action: before
       stage: bgp
-    action_type: bash
-    action: echo "on-maintenance"
+    actions:
+      bash_command: echo "on-maintenance"
   - name: trigger-on-maintenance3
     trigger: on-maintenance
     trigger_on_maintenance:
@@ -35,23 +36,23 @@ event_handlers:
       bgp_peer: 10.0.0.2
       vrf: vrf1
       action: all
-    action_type: bash
-    action: echo "on-maintenance"
+    actions:
+      bash_command: echo "on-maintenance"
   - name: trigger-on-logging
     trigger: on-logging
     trigger_on_logging:
       poll_interval: 10
       regex: "ab*"
-    action_type: bash
-    action: echo "on-logging"
+    actions:
+      increment_device_health_metric: Metric2
   - name: trigger-on-counters
     trigger: on-counters
     trigger_on_counters:
       poll_interval: 10
       condition: ( Arad*.IptCrcErrCnt.delta > 100 ) and ( Arad*.UcFifoFullDrop.delta > 100 )
       granularity_per_source: true
-    action_type: bash
-    action: echo "on-counters"
+    actions:
+      log: true
   - name: trigger-on-intf
     trigger: on-intf
     trigger_on_intf:
@@ -59,9 +60,7 @@ event_handlers:
       ip: true
       ipv6: true
       operstatus: true
-    action_type: bash
-    action: echo "on-intf"
   - name: trigger-vm-tracer
     trigger: "vm-tracer vm"
-    action_type: bash
-    action: echo "vm-tracer vm"
+    actions:
+      bash_command: echo "vm-tracer vm"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -6,8 +6,10 @@ event_handlers:
     trigger: on-startup-config
   - name: trigger-on-boot
     trigger: on-boot
-    action_type: bash
-    action: echo "on-boot"
+    event_handler_action:
+      bash_command: |
+        echo "shivani\n"
+        hello
   - name: trigger-on-maintenance1
     trigger: on-maintenance
     trigger_on_maintenance:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/event-handlers.yml
@@ -11,7 +11,7 @@ event_handlers:
         if [ 15 -gt 10 ]
         then
           echo "a is greater than 10"
-        fi 
+        fi
       increment_device_health_metric: Metric1
   - name: trigger-on-maintenance1
     trigger: on-maintenance

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -450,10 +450,10 @@ vmtracer session session_2
 
 #### Event Handler Summary
 
-| Handler | Action Type | Action | Trigger | Trigger Config |
-| ------- | ----------- | ------ | ------- | -------------- |
-| CONFIG_VERSIONING | bash | <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config | - |
-| evpn-blacklist-recovery | bash | <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging | - |
+| Handler | Actions | Trigger | Trigger Config |
+| ------- | ------- | ------- | -------------- |
+| CONFIG_VERSIONING | bash <code>FN=/mnt/flash/startup-config; LFN="`ls -1 $FN.*-* \| tail -n 1`"; if [ -z "$LFN" -o -n "`diff -I 'last modified' $FN $LFN`" ]; then cp $FN $FN.`date +%Y%m%d-%H%M%S`; ls -1r $FN.*-* \| tail -n +11 \| xargs -I % rm %; fi</code> | on-startup-config | - |
+| evpn-blacklist-recovery | bash <code>FastCli -p 15 -c "clear bgp evpn host-flap"</code> | on-logging | - |
 
 #### Event Handler Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/event-handlers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/event-handlers.yml
@@ -4,11 +4,12 @@
 # Dict type is deprecated in 4.0.0. To be removed in 5.0.0
 event_handlers:
   evpn-blacklist-recovery:
+    # Testing "action_type" and "action" key which are deprecared and will be removed in 5.0.0
     action_type: bash
     action: FastCli -p 15 -c "clear bgp evpn host-flap"
     delay: 300
     trigger: on-logging
-    # Testing regex key which is deprecared and will be removed in 5.0.0
+    # Testing "regex" key which is deprecared and will be removed in 5.0.0
     regex: EVPN-3-BLACKLISTED_DUPLICATE_MAC
     asynchronous: true
   CONFIG_VERSIONING:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -318,8 +318,8 @@ vlan_internal_order:
     ending: 1199
 event_handlers:
 - name: evpn-blacklist-recovery
-  action_type: bash
-  action: FastCli -p 15 -c "clear bgp evpn host-flap"
+  actions:
+    bash_command: FastCli -p 15 -c "clear bgp evpn host-flap"
   delay: 300
   trigger: on-logging
   trigger_on_logging:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
@@ -21,8 +21,8 @@ vtep_vvtep_ip: 192.168.255.255/32
 # Testing event_handlers
 event_handlers:
   - name: evpn-blacklist-recovery
-    action_type: bash
-    action: FastCli -p 15 -c "clear bgp evpn host-flap"
+    actions:
+      bash_command: FastCli -p 15 -c "clear bgp evpn host-flap"
     delay: 300
     trigger: on-logging
     trigger_on_logging:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -9,8 +9,8 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>event_handlers</samp>](## "event_handlers") | List, items: Dictionary |  |  |  | Gives the ability to monitor and react to Syslog messages.<br>Event Handlers provide a powerful and flexible tool that can be used to apply self-healing actions,<br>customize the system behavior, and implement workarounds to problems discovered in the field.<br> |
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "event_handlers.[].name") | String | Required, Unique |  |  | Event Handler Name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;actions</samp>](## "event_handlers.[].actions") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].actions.bash_command") | String |  |  |  | Define BASH command action. Command could be multiline also. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].actions.log") | Boolean |  |  |  | Log a message when the event is triggered. |
@@ -52,13 +52,13 @@
       - name: <str; required; unique>
         # This key is deprecated.
         # Support will be removed in AVD version 5.0.0.
-        # Use <samp>event_handler_action</samp> instead.
+        # Use <samp>event_handlers.actions</samp> instead.
         action_type: <str; "bash" | "increment" | "log">
 
         # Command to execute.
         # This key is deprecated.
         # Support will be removed in AVD version 5.0.0.
-        # Use <samp>event_handler_action</samp> instead.
+        # Use <samp>event_handlers.actions</samp> instead.
         action: <str>
         actions:
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -11,7 +11,7 @@
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "event_handlers.[].name") | String | Required, Unique |  |  | Event Handler Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;actions</samp>](## "event_handlers.[].actions") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;actions</samp>](## "event_handlers.[].actions") | Dictionary |  |  |  | Note: `bash_command` and `log` are mutually exclusive. `bash_command` takes precedence over `log`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].actions.bash_command") | String |  |  |  | Define BASH command action. Command could be multiline also. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].actions.log") | Boolean |  |  |  | Log a message when the event is triggered. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;increment_device_health_metric</samp>](## "event_handlers.[].actions.increment_device_health_metric") | String |  |  |  | Name of device-health metric. |
@@ -60,6 +60,8 @@
         # Support will be removed in AVD version 5.0.0.
         # Use <samp>event_handlers.actions</samp> instead.
         action: <str>
+
+        # Note: `bash_command` and `log` are mutually exclusive. `bash_command` takes precedence over `log`.
         actions:
 
           # Define BASH command action. Command could be multiline also.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -11,10 +11,10 @@
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "event_handlers.[].name") | String | Required, Unique |  |  | Event Handler Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;event_handler_action</samp>](## "event_handlers.[].event_handler_action") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].event_handler_action.bash_command") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].event_handler_action.log") | Boolean |  |  |  | Log a message when the event is triggered. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;increment_device_health_metric</samp>](## "event_handlers.[].event_handler_action.increment_device_health_metric") | String |  |  |  | Name of device-health metric. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;actions</samp>](## "event_handlers.[].actions") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].actions.bash_command") | String |  |  |  | Define BASH command action. Command could be multiline also. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].actions.log") | Boolean |  |  |  | Log a message when the event is triggered. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;increment_device_health_metric</samp>](## "event_handlers.[].actions.increment_device_health_metric") | String |  |  |  | Name of device-health metric. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
@@ -60,7 +60,9 @@
         # Support will be removed in AVD version 5.0.0.
         # Use <samp>event_handler_action</samp> instead.
         action: <str>
-        event_handler_action:
+        actions:
+
+          # Define BASH command action. Command could be multiline also.
           bash_command: <str>
 
           # Log a message when the event is triggered.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/event-handlers.md
@@ -9,8 +9,12 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>event_handlers</samp>](## "event_handlers") | List, items: Dictionary |  |  |  | Gives the ability to monitor and react to Syslog messages.<br>Event Handlers provide a powerful and flexible tool that can be used to apply self-healing actions,<br>customize the system behavior, and implement workarounds to problems discovered in the field.<br> |
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "event_handlers.[].name") | String | Required, Unique |  |  | Event Handler Name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;event_handler_action</samp>](## "event_handlers.[].event_handler_action") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].event_handler_action.bash_command") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].event_handler_action.log") | Boolean |  |  |  | Log a message when the event is triggered. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;increment_device_health_metric</samp>](## "event_handlers.[].event_handler_action.increment_device_health_metric") | String |  |  |  | Name of device-health metric. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
@@ -46,10 +50,24 @@
 
         # Event Handler Name.
       - name: <str; required; unique>
+        # This key is deprecated.
+        # Support will be removed in AVD version 5.0.0.
+        # Use <samp>event_handler_action</samp> instead.
         action_type: <str; "bash" | "increment" | "log">
 
         # Command to execute.
+        # This key is deprecated.
+        # Support will be removed in AVD version 5.0.0.
+        # Use <samp>event_handler_action</samp> instead.
         action: <str>
+        event_handler_action:
+          bash_command: <str>
+
+          # Log a message when the event is triggered.
+          log: <bool>
+
+          # Name of device-health metric.
+          increment_device_health_metric: <str>
 
         # Event-handler delay in seconds.
         delay: <int>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5545,11 +5545,12 @@
             "deprecated": true,
             "title": "Action"
           },
-          "event_handler_action": {
+          "actions": {
             "type": "object",
             "properties": {
               "bash_command": {
                 "type": "string",
+                "description": "Define BASH command action. Command could be multiline also.",
                 "title": "Bash Command"
               },
               "log": {
@@ -5567,7 +5568,7 @@
             "patternProperties": {
               "^_.+$": {}
             },
-            "title": "Event Handler Action"
+            "title": "Actions"
           },
           "delay": {
             "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5541,7 +5541,7 @@
           },
           "action": {
             "type": "string",
-            "description": "Command to execute.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.",
+            "description": "Command to execute.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.",
             "deprecated": true,
             "title": "Action"
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5547,6 +5547,7 @@
           },
           "actions": {
             "type": "object",
+            "description": "Note: `bash_command` and `log` are mutually exclusive. `bash_command` takes precedence over `log`.",
             "properties": {
               "bash_command": {
                 "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -5541,8 +5541,33 @@
           },
           "action": {
             "type": "string",
-            "description": "Command to execute.\n",
+            "description": "Command to execute.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.",
+            "deprecated": true,
             "title": "Action"
+          },
+          "event_handler_action": {
+            "type": "object",
+            "properties": {
+              "bash_command": {
+                "type": "string",
+                "title": "Bash Command"
+              },
+              "log": {
+                "type": "boolean",
+                "description": "Log a message when the event is triggered.",
+                "title": "Log"
+              },
+              "increment_device_health_metric": {
+                "type": "string",
+                "description": "Name of device-health metric.",
+                "title": "Increment Device Health Metric"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Event Handler Action"
           },
           "delay": {
             "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3323,7 +3323,7 @@ keys:
             warning: true
             removed: false
             remove_in_version: 5.0.0
-            new_key: event_handler_action
+            new_key: event_handlers.actions
         action:
           type: str
           description: 'Command to execute.
@@ -3333,7 +3333,7 @@ keys:
             warning: true
             removed: false
             remove_in_version: 5.0.0
-            new_key: event_handler_action
+            new_key: event_handlers.actions
         actions:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3336,6 +3336,8 @@ keys:
             new_key: event_handlers.actions
         actions:
           type: dict
+          description: 'Note: `bash_command` and `log` are mutually exclusive. `bash_command`
+            takes precedence over `log`.'
           keys:
             bash_command:
               type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3319,11 +3319,32 @@ keys:
           - bash
           - increment
           - log
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 5.0.0
+            new_key: event_handler_action
         action:
           type: str
           description: 'Command to execute.
 
             '
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 5.0.0
+            new_key: event_handler_action
+        event_handler_action:
+          type: dict
+          keys:
+            bash_command:
+              type: str
+            log:
+              type: bool
+              description: Log a message when the event is triggered.
+            increment_device_health_metric:
+              type: str
+              description: Name of device-health metric.
         delay:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -3334,11 +3334,13 @@ keys:
             removed: false
             remove_in_version: 5.0.0
             new_key: event_handler_action
-        event_handler_action:
+        actions:
           type: dict
           keys:
             bash_command:
               type: str
+              description: Define BASH command action. Command could be multiline
+                also.
             log:
               type: bool
               description: Log a message when the event is triggered.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -38,11 +38,12 @@ keys:
             removed: false
             remove_in_version: 5.0.0
             new_key: event_handler_action
-        event_handler_action:
+        actions:
           type: dict
           keys:
             bash_command:
               type: str
+              description: Define BASH command action. Command could be multiline also.
             log:
               type: bool
               description: Log a message when the event is triggered.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -28,7 +28,7 @@ keys:
             warning: true
             removed: false
             remove_in_version: 5.0.0
-            new_key: event_handler_action
+            new_key: event_handlers.actions
         action:
           type: str
           description: |
@@ -37,7 +37,7 @@ keys:
             warning: true
             removed: false
             remove_in_version: 5.0.0
-            new_key: event_handler_action
+            new_key: event_handlers.actions
         actions:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -24,10 +24,31 @@ keys:
         action_type:
           type: str
           valid_values: ["bash", "increment", "log"]
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 5.0.0
+            new_key: event_handler_action
         action:
           type: str
           description: |
             Command to execute.
+          deprecation:
+            warning: true
+            removed: false
+            remove_in_version: 5.0.0
+            new_key: event_handler_action
+        event_handler_action:
+          type: dict
+          keys:
+            bash_command:
+              type: str
+            log:
+              type: bool
+              description: Log a message when the event is triggered.
+            increment_device_health_metric:
+              type: str
+              description: Name of device-health metric.
         delay:
           type: int
           convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/event_handlers.schema.yml
@@ -40,6 +40,8 @@ keys:
             new_key: event_handlers.actions
         actions:
           type: dict
+          description: |-
+            Note: `bash_command` and `log` are mutually exclusive. `bash_command` takes precedence over `log`.
           keys:
             bash_command:
               type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
@@ -13,6 +13,13 @@
 | Handler | Actions | Trigger | Trigger Config |
 | ------- | ------- | ------- | -------------- |
 {%     for handler in event_handlers | arista.avd.natural_sort('name') %}
+{%         if handler.action_type is arista.avd.defined %}
+{%             set actions = handler.action_type %}
+{%             if  handler.action is arista.avd.defined %}
+{%                 set action = handler.action | replace('|', '\|') %}
+{%                 set actions = actions ~ ' <code>' ~ action ~ '</code>' %}
+{%             endif %}
+{%         endif %}
 {%         if handler.actions is arista.avd.defined %}
 {%             set actions = [] %}
 {%             if handler.actions.bash_command is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
@@ -10,12 +10,24 @@
 
 #### Event Handler Summary
 
-| Handler | Action Type | Action | Trigger | Trigger Config |
-| ------- | ----------- | ------ | ------- | -------------- |
+| Handler | Actions | Trigger | Trigger Config |
+| ------- | ------- | ------- | -------------- |
 {%     for handler in event_handlers | arista.avd.natural_sort('name') %}
-{%         if handler.action_type is arista.avd.defined('bash') and handler.action is arista.avd.defined %}
-{%             set action = handler.action | replace('|', '\|') %}
-{%             set action = '<code>' ~ action ~ '</code>' %}
+{%         if handler.actions is arista.avd.defined %}
+{%             set actions = [] %}
+{%             if handler.actions.bash_command is arista.avd.defined %}
+{%                 set bash_command = handler.actions.bash_command | replace('\n', '\\n') | replace('|', '\|') %}
+{%                 set bash_command = '<code>' ~ bash_command ~ '</code>' %}
+{%                 set bash_command = "bash " ~ bash_command %}
+{%                 do actions.append(bash_command) %}
+{%             elif handler.actions.log is arista.avd.defined %}
+{%                 do actions.append("log") %}
+{%             endif %}
+{%             if handler.actions.increment_device_health_metric is arista.avd.defined %}
+{%                 set metric = "increment device health metric " ~ handler.actions.increment_device_health_metric %}
+{%                 do actions.append(metric) %}
+{%             endif %}
+{%             set actions = actions | join("<br>") %}
 {%         endif %}
 {%         if handler.trigger is arista.avd.defined("on-maintenance")
             and handler.trigger_on_maintenance.operation is arista.avd.defined
@@ -73,7 +85,7 @@
 {%                 endif %}
 {%             endif %}
 {%         endif %}
-| {{ handler.name }} | {{ handler.action_type | arista.avd.default("-") }} | {{ action | arista.avd.default("-") }} | {{ handler.trigger }} | {{ trigger_config | arista.avd.default("-") }} |
+| {{ handler.name }} | {{ actions | arista.avd.default("-") }} | {{ handler.trigger }} | {{ trigger_config | arista.avd.default("-") }} |
 {%     endfor %}
 
 #### Event Handler Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
@@ -92,7 +92,7 @@
 {%                 endif %}
 {%             endif %}
 {%         endif %}
-| {{ handler.name }} | {{ actions | arista.avd.default("-") }} | {{ handler.trigger }} | {{ trigger_config | arista.avd.default("-") }} |
+| {{ handler.name }} | {{ actions | arista.avd.default("-") }} | {{ handler.trigger | arista.avd.default("-") }} | {{ trigger_config | arista.avd.default("-") }} |
 {%     endfor %}
 
 #### Event Handler Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
@@ -15,7 +15,7 @@
 {%     for handler in event_handlers | arista.avd.natural_sort('name') %}
 {%         if handler.action_type is arista.avd.defined %}
 {%             set actions = handler.action_type %}
-{%             if  handler.action is arista.avd.defined %}
+{%             if handler.action is arista.avd.defined %}
 {%                 set action = handler.action | replace('|', '\|') %}
 {%                 set actions = actions ~ ' <code>' ~ action ~ '</code>' %}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/event-handlers.j2
@@ -13,8 +13,8 @@
 | Handler | Action Type | Action | Trigger | Trigger Config |
 | ------- | ----------- | ------ | ------- | -------------- |
 {%     for handler in event_handlers | arista.avd.natural_sort('name') %}
-{%         set action = handler.action | replace('|', '\|') %}
-{%         if handler.action_type == 'bash' %}
+{%         if handler.action_type is arista.avd.defined('bash') and handler.action is arista.avd.defined %}
+{%             set action = handler.action | replace('|', '\|') %}
 {%             set action = '<code>' ~ action ~ '</code>' %}
 {%         endif %}
 {%         if handler.trigger is arista.avd.defined("on-maintenance")
@@ -73,7 +73,7 @@
 {%                 endif %}
 {%             endif %}
 {%         endif %}
-| {{ handler.name }} | {{ handler.action_type }} | {{ action }} | {{ handler.trigger }} | {{ trigger_config | arista.avd.default("-") }} |
+| {{ handler.name }} | {{ handler.action_type | arista.avd.default("-") }} | {{ action | arista.avd.default("-") }} | {{ handler.trigger }} | {{ trigger_config | arista.avd.default("-") }} |
 {%     endfor %}
 
 #### Event Handler Device Configuration

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -78,8 +78,8 @@ event-handler {{ handler.name }}
 {%         if handler.action_type is arista.avd.defined("bash") and handler.action is arista.avd.defined %}
    action {{ handler.action_type }} {{ handler.action }}
 {%         endif %}
-{%         if handler.event_handler_action.bash_command is arista.avd.defined %}
-{%             set bash_command = handler.event_handler_action.bash_command%}
+{%         if handler.actions.bash_command is arista.avd.defined %}
+{%             set bash_command = handler.actions.bash_command %}
 {%             if bash_command.count('\n') > 0 %}
 {%                 if not bash_command.rstrip().endswith('\nEOF') %}
 {%                     set bash_command = bash_command.rstrip() ~ "\nEOF" %}
@@ -89,11 +89,11 @@ event-handler {{ handler.name }}
 {%             else %}
    action bash {{ bash_command }}
 {%             endif %}
-{%         elif handler.event_handler_action.log is arista.avd.defined(true) %}
+{%         elif handler.actions.log is arista.avd.defined(true) %}
    action log
 {%         endif %}
-{%         if handler.event_handler_action.increment_device_health_metric is arista.avd.defined %}
-   action increment device-health metric {{ handler.event_handler_action.increment_device_health_metric }}
+{%         if handler.actions.increment_device_health_metric is arista.avd.defined %}
+   action increment device-health metric {{ handler.actions.increment_device_health_metric }}
 {%         endif %}
 {%         if handler.delay is arista.avd.defined %}
    delay {{ handler.delay }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -75,7 +75,7 @@ event-handler {{ handler.name }}
       regex {{ handler.regex }}
 {%             endif %}
 {%         endif %}
-{%         if handler.action_type is arista.avd.defined("bash") and handler.action is arista.avd.defined %}
+{%         if handler.action is arista.avd.defined and handler.action_type is arista.avd.defined %}
    action {{ handler.action_type }} {{ handler.action }}
 {%         endif %}
 {%         if handler.actions.bash_command is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -85,7 +85,7 @@ event-handler {{ handler.name }}
 {%                     set bash_command = bash_command.rstrip() ~ "\nEOF" %}
 {%                 endif %}
    action bash
-      {{ bash_command | indent(width=6, first=False) }}
+      {{ bash_command | indent(width=6, first=false) }}
 {%             else %}
    action bash {{ bash_command }}
 {%             endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/event-handlers.j2
@@ -75,8 +75,25 @@ event-handler {{ handler.name }}
       regex {{ handler.regex }}
 {%             endif %}
 {%         endif %}
-{%         if handler.action is arista.avd.defined and handler.action_type is arista.avd.defined %}
+{%         if handler.action_type is arista.avd.defined("bash") and handler.action is arista.avd.defined %}
    action {{ handler.action_type }} {{ handler.action }}
+{%         endif %}
+{%         if handler.event_handler_action.bash_command is arista.avd.defined %}
+{%             set bash_command = handler.event_handler_action.bash_command%}
+{%             if bash_command.count('\n') > 0 %}
+{%                 if not bash_command.rstrip().endswith('\nEOF') %}
+{%                     set bash_command = bash_command.rstrip() ~ "\nEOF" %}
+{%                 endif %}
+   action bash
+      {{ bash_command | indent(width=6, first=False) }}
+{%             else %}
+   action bash {{ bash_command }}
+{%             endif %}
+{%         elif handler.event_handler_action.log is arista.avd.defined(true) %}
+   action log
+{%         endif %}
+{%         if handler.event_handler_action.increment_device_health_metric is arista.avd.defined %}
+   action increment device-health metric {{ handler.event_handler_action.increment_device_health_metric }}
 {%         endif %}
 {%         if handler.delay is arista.avd.defined %}
    delay {{ handler.delay }}

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -11,7 +11,7 @@
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "event_handlers.[].name") | String | Required, Unique |  |  | Event Handler Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;actions</samp>](## "event_handlers.[].actions") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;actions</samp>](## "event_handlers.[].actions") | Dictionary |  |  |  | Note: `bash_command` and `log` are mutually exclusive. `bash_command` takes precedence over `log`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].actions.bash_command") | String |  |  |  | Define BASH command action. Command could be multiline also. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].actions.log") | Boolean |  |  |  | Log a message when the event is triggered. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;increment_device_health_metric</samp>](## "event_handlers.[].actions.increment_device_health_metric") | String |  |  |  | Name of device-health metric. |
@@ -98,6 +98,8 @@
         # Support will be removed in AVD version 5.0.0.
         # Use <samp>event_handlers.actions</samp> instead.
         action: <str>
+
+        # Note: `bash_command` and `log` are mutually exclusive. `bash_command` takes precedence over `log`.
         actions:
 
           # Define BASH command action. Command could be multiline also.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -11,10 +11,10 @@
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "event_handlers.[].name") | String | Required, Unique |  |  | Event Handler Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;event_handler_action</samp>](## "event_handlers.[].event_handler_action") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].event_handler_action.bash_command") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].event_handler_action.log") | Boolean |  |  |  | Log a message when the event is triggered. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;increment_device_health_metric</samp>](## "event_handlers.[].event_handler_action.increment_device_health_metric") | String |  |  |  | Name of device-health metric. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;actions</samp>](## "event_handlers.[].actions") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].actions.bash_command") | String |  |  |  | Define BASH command action. Command could be multiline also. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].actions.log") | Boolean |  |  |  | Log a message when the event is triggered. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;increment_device_health_metric</samp>](## "event_handlers.[].actions.increment_device_health_metric") | String |  |  |  | Name of device-health metric. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
@@ -98,7 +98,9 @@
         # Support will be removed in AVD version 5.0.0.
         # Use <samp>event_handler_action</samp> instead.
         action: <str>
-        event_handler_action:
+        actions:
+
+          # Define BASH command action. Command could be multiline also.
           bash_command: <str>
 
           # Log a message when the event is triggered.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -9,8 +9,8 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>event_handlers</samp>](## "event_handlers") | List, items: Dictionary |  |  |  | Gives the ability to monitor and react to Syslog messages.<br>Event Handlers provide a powerful and flexible tool that can be used to apply self-healing actions,<br>customize the system behavior, and implement workarounds to problems discovered in the field.<br> |
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "event_handlers.[].name") | String | Required, Unique |  |  | Event Handler Name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;actions</samp>](## "event_handlers.[].actions") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].actions.bash_command") | String |  |  |  | Define BASH command action. Command could be multiline also. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].actions.log") | Boolean |  |  |  | Log a message when the event is triggered. |
@@ -90,13 +90,13 @@
       - name: <str; required; unique>
         # This key is deprecated.
         # Support will be removed in AVD version 5.0.0.
-        # Use <samp>event_handler_action</samp> instead.
+        # Use <samp>event_handlers.actions</samp> instead.
         action_type: <str; "bash" | "increment" | "log">
 
         # Command to execute.
         # This key is deprecated.
         # Support will be removed in AVD version 5.0.0.
-        # Use <samp>event_handler_action</samp> instead.
+        # Use <samp>event_handlers.actions</samp> instead.
         action: <str>
         actions:
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -9,8 +9,12 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>event_handlers</samp>](## "event_handlers") | List, items: Dictionary |  |  |  | Gives the ability to monitor and react to Syslog messages.<br>Event Handlers provide a powerful and flexible tool that can be used to apply self-healing actions,<br>customize the system behavior, and implement workarounds to problems discovered in the field.<br> |
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "event_handlers.[].name") | String | Required, Unique |  |  | Event Handler Name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") | String |  |  |  | Command to execute.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action_type</samp>](## "event_handlers.[].action_type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>bash</code><br>- <code>increment</code><br>- <code>log</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "event_handlers.[].action") <span style="color:red">deprecated</span> | String |  |  |  | Command to execute.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;event_handler_action</samp>](## "event_handlers.[].event_handler_action") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bash_command</samp>](## "event_handlers.[].event_handler_action.bash_command") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;log</samp>](## "event_handlers.[].event_handler_action.log") | Boolean |  |  |  | Log a message when the event is triggered. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;increment_device_health_metric</samp>](## "event_handlers.[].event_handler_action.increment_device_health_metric") | String |  |  |  | Name of device-health metric. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "event_handlers.[].delay") | Integer |  |  |  | Event-handler delay in seconds.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger</samp>](## "event_handlers.[].trigger") | String |  |  | Valid Values:<br>- <code>on-boot</code><br>- <code>on-counters</code><br>- <code>on-intf</code><br>- <code>on-logging</code><br>- <code>on-maintenance</code><br>- <code>on-startup-config</code><br>- <code>vm-tracer vm</code> | Configure event trigger condition.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trigger_on_counters</samp>](## "event_handlers.[].trigger_on_counters") | Dictionary |  |  |  |  |
@@ -84,10 +88,24 @@
 
         # Event Handler Name.
       - name: <str; required; unique>
+        # This key is deprecated.
+        # Support will be removed in AVD version 5.0.0.
+        # Use <samp>event_handler_action</samp> instead.
         action_type: <str; "bash" | "increment" | "log">
 
         # Command to execute.
+        # This key is deprecated.
+        # Support will be removed in AVD version 5.0.0.
+        # Use <samp>event_handler_action</samp> instead.
         action: <str>
+        event_handler_action:
+          bash_command: <str>
+
+          # Log a message when the event is triggered.
+          log: <bool>
+
+          # Name of device-health metric.
+          increment_device_health_metric: <str>
 
         # Event-handler delay in seconds.
         delay: <int>

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5045,7 +5045,7 @@
           },
           "action": {
             "type": "string",
-            "description": "Command to execute.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.",
+            "description": "Command to execute.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.",
             "deprecated": true,
             "title": "Action"
           },
@@ -22259,7 +22259,7 @@
                     },
                     "action": {
                       "type": "string",
-                      "description": "Command to execute.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.",
+                      "description": "Command to execute.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handlers.actions</samp> instead.",
                       "deprecated": true,
                       "title": "Action"
                     },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5045,8 +5045,33 @@
           },
           "action": {
             "type": "string",
-            "description": "Command to execute.\n",
+            "description": "Command to execute.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.",
+            "deprecated": true,
             "title": "Action"
+          },
+          "event_handler_action": {
+            "type": "object",
+            "properties": {
+              "bash_command": {
+                "type": "string",
+                "title": "Bash Command"
+              },
+              "log": {
+                "type": "boolean",
+                "description": "Log a message when the event is triggered.",
+                "title": "Log"
+              },
+              "increment_device_health_metric": {
+                "type": "string",
+                "description": "Name of device-health metric.",
+                "title": "Increment Device Health Metric"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Event Handler Action"
           },
           "delay": {
             "type": "integer",
@@ -22233,8 +22258,33 @@
                     },
                     "action": {
                       "type": "string",
-                      "description": "Command to execute.\n",
+                      "description": "Command to execute.\n\nThis key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>event_handler_action</samp> instead.",
+                      "deprecated": true,
                       "title": "Action"
+                    },
+                    "event_handler_action": {
+                      "type": "object",
+                      "properties": {
+                        "bash_command": {
+                          "type": "string",
+                          "title": "Bash Command"
+                        },
+                        "log": {
+                          "type": "boolean",
+                          "description": "Log a message when the event is triggered.",
+                          "title": "Log"
+                        },
+                        "increment_device_health_metric": {
+                          "type": "string",
+                          "description": "Name of device-health metric.",
+                          "title": "Increment Device Health Metric"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Event Handler Action"
                     },
                     "delay": {
                       "type": "integer",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5051,6 +5051,7 @@
           },
           "actions": {
             "type": "object",
+            "description": "Note: `bash_command` and `log` are mutually exclusive. `bash_command` takes precedence over `log`.",
             "properties": {
               "bash_command": {
                 "type": "string",
@@ -22265,6 +22266,7 @@
                     },
                     "actions": {
                       "type": "object",
+                      "description": "Note: `bash_command` and `log` are mutually exclusive. `bash_command` takes precedence over `log`.",
                       "properties": {
                         "bash_command": {
                           "type": "string",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -5049,11 +5049,12 @@
             "deprecated": true,
             "title": "Action"
           },
-          "event_handler_action": {
+          "actions": {
             "type": "object",
             "properties": {
               "bash_command": {
                 "type": "string",
+                "description": "Define BASH command action. Command could be multiline also.",
                 "title": "Bash Command"
               },
               "log": {
@@ -5071,7 +5072,7 @@
             "patternProperties": {
               "^_.+$": {}
             },
-            "title": "Event Handler Action"
+            "title": "Actions"
           },
           "delay": {
             "type": "integer",
@@ -22262,11 +22263,12 @@
                       "deprecated": true,
                       "title": "Action"
                     },
-                    "event_handler_action": {
+                    "actions": {
                       "type": "object",
                       "properties": {
                         "bash_command": {
                           "type": "string",
+                          "description": "Define BASH command action. Command could be multiline also.",
                           "title": "Bash Command"
                         },
                         "log": {
@@ -22284,7 +22286,7 @@
                       "patternProperties": {
                         "^_.+$": {}
                       },
-                      "title": "Event Handler Action"
+                      "title": "Actions"
                     },
                     "delay": {
                       "type": "integer",


### PR DESCRIPTION
## Change Summary

Fix the schema and template for action in event-handler

## Related Issue(s)

Fixes #3899 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Currently, `action_type` key has three valid_values `bash`, `log` and `increment` but the combination of 2 keys can be implemented in config.
```
event-handler handler1
   action bash echo"action"
   action increment device-health metric metric1
```
```
event-handler handler1
   action log
   action increment device-health metric metric1
```
Deprecating the existing `action_type` and `action` key and adding new key - 
```
actions:
   bash_command: <str>

   # Log a message when the event is triggered.
   log: <bool>

    # Name of device-health metric.
    increment_device_health_metric: <str>
```
Also the current template logic for `action_type` generates wrong config if `action_type` is `log` or `increment`, so fixing it.

## How to test
Check the config in CLI.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
