### PR TITLE
Fix(eos_designs): Connected endpoints ESI should only be configured on EVPN VTEPs.

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -303,10 +303,6 @@ interface Ethernet8
 | Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
 | --------- | --------------------------- | --------------------------- | ------------ |
 | Port-Channel3 | 0000:0000:0102:0000:0034 | all-active | 01:02:00:00:00:34 |
-| Port-Channel8 | 0000:0000:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
-| Port-Channel8.111 | 0000:0000:0303:0202:0111 | all-active | 03:03:02:02:01:11 |
-| Port-Channel8.222 | 0000:0000:0303:0202:0222 | all-active | 03:03:02:02:02:22 |
-| Port-Channel8.333 | 0000:0000:0303:0202:0333 | all-active | 03:03:02:02:03:33 |
 
 #### Port-Channel Interfaces Device Configuration
 
@@ -349,34 +345,21 @@ interface Port-Channel8
    description CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111
    encapsulation vlan
       client dot1q 111 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0111
-      route-target import 03:03:02:02:01:11
 !
 interface Port-Channel8.222
    vlan id 222
    encapsulation vlan
       client dot1q 222 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0222
-      route-target import 03:03:02:02:02:22
 !
 interface Port-Channel8.333
    vlan id 434
    encapsulation vlan
       client dot1q 333 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0333
-      route-target import 03:03:02:02:03:33
 ```
 
 ### Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -297,10 +297,6 @@ interface Ethernet8
 | Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
 | --------- | --------------------------- | --------------------------- | ------------ |
 | Port-Channel3 | 0000:0000:0102:0000:0034 | all-active | 01:02:00:00:00:34 |
-| Port-Channel8 | 0000:0000:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
-| Port-Channel8.111 | 0000:0000:0303:0202:0111 | all-active | 03:03:02:02:01:11 |
-| Port-Channel8.222 | 0000:0000:0303:0202:0222 | all-active | 03:03:02:02:02:22 |
-| Port-Channel8.333 | 0000:0000:0303:0202:0333 | all-active | 03:03:02:02:03:33 |
 
 #### Port-Channel Interfaces Device Configuration
 
@@ -343,34 +339,21 @@ interface Port-Channel8
    description CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111
    encapsulation vlan
       client dot1q 111 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0111
-      route-target import 03:03:02:02:01:11
 !
 interface Port-Channel8.222
    vlan id 222
    encapsulation vlan
       client dot1q 222 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0222
-      route-target import 03:03:02:02:02:22
 !
 interface Port-Channel8.333
    vlan id 434
    encapsulation vlan
       client dot1q 333 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0333
-      route-target import 03:03:02:02:03:33
 ```
 
 ### Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -64,34 +64,21 @@ interface Port-Channel8
    description CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111
    encapsulation vlan
       client dot1q 111 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0111
-      route-target import 03:03:02:02:01:11
 !
 interface Port-Channel8.222
    vlan id 222
    encapsulation vlan
       client dot1q 222 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0222
-      route-target import 03:03:02:02:02:22
 !
 interface Port-Channel8.333
    vlan id 434
    encapsulation vlan
       client dot1q 333 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0333
-      route-target import 03:03:02:02:03:33
 !
 interface Ethernet1
    description P2P_LINK_TO_SITE1-LSR1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -66,34 +66,21 @@ interface Port-Channel8
    description CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0101
-      route-target import 03:03:02:02:01:01
-   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111
    encapsulation vlan
       client dot1q 111 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0111
-      route-target import 03:03:02:02:01:11
 !
 interface Port-Channel8.222
    vlan id 222
    encapsulation vlan
       client dot1q 222 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0222
-      route-target import 03:03:02:02:02:22
 !
 interface Port-Channel8.333
    vlan id 434
    encapsulation vlan
       client dot1q 333 network client
-   evpn ethernet-segment
-      identifier 0000:0000:0303:0202:0333
-      route-target import 03:03:02:02:03:33
 !
 interface Ethernet1
    description P2P_LINK_TO_SITE1-LSR2_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -436,10 +436,6 @@ port_channel_interfaces:
   description: CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
   type: routed
   shutdown: false
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0101
-    route_target: 03:03:02:02:01:01
-  lacp_id: 0303.0202.0101
 - name: Port-Channel8.111
   type: l2dot1q
   vlan_id: 111
