### PR TITLE
Feat(eos_cli_config_gen): Support for MSS Clamping on ethernet interfaces.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -171,6 +171,15 @@ sFlow is disabled.
 | --------- | --------------- | -----------| --------- |
 | Ethernet16 | 111-112 | 110 | out |
 
+##### TCP MSS Clamping
+
+| Interface | Ipv4 Segment Size | Ipv6 Segment Size | Egress | Ingress |
+| --------- | ----------------- | ----------------- | ------ | ------- |
+| Ethernet1 | 70 | 75 | True | - |
+| Ethernet2 | 70 | - | - | True |
+| Ethernet3 | - | 65 | - | - |
+| Ethernet4 | 65 | - | - | - |
+
 ##### Transceiver Settings
 
 | Interface | Transceiver Frequency | Media Override |
@@ -369,6 +378,7 @@ interface Ethernet1
    ip igmp host-proxy access-list ACL2
    ip igmp host-proxy report-interval 2
    ip igmp host-proxy version 2
+   tcp mss ceiling ipv4 70 ipv6 75 egress
    switchport port-security
    priority-flow-control on
    priority-flow-control priority 5 drop
@@ -383,6 +393,7 @@ interface Ethernet2
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
+   tcp mss ceiling ipv4 70 ingress
    multicast ipv4 boundary ACL_MULTICAST
    multicast ipv6 boundary ACL_V6_MULTICAST out
    multicast ipv4 static
@@ -407,6 +418,7 @@ interface Ethernet3
    ipv6 nd prefix 2345:ABCD:3FE0::1/96 infinite 50 no-autoconfig
    ipv6 nd prefix 2345:ABCD:3FE0::2/96 50 infinite
    ipv6 nd prefix 2345:ABCD:3FE0::3/96 100000 no-autoconfig
+   tcp mss ceiling ipv6 65
    switchport port-security
    no switchport port-security mac-address maximum disabled
    switchport port-security vlan 1 mac-address maximum 3
@@ -428,6 +440,7 @@ interface Ethernet4
    ipv6 address FE80:FEA::AB65/64 link-local
    ipv6 nd ra disabled
    ipv6 nd managed-config-flag
+   tcp mss ceiling ipv4 65
    ipv6 access-group IPv6_ACL_IN in
    ipv6 access-group IPv6_ACL_OUT out
    multicast ipv4 boundary 224.0.1.0/24 out

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -173,12 +173,12 @@ sFlow is disabled.
 
 ##### TCP MSS Clamping
 
-| Interface | Ipv4 Segment Size | Ipv6 Segment Size | Egress | Ingress |
-| --------- | ----------------- | ----------------- | ------ | ------- |
-| Ethernet1 | 70 | 75 | True | - |
-| Ethernet2 | 70 | - | - | True |
-| Ethernet3 | - | 65 | - | - |
-| Ethernet4 | 65 | - | - | - |
+| Interface | Ipv4 Segment Size | Ipv6 Segment Size | Direction |
+| --------- | ----------------- | ----------------- | --------- |
+| Ethernet1 | 70 | 75 | egress |
+| Ethernet2 | 70 | - | ingress |
+| Ethernet3 | - | 65 | - |
+| Ethernet4 | 65 | - | - |
 
 ##### Transceiver Settings
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -31,6 +31,7 @@ interface Ethernet1
    ip igmp host-proxy access-list ACL2
    ip igmp host-proxy report-interval 2
    ip igmp host-proxy version 2
+   tcp mss ceiling ipv4 70 ipv6 75 egress
    switchport port-security
    priority-flow-control on
    priority-flow-control priority 5 drop
@@ -45,6 +46,7 @@ interface Ethernet2
    switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
+   tcp mss ceiling ipv4 70 ingress
    multicast ipv4 boundary ACL_MULTICAST
    multicast ipv6 boundary ACL_V6_MULTICAST out
    multicast ipv4 static
@@ -69,6 +71,7 @@ interface Ethernet3
    ipv6 nd prefix 2345:ABCD:3FE0::1/96 infinite 50 no-autoconfig
    ipv6 nd prefix 2345:ABCD:3FE0::2/96 50 infinite
    ipv6 nd prefix 2345:ABCD:3FE0::3/96 100000 no-autoconfig
