### PR TITLE
Feat(eos_cli_config_gen): Add Regex pattern for region/zone/site name for router_adapative_virtual_topology

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-adaptive-virtual-topology.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-adaptive-virtual-topology.md
@@ -10,13 +10,13 @@
     | [<samp>router_adaptive_virtual_topology</samp>](## "router_adaptive_virtual_topology") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;topology_role</samp>](## "router_adaptive_virtual_topology.topology_role") | String |  |  | Valid Values:<br>- <code>edge</code><br>- <code>pathfinder</code><br>- <code>transit region</code><br>- <code>transit zone</code> | Role name. |
     | [<samp>&nbsp;&nbsp;region</samp>](## "router_adaptive_virtual_topology.region") | Dictionary |  |  |  | Region name and ID. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_adaptive_virtual_topology.region.name") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_adaptive_virtual_topology.region.name") | String | Required |  | Pattern: ^[A-Za-z0-9_.:{}\[\]-]+$ |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "router_adaptive_virtual_topology.region.id") | Integer | Required |  | Min: 1<br>Max: 255 |  |
     | [<samp>&nbsp;&nbsp;zone</samp>](## "router_adaptive_virtual_topology.zone") | Dictionary |  |  |  | Zone name and ID. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_adaptive_virtual_topology.zone.name") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_adaptive_virtual_topology.zone.name") | String | Required |  | Pattern: ^[A-Za-z0-9_.:{}\[\]-]+$ |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "router_adaptive_virtual_topology.zone.id") | Integer | Required |  | Min: 1<br>Max: 10000 |  |
     | [<samp>&nbsp;&nbsp;site</samp>](## "router_adaptive_virtual_topology.site") | Dictionary |  |  |  | Site name and ID. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_adaptive_virtual_topology.site.name") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "router_adaptive_virtual_topology.site.name") | String | Required |  | Pattern: ^[A-Za-z0-9_.:{}\[\]-]+$ |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "router_adaptive_virtual_topology.site.id") | Integer | Required |  | Min: 1<br>Max: 10000 |  |
     | [<samp>&nbsp;&nbsp;profiles</samp>](## "router_adaptive_virtual_topology.profiles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_adaptive_virtual_topology.profiles.[].name") | String | Required, Unique |  |  | AVT Name. |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -16580,6 +16580,7 @@
           "properties": {
             "name": {
               "type": "string",
+              "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
               "title": "Name"
             },
             "id": {
@@ -16605,6 +16606,7 @@
           "properties": {
             "name": {
               "type": "string",
+              "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
               "title": "Name"
             },
             "id": {
@@ -16630,6 +16632,7 @@
           "properties": {
             "name": {
               "type": "string",
+              "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
               "title": "Name"
             },
             "id": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -9904,6 +9904,7 @@ keys:
           name:
             type: str
             required: true
+            pattern: ^[A-Za-z0-9_.:{}\[\]-]+$
           id:
             type: int
             convert_types:
@@ -9918,6 +9919,7 @@ keys:
           name:
             type: str
             required: true
+            pattern: ^[A-Za-z0-9_.:{}\[\]-]+$
           id:
             type: int
             convert_types:
@@ -9932,6 +9934,7 @@ keys:
           name:
             type: str
             required: true
+            pattern: ^[A-Za-z0-9_.:{}\[\]-]+$
           id:
             type: int
             convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_adaptive_virtual_topology.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_adaptive_virtual_topology.schema.yml
@@ -24,6 +24,7 @@ keys:
           name:
             type: str
             required: true
+            pattern: '^[A-Za-z0-9_.:{}\[\]-]+$'
           id:
             type: int
             convert_types:
@@ -38,6 +39,7 @@ keys:
           name:
             type: str
             required: true
+            pattern: '^[A-Za-z0-9_.:{}\[\]-]+$'
           id:
             type: int
             convert_types:
@@ -52,6 +54,7 @@ keys:
           name:
             type: str
             required: true
+            pattern: '^[A-Za-z0-9_.:{}\[\]-]+$'
           id:
             type: int
             convert_types:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-cv-pathfinder-regions.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-cv-pathfinder-regions.md
@@ -12,11 +12,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "cv_pathfinder_global_sites.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;location</samp>](## "cv_pathfinder_global_sites.[].location") | String |  |  |  | Location as a string is resolved on Cloudvision. |
     | [<samp>cv_pathfinder_regions</samp>](## "cv_pathfinder_regions") | List, items: Dictionary |  |  |  | Define the CV Pathfinder hierarchy. |
-    | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "cv_pathfinder_regions.[].name") | String | Required, Unique |  | Pattern: ^[A-Za-z0-9_.:{}\[\]-]+$ |  |
+    | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "cv_pathfinder_regions.[].name") | String | Required, Unique |  | Min Length: 1<br>Max Length: 128<br>Pattern: ^[A-Za-z0-9_.:{}\[\]-]+$ |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "cv_pathfinder_regions.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "cv_pathfinder_regions.[].id") | Integer | Required |  | Min: 1<br>Max: 255 | The region ID must be unique for the whole WAN deployment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sites</samp>](## "cv_pathfinder_regions.[].sites") | List, items: Dictionary |  |  |  | All sites are placed in a default zone "<region_name>-ZONE" with ID 1. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "cv_pathfinder_regions.[].sites.[].name") | String | Required, Unique |  | Pattern: ^[A-Za-z0-9_.:{}\[\]-]+$ | The site name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "cv_pathfinder_regions.[].sites.[].name") | String | Required, Unique |  | Min Length: 1<br>Max Length: 128<br>Pattern: ^[A-Za-z0-9_.:{}\[\]-]+$ | The site name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "cv_pathfinder_regions.[].sites.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "cv_pathfinder_regions.[].sites.[].id") | Integer | Required |  | Min: 1<br>Max: 10000 | The site ID must be unique within a zone.<br>Given that all the sites are placed in a zone named after the region, the site ID must be unique within a region. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;location</samp>](## "cv_pathfinder_regions.[].sites.[].location") | String |  |  |  | Location as a string is resolved on Cloudvision. |
@@ -39,7 +39,7 @@
 
     # Define the CV Pathfinder hierarchy.
     cv_pathfinder_regions:
-      - name: <str; required; unique>
+      - name: <str; length 1-128; required; unique>
         description: <str>
 
         # The region ID must be unique for the whole WAN deployment.
@@ -49,7 +49,7 @@
         sites:
 
             # The site name.
-          - name: <str; required; unique>
+          - name: <str; length 1-128; required; unique>
             description: <str>
 
             # The site ID must be unique within a zone.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-cv-pathfinder-regions.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-cv-pathfinder-regions.md
@@ -12,11 +12,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "cv_pathfinder_global_sites.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;location</samp>](## "cv_pathfinder_global_sites.[].location") | String |  |  |  | Location as a string is resolved on Cloudvision. |
     | [<samp>cv_pathfinder_regions</samp>](## "cv_pathfinder_regions") | List, items: Dictionary |  |  |  | Define the CV Pathfinder hierarchy. |
-    | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "cv_pathfinder_regions.[].name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "cv_pathfinder_regions.[].name") | String | Required, Unique |  | Pattern: ^[A-Za-z0-9_.:{}\[\]-]+$ |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "cv_pathfinder_regions.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "cv_pathfinder_regions.[].id") | Integer | Required |  | Min: 1<br>Max: 255 | The region ID must be unique for the whole WAN deployment. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sites</samp>](## "cv_pathfinder_regions.[].sites") | List, items: Dictionary |  |  |  | All sites are placed in a default zone "<region_name>-ZONE" with ID 1. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "cv_pathfinder_regions.[].sites.[].name") | String | Required, Unique |  |  | The site name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "cv_pathfinder_regions.[].sites.[].name") | String | Required, Unique |  | Pattern: ^[A-Za-z0-9_.:{}\[\]-]+$ | The site name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "cv_pathfinder_regions.[].sites.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;id</samp>](## "cv_pathfinder_regions.[].sites.[].id") | Integer | Required |  | Min: 1<br>Max: 10000 | The site ID must be unique within a zone.<br>Given that all the sites are placed in a zone named after the region, the site ID must be unique within a region. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;location</samp>](## "cv_pathfinder_regions.[].sites.[].location") | String |  |  |  | Location as a string is resolved on Cloudvision. |

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4647,6 +4647,8 @@
         "properties": {
           "name": {
             "type": "string",
+            "minLength": 1,
+            "maxLength": 128,
             "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
             "title": "Name"
           },
@@ -4670,6 +4672,8 @@
                 "name": {
                   "type": "string",
                   "description": "The site name.",
+                  "minLength": 1,
+                  "maxLength": 128,
                   "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
                   "title": "Name"
                 },

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -4647,6 +4647,7 @@
         "properties": {
           "name": {
             "type": "string",
+            "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
             "title": "Name"
           },
           "description": {
@@ -4669,6 +4670,7 @@
                 "name": {
                   "type": "string",
                   "description": "The site name.",
+                  "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
                   "title": "Name"
                 },
                 "description": {
@@ -33299,6 +33301,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
+                        "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
                         "title": "Name"
                       },
                       "id": {
@@ -33324,6 +33327,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
+                        "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
                         "title": "Name"
                       },
                       "id": {
@@ -33349,6 +33353,7 @@
                     "properties": {
                       "name": {
                         "type": "string",
+                        "pattern": "^[A-Za-z0-9_.:{}\\[\\]-]+$",
                         "title": "Name"
                       },
                       "id": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.schema.yml
@@ -704,6 +704,8 @@ keys:
       keys:
         name:
           type: str
+          min_length: 1
+          max_length: 128
         description:
           type: str
         id:
@@ -721,6 +723,8 @@ keys:
               name:
                 type: str
                 description: The site name.
+                min_length: 1
+                max_length: 128
               description:
                 type: str
               id:

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/cv_pathfinder_regions.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/cv_pathfinder_regions.schema.yml
@@ -18,6 +18,8 @@ keys:
       keys:
         name:
           type: str
+          min_length: 1
+          max_length: 128
         description:
           type: str
         id:
@@ -37,6 +39,8 @@ keys:
                 type: str
                 description: |-
                   The site name.
+                min_length: 1
+                max_length: 128
               description:
                 type: str
               id:


### PR DESCRIPTION
## Change Summary
Add pattern `'^[A-Za-z0-9_.:{}\[\]-]+$'` for the region/zone/site name fields.

## Related Issue(s)

Fixes #4001 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes


## How to test
manual

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