@@ -449,9 +445,6 @@ port_channel_interfaces:
         vlan: 111
     network:
       client: true
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0111
-    route_target: 03:03:02:02:01:11
 - name: Port-Channel8.222
   type: l2dot1q
   vlan_id: 222
@@ -461,9 +454,6 @@ port_channel_interfaces:
         vlan: 222
     network:
       client: true
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0222
-    route_target: 03:03:02:02:02:22
 - name: Port-Channel8.333
   type: l2dot1q
   vlan_id: 434
@@ -473,9 +463,6 @@ port_channel_interfaces:
         vlan: 333
     network:
       client: true
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0333
-    route_target: 03:03:02:02:03:33
 router_ospf:
   process_ids:
   - id: 19

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -466,10 +466,6 @@ port_channel_interfaces:
   description: CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
   type: routed
   shutdown: false
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0101
-    route_target: 03:03:02:02:01:01
-  lacp_id: 0303.0202.0101
 - name: Port-Channel8.111
   type: l2dot1q
   vlan_id: 111
@@ -479,9 +475,6 @@ port_channel_interfaces:
         vlan: 111
     network:
       client: true
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0111
-    route_target: 03:03:02:02:01:11
 - name: Port-Channel8.222
   type: l2dot1q
   vlan_id: 222
@@ -491,9 +484,6 @@ port_channel_interfaces:
         vlan: 222
     network:
       client: true
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0222
-    route_target: 03:03:02:02:02:22
 - name: Port-Channel8.333
   type: l2dot1q
   vlan_id: 434
@@ -503,8 +493,5 @@ port_channel_interfaces:
         vlan: 333
     network:
       client: true
-  evpn_ethernet_segment:
-    identifier: 0000:0000:0303:0202:0333
-    route_target: 03:03:02:02:03:33
 metadata:
   platform: 7280SR3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
@@ -87,6 +87,14 @@ interface Port-Channel3
    switchport mode trunk
    switchport trunk group MLAG
 !
+interface Port-Channel5
+   description server03_ESI_L2LEAF_PortChanne1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+   mlag 5
+!
 interface Ethernet1
    description DC1-LEAF2A_Ethernet7
    no shutdown
@@ -110,6 +118,11 @@ interface Ethernet4
    no shutdown
    speed forced 40gfull
    channel-group 3 mode active
+!
+interface Ethernet5
+   description server03_ESI_L2LEAF_Eth1
+   no shutdown
+   channel-group 5 mode active
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
@@ -87,6 +87,14 @@ interface Port-Channel3
    switchport mode trunk
    switchport trunk group MLAG
 !
+interface Port-Channel5
+   description server03_ESI_L2LEAF_PortChanne1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode trunk
+   mlag 5
+!
 interface Ethernet1
    description DC1-LEAF2A_Ethernet8
    no shutdown
@@ -110,6 +118,11 @@ interface Ethernet4
    no shutdown
    speed forced 40gfull
    channel-group 3 mode active
+!
+interface Ethernet5
+   description server03_ESI_L2LEAF_Eth2
+   no shutdown
+   channel-group 5 mode active
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -133,6 +133,13 @@ port_channel_interfaces:
   mode: trunk
   vlans: 110-112,120-121,130-131,160-161
   mlag: 1
+- name: Port-Channel5
+  description: server03_ESI_L2LEAF_PortChanne1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: 110-111,210-211
+  mlag: 5
 ethernet_interfaces:
 - name: Ethernet3
   peer: DC1-L2LEAF1B
@@ -177,6 +184,17 @@ ethernet_interfaces:
   type: port-channel-member
   channel_group:
     id: 1
+    mode: active
+- name: Ethernet5
+  peer: server03_ESI_L2LEAF
+  peer_interface: Eth1
+  peer_type: server
+  port_profile: TENANT_A_B
+  description: server03_ESI_L2LEAF_Eth1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 5
     mode: active
 mlag_configuration:
   domain_id: DC1_L2LEAF1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -133,6 +133,13 @@ port_channel_interfaces:
   mode: trunk
   vlans: 110-112,120-121,130-131,160-161
   mlag: 1