+   tcp mss ceiling ipv6 65
    switchport port-security
    no switchport port-security mac-address maximum disabled
    switchport port-security vlan 1 mac-address maximum 3
@@ -90,6 +93,7 @@ interface Ethernet4
    ipv6 address FE80:FEA::AB65/64 link-local
    ipv6 nd ra disabled
    ipv6 nd managed-config-flag
+   tcp mss ceiling ipv4 65
    ipv6 access-group IPv6_ACL_IN in
    ipv6 access-group IPv6_ACL_OUT out
    multicast ipv4 boundary 224.0.1.0/24 out

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -29,6 +29,10 @@ ethernet_interfaces:
     bgp:
       session_tracker: ST1
     ip_verify_unicast_source_reachable_via: rx
+    tcp_mss_ceiling:
+      ipv4_segment_size: 70
+      ipv6_segment_size: 75
+      egress: true
     switchport:
       port_security:
         enabled: true
@@ -66,6 +70,9 @@ ethernet_interfaces:
     description: SRV-POD02_Eth1
     mode: trunk
     vlans: 110-111,210-211
+    tcp_mss_ceiling:
+      ipv4_segment_size: 70
+      ingress: true
     multicast:
       ipv4:
         static: true
@@ -128,6 +135,8 @@ ethernet_interfaces:
     priority_flow_control:
       enabled: false
     spanning_tree_guard: root
+    tcp_mss_ceiling:
+      ipv6_segment_size: 65
     switchport:
       port_security:
         mac_address_maximum:
@@ -155,6 +164,8 @@ ethernet_interfaces:
     priority_flow_control:
       enabled: true
     spanning_tree_guard: disabled
+    tcp_mss_ceiling:
+      ipv4_segment_size: 65
     multicast:
       ipv4:
         static: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -32,7 +32,7 @@ ethernet_interfaces:
     tcp_mss_ceiling:
       ipv4_segment_size: 70
       ipv6_segment_size: 75
-      egress: true
+      direction: egress
     switchport:
       port_security:
         enabled: true
@@ -72,7 +72,7 @@ ethernet_interfaces:
     vlans: 110-111,210-211
     tcp_mss_ceiling:
       ipv4_segment_size: 70
-      ingress: true
+      direction: ingress
     multicast:
       ipv4:
         static: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -176,6 +176,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].pim.ipv4.hello.interval") | Integer |  |  | Min: 1<br>Max: 65535 | PIM hello interval in seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mac_security</samp>](## "ethernet_interfaces.[].mac_security") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ethernet_interfaces.[].mac_security.profile") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tcp_mss_ceiling</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling") | Dictionary |  |  |  | The TCP MSS clamping feature involves clamping the maximum segment size (MSS) in the TCP header<br>of TCP SYN packets if it exceeds the configured MSS ceiling limit for the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_segment_size</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling.ipv4_segment_size") | Integer |  |  | Min: 64<br>Max: 65475 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_segment_size</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling.ipv6_segment_size") | Integer |  |  | Min: 64<br>Max: 65475 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;egress</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling.egress") | Boolean |  |  |  | Enforce on packets forwarded to the network. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ingress</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling.ingress") | Boolean |  |  |  | Enforce on packets arriving from the network. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;channel_group</samp>](## "ethernet_interfaces.[].channel_group") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "ethernet_interfaces.[].channel_group.id") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].channel_group.mode") | String |  |  | Valid Values:<br>- <code>on</code><br>- <code>active</code><br>- <code>passive</code> |  |
@@ -725,6 +730,18 @@
               interval: <int; 1-65535>
         mac_security:
           profile: <str>
