### PR TITLE
Feat(eos_cli_config_gen): Add option for dot1x aaa accounting update interval x seconds.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dot1x.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dot1x.cfg
@@ -20,6 +20,7 @@ dot1x
    aaa unresponsive action traffic allow vlan 10
    aaa unresponsive eap response success
    aaa unresponsive recovery action reauthenticate
+   aaa accounting update interval 6 seconds
    mac based authentication delay 300 seconds
    mac based authentication hold period 300 seconds
    radius av-pair service-type

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dot1x.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dot1x.yml
@@ -23,3 +23,4 @@ dot1x:
         traffic_allow: true
         apply_alternate: true
       recovery_action_reauthenticate: true
+    accounting_update_interval: 6

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
@@ -37,6 +37,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;apply_alternate</samp>](## "dot1x.aaa.unresponsive.phone_action.apply_alternate") | Boolean |  |  |  | Apply alternate action if primary action fails.<br>eg. aaa unresponsive phone action apply cached-results else traffic allow |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;traffic_allow</samp>](## "dot1x.aaa.unresponsive.phone_action.traffic_allow") | Boolean |  |  |  | Set action for supplicant traffic when AAA times out. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_action_reauthenticate</samp>](## "dot1x.aaa.unresponsive.recovery_action_reauthenticate") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;accounting_update_interval</samp>](## "dot1x.aaa.accounting_update_interval") | Integer |  |  | Min: 5<br>Max: 65535 |  |
 
 === "YAML"
 
@@ -107,4 +108,5 @@
             # Set action for supplicant traffic when AAA times out.
             traffic_allow: <bool>
           recovery_action_reauthenticate: <bool>
+        accounting_update_interval: <int; 5-65535>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
@@ -37,7 +37,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;apply_alternate</samp>](## "dot1x.aaa.unresponsive.phone_action.apply_alternate") | Boolean |  |  |  | Apply alternate action if primary action fails.<br>eg. aaa unresponsive phone action apply cached-results else traffic allow |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;traffic_allow</samp>](## "dot1x.aaa.unresponsive.phone_action.traffic_allow") | Boolean |  |  |  | Set action for supplicant traffic when AAA times out. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery_action_reauthenticate</samp>](## "dot1x.aaa.unresponsive.recovery_action_reauthenticate") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;accounting_update_interval</samp>](## "dot1x.aaa.accounting_update_interval") | Integer |  |  | Min: 5<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;accounting_update_interval</samp>](## "dot1x.aaa.accounting_update_interval") | Integer |  |  | Min: 5<br>Max: 65535 | Interval period in seconds. |
 
 === "YAML"
 
@@ -108,5 +108,7 @@
             # Set action for supplicant traffic when AAA times out.
             traffic_allow: <bool>
           recovery_action_reauthenticate: <bool>
+
+        # Interval period in seconds.
         accounting_update_interval: <int; 5-65535>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2355,6 +2355,7 @@
               "type": "integer",
               "minimum": 5,
               "maximum": 65535,
+              "description": "Interval period in seconds.",
               "title": "Accounting Update Interval"
             }
           },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -2350,6 +2350,12 @@
                 "^_.+$": {}
               },
               "title": "Unresponsive"
+            },
+            "accounting_update_interval": {
+              "type": "integer",
+              "minimum": 5,
+              "maximum": 65535,
+              "title": "Accounting Update Interval"
             }
           },
           "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1569,6 +1569,12 @@ keys:
                     type: bool
               recovery_action_reauthenticate:
                 type: bool
+          accounting_update_interval:
+            type: int
+            convert_types:
+            - str
+            min: 5
+            max: 65535
   dps_interfaces:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -1575,6 +1575,7 @@ keys:
             - str
             min: 5
             max: 65535
+            description: Interval period in seconds.
   dps_interfaces:
     type: list
     primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dot1x.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dot1x.schema.yml
@@ -140,3 +140,9 @@ keys:
                     type: bool
               recovery_action_reauthenticate:
                 type: bool
+          accounting_update_interval:
+              type: int
+              convert_types:
+                - str
+              min: 5
+              max: 65535

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dot1x.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/dot1x.schema.yml
@@ -141,8 +141,9 @@ keys:
               recovery_action_reauthenticate:
                 type: bool
           accounting_update_interval:
-              type: int
-              convert_types:
-                - str
-              min: 5
-              max: 65535
+            type: int
+            convert_types:
+              - str
+            min: 5
+            max: 65535
+            description: Interval period in seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dot1x.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dot1x.j2
@@ -62,7 +62,7 @@ dot1x
 {%         endif %}
 {%         if dot1x.aaa.accounting_update_interval is arista.avd.defined %}
    aaa accounting update interval {{ dot1x.aaa.accounting_update_interval }} seconds
-{%         endif%}
+{%         endif %}
 {%         if dot1x.mac_based_authentication is arista.avd.defined %}
 {%             if dot1x.mac_based_authentication.delay is arista.avd.defined %}
    mac based authentication delay {{ dot1x.mac_based_authentication.delay }} seconds

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dot1x.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/dot1x.j2
@@ -60,6 +60,9 @@ dot1x
    {{ aaa_config }} recovery action reauthenticate
 {%             endif %}
 {%         endif %}
+{%         if dot1x.aaa.accounting_update_interval is arista.avd.defined %}
+   aaa accounting update interval {{ dot1x.aaa.accounting_update_interval }} seconds
+{%         endif%}
 {%         if dot1x.mac_based_authentication is arista.avd.defined %}
 {%             if dot1x.mac_based_authentication.delay is arista.avd.defined %}
    mac based authentication delay {{ dot1x.mac_based_authentication.delay }} seconds

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -19042,6 +19042,12 @@
                           "^_.+$": {}
                         },
                         "title": "Unresponsive"
+                      },
+                      "accounting_update_interval": {
+                        "type": "integer",
+                        "minimum": 5,
+                        "maximum": 65535,
+                        "title": "Accounting Update Interval"
                       }
                     },
                     "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -19047,6 +19047,7 @@
                         "type": "integer",
                         "minimum": 5,
                         "maximum": 65535,
+                        "description": "Interval period in seconds.",
                         "title": "Accounting Update Interval"
                       }
                     },


### PR DESCRIPTION
## Change Summary

Add option for dot1x aaa accounting update interval <x> seconds.

## Related Issue(s)

Fixes #3943 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