+- name: Port-Channel5
+  description: server03_ESI_L2LEAF_PortChanne1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: 110-111,210-211
+  mlag: 5
 ethernet_interfaces:
 - name: Ethernet3
   peer: DC1-L2LEAF1A
@@ -177,6 +184,17 @@ ethernet_interfaces:
   type: port-channel-member
   channel_group:
     id: 1
+    mode: active
+- name: Ethernet5
+  peer: server03_ESI_L2LEAF
+  peer_interface: Eth2
+  peer_type: server
+  port_profile: TENANT_A_B
+  description: server03_ESI_L2LEAF_Eth2
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 5
     mode: active
 mlag_configuration:
   domain_id: DC1_L2LEAF1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_SERVERS.yml
@@ -213,6 +213,20 @@ servers:
           description: PortChanne1
           mode: active
 
+  # Test short_esi on non-vtep device.
+  - name: server03_ESI_L2LEAF
+    rack: RackC
+    adapters:
+      - endpoint_ports: [ Eth1, Eth2 ]
+        switch_ports: [ Ethernet5, Ethernet5 ]
+        switches: [ DC1-L2LEAF1A, DC1-L2LEAF1B ]
+        profile: TENANT_A_B
+        ethernet_segment:
+          short_esi: '0303:0202:0101'
+        port_channel:
+          description: PortChanne1
+          mode: active
+
   - name: server04_inherit_all_from_profile
     rack: RackC
     adapters:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
@@ -97,18 +97,15 @@ class UtilsMixin:
         """
         Return short_esi for one adapter
         """
-        if len(set(adapter["switches"])) < 2:
+        if len(set(adapter["switches"])) < 2 and not self.shared_utils.overlay_evpn and not self.shared_utils.overlay_vtep:
             # Only configure ESI for multi-homing.
             return None
 
         # short_esi is only set when called from sub-interface port-channels.
         if short_esi is None:
             # Setting short_esi under port_channel will be removed in AVD5.0
-            if self._hostvars["type"] != "l2leaf":
-                port_channel_short_esi = get(adapter, "port_channel.short_esi")
-                if (short_esi := get(adapter, "ethernet_segment.short_esi", default=port_channel_short_esi)) is None:
-                    return None
-            else:
+            port_channel_short_esi = get(adapter, "port_channel.short_esi")
+            if (short_esi := get(adapter, "ethernet_segment.short_esi", default=port_channel_short_esi)) is None:
                 return None
 
         endpoint_ports: list = adapter.get("endpoint_ports")

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
@@ -97,7 +97,7 @@ class UtilsMixin:
         """
         Return short_esi for one adapter
         """
-        if len(set(adapter["switches"])) < 2 and not self.shared_utils.overlay_evpn and not self.shared_utils.overlay_vtep:
+        if len(set(adapter["switches"])) < 2 or not self.shared_utils.overlay_evpn or not self.shared_utils.overlay_vtep:
             # Only configure ESI for multi-homing.
             return None
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/connected_endpoints/utils.py
@@ -104,8 +104,11 @@ class UtilsMixin:
         # short_esi is only set when called from sub-interface port-channels.
         if short_esi is None:
             # Setting short_esi under port_channel will be removed in AVD5.0
-            port_channel_short_esi = get(adapter, "port_channel.short_esi")
-            if (short_esi := get(adapter, "ethernet_segment.short_esi", default=port_channel_short_esi)) is None:
+            if self._hostvars["type"] != "l2leaf":
+                port_channel_short_esi = get(adapter, "port_channel.short_esi")
+                if (short_esi := get(adapter, "ethernet_segment.short_esi", default=port_channel_short_esi)) is None:
+                    return None
+            else:
                 return None
 
         endpoint_ports: list = adapter.get("endpoint_ports")


### PR DESCRIPTION
## Change Summary

 Connected endpoints ESI should only matter for EVPN VTEPs. It is not needed to configure short_esi on l2leafs. 

## Related Issue(s)

Fixes #3064

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Change python module to skip generating short_esi for l2leafs.

## How to test
Add short_esi under l2leaf and make sure it is not generated in structured config.

## Checklist

### User Checklist



### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