+
+        # The TCP MSS clamping feature involves clamping the maximum segment size (MSS) in the TCP header
+        # of TCP SYN packets if it exceeds the configured MSS ceiling limit for the interface.
+        tcp_mss_ceiling:
+          ipv4_segment_size: <int; 64-65475>
+          ipv6_segment_size: <int; 64-65475>
+
+          # Enforce on packets forwarded to the network.
+          egress: <bool>
+
+          # Enforce on packets arriving from the network.
+          ingress: <bool>
         channel_group:
           id: <int>
           mode: <str; "on" | "active" | "passive">

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -179,8 +179,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tcp_mss_ceiling</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling") | Dictionary |  |  |  | The TCP MSS clamping feature involves clamping the maximum segment size (MSS) in the TCP header<br>of TCP SYN packets if it exceeds the configured MSS ceiling limit for the interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_segment_size</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling.ipv4_segment_size") | Integer |  |  | Min: 64<br>Max: 65475 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_segment_size</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling.ipv6_segment_size") | Integer |  |  | Min: 64<br>Max: 65475 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;egress</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling.egress") | Boolean |  |  |  | Enforce on packets forwarded to the network. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ingress</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling.ingress") | Boolean |  |  |  | Enforce on packets arriving from the network. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;direction</samp>](## "ethernet_interfaces.[].tcp_mss_ceiling.direction") | String |  |  | Valid Values:<br>- <code>egress</code><br>- <code>ingress</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;channel_group</samp>](## "ethernet_interfaces.[].channel_group") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "ethernet_interfaces.[].channel_group.id") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "ethernet_interfaces.[].channel_group.mode") | String |  |  | Valid Values:<br>- <code>on</code><br>- <code>active</code><br>- <code>passive</code> |  |
@@ -736,12 +735,7 @@
         tcp_mss_ceiling:
           ipv4_segment_size: <int; 64-65475>
           ipv6_segment_size: <int; 64-65475>
-
-          # Enforce on packets forwarded to the network.
-          egress: <bool>
-
-          # Enforce on packets arriving from the network.
-          ingress: <bool>
+          direction: <str; "egress" | "ingress">
         channel_group:
           id: <int>
           mode: <str; "on" | "active" | "passive">

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3801,15 +3801,13 @@
                 "maximum": 65475,
                 "title": "IPv6 Segment Size"
               },
-              "egress": {
-                "type": "boolean",
-                "description": "Enforce on packets forwarded to the network.",
-                "title": "Egress"
-              },
-              "ingress": {
-                "type": "boolean",
-                "description": "Enforce on packets arriving from the network.",
-                "title": "Ingress"
+              "direction": {
+                "type": "string",
+                "enum": [
+                  "egress",
+                  "ingress"
+                ],
+                "title": "Direction"
               }
             },
             "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -3785,6 +3785,39 @@
             },
             "title": "MAC Security"
           },
+          "tcp_mss_ceiling": {
+            "type": "object",
+            "description": "The TCP MSS clamping feature involves clamping the maximum segment size (MSS) in the TCP header\nof TCP SYN packets if it exceeds the configured MSS ceiling limit for the interface.",
+            "properties": {
+              "ipv4_segment_size": {
+                "type": "integer",
+                "minimum": 64,
+                "maximum": 65475,
+                "title": "IPv4 Segment Size"
+              },
+              "ipv6_segment_size": {
+                "type": "integer",
+                "minimum": 64,
+                "maximum": 65475,
+                "title": "IPv6 Segment Size"
+              },
+              "egress": {
+                "type": "boolean",
+                "description": "Enforce on packets forwarded to the network.",
+                "title": "Egress"
+              },
+              "ingress": {
+                "type": "boolean",
+                "description": "Enforce on packets arriving from the network.",
+                "title": "Ingress"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "TCP Mss Ceiling"
+          },
           "channel_group": {
             "type": "object",
             "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2304,12 +2304,11 @@ keys:
               - str
               min: 64
               max: 65475
-            egress:
-              type: bool
-              description: Enforce on packets forwarded to the network.
-            ingress:
-              type: bool
-              description: Enforce on packets arriving from the network.
+            direction:
+              type: str
+              valid_values:
+              - egress
+              - ingress
         channel_group:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -2284,6 +2284,32 @@ keys:
           keys:
             profile:
               type: str
+        tcp_mss_ceiling:
+          type: dict
+          description: 'The TCP MSS clamping feature involves clamping the maximum
+            segment size (MSS) in the TCP header
+
+            of TCP SYN packets if it exceeds the configured MSS ceiling limit for
+            the interface.'
+          keys:
+            ipv4_segment_size:
+              type: int
+              convert_types:
+              - str
+              min: 64
+              max: 65475
+            ipv6_segment_size:
+              type: int
+              convert_types:
+              - str
+              min: 64
+              max: 65475
+            egress:
+              type: bool
+              description: Enforce on packets forwarded to the network.
+            ingress:
+              type: bool
+              description: Enforce on packets arriving from the network.
         channel_group:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -497,6 +497,30 @@ keys:
           keys:
             profile:
               type: str
+        tcp_mss_ceiling:
+          type: dict
+          description: |-
+            The TCP MSS clamping feature involves clamping the maximum segment size (MSS) in the TCP header
+            of TCP SYN packets if it exceeds the configured MSS ceiling limit for the interface.
+          keys:
+            ipv4_segment_size:
+              type: int
+              convert_types:
+                - str
+              min: 64
+              max: 65475
+            ipv6_segment_size:
+              type: int
+              convert_types:
+                - str
+              min: 64
+              max: 65475
+            egress:
+              type: bool
+              description: Enforce on packets forwarded to the network.
+            ingress:
+              type: bool
+              description: Enforce on packets arriving from the network.
         channel_group:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/ethernet_interfaces.schema.yml
@@ -515,12 +515,11 @@ keys:
                 - str
               min: 64
               max: 65475
-            egress:
-              type: bool
-              description: Enforce on packets forwarded to the network.
-            ingress:
-              type: bool
-              description: Enforce on packets arriving from the network.
+            direction:
+              type: str
+              valid_values:
+                - egress
+                - ingress
         channel_group:
           type: dict
           keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -176,8 +176,8 @@
 
 ##### TCP MSS Clamping
 
-| Interface | Ipv4 Segment Size | Ipv6 Segment Size | Egress | Ingress |
-| --------- | ----------------- | ----------------- | ------ | ------- |
+| Interface | Ipv4 Segment Size | Ipv6 Segment Size | Direction |
+| --------- | ----------------- | ----------------- | --------- |
 {%         for tcp_mss_clamping in tcp_mss_clampings | arista.avd.natural_sort('name') %}
 {%             set interface = tcp_mss_clamping.name %}
 {%             if tcp_mss_clamping.tcp_mss_ceiling.ipv4_segment_size is arista.avd.defined %}
@@ -186,12 +186,7 @@
 {%             if tcp_mss_clamping.tcp_mss_ceiling.ipv6_segment_size is arista.avd.defined %}
 {%                 set ipv6_segment_size = tcp_mss_clamping.tcp_mss_ceiling.ipv6_segment_size %}
 {%             endif %}
-{%             if tcp_mss_clamping.tcp_mss_ceiling.egress is arista.avd.defined(true) %}
-{%                 set egress = "True" %}
-{%             elif tcp_mss_clamping.tcp_mss_ceiling.ingress is arista.avd.defined(true) %}
-{%                 set ingress = "True" %}
-{%             endif %}
-| {{ interface }} | {{ ipv4_segment_size | arista.avd.default("-") }} | {{ ipv6_segment_size | arista.avd.default("-") }} | {{ egress | arista.avd.default("-") }} | {{ ingress | arista.avd.default("-") }} |
+| {{ interface }} | {{ ipv4_segment_size | arista.avd.default("-") }} | {{ ipv6_segment_size | arista.avd.default("-") }} | {{ tcp_mss_clamping.tcp_mss_ceiling.direction | arista.avd.default("-") }} |
 {%         endfor %}
 {%     endif %}
 {# Transceiver Settings #}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/ethernet-interfaces.j2
@@ -165,6 +165,35 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{# TCP MSS Clamping #}
+{%     set tcp_mss_clampings = [] %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
+{%         if ethernet_interface.tcp_mss_ceiling is arista.avd.defined %}
+{%             do tcp_mss_clampings.append(ethernet_interface) %}
+{%         endif %}
+{%     endfor %}
+{%     if tcp_mss_clampings | length > 0 %}
+
+##### TCP MSS Clamping
+
+| Interface | Ipv4 Segment Size | Ipv6 Segment Size | Egress | Ingress |
+| --------- | ----------------- | ----------------- | ------ | ------- |
+{%         for tcp_mss_clamping in tcp_mss_clampings | arista.avd.natural_sort('name') %}
+{%             set interface = tcp_mss_clamping.name %}
+{%             if tcp_mss_clamping.tcp_mss_ceiling.ipv4_segment_size is arista.avd.defined %}
+{%                 set ipv4_segment_size = tcp_mss_clamping.tcp_mss_ceiling.ipv4_segment_size %}
+{%             endif %}
+{%             if tcp_mss_clamping.tcp_mss_ceiling.ipv6_segment_size is arista.avd.defined %}
+{%                 set ipv6_segment_size = tcp_mss_clamping.tcp_mss_ceiling.ipv6_segment_size %}
+{%             endif %}
+{%             if tcp_mss_clamping.tcp_mss_ceiling.egress is arista.avd.defined(true) %}
+{%                 set egress = "True" %}
+{%             elif tcp_mss_clamping.tcp_mss_ceiling.ingress is arista.avd.defined(true) %}
+{%                 set ingress = "True" %}
+{%             endif %}
+| {{ interface }} | {{ ipv4_segment_size | arista.avd.default("-") }} | {{ ipv6_segment_size | arista.avd.default("-") }} | {{ egress | arista.avd.default("-") }} | {{ ingress | arista.avd.default("-") }} |
+{%         endfor %}
+{%     endif %}
 {# Transceiver Settings #}
 {%     set transceiver_settings = [] %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -446,10 +446,8 @@ interface {{ ethernet_interface.name }}
 {%         if ethernet_interface.tcp_mss_ceiling.ipv6_segment_size is arista.avd.defined %}
 {%             set tcp_mss_ceiling_cli = tcp_mss_ceiling_cli ~ " ipv6 " ~ ethernet_interface.tcp_mss_ceiling.ipv6_segment_size %}
 {%         endif %}
-{%         if ethernet_interface.tcp_mss_ceiling.egress is arista.avd.defined(true) %}
-{%             set tcp_mss_ceiling_cli = tcp_mss_ceiling_cli ~ " egress" %}
-{%         elif ethernet_interface.tcp_mss_ceiling.ingress is arista.avd.defined(true) %}
-{%             set tcp_mss_ceiling_cli = tcp_mss_ceiling_cli ~ " ingress" %}
+{%         if ethernet_interface.tcp_mss_ceiling.direction is arista.avd.defined %}
+{%             set tcp_mss_ceiling_cli = tcp_mss_ceiling_cli ~ " " ~ ethernet_interface.tcp_mss_ceiling.direction %}
 {%         endif %}
    {{ tcp_mss_ceiling_cli }}
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/ethernet-interfaces.j2
@@ -438,6 +438,21 @@ interface {{ ethernet_interface.name }}
 {%         endif %}
    {{ destination_cli }}
 {%     endfor %}
+{%     if ethernet_interface.tcp_mss_ceiling.ipv4_segment_size is arista.avd.defined or ethernet_interface.tcp_mss_ceiling.ipv6_segment_size is arista.avd.defined %}
+{%         set tcp_mss_ceiling_cli = "tcp mss ceiling" %}
+{%         if ethernet_interface.tcp_mss_ceiling.ipv4_segment_size is arista.avd.defined %}
+{%             set tcp_mss_ceiling_cli = tcp_mss_ceiling_cli ~ " ipv4 " ~ ethernet_interface.tcp_mss_ceiling.ipv4_segment_size %}
+{%         endif %}
+{%         if ethernet_interface.tcp_mss_ceiling.ipv6_segment_size is arista.avd.defined %}
+{%             set tcp_mss_ceiling_cli = tcp_mss_ceiling_cli ~ " ipv6 " ~ ethernet_interface.tcp_mss_ceiling.ipv6_segment_size %}
+{%         endif %}
+{%         if ethernet_interface.tcp_mss_ceiling.egress is arista.avd.defined(true) %}
+{%             set tcp_mss_ceiling_cli = tcp_mss_ceiling_cli ~ " egress" %}
+{%         elif ethernet_interface.tcp_mss_ceiling.ingress is arista.avd.defined(true) %}
+{%             set tcp_mss_ceiling_cli = tcp_mss_ceiling_cli ~ " ingress" %}
+{%         endif %}
+   {{ tcp_mss_ceiling_cli }}
+{%     endif %}
 {%     if ethernet_interface.channel_group.id is arista.avd.defined and ethernet_interface.channel_group.mode is arista.avd.defined %}
    channel-group {{ ethernet_interface.channel_group.id }} mode {{ ethernet_interface.channel_group.mode }}
 {%         if ethernet_interface.lacp_timer.mode is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -8404,15 +8404,13 @@
                     "maximum": 65475,
                     "title": "IPv6 Segment Size"
                   },
-                  "egress": {
-                    "type": "boolean",
-                    "description": "Enforce on packets forwarded to the network.",
-                    "title": "Egress"
-                  },
-                  "ingress": {
-                    "type": "boolean",
-                    "description": "Enforce on packets arriving from the network.",
-                    "title": "Ingress"
+                  "direction": {
+                    "type": "string",
+                    "enum": [
+                      "egress",
+                      "ingress"
+                    ],
+                    "title": "Direction"
                   }
                 },
                 "additionalProperties": false,
@@ -14203,15 +14201,13 @@
                     "maximum": 65475,
                     "title": "IPv6 Segment Size"
                   },
-                  "egress": {
-                    "type": "boolean",
-                    "description": "Enforce on packets forwarded to the network.",
-                    "title": "Egress"
-                  },
-                  "ingress": {
-                    "type": "boolean",
-                    "description": "Enforce on packets arriving from the network.",
-                    "title": "Ingress"
+                  "direction": {
+                    "type": "string",
+                    "enum": [
+                      "egress",
+                      "ingress"
+                    ],
+                    "title": "Direction"
                   }
                 },
                 "additionalProperties": false,
@@ -20559,15 +20555,13 @@
                           "maximum": 65475,
                           "title": "IPv6 Segment Size"
                         },
-                        "egress": {
-                          "type": "boolean",
-                          "description": "Enforce on packets forwarded to the network.",
-                          "title": "Egress"
-                        },
-                        "ingress": {
-                          "type": "boolean",
-                          "description": "Enforce on packets arriving from the network.",
-                          "title": "Ingress"
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "egress",
+                            "ingress"
+                          ],
+                          "title": "Direction"
                         }
                       },
                       "additionalProperties": false,
@@ -50955,15 +50949,13 @@
                     "maximum": 65475,
                     "title": "IPv6 Segment Size"
                   },
-                  "egress": {
-                    "type": "boolean",
-                    "description": "Enforce on packets forwarded to the network.",
-                    "title": "Egress"
-                  },
-                  "ingress": {
-                    "type": "boolean",
-                    "description": "Enforce on packets arriving from the network.",
-                    "title": "Ingress"
+                  "direction": {
+                    "type": "string",
+                    "enum": [
+                      "egress",
+                      "ingress"
+                    ],
+                    "title": "Direction"
                   }
                 },
                 "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -8388,6 +8388,39 @@
                 },
                 "title": "MAC Security"
               },
+              "tcp_mss_ceiling": {
+                "type": "object",
+                "description": "The TCP MSS clamping feature involves clamping the maximum segment size (MSS) in the TCP header\nof TCP SYN packets if it exceeds the configured MSS ceiling limit for the interface.",
+                "properties": {
+                  "ipv4_segment_size": {
+                    "type": "integer",
+                    "minimum": 64,
+                    "maximum": 65475,
+                    "title": "IPv4 Segment Size"
+                  },
+                  "ipv6_segment_size": {
+                    "type": "integer",
+                    "minimum": 64,
+                    "maximum": 65475,
+                    "title": "IPv6 Segment Size"
+                  },
+                  "egress": {
+                    "type": "boolean",
+                    "description": "Enforce on packets forwarded to the network.",
+                    "title": "Egress"
+                  },
+                  "ingress": {
+                    "type": "boolean",
+                    "description": "Enforce on packets arriving from the network.",
+                    "title": "Ingress"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "TCP Mss Ceiling"
+              },
               "channel_group": {
                 "type": "object",
                 "properties": {
@@ -14153,6 +14186,39 @@
                   "^_.+$": {}
                 },
                 "title": "MAC Security"
+              },
+              "tcp_mss_ceiling": {
+                "type": "object",
+                "description": "The TCP MSS clamping feature involves clamping the maximum segment size (MSS) in the TCP header\nof TCP SYN packets if it exceeds the configured MSS ceiling limit for the interface.",
+                "properties": {
+                  "ipv4_segment_size": {
+                    "type": "integer",
+                    "minimum": 64,
+                    "maximum": 65475,
+                    "title": "IPv4 Segment Size"
+                  },
+                  "ipv6_segment_size": {
+                    "type": "integer",
+                    "minimum": 64,
+                    "maximum": 65475,
+                    "title": "IPv6 Segment Size"
+                  },
+                  "egress": {
+                    "type": "boolean",
+                    "description": "Enforce on packets forwarded to the network.",
+                    "title": "Egress"
+                  },
+                  "ingress": {
+                    "type": "boolean",
+                    "description": "Enforce on packets arriving from the network.",
+                    "title": "Ingress"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "TCP Mss Ceiling"
               },
               "channel_group": {
                 "type": "object",
@@ -20476,6 +20542,39 @@
                         "^_.+$": {}
                       },
                       "title": "MAC Security"
+                    },
+                    "tcp_mss_ceiling": {
+                      "type": "object",
+                      "description": "The TCP MSS clamping feature involves clamping the maximum segment size (MSS) in the TCP header\nof TCP SYN packets if it exceeds the configured MSS ceiling limit for the interface.",
+                      "properties": {
+                        "ipv4_segment_size": {
+                          "type": "integer",
+                          "minimum": 64,
+                          "maximum": 65475,
+                          "title": "IPv4 Segment Size"
+                        },
+                        "ipv6_segment_size": {
+                          "type": "integer",
+                          "minimum": 64,
+                          "maximum": 65475,
+                          "title": "IPv6 Segment Size"
+                        },
+                        "egress": {
+                          "type": "boolean",
+                          "description": "Enforce on packets forwarded to the network.",
+                          "title": "Egress"
+                        },
+                        "ingress": {
+                          "type": "boolean",
+                          "description": "Enforce on packets arriving from the network.",
+                          "title": "Ingress"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "TCP Mss Ceiling"
                     },
                     "channel_group": {
                       "type": "object",
@@ -50839,6 +50938,39 @@
                   "^_.+$": {}
                 },
                 "title": "MAC Security"
+              },
+              "tcp_mss_ceiling": {
+                "type": "object",
+                "description": "The TCP MSS clamping feature involves clamping the maximum segment size (MSS) in the TCP header\nof TCP SYN packets if it exceeds the configured MSS ceiling limit for the interface.",
+                "properties": {
+                  "ipv4_segment_size": {
+                    "type": "integer",
+                    "minimum": 64,
+                    "maximum": 65475,
+                    "title": "IPv4 Segment Size"
+                  },
+                  "ipv6_segment_size": {
+                    "type": "integer",
+                    "minimum": 64,
+                    "maximum": 65475,
+                    "title": "IPv6 Segment Size"
+                  },
+                  "egress": {
+                    "type": "boolean",
+                    "description": "Enforce on packets forwarded to the network.",
+                    "title": "Egress"
+                  },
+                  "ingress": {
+                    "type": "boolean",
+                    "description": "Enforce on packets arriving from the network.",
+                    "title": "Ingress"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "TCP Mss Ceiling"
               },
               "channel_group": {
                 "type": "object",


### PR DESCRIPTION
## Change Summary

 Support for MSS Clamping on ethernet interfaces.

## Related Issue(s)

Fixes #3919 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
 Updated `ethernet_interfaces` schema to add `tcp_mss_ceiling` :
```
tcp_mss_ceiling:
     ipv4_segment_size: <int; 64-65475>
     ipv6_segment_size: <int; 64-65475>

     # Enforce on packets forwarded to the network.
     egress: <bool>

     # Enforce on packets arriving from the network.
     ingress: <bool>
```

## How to test
 Molecule tests are added. Test the config in EOS CLI.

## Checklist

### PR Checklist

- [x] Check the command ordering on EOS CLI.
- [x] Implement the documentation template (if required).

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
