### PR TITLE
Feat(eos_cli_config_gen): Add option for `ospf_type` when redistributing OSPF into BGP

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -226,7 +226,7 @@ router bgp 65101
    redistribute ospf include leaked
    redistribute ospf match internal
    redistribute ospf match external
-   redistribute ospf match nssa-external 1
+   redistribute ospf match nssa-external 1 include leaked route-map RM-REDISTRIBUTE-OSPF-NSSA-1
    redistribute static rcf Router_BGP_Static()
    !
    address-family ipv4
@@ -244,7 +244,7 @@ router bgp 65101
       redistribute connected include leaked rcf Address_Family_IPV4_Connected()
       redistribute dynamic route-map Address_Family_IPV4_Dynamic_RM
       redistribute ospf match internal include leaked
-      redistribute ospf match external
+      redistribute ospf match external include leaked route-map RM-REDISTRIBUTE-OSPF-EXTERNAL
       redistribute ospf match nssa-external
       redistribute static rcf Address_Family_IPV4_Static()
    !
@@ -260,9 +260,8 @@ router bgp 65101
       redistribute bgp leaked route-map RM-REDISTRIBUTE-BGP
       redistribute connected rcf Address_Family_IPV6_Connected()
       redistribute ospfv3 match external include leaked
-      redistribute ospfv3 match internal
+      redistribute ospfv3 match internal include leaked route-map RM-REDISTRIBUTE-OSPF-INTERNAL
       redistribute ospfv3 match nssa-external 1
-      redistribute ospfv3 include leaked
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
    session tracker ST1
       recovery delay 666 seconds

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-base.md
@@ -224,6 +224,9 @@ router bgp 65101
    redistribute bgp leaked route-map RM-REDISTRIBUTE-BGP
    redistribute connected rcf Router_BGP_Connected()
    redistribute ospf include leaked
+   redistribute ospf match internal
+   redistribute ospf match external
+   redistribute ospf match nssa-external 1
    redistribute static rcf Router_BGP_Static()
    !
    address-family ipv4
@@ -240,6 +243,9 @@ router bgp 65101
       redistribute bgp leaked
       redistribute connected include leaked rcf Address_Family_IPV4_Connected()
       redistribute dynamic route-map Address_Family_IPV4_Dynamic_RM
+      redistribute ospf match internal include leaked
+      redistribute ospf match external
+      redistribute ospf match nssa-external
       redistribute static rcf Address_Family_IPV4_Static()
    !
    address-family ipv6
@@ -253,6 +259,9 @@ router bgp 65101
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute bgp leaked route-map RM-REDISTRIBUTE-BGP
       redistribute connected rcf Address_Family_IPV6_Connected()
+      redistribute ospfv3 match external include leaked
+      redistribute ospfv3 match internal
+      redistribute ospfv3 match nssa-external 1
       redistribute ospfv3 include leaked
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
    session tracker ST1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-v4-v6-evpn.md
@@ -141,7 +141,7 @@ ASN Notation: asplain
 
 | VRF | Route-Distinguisher | Redistribute |
 | --- | ------------------- | ------------ |
-| Tenant_A | 10.50.64.15:30001 | connected |
+| Tenant_A | 10.50.64.15:30001 | ospf<br>ospfv3<br>ospfv3<br>connected |
 | Tenant_B | 10.50.64.15:30002 | - |
 
 #### Router BGP Device Configuration
@@ -241,6 +241,9 @@ router bgp 65100
       neighbor IPV4-UNDERLAY-MLAG activate
       redistribute attached-host
       redistribute isis rcf Router_BGP_Isis()
+      redistribute ospf match external
+      redistribute ospf match internal
+      redistribute ospf match nssa-external 2
    !
    address-family ipv6
       neighbor IPV6-UNDERLAY route-map RM-HIDE-AS-PATH in
@@ -260,6 +263,9 @@ router bgp 65100
       route-target export evpn 1:30001
       route-target export evpn rcf RT_EXPORT_AF_RCF()
       redistribute connected
+      redistribute ospf match external include leaked
+      redistribute ospfv3 match internal
+      redistribute ospfv3 match nssa-external
    !
    vrf Tenant_B
       rd 10.50.64.15:30002

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-address-families.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-address-families.md
@@ -81,6 +81,9 @@ router bgp 65001
    address-family ipv6 multicast
       no neighbor FOOBAR activate
       redistribute isis rcf Router_BGP_Isis()
+      redistribute ospf match internal
+      redistribute ospfv3 match external
+      redistribute ospfv3 match nssa-external 2
    !
    vrf VRF01
       !
@@ -105,6 +108,9 @@ router bgp 65001
          neighbor 1.2.3.4 route-map BAR out
          network 2.3.4.0/24 route-map BARFOO
          redistribute connected rcf VRF_AFIPV4_RCF_CONNECTED_1()
+         redistribute ospf match external
+         redistribute ospf match nssa-external 1
+         redistribute ospfv3 match internal
          redistribute static route-map VRF_AFIPV4_RM_STATIC_1
       !
       address-family ipv4 multicast
@@ -115,6 +121,9 @@ router bgp 65001
          neighbor 1.2.3.4 route-map BAR out
          network 239.0.0.0/24 route-map BARFOO
          redistribute connected
+         redistribute ospf match internal
+         redistribute ospf match nssa-external 2
+         redistribute ospfv3 match external
          redistribute static route-map VRF_AFIPV4MULTI_RM_STATIC
       !
       address-family ipv6
@@ -132,6 +141,9 @@ router bgp 65001
          network aa::/64
       redistribute connected rcf VRF_AFIPV6_RCF_CONNECTED()
       redistribute isis include leaked
+      redistribute ospfv3 match external
+      redistribute ospfv3 match internal include leaked
+      redistribute ospfv3 match nssa-external
       redistribute static route-map VRF_AFIPV6_RM_STATIC
       !
       address-family ipv6 multicast
@@ -139,6 +151,9 @@ router bgp 65001
          bgp missing-policy direction out action deny
          network ff08:1::/64
          redistribute connected
+         redistribute ospf match external
+         redistribute ospf match nssa-external
+         redistribute ospfv3 match internal
          redistribute static route-map VRF_AFIPV6MULTI_RM_STATIC
    !
    vrf VRF02

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -93,6 +93,9 @@ router bgp 65101
    redistribute bgp leaked route-map RM-REDISTRIBUTE-BGP
    redistribute connected rcf Router_BGP_Connected()
    redistribute ospf include leaked
+   redistribute ospf match internal
+   redistribute ospf match external
+   redistribute ospf match nssa-external 1
    redistribute static rcf Router_BGP_Static()
    !
    address-family ipv4
@@ -109,6 +112,9 @@ router bgp 65101
       redistribute bgp leaked
       redistribute connected include leaked rcf Address_Family_IPV4_Connected()
       redistribute dynamic route-map Address_Family_IPV4_Dynamic_RM
+      redistribute ospf match internal include leaked
+      redistribute ospf match external
+      redistribute ospf match nssa-external
       redistribute static rcf Address_Family_IPV4_Static()
    !
    address-family ipv6
@@ -122,6 +128,9 @@ router bgp 65101
       network 2001:db8:200::/40 route-map RM-BAR-MATCH
       redistribute bgp leaked route-map RM-REDISTRIBUTE-BGP
       redistribute connected rcf Address_Family_IPV6_Connected()
+      redistribute ospfv3 match external include leaked
+      redistribute ospfv3 match internal
+      redistribute ospfv3 match nssa-external 1
       redistribute ospfv3 include leaked
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
    session tracker ST1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-base.cfg
@@ -95,7 +95,7 @@ router bgp 65101
    redistribute ospf include leaked
    redistribute ospf match internal
    redistribute ospf match external
-   redistribute ospf match nssa-external 1
+   redistribute ospf match nssa-external 1 include leaked route-map RM-REDISTRIBUTE-OSPF-NSSA-1
    redistribute static rcf Router_BGP_Static()
    !
    address-family ipv4
@@ -113,7 +113,7 @@ router bgp 65101
       redistribute connected include leaked rcf Address_Family_IPV4_Connected()
       redistribute dynamic route-map Address_Family_IPV4_Dynamic_RM
       redistribute ospf match internal include leaked
-      redistribute ospf match external
+      redistribute ospf match external include leaked route-map RM-REDISTRIBUTE-OSPF-EXTERNAL
       redistribute ospf match nssa-external
       redistribute static rcf Address_Family_IPV4_Static()
    !
@@ -129,9 +129,8 @@ router bgp 65101
       redistribute bgp leaked route-map RM-REDISTRIBUTE-BGP
       redistribute connected rcf Address_Family_IPV6_Connected()
       redistribute ospfv3 match external include leaked
-      redistribute ospfv3 match internal
+      redistribute ospfv3 match internal include leaked route-map RM-REDISTRIBUTE-OSPF-INTERNAL
       redistribute ospfv3 match nssa-external 1
-      redistribute ospfv3 include leaked
       redistribute static route-map RM-IPV6-STATIC-TO-BGP
    session tracker ST1
       recovery delay 666 seconds

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-v4-v6-evpn.cfg
@@ -105,6 +105,9 @@ router bgp 65100
       neighbor IPV4-UNDERLAY-MLAG activate
       redistribute attached-host
       redistribute isis rcf Router_BGP_Isis()
+      redistribute ospf match external
+      redistribute ospf match internal
+      redistribute ospf match nssa-external 2
    !
    address-family ipv6
       neighbor IPV6-UNDERLAY route-map RM-HIDE-AS-PATH in
@@ -124,6 +127,9 @@ router bgp 65100
       route-target export evpn 1:30001
       route-target export evpn rcf RT_EXPORT_AF_RCF()
       redistribute connected
+      redistribute ospf match external include leaked
+      redistribute ospfv3 match internal
+      redistribute ospfv3 match nssa-external
    !
    vrf Tenant_B
       rd 10.50.64.15:30002

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-address-families.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-address-families.cfg
@@ -34,6 +34,9 @@ router bgp 65001
    address-family ipv6 multicast
       no neighbor FOOBAR activate
       redistribute isis rcf Router_BGP_Isis()
+      redistribute ospf match internal
+      redistribute ospfv3 match external
+      redistribute ospfv3 match nssa-external 2
    !
    vrf VRF01
       !
@@ -58,6 +61,9 @@ router bgp 65001
          neighbor 1.2.3.4 route-map BAR out
          network 2.3.4.0/24 route-map BARFOO
          redistribute connected rcf VRF_AFIPV4_RCF_CONNECTED_1()
+         redistribute ospf match external
+         redistribute ospf match nssa-external 1
+         redistribute ospfv3 match internal
          redistribute static route-map VRF_AFIPV4_RM_STATIC_1
       !
       address-family ipv4 multicast
@@ -68,6 +74,9 @@ router bgp 65001
          neighbor 1.2.3.4 route-map BAR out
          network 239.0.0.0/24 route-map BARFOO
          redistribute connected
+         redistribute ospf match internal
+         redistribute ospf match nssa-external 2
+         redistribute ospfv3 match external
          redistribute static route-map VRF_AFIPV4MULTI_RM_STATIC
       !
       address-family ipv6
@@ -85,6 +94,9 @@ router bgp 65001
          network aa::/64
       redistribute connected rcf VRF_AFIPV6_RCF_CONNECTED()
       redistribute isis include leaked
+      redistribute ospfv3 match external
+      redistribute ospfv3 match internal include leaked
+      redistribute ospfv3 match nssa-external
       redistribute static route-map VRF_AFIPV6_RM_STATIC
       !
       address-family ipv6 multicast
@@ -92,6 +104,9 @@ router bgp 65001
          bgp missing-policy direction out action deny
          network ff08:1::/64
          redistribute connected
+         redistribute ospf match external
+         redistribute ospf match nssa-external
+         redistribute ospfv3 match internal
          redistribute static route-map VRF_AFIPV6MULTI_RM_STATIC
    !
    vrf VRF02

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -77,11 +77,11 @@ router_bgp:
     - source_protocol: ospf
       include_leaked: true
     - source_protocol: ospf
-      ospf_match_internal: true
+      ospf_route_type: internal
     - source_protocol: ospf
-      ospf_match_external: true
+      ospf_route_type: external
     - source_protocol: ospf
-      ospf_match_nssa_external: nssa-external 1
+      ospf_route_type: nssa-external 1
     - source_protocol: bgp
       route_map: RM-REDISTRIBUTE-BGP
       # this should not do anything as leaked is generated when source protocol is bgp
@@ -114,11 +114,11 @@ router_bgp:
     redistribute_routes:
       - source_protocol: ospf
         include_leaked: true
-        ospf_match_internal: true
+        ospf_route_type: internal
       - source_protocol: ospf
-        ospf_match_external: true
+        ospf_route_type: external
       - source_protocol: ospf
-        ospf_match_nssa_external: nssa-external
+        ospf_route_type: nssa-external
       - source_protocol: connected
         include_leaked: true
         rcf: Address_Family_IPV4_Connected()
@@ -146,11 +146,11 @@ router_bgp:
     redistribute_routes:
       - source_protocol: ospfv3
         include_leaked: true
-        ospf_match_external: true
+        ospf_route_type: external
       - source_protocol: ospfv3
-        ospf_match_internal: true
+        ospf_route_type: internal
       - source_protocol: ospfv3
-        ospf_match_nssa_external: nssa-external 1
+        ospf_route_type: nssa-external 1
       - source_protocol: static
         route_map: RM-IPV6-STATIC-TO-BGP
       - source_protocol: ospfv3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -82,6 +82,8 @@ router_bgp:
       ospf_route_type: external
     - source_protocol: ospf
       ospf_route_type: nssa-external 1
+      route_map: RM-REDISTRIBUTE-OSPF-NSSA-1
+      include_leaked: true
     - source_protocol: bgp
       route_map: RM-REDISTRIBUTE-BGP
       # this should not do anything as leaked is generated when source protocol is bgp
@@ -117,6 +119,8 @@ router_bgp:
         ospf_route_type: internal
       - source_protocol: ospf
         ospf_route_type: external
+        route_map: RM-REDISTRIBUTE-OSPF-EXTERNAL
+        include_leaked: true
       - source_protocol: ospf
         ospf_route_type: nssa-external
       - source_protocol: connected
@@ -149,12 +153,12 @@ router_bgp:
         ospf_route_type: external
       - source_protocol: ospfv3
         ospf_route_type: internal
+        route_map: RM-REDISTRIBUTE-OSPF-INTERNAL
+        include_leaked: true
       - source_protocol: ospfv3
         ospf_route_type: nssa-external 1
       - source_protocol: static
         route_map: RM-IPV6-STATIC-TO-BGP
-      - source_protocol: ospfv3
-        include_leaked: true
       - source_protocol: bgp
         route_map: RM-REDISTRIBUTE-BGP
         # this should not do anything as leaked is generated when source protocol is bgp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-base.yml
@@ -76,6 +76,12 @@ router_bgp:
   redistribute_routes:
     - source_protocol: ospf
       include_leaked: true
+    - source_protocol: ospf
+      ospf_match_internal: true
+    - source_protocol: ospf
+      ospf_match_external: true
+    - source_protocol: ospf
+      ospf_match_nssa_external: nssa-external 1
     - source_protocol: bgp
       route_map: RM-REDISTRIBUTE-BGP
       # this should not do anything as leaked is generated when source protocol is bgp
@@ -106,6 +112,13 @@ router_bgp:
       - ip_address: 10.2.3.9
         rcf_out: Address_Family_IPV4_Out()
     redistribute_routes:
+      - source_protocol: ospf
+        include_leaked: true
+        ospf_match_internal: true
+      - source_protocol: ospf
+        ospf_match_external: true
+      - source_protocol: ospf
+        ospf_match_nssa_external: nssa-external
       - source_protocol: connected
         include_leaked: true
         rcf: Address_Family_IPV4_Connected()
@@ -131,6 +144,13 @@ router_bgp:
         rcf_in: Address_Family_IPV6_In()
         rcf_out: Address_Family_IPV6_Out()
     redistribute_routes:
+      - source_protocol: ospfv3
+        include_leaked: true
+        ospf_match_external: true
+      - source_protocol: ospfv3
+        ospf_match_internal: true
+      - source_protocol: ospfv3
+        ospf_match_nssa_external: nssa-external 1
       - source_protocol: static
         route_map: RM-IPV6-STATIC-TO-BGP
       - source_protocol: ospfv3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-evpn.yml
@@ -99,11 +99,11 @@ router_bgp:
         activate: true
     redistribute_routes:
       - source_protocol: ospf
-        ospf_match_external: true
+        ospf_route_type: external
       - source_protocol: ospf
-        ospf_match_internal: true
+        ospf_route_type: internal
       - source_protocol: ospf
-        ospf_match_nssa_external: nssa-external 2
+        ospf_route_type: nssa-external 2
       - source_protocol: attached-host
       - source_protocol: isis
         rcf: Router_BGP_Isis()
@@ -170,11 +170,11 @@ router_bgp:
       redistribute_routes:
         - source_protocol: ospf
           include_leaked: true
-          ospf_match_external: true
+          ospf_route_type: external
         - source_protocol: ospfv3
-          ospf_match_internal: true
+          ospf_route_type: internal
         - source_protocol: ospfv3
-          ospf_match_nssa_external: nssa-external
+          ospf_route_type: nssa-external
         - source_protocol: connected
     - name: Tenant_B
       rd: "10.50.64.15:30002"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-evpn.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-v4-v6-evpn.yml
@@ -98,6 +98,12 @@ router_bgp:
       - name: IPV4-UNDERLAY-MLAG
         activate: true
     redistribute_routes:
+      - source_protocol: ospf
+        ospf_match_external: true
+      - source_protocol: ospf
+        ospf_match_internal: true
+      - source_protocol: ospf
+        ospf_match_nssa_external: nssa-external 2
       - source_protocol: attached-host
       - source_protocol: isis
         rcf: Router_BGP_Isis()
@@ -162,6 +168,13 @@ router_bgp:
               - "1:30001"
             rcf: RT_EXPORT_AF_RCF()
       redistribute_routes:
+        - source_protocol: ospf
+          include_leaked: true
+          ospf_match_external: true
+        - source_protocol: ospfv3
+          ospf_match_internal: true
+        - source_protocol: ospfv3
+          ospf_match_nssa_external: nssa-external
         - source_protocol: connected
     - name: Tenant_B
       rd: "10.50.64.15:30002"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-address-families.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-address-families.yml
@@ -22,6 +22,12 @@ router_bgp:
       - name: FOOBAR
         activate: false
     redistribute_routes:
+      - source_protocol: ospfv3
+        ospf_match_external: true
+      - source_protocol: ospf
+        ospf_match_internal: true
+      - source_protocol: ospfv3
+        ospf_match_nssa_external: nssa-external 2
       - source_protocol: isis
         rcf: Router_BGP_Isis()
   address_family_flow_spec_ipv4:
@@ -53,6 +59,12 @@ router_bgp:
           - prefix: 2.3.4.0/24
             route_map: BARFOO
         redistribute_routes:
+          - source_protocol: ospf
+            ospf_match_external: true
+          - source_protocol: ospfv3
+            ospf_match_internal: true
+          - source_protocol: ospf
+            ospf_match_nssa_external: nssa-external 1
           - source_protocol: connected
             rcf: VRF_AFIPV4_RCF_CONNECTED_1()
           - source_protocol: static
@@ -79,6 +91,13 @@ router_bgp:
         networks:
           - prefix: aa::/64
         redistribute_routes:
+          - source_protocol: ospfv3
+            ospf_match_external: true
+          - source_protocol: ospfv3
+            include_leaked: true
+            ospf_match_internal: true
+          - source_protocol: ospfv3
+            ospf_match_nssa_external: nssa-external
           - source_protocol: connected
             rcf: VRF_AFIPV6_RCF_CONNECTED()
           - source_protocol: static
@@ -101,6 +120,12 @@ router_bgp:
           - prefix: 239.0.0.0/24
             route_map: BARFOO
         redistribute_routes:
+          - source_protocol: ospfv3
+            ospf_match_external: true
+          - source_protocol: ospf
+            ospf_match_internal: true
+          - source_protocol: ospf
+            ospf_match_nssa_external: nssa-external 2
           - source_protocol: connected
             rcf: VRF_AFIPV4MULTI_RCF_CONNECTED()
           - source_protocol: static
@@ -116,6 +141,12 @@ router_bgp:
         networks:
           - prefix: ff08:1::/64
         redistribute_routes:
+          - source_protocol: ospf
+            ospf_match_external: true
+          - source_protocol: ospfv3
+            ospf_match_internal: true
+          - source_protocol: ospf
+            ospf_match_nssa_external: nssa-external
           - source_protocol: connected
             rcf: VRF_AFIPV6MULTI_RCF_CONNECTED()
           - source_protocol: static

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-address-families.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-vrf-address-families.yml
@@ -23,11 +23,11 @@ router_bgp:
         activate: false
     redistribute_routes:
       - source_protocol: ospfv3
-        ospf_match_external: true
+        ospf_route_type: external
       - source_protocol: ospf
-        ospf_match_internal: true
+        ospf_route_type: internal
       - source_protocol: ospfv3
-        ospf_match_nssa_external: nssa-external 2
+        ospf_route_type: nssa-external 2
       - source_protocol: isis
         rcf: Router_BGP_Isis()
   address_family_flow_spec_ipv4:
@@ -60,11 +60,11 @@ router_bgp:
             route_map: BARFOO
         redistribute_routes:
           - source_protocol: ospf
-            ospf_match_external: true
+            ospf_route_type: external
           - source_protocol: ospfv3
-            ospf_match_internal: true
+            ospf_route_type: internal
           - source_protocol: ospf
-            ospf_match_nssa_external: nssa-external 1
+            ospf_route_type: nssa-external 1
           - source_protocol: connected
             rcf: VRF_AFIPV4_RCF_CONNECTED_1()
           - source_protocol: static
@@ -92,12 +92,12 @@ router_bgp:
           - prefix: aa::/64
         redistribute_routes:
           - source_protocol: ospfv3
-            ospf_match_external: true
+            ospf_route_type: external
           - source_protocol: ospfv3
             include_leaked: true
-            ospf_match_internal: true
+            ospf_route_type: internal
           - source_protocol: ospfv3
-            ospf_match_nssa_external: nssa-external
+            ospf_route_type: nssa-external
           - source_protocol: connected
             rcf: VRF_AFIPV6_RCF_CONNECTED()
           - source_protocol: static
@@ -121,11 +121,11 @@ router_bgp:
             route_map: BARFOO
         redistribute_routes:
           - source_protocol: ospfv3
-            ospf_match_external: true
+            ospf_route_type: external
           - source_protocol: ospf
-            ospf_match_internal: true
+            ospf_route_type: internal
           - source_protocol: ospf
-            ospf_match_nssa_external: nssa-external 2
+            ospf_route_type: nssa-external 2
           - source_protocol: connected
             rcf: VRF_AFIPV4MULTI_RCF_CONNECTED()
           - source_protocol: static
@@ -142,11 +142,11 @@ router_bgp:
           - prefix: ff08:1::/64
         redistribute_routes:
           - source_protocol: ospf
-            ospf_match_external: true
+            ospf_route_type: external
           - source_protocol: ospfv3
-            ospf_match_internal: true
+            ospf_route_type: internal
           - source_protocol: ospf
-            ospf_match_nssa_external: nssa-external
+            ospf_route_type: nssa-external
           - source_protocol: connected
             rcf: VRF_AFIPV6MULTI_RCF_CONNECTED()
           - source_protocol: static

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -180,9 +180,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;vlan_aware_bundles</samp>](## "router_bgp.vlan_aware_bundles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.vlan_aware_bundles.[].name") | String | Required, Unique |  |  | VLAN aware bundle name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenant</samp>](## "router_bgp.vlan_aware_bundles.[].tenant") | String |  |  |  | Key only used for documentation or validation purposes. |
@@ -355,9 +353,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `ospf`, `ospfv3`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;address_family_ipv4_multicast</samp>](## "router_bgp.address_family_ipv4_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_ipv4_multicast.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.address_family_ipv4_multicast.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name. |
@@ -374,9 +370,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;address_family_ipv4_sr_te</samp>](## "router_bgp.address_family_ipv4_sr_te") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_address</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
@@ -415,9 +409,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;address_family_ipv6_multicast</samp>](## "router_bgp.address_family_ipv6_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.address_family_ipv6_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.address_family_ipv6_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -441,9 +433,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;address_family_ipv6_sr_te</samp>](## "router_bgp.address_family_ipv6_sr_te") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_address</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
@@ -670,9 +660,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aggregate_addresses</samp>](## "router_bgp.vrfs.[].aggregate_addresses") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.vrfs.[].aggregate_addresses.[].prefix") | String | Required, Unique |  |  | IPv4 prefix "A.B.C.D/E" or IPv6 prefix "A:B:C:D:E:F:G:H/I". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;advertise_only</samp>](## "router_bgp.vrfs.[].aggregate_addresses.[].advertise_only") | Boolean |  |  |  |  |
@@ -718,9 +706,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv6</samp>](## "router_bgp.vrfs.[].address_family_ipv6") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_ipv6.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_ipv6.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -753,9 +739,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv4_multicast</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -776,9 +760,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv6_multicast</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -799,9 +781,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_flow_spec_ipv4</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv4") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv4.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv4.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -1212,14 +1192,8 @@
           rcf: <str>
           include_leaked: <bool>
 
-          # OSPF routes learned from internal sources.
-          ospf_match_internal: <bool>
-
-          # OSPF routes learned from external sources.
-          ospf_match_external: <bool>
-
-          # OSPF routes learned from external NSSA sources.
-          ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+          # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+          ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       vlan_aware_bundles:
 
           # VLAN aware bundle name.
@@ -1531,14 +1505,8 @@
             # Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
             rcf: <str>
 
-            # OSPF routes learned from internal sources.
-            ospf_match_internal: <bool>
-
-            # OSPF routes learned from external sources.
-            ospf_match_external: <bool>
-
-            # OSPF routes learned from external NSSA sources.
-            ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+            # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+            ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv4_multicast:
         peer_groups:
 
@@ -1573,14 +1541,8 @@
             # Only applicable if `source_protocol` is `isis`.
             rcf: <str>
 
-            # OSPF routes learned from internal sources.
-            ospf_match_internal: <bool>
-
-            # OSPF routes learned from external sources.
-            ospf_match_external: <bool>
-
-            # OSPF routes learned from external NSSA sources.
-            ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+            # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+            ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv4_sr_te:
         neighbors:
           - ip_address: <str; required; unique>
@@ -1669,14 +1631,8 @@
             # Only used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
             rcf: <str>
 
-            # OSPF routes learned from internal sources.
-            ospf_match_internal: <bool>
-
-            # OSPF routes learned from external sources.
-            ospf_match_external: <bool>
-
-            # OSPF routes learned from external NSSA sources.
-            ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+            # The `ospf_route_type` is required with source_protocols 'ospfv3'.
+            ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv6_multicast:
         bgp:
           missing_policy:
@@ -1716,14 +1672,8 @@
             # Only applicable if `source_protocol` is `isis`.
             rcf: <str>
 
-            # OSPF routes learned from internal sources.
-            ospf_match_internal: <bool>
-
-            # OSPF routes learned from external sources.
-            ospf_match_external: <bool>
-
-            # OSPF routes learned from external NSSA sources.
-            ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+            # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+            ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv6_sr_te:
         neighbors:
           - ip_address: <str; required; unique>
@@ -2142,14 +2092,8 @@
               # Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
               rcf: <str>
 
-              # OSPF routes learned from internal sources.
-              ospf_match_internal: <bool>
-
-              # OSPF routes learned from external sources.
-              ospf_match_external: <bool>
-
-              # OSPF routes learned from external NSSA sources.
-              ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+              # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+              ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           aggregate_addresses:
 
               # IPv4 prefix "A.B.C.D/E" or IPv6 prefix "A:B:C:D:E:F:G:H/I".
@@ -2227,14 +2171,8 @@
                 # Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
                 rcf: <str>
 
-                # OSPF routes learned from internal sources.
-                ospf_match_internal: <bool>
-
-                # OSPF routes learned from external sources.
-                ospf_match_external: <bool>
-
-                # OSPF routes learned from external NSSA sources.
-                ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+                # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_ipv6:
             bgp:
               missing_policy:
@@ -2293,14 +2231,8 @@
                 # Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
                 rcf: <str>
 
-                # OSPF routes learned from internal sources.
-                ospf_match_internal: <bool>
-
-                # OSPF routes learned from external sources.
-                ospf_match_external: <bool>
-
-                # OSPF routes learned from external NSSA sources.
-                ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+                # The `ospf_route_type` is required with source_protocols 'ospfv3'.
+                ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_ipv4_multicast:
             bgp:
               missing_policy:
@@ -2335,14 +2267,8 @@
                 # Only applicable if `source_protocol` is `isis`.
                 rcf: <str>
 
-                # OSPF routes learned from internal sources.
-                ospf_match_internal: <bool>
-
-                # OSPF routes learned from external sources.
-                ospf_match_external: <bool>
-
-                # OSPF routes learned from external NSSA sources.
-                ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+                # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_ipv6_multicast:
             bgp:
               missing_policy:
@@ -2377,14 +2303,8 @@
                 # Only applicable if `source_protocol` is `isis`.
                 rcf: <str>
 
-                # OSPF routes learned from internal sources.
-                ospf_match_internal: <bool>
-
-                # OSPF routes learned from external sources.
-                ospf_match_external: <bool>
-
-                # OSPF routes learned from external NSSA sources.
-                ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
+                # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_flow_spec_ipv4:
             bgp:
               missing_policy:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -180,7 +180,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;vlan_aware_bundles</samp>](## "router_bgp.vlan_aware_bundles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.vlan_aware_bundles.[].name") | String | Required, Unique |  |  | VLAN aware bundle name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenant</samp>](## "router_bgp.vlan_aware_bundles.[].tenant") | String |  |  |  | Key only used for documentation or validation purposes. |
@@ -353,7 +353,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `ospf`, `ospfv3`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;address_family_ipv4_multicast</samp>](## "router_bgp.address_family_ipv4_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_ipv4_multicast.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.address_family_ipv4_multicast.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name. |
@@ -370,7 +370,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;address_family_ipv4_sr_te</samp>](## "router_bgp.address_family_ipv4_sr_te") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_address</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
@@ -409,7 +409,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;address_family_ipv6_multicast</samp>](## "router_bgp.address_family_ipv6_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.address_family_ipv6_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.address_family_ipv6_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -433,7 +433,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;address_family_ipv6_sr_te</samp>](## "router_bgp.address_family_ipv6_sr_te") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_address</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
@@ -660,7 +660,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aggregate_addresses</samp>](## "router_bgp.vrfs.[].aggregate_addresses") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.vrfs.[].aggregate_addresses.[].prefix") | String | Required, Unique |  |  | IPv4 prefix "A.B.C.D/E" or IPv6 prefix "A:B:C:D:E:F:G:H/I". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;advertise_only</samp>](## "router_bgp.vrfs.[].aggregate_addresses.[].advertise_only") | Boolean |  |  |  |  |
@@ -706,7 +706,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv6</samp>](## "router_bgp.vrfs.[].address_family_ipv6") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_ipv6.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_ipv6.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -739,7 +739,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv4_multicast</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -760,7 +760,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv6_multicast</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -781,7 +781,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_route_type</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].ospf_route_type") | String |  |  | Valid Values:<br>- <code>external</code><br>- <code>internal</code><br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | Routes learned by the OSPF protocol.<br>The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_flow_spec_ipv4</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv4") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv4.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv4.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -1192,7 +1192,8 @@
           rcf: <str>
           include_leaked: <bool>
 
-          # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+          # Routes learned by the OSPF protocol.
+          # The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
           ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       vlan_aware_bundles:
 
@@ -1505,7 +1506,8 @@
             # Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
             rcf: <str>
 
-            # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+            # Routes learned by the OSPF protocol.
+            # The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
             ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv4_multicast:
         peer_groups:
@@ -1541,7 +1543,8 @@
             # Only applicable if `source_protocol` is `isis`.
             rcf: <str>
 
-            # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+            # Routes learned by the OSPF protocol.
+            # The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
             ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv4_sr_te:
         neighbors:
@@ -1631,7 +1634,8 @@
             # Only used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
             rcf: <str>
 
-            # The `ospf_route_type` is required with source_protocols 'ospfv3'.
+            # Routes learned by the OSPF protocol.
+            # The `ospf_route_type` is valid for source_protocols 'ospfv3'.
             ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv6_multicast:
         bgp:
@@ -1672,7 +1676,8 @@
             # Only applicable if `source_protocol` is `isis`.
             rcf: <str>
 
-            # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+            # Routes learned by the OSPF protocol.
+            # The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
             ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv6_sr_te:
         neighbors:
@@ -2092,7 +2097,8 @@
               # Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
               rcf: <str>
 
-              # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+              # Routes learned by the OSPF protocol.
+              # The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
               ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           aggregate_addresses:
 
@@ -2171,7 +2177,8 @@
                 # Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
                 rcf: <str>
 
-                # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                # Routes learned by the OSPF protocol.
+                # The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
                 ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_ipv6:
             bgp:
@@ -2231,7 +2238,8 @@
                 # Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
                 rcf: <str>
 
-                # The `ospf_route_type` is required with source_protocols 'ospfv3'.
+                # Routes learned by the OSPF protocol.
+                # The `ospf_route_type` is valid for source_protocols 'ospfv3'.
                 ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_ipv4_multicast:
             bgp:
@@ -2267,7 +2275,8 @@
                 # Only applicable if `source_protocol` is `isis`.
                 rcf: <str>
 
-                # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                # Routes learned by the OSPF protocol.
+                # The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
                 ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_ipv6_multicast:
             bgp:
@@ -2303,7 +2312,8 @@
                 # Only applicable if `source_protocol` is `isis`.
                 rcf: <str>
 
-                # The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                # Routes learned by the OSPF protocol.
+                # The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
                 ospf_route_type: <str; "external" | "internal" | "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_flow_spec_ipv4:
             bgp:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -176,10 +176,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;attribute_map</samp>](## "router_bgp.aggregate_addresses.[].attribute_map") | String |  |  |  | Route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;match_map</samp>](## "router_bgp.aggregate_addresses.[].match_map") | String |  |  |  | Route-map name. |
     | [<samp>&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.redistribute_routes.[].source_protocol") | String | Required, Unique |  | Valid Values:<br>- <code>attached-host</code><br>- <code>bgp</code><br>- <code>connected</code><br>- <code>dynamic</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>rip</code><br>- <code>static</code><br>- <code>user</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.redistribute_routes.[].source_protocol") | String | Required |  | Valid Values:<br>- <code>attached-host</code><br>- <code>bgp</code><br>- <code>connected</code><br>- <code>dynamic</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>rip</code><br>- <code>static</code><br>- <code>user</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;vlan_aware_bundles</samp>](## "router_bgp.vlan_aware_bundles") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.vlan_aware_bundles.[].name") | String | Required, Unique |  |  | VLAN aware bundle name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tenant</samp>](## "router_bgp.vlan_aware_bundles.[].tenant") | String |  |  |  | Key only used for documentation or validation purposes. |
@@ -348,10 +351,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.address_family_ipv4.neighbors.[].default_originate.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv4.neighbors.[].default_originate.route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.address_family_ipv4.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].source_protocol") | String | Required, Unique |  | Valid Values:<br>- <code>attached-host</code><br>- <code>bgp</code><br>- <code>connected</code><br>- <code>dynamic</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>rip</code><br>- <code>static</code><br>- <code>user</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].source_protocol") | String | Required |  | Valid Values:<br>- <code>attached-host</code><br>- <code>bgp</code><br>- <code>connected</code><br>- <code>dynamic</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>rip</code><br>- <code>static</code><br>- <code>user</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `ospf`, `ospfv3`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.address_family_ipv4.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;address_family_ipv4_multicast</samp>](## "router_bgp.address_family_ipv4_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_groups</samp>](## "router_bgp.address_family_ipv4_multicast.peer_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_bgp.address_family_ipv4_multicast.peer_groups.[].name") | String | Required, Unique |  |  | Peer-group name. |
@@ -364,10 +370,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_in</samp>](## "router_bgp.address_family_ipv4_multicast.neighbors.[].route_map_in") | String |  |  |  | Inbound route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map_out</samp>](## "router_bgp.address_family_ipv4_multicast.neighbors.[].route_map_out") | String |  |  |  | Outbound route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].source_protocol") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].source_protocol") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.address_family_ipv4_multicast.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;address_family_ipv4_sr_te</samp>](## "router_bgp.address_family_ipv4_sr_te") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_address</samp>](## "router_bgp.address_family_ipv4_sr_te.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
@@ -402,10 +411,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_in</samp>](## "router_bgp.address_family_ipv6.neighbors.[].prefix_list_in") | String |  |  |  | Inbound prefix-list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_list_out</samp>](## "router_bgp.address_family_ipv6.neighbors.[].prefix_list_out") | String |  |  |  | Outbound prefix-list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.address_family_ipv6.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].source_protocol") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].source_protocol") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.address_family_ipv6.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;address_family_ipv6_multicast</samp>](## "router_bgp.address_family_ipv6_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.address_family_ipv6_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.address_family_ipv6_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -425,10 +437,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.address_family_ipv6_multicast.networks.[].prefix") | String | Required, Unique |  |  | IPv6 prefix "A:B:C:D:E:F:G:H/I". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv6_multicast.networks.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].source_protocol") | String | Required, Unique |  | Valid Values:<br>- <code>connected</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>static</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].source_protocol") | String | Required |  | Valid Values:<br>- <code>connected</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>static</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.address_family_ipv6_multicast.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;address_family_ipv6_sr_te</samp>](## "router_bgp.address_family_ipv6_sr_te") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;neighbors</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_address</samp>](## "router_bgp.address_family_ipv6_sr_te.neighbors.[].ip_address") | String | Required, Unique |  |  |  |
@@ -651,10 +666,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_filter</samp>](## "router_bgp.vrfs.[].neighbor_interfaces.[].peer_filter") | String |  |  |  | Peer-filter name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "router_bgp.vrfs.[].neighbor_interfaces.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.vrfs.[].redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].source_protocol") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].source_protocol") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aggregate_addresses</samp>](## "router_bgp.vrfs.[].aggregate_addresses") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.vrfs.[].aggregate_addresses.[].prefix") | String | Required, Unique |  |  | IPv4 prefix "A.B.C.D/E" or IPv6 prefix "A:B:C:D:E:F:G:H/I". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;advertise_only</samp>](## "router_bgp.vrfs.[].aggregate_addresses.[].advertise_only") | Boolean |  |  |  |  |
@@ -696,10 +714,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.vrfs.[].address_family_ipv4.networks.[].prefix") | String | Required, Unique |  |  | IPv4 prefix "A.B.C.D/E". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv4.networks.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].source_protocol") | String | Required, Unique |  | Valid Values:<br>- <code>attached-host</code><br>- <code>bgp</code><br>- <code>connected</code><br>- <code>dynamic</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>rip</code><br>- <code>static</code><br>- <code>user</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].source_protocol") | String | Required |  | Valid Values:<br>- <code>attached-host</code><br>- <code>bgp</code><br>- <code>connected</code><br>- <code>dynamic</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>rip</code><br>- <code>static</code><br>- <code>user</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].address_family_ipv4.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv6</samp>](## "router_bgp.vrfs.[].address_family_ipv6") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_ipv6.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_ipv6.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -728,10 +749,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.vrfs.[].address_family_ipv6.networks.[].prefix") | String | Required, Unique |  |  | IPv6 prefix "A:B:C:D:E:F:G:H/I". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv6.networks.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].source_protocol") | String | Required, Unique |  | Valid Values:<br>- <code>attached-host</code><br>- <code>bgp</code><br>- <code>connected</code><br>- <code>dhcp</code><br>- <code>dynamic</code><br>- <code>isis</code><br>- <code>ospfv3</code><br>- <code>static</code><br>- <code>user</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].source_protocol") | String | Required |  | Valid Values:<br>- <code>attached-host</code><br>- <code>bgp</code><br>- <code>connected</code><br>- <code>dhcp</code><br>- <code>dynamic</code><br>- <code>isis</code><br>- <code>ospfv3</code><br>- <code>static</code><br>- <code>user</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].include_leaked") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].address_family_ipv6.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv4_multicast</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -748,10 +772,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.networks.[].prefix") | String | Required, Unique |  |  | IPv6 prefix "A.B.C.D/E". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.networks.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].source_protocol") | String | Required, Unique |  | Valid Values:<br>- <code>attached-host</code><br>- <code>connected</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>static</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].source_protocol") | String | Required |  | Valid Values:<br>- <code>attached-host</code><br>- <code>connected</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>static</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].address_family_ipv4_multicast.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_ipv6_multicast</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -768,10 +795,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.networks.[].prefix") | String | Required, Unique |  |  | IPv6 prefix "A:B:C:D:E:F:G:H/I". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.networks.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_routes</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].source_protocol") | String | Required, Unique |  | Valid Values:<br>- <code>connected</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>static</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;source_protocol</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].source_protocol") | String | Required |  | Valid Values:<br>- <code>connected</code><br>- <code>isis</code><br>- <code>ospf</code><br>- <code>ospfv3</code><br>- <code>static</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].route_map") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;include_leaked</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].include_leaked") | Boolean |  |  |  | Only applicable if `source_protocol` is `isis`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.<br>Only applicable if `source_protocol` is `isis`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_internal</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].ospf_match_internal") | Boolean |  |  |  | OSPF routes learned from internal sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_external</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].ospf_match_external") | Boolean |  |  |  | OSPF routes learned from external sources. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf_match_nssa_external</samp>](## "router_bgp.vrfs.[].address_family_ipv6_multicast.redistribute_routes.[].ospf_match_nssa_external") | String |  |  | Valid Values:<br>- <code>nssa-external</code><br>- <code>nssa-external 1</code><br>- <code>nssa-external 2</code> | OSPF routes learned from external NSSA sources. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family_flow_spec_ipv4</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv4") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv4.bgp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;missing_policy</samp>](## "router_bgp.vrfs.[].address_family_flow_spec_ipv4.bgp.missing_policy") | Dictionary |  |  |  |  |
@@ -1181,6 +1211,15 @@
           # Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
           rcf: <str>
           include_leaked: <bool>
+
+          # OSPF routes learned from internal sources.
+          ospf_match_internal: <bool>
+
+          # OSPF routes learned from external sources.
+          ospf_match_external: <bool>
+
+          # OSPF routes learned from external NSSA sources.
+          ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
       vlan_aware_bundles:
 
           # VLAN aware bundle name.
@@ -1491,6 +1530,15 @@
             # `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
             # Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
             rcf: <str>
+
+            # OSPF routes learned from internal sources.
+            ospf_match_internal: <bool>
+
+            # OSPF routes learned from external sources.
+            ospf_match_external: <bool>
+
+            # OSPF routes learned from external NSSA sources.
+            ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv4_multicast:
         peer_groups:
 
@@ -1524,6 +1572,15 @@
             # `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
             # Only applicable if `source_protocol` is `isis`.
             rcf: <str>
+
+            # OSPF routes learned from internal sources.
+            ospf_match_internal: <bool>
+
+            # OSPF routes learned from external sources.
+            ospf_match_external: <bool>
+
+            # OSPF routes learned from external NSSA sources.
+            ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv4_sr_te:
         neighbors:
           - ip_address: <str; required; unique>
@@ -1611,6 +1668,15 @@
             # `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
             # Only used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
             rcf: <str>
+
+            # OSPF routes learned from internal sources.
+            ospf_match_internal: <bool>
+
+            # OSPF routes learned from external sources.
+            ospf_match_external: <bool>
+
+            # OSPF routes learned from external NSSA sources.
+            ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv6_multicast:
         bgp:
           missing_policy:
@@ -1649,6 +1715,15 @@
             # `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
             # Only applicable if `source_protocol` is `isis`.
             rcf: <str>
+
+            # OSPF routes learned from internal sources.
+            ospf_match_internal: <bool>
+
+            # OSPF routes learned from external sources.
+            ospf_match_external: <bool>
+
+            # OSPF routes learned from external NSSA sources.
+            ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
       address_family_ipv6_sr_te:
         neighbors:
           - ip_address: <str; required; unique>
@@ -2066,6 +2141,15 @@
               # `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
               # Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
               rcf: <str>
+
+              # OSPF routes learned from internal sources.
+              ospf_match_internal: <bool>
+
+              # OSPF routes learned from external sources.
+              ospf_match_external: <bool>
+
+              # OSPF routes learned from external NSSA sources.
+              ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
           aggregate_addresses:
 
               # IPv4 prefix "A.B.C.D/E" or IPv6 prefix "A:B:C:D:E:F:G:H/I".
@@ -2142,6 +2226,15 @@
                 # `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                 # Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
                 rcf: <str>
+
+                # OSPF routes learned from internal sources.
+                ospf_match_internal: <bool>
+
+                # OSPF routes learned from external sources.
+                ospf_match_external: <bool>
+
+                # OSPF routes learned from external NSSA sources.
+                ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_ipv6:
             bgp:
               missing_policy:
@@ -2199,6 +2292,15 @@
                 # `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                 # Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
                 rcf: <str>
+
+                # OSPF routes learned from internal sources.
+                ospf_match_internal: <bool>
+
+                # OSPF routes learned from external sources.
+                ospf_match_external: <bool>
+
+                # OSPF routes learned from external NSSA sources.
+                ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_ipv4_multicast:
             bgp:
               missing_policy:
@@ -2232,6 +2334,15 @@
                 # `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                 # Only applicable if `source_protocol` is `isis`.
                 rcf: <str>
+
+                # OSPF routes learned from internal sources.
+                ospf_match_internal: <bool>
+
+                # OSPF routes learned from external sources.
+                ospf_match_external: <bool>
+
+                # OSPF routes learned from external NSSA sources.
+                ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_ipv6_multicast:
             bgp:
               missing_policy:
@@ -2265,6 +2376,15 @@
                 # `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                 # Only applicable if `source_protocol` is `isis`.
                 rcf: <str>
+
+                # OSPF routes learned from internal sources.
+                ospf_match_internal: <bool>
+
+                # OSPF routes learned from external sources.
+                ospf_match_external: <bool>
+
+                # OSPF routes learned from external NSSA sources.
+                ospf_match_nssa_external: <str; "nssa-external" | "nssa-external 1" | "nssa-external 2">
           address_family_flow_spec_ipv4:
             bgp:
               missing_policy:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -18293,7 +18293,7 @@
                   "nssa-external 1",
                   "nssa-external 2"
                 ],
-                "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                 "title": "OSPF Route Type"
               }
             },
@@ -19458,7 +19458,7 @@
                       "nssa-external 1",
                       "nssa-external 2"
                     ],
-                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                    "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                     "title": "OSPF Route Type"
                   }
                 },
@@ -19583,7 +19583,7 @@
                       "nssa-external 1",
                       "nssa-external 2"
                     ],
-                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                    "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                     "title": "OSPF Route Type"
                   }
                 },
@@ -19852,7 +19852,7 @@
                       "nssa-external 1",
                       "nssa-external 2"
                     ],
-                    "description": "The `ospf_route_type` is required with source_protocols 'ospfv3'.",
+                    "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospfv3'.\n",
                     "title": "OSPF Route Type"
                   }
                 },
@@ -20051,7 +20051,7 @@
                       "nssa-external 1",
                       "nssa-external 2"
                     ],
-                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                    "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                     "title": "OSPF Route Type"
                   }
                 },
@@ -21622,7 +21622,7 @@
                         "nssa-external 1",
                         "nssa-external 2"
                       ],
-                      "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                      "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                       "title": "OSPF Route Type"
                     }
                   },
@@ -21939,7 +21939,7 @@
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                          "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                           "title": "OSPF Route Type"
                         }
                       },
@@ -22180,7 +22180,7 @@
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "description": "The `ospf_route_type` is required with source_protocols 'ospfv3'.",
+                          "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospfv3'.\n",
                           "title": "OSPF Route Type"
                         }
                       },
@@ -22355,7 +22355,7 @@
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                          "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                           "title": "OSPF Route Type"
                         }
                       },
@@ -22529,7 +22529,7 @@
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                          "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                           "title": "OSPF Route Type"
                         }
                       },

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -18284,25 +18284,17 @@
                 "type": "boolean",
                 "title": "Include Leaked"
               },
-              "ospf_match_internal": {
-                "type": "boolean",
-                "description": "OSPF routes learned from internal sources.",
-                "title": "OSPF Match Internal"
-              },
-              "ospf_match_external": {
-                "type": "boolean",
-                "description": "OSPF routes learned from external sources.",
-                "title": "OSPF Match External"
-              },
-              "ospf_match_nssa_external": {
+              "ospf_route_type": {
                 "type": "string",
-                "description": "OSPF routes learned from external NSSA sources.",
                 "enum": [
+                  "external",
+                  "internal",
                   "nssa-external",
                   "nssa-external 1",
                   "nssa-external 2"
                 ],
-                "title": "OSPF Match Nssa External"
+                "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                "title": "OSPF Route Type"
               }
             },
             "additionalProperties": false,
@@ -19457,25 +19449,17 @@
                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.",
                     "title": "RCF"
                   },
-                  "ospf_match_internal": {
-                    "type": "boolean",
-                    "description": "OSPF routes learned from internal sources.",
-                    "title": "OSPF Match Internal"
-                  },
-                  "ospf_match_external": {
-                    "type": "boolean",
-                    "description": "OSPF routes learned from external sources.",
-                    "title": "OSPF Match External"
-                  },
-                  "ospf_match_nssa_external": {
+                  "ospf_route_type": {
                     "type": "string",
-                    "description": "OSPF routes learned from external NSSA sources.",
                     "enum": [
+                      "external",
+                      "internal",
                       "nssa-external",
                       "nssa-external 1",
                       "nssa-external 2"
                     ],
-                    "title": "OSPF Match Nssa External"
+                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                    "title": "OSPF Route Type"
                   }
                 },
                 "additionalProperties": false,
@@ -19590,25 +19574,17 @@
                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                     "title": "RCF"
                   },
-                  "ospf_match_internal": {
-                    "type": "boolean",
-                    "description": "OSPF routes learned from internal sources.",
-                    "title": "OSPF Match Internal"
-                  },
-                  "ospf_match_external": {
-                    "type": "boolean",
-                    "description": "OSPF routes learned from external sources.",
-                    "title": "OSPF Match External"
-                  },
-                  "ospf_match_nssa_external": {
+                  "ospf_route_type": {
                     "type": "string",
-                    "description": "OSPF routes learned from external NSSA sources.",
                     "enum": [
+                      "external",
+                      "internal",
                       "nssa-external",
                       "nssa-external 1",
                       "nssa-external 2"
                     ],
-                    "title": "OSPF Match Nssa External"
+                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                    "title": "OSPF Route Type"
                   }
                 },
                 "additionalProperties": false,
@@ -19867,25 +19843,17 @@
                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.",
                     "title": "RCF"
                   },
-                  "ospf_match_internal": {
-                    "type": "boolean",
-                    "description": "OSPF routes learned from internal sources.",
-                    "title": "OSPF Match Internal"
-                  },
-                  "ospf_match_external": {
-                    "type": "boolean",
-                    "description": "OSPF routes learned from external sources.",
-                    "title": "OSPF Match External"
-                  },
-                  "ospf_match_nssa_external": {
+                  "ospf_route_type": {
                     "type": "string",
-                    "description": "OSPF routes learned from external NSSA sources.",
                     "enum": [
+                      "external",
+                      "internal",
                       "nssa-external",
                       "nssa-external 1",
                       "nssa-external 2"
                     ],
-                    "title": "OSPF Match Nssa External"
+                    "description": "The `ospf_route_type` is required with source_protocols 'ospfv3'.",
+                    "title": "OSPF Route Type"
                   }
                 },
                 "additionalProperties": false,
@@ -20074,25 +20042,17 @@
                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                     "title": "RCF"
                   },
-                  "ospf_match_internal": {
-                    "type": "boolean",
-                    "description": "OSPF routes learned from internal sources.",
-                    "title": "OSPF Match Internal"
-                  },
-                  "ospf_match_external": {
-                    "type": "boolean",
-                    "description": "OSPF routes learned from external sources.",
-                    "title": "OSPF Match External"
-                  },
-                  "ospf_match_nssa_external": {
+                  "ospf_route_type": {
                     "type": "string",
-                    "description": "OSPF routes learned from external NSSA sources.",
                     "enum": [
+                      "external",
+                      "internal",
                       "nssa-external",
                       "nssa-external 1",
                       "nssa-external 2"
                     ],
-                    "title": "OSPF Match Nssa External"
+                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                    "title": "OSPF Route Type"
                   }
                 },
                 "additionalProperties": false,
@@ -21653,25 +21613,17 @@
                       "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                       "title": "RCF"
                     },
-                    "ospf_match_internal": {
-                      "type": "boolean",
-                      "description": "OSPF routes learned from internal sources.",
-                      "title": "OSPF Match Internal"
-                    },
-                    "ospf_match_external": {
-                      "type": "boolean",
-                      "description": "OSPF routes learned from external sources.",
-                      "title": "OSPF Match External"
-                    },
-                    "ospf_match_nssa_external": {
+                    "ospf_route_type": {
                       "type": "string",
-                      "description": "OSPF routes learned from external NSSA sources.",
                       "enum": [
+                        "external",
+                        "internal",
                         "nssa-external",
                         "nssa-external 1",
                         "nssa-external 2"
                       ],
-                      "title": "OSPF Match Nssa External"
+                      "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                      "title": "OSPF Route Type"
                     }
                   },
                   "additionalProperties": false,
@@ -21978,25 +21930,17 @@
                           "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                           "title": "RCF"
                         },
-                        "ospf_match_internal": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from internal sources.",
-                          "title": "OSPF Match Internal"
-                        },
-                        "ospf_match_external": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from external sources.",
-                          "title": "OSPF Match External"
-                        },
-                        "ospf_match_nssa_external": {
+                        "ospf_route_type": {
                           "type": "string",
-                          "description": "OSPF routes learned from external NSSA sources.",
                           "enum": [
+                            "external",
+                            "internal",
                             "nssa-external",
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "title": "OSPF Match Nssa External"
+                          "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                          "title": "OSPF Route Type"
                         }
                       },
                       "additionalProperties": false,
@@ -22227,25 +22171,17 @@
                           "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                           "title": "RCF"
                         },
-                        "ospf_match_internal": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from internal sources.",
-                          "title": "OSPF Match Internal"
-                        },
-                        "ospf_match_external": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from external sources.",
-                          "title": "OSPF Match External"
-                        },
-                        "ospf_match_nssa_external": {
+                        "ospf_route_type": {
                           "type": "string",
-                          "description": "OSPF routes learned from external NSSA sources.",
                           "enum": [
+                            "external",
+                            "internal",
                             "nssa-external",
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "title": "OSPF Match Nssa External"
+                          "description": "The `ospf_route_type` is required with source_protocols 'ospfv3'.",
+                          "title": "OSPF Route Type"
                         }
                       },
                       "additionalProperties": false,
@@ -22410,25 +22346,17 @@
                           "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                           "title": "RCF"
                         },
-                        "ospf_match_internal": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from internal sources.",
-                          "title": "OSPF Match Internal"
-                        },
-                        "ospf_match_external": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from external sources.",
-                          "title": "OSPF Match External"
-                        },
-                        "ospf_match_nssa_external": {
+                        "ospf_route_type": {
                           "type": "string",
-                          "description": "OSPF routes learned from external NSSA sources.",
                           "enum": [
+                            "external",
+                            "internal",
                             "nssa-external",
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "title": "OSPF Match Nssa External"
+                          "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                          "title": "OSPF Route Type"
                         }
                       },
                       "additionalProperties": false,
@@ -22592,25 +22520,17 @@
                           "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                           "title": "RCF"
                         },
-                        "ospf_match_internal": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from internal sources.",
-                          "title": "OSPF Match Internal"
-                        },
-                        "ospf_match_external": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from external sources.",
-                          "title": "OSPF Match External"
-                        },
-                        "ospf_match_nssa_external": {
+                        "ospf_route_type": {
                           "type": "string",
-                          "description": "OSPF routes learned from external NSSA sources.",
                           "enum": [
+                            "external",
+                            "internal",
                             "nssa-external",
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "title": "OSPF Match Nssa External"
+                          "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                          "title": "OSPF Route Type"
                         }
                       },
                       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -18283,6 +18283,26 @@
               "include_leaked": {
                 "type": "boolean",
                 "title": "Include Leaked"
+              },
+              "ospf_match_internal": {
+                "type": "boolean",
+                "description": "OSPF routes learned from internal sources.",
+                "title": "OSPF Match Internal"
+              },
+              "ospf_match_external": {
+                "type": "boolean",
+                "description": "OSPF routes learned from external sources.",
+                "title": "OSPF Match External"
+              },
+              "ospf_match_nssa_external": {
+                "type": "string",
+                "description": "OSPF routes learned from external NSSA sources.",
+                "enum": [
+                  "nssa-external",
+                  "nssa-external 1",
+                  "nssa-external 2"
+                ],
+                "title": "OSPF Match Nssa External"
               }
             },
             "additionalProperties": false,
@@ -19436,6 +19456,26 @@
                     "type": "string",
                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.",
                     "title": "RCF"
+                  },
+                  "ospf_match_internal": {
+                    "type": "boolean",
+                    "description": "OSPF routes learned from internal sources.",
+                    "title": "OSPF Match Internal"
+                  },
+                  "ospf_match_external": {
+                    "type": "boolean",
+                    "description": "OSPF routes learned from external sources.",
+                    "title": "OSPF Match External"
+                  },
+                  "ospf_match_nssa_external": {
+                    "type": "string",
+                    "description": "OSPF routes learned from external NSSA sources.",
+                    "enum": [
+                      "nssa-external",
+                      "nssa-external 1",
+                      "nssa-external 2"
+                    ],
+                    "title": "OSPF Match Nssa External"
                   }
                 },
                 "additionalProperties": false,
@@ -19549,6 +19589,26 @@
                     "type": "string",
                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                     "title": "RCF"
+                  },
+                  "ospf_match_internal": {
+                    "type": "boolean",
+                    "description": "OSPF routes learned from internal sources.",
+                    "title": "OSPF Match Internal"
+                  },
+                  "ospf_match_external": {
+                    "type": "boolean",
+                    "description": "OSPF routes learned from external sources.",
+                    "title": "OSPF Match External"
+                  },
+                  "ospf_match_nssa_external": {
+                    "type": "string",
+                    "description": "OSPF routes learned from external NSSA sources.",
+                    "enum": [
+                      "nssa-external",
+                      "nssa-external 1",
+                      "nssa-external 2"
+                    ],
+                    "title": "OSPF Match Nssa External"
                   }
                 },
                 "additionalProperties": false,
@@ -19806,6 +19866,26 @@
                     "type": "string",
                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.",
                     "title": "RCF"
+                  },
+                  "ospf_match_internal": {
+                    "type": "boolean",
+                    "description": "OSPF routes learned from internal sources.",
+                    "title": "OSPF Match Internal"
+                  },
+                  "ospf_match_external": {
+                    "type": "boolean",
+                    "description": "OSPF routes learned from external sources.",
+                    "title": "OSPF Match External"
+                  },
+                  "ospf_match_nssa_external": {
+                    "type": "string",
+                    "description": "OSPF routes learned from external NSSA sources.",
+                    "enum": [
+                      "nssa-external",
+                      "nssa-external 1",
+                      "nssa-external 2"
+                    ],
+                    "title": "OSPF Match Nssa External"
                   }
                 },
                 "additionalProperties": false,
@@ -19993,6 +20073,26 @@
                     "type": "string",
                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                     "title": "RCF"
+                  },
+                  "ospf_match_internal": {
+                    "type": "boolean",
+                    "description": "OSPF routes learned from internal sources.",
+                    "title": "OSPF Match Internal"
+                  },
+                  "ospf_match_external": {
+                    "type": "boolean",
+                    "description": "OSPF routes learned from external sources.",
+                    "title": "OSPF Match External"
+                  },
+                  "ospf_match_nssa_external": {
+                    "type": "string",
+                    "description": "OSPF routes learned from external NSSA sources.",
+                    "enum": [
+                      "nssa-external",
+                      "nssa-external 1",
+                      "nssa-external 2"
+                    ],
+                    "title": "OSPF Match Nssa External"
                   }
                 },
                 "additionalProperties": false,
@@ -21552,6 +21652,26 @@
                       "type": "string",
                       "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                       "title": "RCF"
+                    },
+                    "ospf_match_internal": {
+                      "type": "boolean",
+                      "description": "OSPF routes learned from internal sources.",
+                      "title": "OSPF Match Internal"
+                    },
+                    "ospf_match_external": {
+                      "type": "boolean",
+                      "description": "OSPF routes learned from external sources.",
+                      "title": "OSPF Match External"
+                    },
+                    "ospf_match_nssa_external": {
+                      "type": "string",
+                      "description": "OSPF routes learned from external NSSA sources.",
+                      "enum": [
+                        "nssa-external",
+                        "nssa-external 1",
+                        "nssa-external 2"
+                      ],
+                      "title": "OSPF Match Nssa External"
                     }
                   },
                   "additionalProperties": false,
@@ -21857,6 +21977,26 @@
                           "type": "string",
                           "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                           "title": "RCF"
+                        },
+                        "ospf_match_internal": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from internal sources.",
+                          "title": "OSPF Match Internal"
+                        },
+                        "ospf_match_external": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from external sources.",
+                          "title": "OSPF Match External"
+                        },
+                        "ospf_match_nssa_external": {
+                          "type": "string",
+                          "description": "OSPF routes learned from external NSSA sources.",
+                          "enum": [
+                            "nssa-external",
+                            "nssa-external 1",
+                            "nssa-external 2"
+                          ],
+                          "title": "OSPF Match Nssa External"
                         }
                       },
                       "additionalProperties": false,
@@ -22086,6 +22226,26 @@
                           "type": "string",
                           "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                           "title": "RCF"
+                        },
+                        "ospf_match_internal": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from internal sources.",
+                          "title": "OSPF Match Internal"
+                        },
+                        "ospf_match_external": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from external sources.",
+                          "title": "OSPF Match External"
+                        },
+                        "ospf_match_nssa_external": {
+                          "type": "string",
+                          "description": "OSPF routes learned from external NSSA sources.",
+                          "enum": [
+                            "nssa-external",
+                            "nssa-external 1",
+                            "nssa-external 2"
+                          ],
+                          "title": "OSPF Match Nssa External"
                         }
                       },
                       "additionalProperties": false,
@@ -22249,6 +22409,26 @@
                           "type": "string",
                           "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                           "title": "RCF"
+                        },
+                        "ospf_match_internal": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from internal sources.",
+                          "title": "OSPF Match Internal"
+                        },
+                        "ospf_match_external": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from external sources.",
+                          "title": "OSPF Match External"
+                        },
+                        "ospf_match_nssa_external": {
+                          "type": "string",
+                          "description": "OSPF routes learned from external NSSA sources.",
+                          "enum": [
+                            "nssa-external",
+                            "nssa-external 1",
+                            "nssa-external 2"
+                          ],
+                          "title": "OSPF Match Nssa External"
                         }
                       },
                       "additionalProperties": false,
@@ -22411,6 +22591,26 @@
                           "type": "string",
                           "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                           "title": "RCF"
+                        },
+                        "ospf_match_internal": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from internal sources.",
+                          "title": "OSPF Match Internal"
+                        },
+                        "ospf_match_external": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from external sources.",
+                          "title": "OSPF Match External"
+                        },
+                        "ospf_match_nssa_external": {
+                          "type": "string",
+                          "description": "OSPF routes learned from external NSSA sources.",
+                          "enum": [
+                            "nssa-external",
+                            "nssa-external 1",
+                            "nssa-external 2"
+                          ],
+                          "title": "OSPF Match Nssa External"
                         }
                       },
                       "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -10993,6 +10993,7 @@ keys:
       redistribute_routes:
         type: list
         primary_key: source_protocol
+        allow_duplicate_primary_key: true
         convert_types:
         - dict
         - list
@@ -11026,6 +11027,19 @@ keys:
                 `isis`, `user`, `dynamic`.'
             include_leaked:
               type: bool
+            ospf_match_internal:
+              type: bool
+              description: OSPF routes learned from internal sources.
+            ospf_match_external:
+              type: bool
+              description: OSPF routes learned from external sources.
+            ospf_match_nssa_external:
+              type: str
+              description: OSPF routes learned from external NSSA sources.
+              valid_values:
+              - nssa-external
+              - nssa-external 1
+              - nssa-external 2
       vlan_aware_bundles:
         type: list
         primary_key: name
@@ -11635,6 +11649,7 @@ keys:
           redistribute_routes:
             type: list
             primary_key: source_protocol
+            allow_duplicate_primary_key: true
             items:
               type: dict
               keys:
@@ -11668,6 +11683,19 @@ keys:
 
                     Only applicable if `source_protocol` is one of `connected`, `static`,
                     `isis`, `user`, `dynamic`.'
+                ospf_match_internal:
+                  type: bool
+                  description: OSPF routes learned from internal sources.
+                ospf_match_external:
+                  type: bool
+                  description: OSPF routes learned from external sources.
+                ospf_match_nssa_external:
+                  type: str
+                  description: OSPF routes learned from external NSSA sources.
+                  valid_values:
+                  - nssa-external
+                  - nssa-external 1
+                  - nssa-external 2
       address_family_ipv4_multicast:
         type: dict
         keys:
@@ -11711,6 +11739,7 @@ keys:
           redistribute_routes:
             type: list
             primary_key: source_protocol
+            allow_duplicate_primary_key: true
             convert_types:
             - dict
             items:
@@ -11733,6 +11762,19 @@ keys:
                     precedence.
 
                     Only applicable if `source_protocol` is `isis`.'
+                ospf_match_internal:
+                  type: bool
+                  description: OSPF routes learned from internal sources.
+                ospf_match_external:
+                  type: bool
+                  description: OSPF routes learned from external sources.
+                ospf_match_nssa_external:
+                  type: str
+                  description: OSPF routes learned from external NSSA sources.
+                  valid_values:
+                  - nssa-external
+                  - nssa-external 1
+                  - nssa-external 2
       address_family_ipv4_sr_te:
         type: dict
         keys:
@@ -11858,6 +11900,7 @@ keys:
           redistribute_routes:
             type: list
             primary_key: source_protocol
+            allow_duplicate_primary_key: true
             convert_types:
             - dict
             items:
@@ -11880,6 +11923,19 @@ keys:
 
                     Only used if `source_protocol` is one of `connected`, `static`,
                     `isis`, `user`, `dynamic`.'
+                ospf_match_internal:
+                  type: bool
+                  description: OSPF routes learned from internal sources.
+                ospf_match_external:
+                  type: bool
+                  description: OSPF routes learned from external sources.
+                ospf_match_nssa_external:
+                  type: str
+                  description: OSPF routes learned from external NSSA sources.
+                  valid_values:
+                  - nssa-external
+                  - nssa-external 1
+                  - nssa-external 2
       address_family_ipv6_multicast:
         type: dict
         keys:
@@ -11953,6 +12009,7 @@ keys:
           redistribute_routes:
             type: list
             primary_key: source_protocol
+            allow_duplicate_primary_key: true
             convert_types:
             - dict
             items:
@@ -11981,6 +12038,19 @@ keys:
                     precedence.
 
                     Only applicable if `source_protocol` is `isis`.'
+                ospf_match_internal:
+                  type: bool
+                  description: OSPF routes learned from internal sources.
+                ospf_match_external:
+                  type: bool
+                  description: OSPF routes learned from external sources.
+                ospf_match_nssa_external:
+                  type: str
+                  description: OSPF routes learned from external NSSA sources.
+                  valid_values:
+                  - nssa-external
+                  - nssa-external 1
+                  - nssa-external 2
       address_family_ipv6_sr_te:
         type: dict
         keys:
@@ -12862,6 +12932,7 @@ keys:
             redistribute_routes:
               type: list
               primary_key: source_protocol
+              allow_duplicate_primary_key: true
               convert_types:
               - dict
               - list
@@ -12885,6 +12956,19 @@ keys:
 
                       Only applicable if `source_protocol` is one of `connected`,
                       `dynamic`, `isis`, `static` and `user`.'
+                  ospf_match_internal:
+                    type: bool
+                    description: OSPF routes learned from internal sources.
+                  ospf_match_external:
+                    type: bool
+                    description: OSPF routes learned from external sources.
+                  ospf_match_nssa_external:
+                    type: str
+                    description: OSPF routes learned from external NSSA sources.
+                    valid_values:
+                    - nssa-external
+                    - nssa-external 1
+                    - nssa-external 2
             aggregate_addresses:
               type: list
               primary_key: prefix
@@ -13026,6 +13110,7 @@ keys:
                 redistribute_routes:
                   type: list
                   primary_key: source_protocol
+                  allow_duplicate_primary_key: true
                   convert_types:
                   - dict
                   items:
@@ -13059,6 +13144,19 @@ keys:
 
                           Only applicable if `source_protocol` is one of `connected`,
                           `dynamic`, `isis`, `static` and `user`.'
+                      ospf_match_internal:
+                        type: bool
+                        description: OSPF routes learned from internal sources.
+                      ospf_match_external:
+                        type: bool
+                        description: OSPF routes learned from external sources.
+                      ospf_match_nssa_external:
+                        type: str
+                        description: OSPF routes learned from external NSSA sources.
+                        valid_values:
+                        - nssa-external
+                        - nssa-external 1
+                        - nssa-external 2
             address_family_ipv6:
               type: dict
               keys:
@@ -13162,6 +13260,7 @@ keys:
                 redistribute_routes:
                   type: list
                   primary_key: source_protocol
+                  allow_duplicate_primary_key: true
                   convert_types:
                   - dict
                   items:
@@ -13194,6 +13293,19 @@ keys:
 
                           Only applicable if `source_protocol` is one of `connected`,
                           `dynamic`, `isis`, `static` and `user`.'
+                      ospf_match_internal:
+                        type: bool
+                        description: OSPF routes learned from internal sources.
+                      ospf_match_external:
+                        type: bool
+                        description: OSPF routes learned from external sources.
+                      ospf_match_nssa_external:
+                        type: str
+                        description: OSPF routes learned from external NSSA sources.
+                        valid_values:
+                        - nssa-external
+                        - nssa-external 1
+                        - nssa-external 2
             address_family_ipv4_multicast:
               type: dict
               keys:
@@ -13254,6 +13366,7 @@ keys:
                 redistribute_routes:
                   type: list
                   primary_key: source_protocol
+                  allow_duplicate_primary_key: true
                   convert_types:
                   - dict
                   items:
@@ -13283,6 +13396,19 @@ keys:
                           takes precedence.
 
                           Only applicable if `source_protocol` is `isis`.'
+                      ospf_match_internal:
+                        type: bool
+                        description: OSPF routes learned from internal sources.
+                      ospf_match_external:
+                        type: bool
+                        description: OSPF routes learned from external sources.
+                      ospf_match_nssa_external:
+                        type: str
+                        description: OSPF routes learned from external NSSA sources.
+                        valid_values:
+                        - nssa-external
+                        - nssa-external 1
+                        - nssa-external 2
             address_family_ipv6_multicast:
               type: dict
               keys:
@@ -13343,6 +13469,7 @@ keys:
                 redistribute_routes:
                   type: list
                   primary_key: source_protocol
+                  allow_duplicate_primary_key: true
                   convert_types:
                   - dict
                   items:
@@ -13371,6 +13498,19 @@ keys:
                           takes precedence.
 
                           Only applicable if `source_protocol` is `isis`.'
+                      ospf_match_internal:
+                        type: bool
+                        description: OSPF routes learned from internal sources.
+                      ospf_match_external:
+                        type: bool
+                        description: OSPF routes learned from external sources.
+                      ospf_match_nssa_external:
+                        type: str
+                        description: OSPF routes learned from external NSSA sources.
+                        valid_values:
+                        - nssa-external
+                        - nssa-external 1
+                        - nssa-external 2
             address_family_flow_spec_ipv4:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11035,8 +11035,11 @@ keys:
               - nssa-external
               - nssa-external 1
               - nssa-external 2
-              description: The `ospf_route_type` is required with source_protocols
-                'ospf' and 'ospfv3'.
+              description: 'Routes learned by the OSPF protocol.
+
+                The `ospf_route_type` is valid for source_protocols ''ospf'' and ''ospfv3''.
+
+                '
       vlan_aware_bundles:
         type: list
         primary_key: name
@@ -11688,8 +11691,12 @@ keys:
                   - nssa-external
                   - nssa-external 1
                   - nssa-external 2
-                  description: The `ospf_route_type` is required with source_protocols
-                    'ospf' and 'ospfv3'.
+                  description: 'Routes learned by the OSPF protocol.
+
+                    The `ospf_route_type` is valid for source_protocols ''ospf'' and
+                    ''ospfv3''.
+
+                    '
       address_family_ipv4_multicast:
         type: dict
         keys:
@@ -11764,8 +11771,12 @@ keys:
                   - nssa-external
                   - nssa-external 1
                   - nssa-external 2
-                  description: The `ospf_route_type` is required with source_protocols
-                    'ospf' and 'ospfv3'.
+                  description: 'Routes learned by the OSPF protocol.
+
+                    The `ospf_route_type` is valid for source_protocols ''ospf'' and
+                    ''ospfv3''.
+
+                    '
       address_family_ipv4_sr_te:
         type: dict
         keys:
@@ -11922,8 +11933,11 @@ keys:
                   - nssa-external
                   - nssa-external 1
                   - nssa-external 2
-                  description: The `ospf_route_type` is required with source_protocols
-                    'ospfv3'.
+                  description: 'Routes learned by the OSPF protocol.
+
+                    The `ospf_route_type` is valid for source_protocols ''ospfv3''.
+
+                    '
       address_family_ipv6_multicast:
         type: dict
         keys:
@@ -12034,8 +12048,12 @@ keys:
                   - nssa-external
                   - nssa-external 1
                   - nssa-external 2
-                  description: The `ospf_route_type` is required with source_protocols
-                    'ospf' and 'ospfv3'.
+                  description: 'Routes learned by the OSPF protocol.
+
+                    The `ospf_route_type` is valid for source_protocols ''ospf'' and
+                    ''ospfv3''.
+
+                    '
       address_family_ipv6_sr_te:
         type: dict
         keys:
@@ -12949,8 +12967,12 @@ keys:
                     - nssa-external
                     - nssa-external 1
                     - nssa-external 2
-                    description: The `ospf_route_type` is required with source_protocols
-                      'ospf' and 'ospfv3'.
+                    description: 'Routes learned by the OSPF protocol.
+
+                      The `ospf_route_type` is valid for source_protocols ''ospf''
+                      and ''ospfv3''.
+
+                      '
             aggregate_addresses:
               type: list
               primary_key: prefix
@@ -13134,8 +13156,12 @@ keys:
                         - nssa-external
                         - nssa-external 1
                         - nssa-external 2
-                        description: The `ospf_route_type` is required with source_protocols
-                          'ospf' and 'ospfv3'.
+                        description: 'Routes learned by the OSPF protocol.
+
+                          The `ospf_route_type` is valid for source_protocols ''ospf''
+                          and ''ospfv3''.
+
+                          '
             address_family_ipv6:
               type: dict
               keys:
@@ -13280,8 +13306,11 @@ keys:
                         - nssa-external
                         - nssa-external 1
                         - nssa-external 2
-                        description: The `ospf_route_type` is required with source_protocols
-                          'ospfv3'.
+                        description: 'Routes learned by the OSPF protocol.
+
+                          The `ospf_route_type` is valid for source_protocols ''ospfv3''.
+
+                          '
             address_family_ipv4_multicast:
               type: dict
               keys:
@@ -13380,8 +13409,12 @@ keys:
                         - nssa-external
                         - nssa-external 1
                         - nssa-external 2
-                        description: The `ospf_route_type` is required with source_protocols
-                          'ospf' and 'ospfv3'.
+                        description: 'Routes learned by the OSPF protocol.
+
+                          The `ospf_route_type` is valid for source_protocols ''ospf''
+                          and ''ospfv3''.
+
+                          '
             address_family_ipv6_multicast:
               type: dict
               keys:
@@ -13479,8 +13512,12 @@ keys:
                         - nssa-external
                         - nssa-external 1
                         - nssa-external 2
-                        description: The `ospf_route_type` is required with source_protocols
-                          'ospf' and 'ospfv3'.
+                        description: 'Routes learned by the OSPF protocol.
+
+                          The `ospf_route_type` is valid for source_protocols ''ospf''
+                          and ''ospfv3''.
+
+                          '
             address_family_flow_spec_ipv4:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -11027,19 +11027,16 @@ keys:
                 `isis`, `user`, `dynamic`.'
             include_leaked:
               type: bool
-            ospf_match_internal:
-              type: bool
-              description: OSPF routes learned from internal sources.
-            ospf_match_external:
-              type: bool
-              description: OSPF routes learned from external sources.
-            ospf_match_nssa_external:
+            ospf_route_type:
               type: str
-              description: OSPF routes learned from external NSSA sources.
               valid_values:
+              - external
+              - internal
               - nssa-external
               - nssa-external 1
               - nssa-external 2
+              description: The `ospf_route_type` is required with source_protocols
+                'ospf' and 'ospfv3'.
       vlan_aware_bundles:
         type: list
         primary_key: name
@@ -11683,19 +11680,16 @@ keys:
 
                     Only applicable if `source_protocol` is one of `connected`, `static`,
                     `isis`, `user`, `dynamic`.'
-                ospf_match_internal:
-                  type: bool
-                  description: OSPF routes learned from internal sources.
-                ospf_match_external:
-                  type: bool
-                  description: OSPF routes learned from external sources.
-                ospf_match_nssa_external:
+                ospf_route_type:
                   type: str
-                  description: OSPF routes learned from external NSSA sources.
                   valid_values:
+                  - external
+                  - internal
                   - nssa-external
                   - nssa-external 1
                   - nssa-external 2
+                  description: The `ospf_route_type` is required with source_protocols
+                    'ospf' and 'ospfv3'.
       address_family_ipv4_multicast:
         type: dict
         keys:
@@ -11762,19 +11756,16 @@ keys:
                     precedence.
 
                     Only applicable if `source_protocol` is `isis`.'
-                ospf_match_internal:
-                  type: bool
-                  description: OSPF routes learned from internal sources.
-                ospf_match_external:
-                  type: bool
-                  description: OSPF routes learned from external sources.
-                ospf_match_nssa_external:
+                ospf_route_type:
                   type: str
-                  description: OSPF routes learned from external NSSA sources.
                   valid_values:
+                  - external
+                  - internal
                   - nssa-external
                   - nssa-external 1
                   - nssa-external 2
+                  description: The `ospf_route_type` is required with source_protocols
+                    'ospf' and 'ospfv3'.
       address_family_ipv4_sr_te:
         type: dict
         keys:
@@ -11923,19 +11914,16 @@ keys:
 
                     Only used if `source_protocol` is one of `connected`, `static`,
                     `isis`, `user`, `dynamic`.'
-                ospf_match_internal:
-                  type: bool
-                  description: OSPF routes learned from internal sources.
-                ospf_match_external:
-                  type: bool
-                  description: OSPF routes learned from external sources.
-                ospf_match_nssa_external:
+                ospf_route_type:
                   type: str
-                  description: OSPF routes learned from external NSSA sources.
                   valid_values:
+                  - external
+                  - internal
                   - nssa-external
                   - nssa-external 1
                   - nssa-external 2
+                  description: The `ospf_route_type` is required with source_protocols
+                    'ospfv3'.
       address_family_ipv6_multicast:
         type: dict
         keys:
@@ -12038,19 +12026,16 @@ keys:
                     precedence.
 
                     Only applicable if `source_protocol` is `isis`.'
-                ospf_match_internal:
-                  type: bool
-                  description: OSPF routes learned from internal sources.
-                ospf_match_external:
-                  type: bool
-                  description: OSPF routes learned from external sources.
-                ospf_match_nssa_external:
+                ospf_route_type:
                   type: str
-                  description: OSPF routes learned from external NSSA sources.
                   valid_values:
+                  - external
+                  - internal
                   - nssa-external
                   - nssa-external 1
                   - nssa-external 2
+                  description: The `ospf_route_type` is required with source_protocols
+                    'ospf' and 'ospfv3'.
       address_family_ipv6_sr_te:
         type: dict
         keys:
@@ -12956,19 +12941,16 @@ keys:
 
                       Only applicable if `source_protocol` is one of `connected`,
                       `dynamic`, `isis`, `static` and `user`.'
-                  ospf_match_internal:
-                    type: bool
-                    description: OSPF routes learned from internal sources.
-                  ospf_match_external:
-                    type: bool
-                    description: OSPF routes learned from external sources.
-                  ospf_match_nssa_external:
+                  ospf_route_type:
                     type: str
-                    description: OSPF routes learned from external NSSA sources.
                     valid_values:
+                    - external
+                    - internal
                     - nssa-external
                     - nssa-external 1
                     - nssa-external 2
+                    description: The `ospf_route_type` is required with source_protocols
+                      'ospf' and 'ospfv3'.
             aggregate_addresses:
               type: list
               primary_key: prefix
@@ -13144,19 +13126,16 @@ keys:
 
                           Only applicable if `source_protocol` is one of `connected`,
                           `dynamic`, `isis`, `static` and `user`.'
-                      ospf_match_internal:
-                        type: bool
-                        description: OSPF routes learned from internal sources.
-                      ospf_match_external:
-                        type: bool
-                        description: OSPF routes learned from external sources.
-                      ospf_match_nssa_external:
+                      ospf_route_type:
                         type: str
-                        description: OSPF routes learned from external NSSA sources.
                         valid_values:
+                        - external
+                        - internal
                         - nssa-external
                         - nssa-external 1
                         - nssa-external 2
+                        description: The `ospf_route_type` is required with source_protocols
+                          'ospf' and 'ospfv3'.
             address_family_ipv6:
               type: dict
               keys:
@@ -13293,19 +13272,16 @@ keys:
 
                           Only applicable if `source_protocol` is one of `connected`,
                           `dynamic`, `isis`, `static` and `user`.'
-                      ospf_match_internal:
-                        type: bool
-                        description: OSPF routes learned from internal sources.
-                      ospf_match_external:
-                        type: bool
-                        description: OSPF routes learned from external sources.
-                      ospf_match_nssa_external:
+                      ospf_route_type:
                         type: str
-                        description: OSPF routes learned from external NSSA sources.
                         valid_values:
+                        - external
+                        - internal
                         - nssa-external
                         - nssa-external 1
                         - nssa-external 2
+                        description: The `ospf_route_type` is required with source_protocols
+                          'ospfv3'.
             address_family_ipv4_multicast:
               type: dict
               keys:
@@ -13396,19 +13372,16 @@ keys:
                           takes precedence.
 
                           Only applicable if `source_protocol` is `isis`.'
-                      ospf_match_internal:
-                        type: bool
-                        description: OSPF routes learned from internal sources.
-                      ospf_match_external:
-                        type: bool
-                        description: OSPF routes learned from external sources.
-                      ospf_match_nssa_external:
+                      ospf_route_type:
                         type: str
-                        description: OSPF routes learned from external NSSA sources.
                         valid_values:
+                        - external
+                        - internal
                         - nssa-external
                         - nssa-external 1
                         - nssa-external 2
+                        description: The `ospf_route_type` is required with source_protocols
+                          'ospf' and 'ospfv3'.
             address_family_ipv6_multicast:
               type: dict
               keys:
@@ -13498,19 +13471,16 @@ keys:
                           takes precedence.
 
                           Only applicable if `source_protocol` is `isis`.'
-                      ospf_match_internal:
-                        type: bool
-                        description: OSPF routes learned from internal sources.
-                      ospf_match_external:
-                        type: bool
-                        description: OSPF routes learned from external sources.
-                      ospf_match_nssa_external:
+                      ospf_route_type:
                         type: str
-                        description: OSPF routes learned from external NSSA sources.
                         valid_values:
+                        - external
+                        - internal
                         - nssa-external
                         - nssa-external 1
                         - nssa-external 2
+                        description: The `ospf_route_type` is required with source_protocols
+                          'ospf' and 'ospfv3'.
             address_family_flow_spec_ipv4:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -670,6 +670,7 @@ keys:
       redistribute_routes:
         type: list
         primary_key: source_protocol
+        allow_duplicate_primary_key: True
         convert_types:
           - dict
           - list
@@ -700,6 +701,19 @@ keys:
                 Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
             include_leaked:
               type: bool
+            ospf_match_internal:
+              type: bool
+              description: OSPF routes learned from internal sources.
+            ospf_match_external:
+              type: bool
+              description: OSPF routes learned from external sources.
+            ospf_match_nssa_external:
+              type: str
+              description: OSPF routes learned from external NSSA sources.
+              valid_values:
+                - "nssa-external"
+                - "nssa-external 1"
+                - "nssa-external 2"
       vlan_aware_bundles:
         type: list
         primary_key: name
@@ -1303,6 +1317,7 @@ keys:
           redistribute_routes:
             type: list
             primary_key: source_protocol
+            allow_duplicate_primary_key: True
             items:
               type: dict
               keys:
@@ -1331,6 +1346,19 @@ keys:
                     Example: MyFunction(myarg).
                     `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                     Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
+                ospf_match_internal:
+                  type: bool
+                  description: OSPF routes learned from internal sources.
+                ospf_match_external:
+                  type: bool
+                  description: OSPF routes learned from external sources.
+                ospf_match_nssa_external:
+                  type: str
+                  description: OSPF routes learned from external NSSA sources.
+                  valid_values:
+                    - "nssa-external"
+                    - "nssa-external 1"
+                    - "nssa-external 2"
       address_family_ipv4_multicast:
         type: dict
         keys:
@@ -1374,6 +1402,7 @@ keys:
           redistribute_routes:
             type: list
             primary_key: source_protocol
+            allow_duplicate_primary_key: true
             convert_types:
               - dict
             items:
@@ -1401,6 +1430,19 @@ keys:
                     Example: MyFunction(myarg).
                     `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                     Only applicable if `source_protocol` is `isis`.
+                ospf_match_internal:
+                  type: bool
+                  description: OSPF routes learned from internal sources.
+                ospf_match_external:
+                  type: bool
+                  description: OSPF routes learned from external sources.
+                ospf_match_nssa_external:
+                  type: str
+                  description: OSPF routes learned from external NSSA sources.
+                  valid_values:
+                    - "nssa-external"
+                    - "nssa-external 1"
+                    - "nssa-external 2"
       address_family_ipv4_sr_te:
         type: dict
         keys:
@@ -1526,6 +1568,7 @@ keys:
           redistribute_routes:
             type: list
             primary_key: source_protocol
+            allow_duplicate_primary_key: True
             convert_types:
               - dict
             items:
@@ -1555,6 +1598,19 @@ keys:
                     Example: MyFunction(myarg).
                     `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                     Only used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
+                ospf_match_internal:
+                  type: bool
+                  description: OSPF routes learned from internal sources.
+                ospf_match_external:
+                  type: bool
+                  description: OSPF routes learned from external sources.
+                ospf_match_nssa_external:
+                  type: str
+                  description: OSPF routes learned from external NSSA sources.
+                  valid_values:
+                    - "nssa-external"
+                    - "nssa-external 1"
+                    - "nssa-external 2"
       address_family_ipv6_multicast:
         type: dict
         keys:
@@ -1628,6 +1684,7 @@ keys:
           redistribute_routes:
             type: list
             primary_key: source_protocol
+            allow_duplicate_primary_key: true
             convert_types:
               - dict
             items:
@@ -1653,6 +1710,19 @@ keys:
                     Example: MyFunction(myarg).
                     `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                     Only applicable if `source_protocol` is `isis`.
+                ospf_match_internal:
+                  type: bool
+                  description: OSPF routes learned from internal sources.
+                ospf_match_external:
+                  type: bool
+                  description: OSPF routes learned from external sources.
+                ospf_match_nssa_external:
+                  type: str
+                  description: OSPF routes learned from external NSSA sources.
+                  valid_values:
+                    - "nssa-external"
+                    - "nssa-external 1"
+                    - "nssa-external 2"
       address_family_ipv6_sr_te:
         type: dict
         keys:
@@ -2491,6 +2561,7 @@ keys:
             redistribute_routes:
               type: list
               primary_key: source_protocol
+              allow_duplicate_primary_key: true
               convert_types:
                 - dict
                 - list
@@ -2522,6 +2593,19 @@ keys:
                       Example: MyFunction(myarg).
                       `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                       Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
+                  ospf_match_internal:
+                    type: bool
+                    description: OSPF routes learned from internal sources.
+                  ospf_match_external:
+                    type: bool
+                    description: OSPF routes learned from external sources.
+                  ospf_match_nssa_external:
+                    type: str
+                    description: OSPF routes learned from external NSSA sources.
+                    valid_values:
+                      - "nssa-external"
+                      - "nssa-external 1"
+                      - "nssa-external 2"
             aggregate_addresses:
               type: list
               primary_key: prefix
@@ -2663,6 +2747,7 @@ keys:
                 redistribute_routes:
                   type: list
                   primary_key: source_protocol
+                  allow_duplicate_primary_key: true
                   convert_types:
                     - dict
                   items:
@@ -2692,6 +2777,19 @@ keys:
                           Example: MyFunction(myarg).
                           `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                           Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
+                      ospf_match_internal:
+                        type: bool
+                        description: OSPF routes learned from internal sources.
+                      ospf_match_external:
+                        type: bool
+                        description: OSPF routes learned from external sources.
+                      ospf_match_nssa_external:
+                        type: str
+                        description: OSPF routes learned from external NSSA sources.
+                        valid_values:
+                          - "nssa-external"
+                          - "nssa-external 1"
+                          - "nssa-external 2"
             address_family_ipv6:
               type: dict
               keys:
@@ -2795,6 +2893,7 @@ keys:
                 redistribute_routes:
                   type: list
                   primary_key: source_protocol
+                  allow_duplicate_primary_key: true
                   convert_types:
                     - dict
                   items:
@@ -2823,6 +2922,19 @@ keys:
                           Example: MyFunction(myarg).
                           `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                           Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
+                      ospf_match_internal:
+                        type: bool
+                        description: OSPF routes learned from internal sources.
+                      ospf_match_external:
+                        type: bool
+                        description: OSPF routes learned from external sources.
+                      ospf_match_nssa_external:
+                        type: str
+                        description: OSPF routes learned from external NSSA sources.
+                        valid_values:
+                          - "nssa-external"
+                          - "nssa-external 1"
+                          - "nssa-external 2"
             address_family_ipv4_multicast:
               type: dict
               keys:
@@ -2883,6 +2995,7 @@ keys:
                 redistribute_routes:
                   type: list
                   primary_key: source_protocol
+                  allow_duplicate_primary_key: true
                   convert_types:
                     - dict
                   items:
@@ -2909,6 +3022,19 @@ keys:
                           Example: MyFunction(myarg).
                           `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                           Only applicable if `source_protocol` is `isis`.
+                      ospf_match_internal:
+                        type: bool
+                        description: OSPF routes learned from internal sources.
+                      ospf_match_external:
+                        type: bool
+                        description: OSPF routes learned from external sources.
+                      ospf_match_nssa_external:
+                        type: str
+                        description: OSPF routes learned from external NSSA sources.
+                        valid_values:
+                          - "nssa-external"
+                          - "nssa-external 1"
+                          - "nssa-external 2"
             address_family_ipv6_multicast:
               type: dict
               keys:
@@ -2969,6 +3095,7 @@ keys:
                 redistribute_routes:
                   type: list
                   primary_key: source_protocol
+                  allow_duplicate_primary_key: true
                   convert_types:
                     - dict
                   items:
@@ -2994,6 +3121,19 @@ keys:
                           Example: MyFunction(myarg).
                           `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                           Only applicable if `source_protocol` is `isis`.
+                      ospf_match_internal:
+                        type: bool
+                        description: OSPF routes learned from internal sources.
+                      ospf_match_external:
+                        type: bool
+                        description: OSPF routes learned from external sources.
+                      ospf_match_nssa_external:
+                        type: str
+                        description: OSPF routes learned from external NSSA sources.
+                        valid_values:
+                          - "nssa-external"
+                          - "nssa-external 1"
+                          - "nssa-external 2"
             address_family_flow_spec_ipv4:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -701,19 +701,15 @@ keys:
                 Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
             include_leaked:
               type: bool
-            ospf_match_internal:
-              type: bool
-              description: OSPF routes learned from internal sources.
-            ospf_match_external:
-              type: bool
-              description: OSPF routes learned from external sources.
-            ospf_match_nssa_external:
+            ospf_route_type:
               type: str
-              description: OSPF routes learned from external NSSA sources.
               valid_values:
+                - "external"
+                - "internal"
                 - "nssa-external"
                 - "nssa-external 1"
                 - "nssa-external 2"
+              description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
       vlan_aware_bundles:
         type: list
         primary_key: name
@@ -1346,19 +1342,15 @@ keys:
                     Example: MyFunction(myarg).
                     `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                     Only applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
-                ospf_match_internal:
-                  type: bool
-                  description: OSPF routes learned from internal sources.
-                ospf_match_external:
-                  type: bool
-                  description: OSPF routes learned from external sources.
-                ospf_match_nssa_external:
+                ospf_route_type:
                   type: str
-                  description: OSPF routes learned from external NSSA sources.
                   valid_values:
+                    - "external"
+                    - "internal"
                     - "nssa-external"
                     - "nssa-external 1"
                     - "nssa-external 2"
+                  description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
       address_family_ipv4_multicast:
         type: dict
         keys:
@@ -1430,19 +1422,15 @@ keys:
                     Example: MyFunction(myarg).
                     `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                     Only applicable if `source_protocol` is `isis`.
-                ospf_match_internal:
-                  type: bool
-                  description: OSPF routes learned from internal sources.
-                ospf_match_external:
-                  type: bool
-                  description: OSPF routes learned from external sources.
-                ospf_match_nssa_external:
+                ospf_route_type:
                   type: str
-                  description: OSPF routes learned from external NSSA sources.
                   valid_values:
+                    - "external"
+                    - "internal"
                     - "nssa-external"
                     - "nssa-external 1"
                     - "nssa-external 2"
+                  description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
       address_family_ipv4_sr_te:
         type: dict
         keys:
@@ -1598,19 +1586,15 @@ keys:
                     Example: MyFunction(myarg).
                     `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                     Only used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.
-                ospf_match_internal:
-                  type: bool
-                  description: OSPF routes learned from internal sources.
-                ospf_match_external:
-                  type: bool
-                  description: OSPF routes learned from external sources.
-                ospf_match_nssa_external:
+                ospf_route_type:
                   type: str
-                  description: OSPF routes learned from external NSSA sources.
                   valid_values:
+                    - "external"
+                    - "internal"
                     - "nssa-external"
                     - "nssa-external 1"
                     - "nssa-external 2"
+                  description: The `ospf_route_type` is required with source_protocols 'ospfv3'.
       address_family_ipv6_multicast:
         type: dict
         keys:
@@ -1710,19 +1694,15 @@ keys:
                     Example: MyFunction(myarg).
                     `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                     Only applicable if `source_protocol` is `isis`.
-                ospf_match_internal:
-                  type: bool
-                  description: OSPF routes learned from internal sources.
-                ospf_match_external:
-                  type: bool
-                  description: OSPF routes learned from external sources.
-                ospf_match_nssa_external:
+                ospf_route_type:
                   type: str
-                  description: OSPF routes learned from external NSSA sources.
                   valid_values:
+                    - "external"
+                    - "internal"
                     - "nssa-external"
                     - "nssa-external 1"
                     - "nssa-external 2"
+                  description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
       address_family_ipv6_sr_te:
         type: dict
         keys:
@@ -2593,19 +2573,15 @@ keys:
                       Example: MyFunction(myarg).
                       `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                       Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
-                  ospf_match_internal:
-                    type: bool
-                    description: OSPF routes learned from internal sources.
-                  ospf_match_external:
-                    type: bool
-                    description: OSPF routes learned from external sources.
-                  ospf_match_nssa_external:
+                  ospf_route_type:
                     type: str
-                    description: OSPF routes learned from external NSSA sources.
                     valid_values:
+                      - "external"
+                      - "internal"
                       - "nssa-external"
                       - "nssa-external 1"
                       - "nssa-external 2"
+                    description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
             aggregate_addresses:
               type: list
               primary_key: prefix
@@ -2777,19 +2753,15 @@ keys:
                           Example: MyFunction(myarg).
                           `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                           Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
-                      ospf_match_internal:
-                        type: bool
-                        description: OSPF routes learned from internal sources.
-                      ospf_match_external:
-                        type: bool
-                        description: OSPF routes learned from external sources.
-                      ospf_match_nssa_external:
+                      ospf_route_type:
                         type: str
-                        description: OSPF routes learned from external NSSA sources.
                         valid_values:
+                          - "external"
+                          - "internal"
                           - "nssa-external"
                           - "nssa-external 1"
                           - "nssa-external 2"
+                        description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
             address_family_ipv6:
               type: dict
               keys:
@@ -2922,19 +2894,15 @@ keys:
                           Example: MyFunction(myarg).
                           `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                           Only applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.
-                      ospf_match_internal:
-                        type: bool
-                        description: OSPF routes learned from internal sources.
-                      ospf_match_external:
-                        type: bool
-                        description: OSPF routes learned from external sources.
-                      ospf_match_nssa_external:
+                      ospf_route_type:
                         type: str
-                        description: OSPF routes learned from external NSSA sources.
                         valid_values:
+                          - "external"
+                          - "internal"
                           - "nssa-external"
                           - "nssa-external 1"
                           - "nssa-external 2"
+                        description: The `ospf_route_type` is required with source_protocols 'ospfv3'.
             address_family_ipv4_multicast:
               type: dict
               keys:
@@ -3022,19 +2990,15 @@ keys:
                           Example: MyFunction(myarg).
                           `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                           Only applicable if `source_protocol` is `isis`.
-                      ospf_match_internal:
-                        type: bool
-                        description: OSPF routes learned from internal sources.
-                      ospf_match_external:
-                        type: bool
-                        description: OSPF routes learned from external sources.
-                      ospf_match_nssa_external:
+                      ospf_route_type:
                         type: str
-                        description: OSPF routes learned from external NSSA sources.
                         valid_values:
+                          - "external"
+                          - "internal"
                           - "nssa-external"
                           - "nssa-external 1"
                           - "nssa-external 2"
+                        description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
             address_family_ipv6_multicast:
               type: dict
               keys:
@@ -3121,19 +3085,15 @@ keys:
                           Example: MyFunction(myarg).
                           `route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.
                           Only applicable if `source_protocol` is `isis`.
-                      ospf_match_internal:
-                        type: bool
-                        description: OSPF routes learned from internal sources.
-                      ospf_match_external:
-                        type: bool
-                        description: OSPF routes learned from external sources.
-                      ospf_match_nssa_external:
+                      ospf_route_type:
                         type: str
-                        description: OSPF routes learned from external NSSA sources.
                         valid_values:
+                          - "external"
+                          - "internal"
                           - "nssa-external"
                           - "nssa-external 1"
                           - "nssa-external 2"
+                        description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
             address_family_flow_spec_ipv4:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/router_bgp.schema.yml
@@ -709,7 +709,9 @@ keys:
                 - "nssa-external"
                 - "nssa-external 1"
                 - "nssa-external 2"
-              description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+              description: |
+                Routes learned by the OSPF protocol.
+                The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
       vlan_aware_bundles:
         type: list
         primary_key: name
@@ -1350,7 +1352,9 @@ keys:
                     - "nssa-external"
                     - "nssa-external 1"
                     - "nssa-external 2"
-                  description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                  description: |
+                    Routes learned by the OSPF protocol.
+                    The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
       address_family_ipv4_multicast:
         type: dict
         keys:
@@ -1430,7 +1434,9 @@ keys:
                     - "nssa-external"
                     - "nssa-external 1"
                     - "nssa-external 2"
-                  description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                  description: |
+                    Routes learned by the OSPF protocol.
+                    The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
       address_family_ipv4_sr_te:
         type: dict
         keys:
@@ -1594,7 +1600,9 @@ keys:
                     - "nssa-external"
                     - "nssa-external 1"
                     - "nssa-external 2"
-                  description: The `ospf_route_type` is required with source_protocols 'ospfv3'.
+                  description: |
+                    Routes learned by the OSPF protocol.
+                    The `ospf_route_type` is valid for source_protocols 'ospfv3'.
       address_family_ipv6_multicast:
         type: dict
         keys:
@@ -1702,7 +1710,9 @@ keys:
                     - "nssa-external"
                     - "nssa-external 1"
                     - "nssa-external 2"
-                  description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                  description: |
+                    Routes learned by the OSPF protocol.
+                    The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
       address_family_ipv6_sr_te:
         type: dict
         keys:
@@ -2581,7 +2591,9 @@ keys:
                       - "nssa-external"
                       - "nssa-external 1"
                       - "nssa-external 2"
-                    description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                    description: |
+                      Routes learned by the OSPF protocol.
+                      The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
             aggregate_addresses:
               type: list
               primary_key: prefix
@@ -2761,7 +2773,9 @@ keys:
                           - "nssa-external"
                           - "nssa-external 1"
                           - "nssa-external 2"
-                        description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                        description: |
+                          Routes learned by the OSPF protocol.
+                          The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
             address_family_ipv6:
               type: dict
               keys:
@@ -2902,7 +2916,9 @@ keys:
                           - "nssa-external"
                           - "nssa-external 1"
                           - "nssa-external 2"
-                        description: The `ospf_route_type` is required with source_protocols 'ospfv3'.
+                        description: |
+                          Routes learned by the OSPF protocol.
+                          The `ospf_route_type` is valid for source_protocols 'ospfv3'.
             address_family_ipv4_multicast:
               type: dict
               keys:
@@ -2998,7 +3014,9 @@ keys:
                           - "nssa-external"
                           - "nssa-external 1"
                           - "nssa-external 2"
-                        description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                        description: |
+                          Routes learned by the OSPF protocol.
+                          The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
             address_family_ipv6_multicast:
               type: dict
               keys:
@@ -3093,7 +3111,9 @@ keys:
                           - "nssa-external"
                           - "nssa-external 1"
                           - "nssa-external 2"
-                        description: The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.
+                        description: |
+                          Routes learned by the OSPF protocol.
+                          The `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.
             address_family_flow_spec_ipv4:
               type: dict
               keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -419,14 +419,8 @@ router bgp {{ router_bgp.as }}
 {%         if redistribute_route.source_protocol is arista.avd.defined %}
 {%             set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%             if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
-{%                 if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                     set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                 endif %}
-{%                 if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                     set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                 endif %}
-{%                 if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                     set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                 if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                     set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                 endif %}
 {%             endif %}
 {%             if redistribute_route.source_protocol == "bgp" %}
@@ -871,14 +865,8 @@ router bgp {{ router_bgp.as }}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%                 if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
-{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                     endif %}
 {%                 endif %}
 {%                 if redistribute_route.source_protocol == "bgp" %}
@@ -931,14 +919,8 @@ router bgp {{ router_bgp.as }}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%                 if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
-{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                     endif %}
 {%                 endif %}
 {%                 if redistribute_route.include_leaked is arista.avd.defined and redistribute_route.source_protocol == "isis" %}
@@ -1049,14 +1031,8 @@ router bgp {{ router_bgp.as }}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%                 if redistribute_route.source_protocol == "ospfv3" %}
-{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                     endif %}
 {%                 endif %}
 {%                 if redistribute_route.source_protocol == "bgp" %}
@@ -1117,14 +1093,8 @@ router bgp {{ router_bgp.as }}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%                 if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
-{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                     endif %}
 {%                 endif %}
 {%                 if redistribute_route.include_leaked is arista.avd.defined and redistribute_route.source_protocol == "isis" %}
@@ -1659,14 +1629,8 @@ router bgp {{ router_bgp.as }}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%                 if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
-{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                     endif %}
-{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                     endif %}
 {%                 endif %}
 {%                 if redistribute_route.source_protocol == "bgp" %}
@@ -1806,14 +1770,8 @@ router bgp {{ router_bgp.as }}
 {%                 if redistribute_route.source_protocol is arista.avd.defined %}
 {%                     set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%                     if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
-{%                         if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                         endif %}
-{%                         if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                         endif %}
-{%                         if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                         if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                         endif %}
 {%                     endif %}
 {%                     if redistribute_route.source_protocol == "bgp" %}
@@ -1866,14 +1824,8 @@ router bgp {{ router_bgp.as }}
 {%                 if redistribute_route.source_protocol is arista.avd.defined %}
 {%                     set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%                     if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
-{%                         if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                         endif %}
-{%                         if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                         endif %}
-{%                         if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                         if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                         endif %}
 {%                     endif %}
 {%                     if redistribute_route.include_leaked is arista.avd.defined and redistribute_route.source_protocol == "isis" %}
@@ -1952,14 +1904,8 @@ router bgp {{ router_bgp.as }}
 {%                 if redistribute_route.source_protocol is arista.avd.defined %}
 {%                     set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%                     if redistribute_route.source_protocol == "ospfv3" %}
-{%                         if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                         endif %}
-{%                         if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                         endif %}
-{%                         if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                         if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                         endif %}
 {%                     endif %}
 {%                     if redistribute_route.source_protocol == "bgp" %}
@@ -2012,14 +1958,8 @@ router bgp {{ router_bgp.as }}
 {%                 if redistribute_route.source_protocol is arista.avd.defined %}
 {%                     set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
 {%                     if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
-{%                         if redistribute_route.ospf_match_internal is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
-{%                         endif %}
-{%                         if redistribute_route.ospf_match_external is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
-{%                         endif %}
-{%                         if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
-{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                         if redistribute_route.ospf_route_type is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~  redistribute_route.ospf_route_type %}
 {%                         endif %}
 {%                     endif %}
 {%                     if redistribute_route.include_leaked is arista.avd.defined and redistribute_route.source_protocol == "isis" %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/router-bgp.j2
@@ -418,6 +418,17 @@ router bgp {{ router_bgp.as }}
 {%     for redistribute_route in router_bgp.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%         if redistribute_route.source_protocol is arista.avd.defined %}
 {%             set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%             if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
+{%                 if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                     set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                 endif %}
+{%                 if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                     set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                 endif %}
+{%                 if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                     set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                 endif %}
+{%             endif %}
 {%             if redistribute_route.source_protocol == "bgp" %}
 {%                 set redistribute_route_cli = redistribute_route_cli ~ " leaked" %}
 {%             elif redistribute_route.include_leaked is arista.avd.defined %}
@@ -859,6 +870,17 @@ router bgp {{ router_bgp.as }}
 {%         for redistribute_route in router_bgp.address_family_ipv4.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                 if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
+{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     endif %}
+{%                 endif %}
 {%                 if redistribute_route.source_protocol == "bgp" %}
 {%                     set redistribute_route_cli = redistribute_route_cli ~ " leaked" %}
 {%                 elif redistribute_route.include_leaked is arista.avd.defined  and redistribute_route.source_protocol in ["connected", "static", "isis", "ospf", "ospfv3"] %}
@@ -908,6 +930,17 @@ router bgp {{ router_bgp.as }}
 {%         for redistribute_route in router_bgp.address_family_ipv4_multicast.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                 if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
+{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     endif %}
+{%                 endif %}
 {%                 if redistribute_route.include_leaked is arista.avd.defined and redistribute_route.source_protocol == "isis" %}
 {%                     set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
 {%                 endif %}
@@ -1015,6 +1048,17 @@ router bgp {{ router_bgp.as }}
 {%         for redistribute_route in router_bgp.address_family_ipv6.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                 if redistribute_route.source_protocol == "ospfv3" %}
+{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     endif %}
+{%                 endif %}
 {%                 if redistribute_route.source_protocol == "bgp" %}
 {%                     set redistribute_route_cli = redistribute_route_cli ~ " leaked" %}
 {%                 elif redistribute_route.include_leaked is arista.avd.defined %}
@@ -1072,6 +1116,17 @@ router bgp {{ router_bgp.as }}
 {%         for redistribute_route in router_bgp.address_family_ipv6_multicast.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                 if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
+{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     endif %}
+{%                 endif %}
 {%                 if redistribute_route.include_leaked is arista.avd.defined and redistribute_route.source_protocol == "isis" %}
 {%                     set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
 {%                 endif %}
@@ -1603,6 +1658,17 @@ router bgp {{ router_bgp.as }}
 {%         for redistribute_route in vrf.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%             if redistribute_route.source_protocol is arista.avd.defined %}
 {%                 set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                 if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
+{%                     if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                     endif %}
+{%                     if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                         set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                     endif %}
+{%                 endif %}
 {%                 if redistribute_route.source_protocol == "bgp" %}
 {%                     set redistribute_route_cli = redistribute_route_cli ~ " leaked" %}
 {%                 elif redistribute_route.include_leaked is arista.avd.defined %}
@@ -1739,6 +1805,17 @@ router bgp {{ router_bgp.as }}
 {%             for redistribute_route in vrf.address_family_ipv4.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%                 if redistribute_route.source_protocol is arista.avd.defined %}
 {%                     set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                     if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
+{%                         if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                         endif %}
+{%                         if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                         endif %}
+{%                         if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                         endif %}
+{%                     endif %}
 {%                     if redistribute_route.source_protocol == "bgp" %}
 {%                         set redistribute_route_cli = redistribute_route_cli ~ " leaked" %}
 {%                     elif redistribute_route.include_leaked is arista.avd.defined %}
@@ -1788,6 +1865,17 @@ router bgp {{ router_bgp.as }}
 {%             for redistribute_route in vrf.address_family_ipv4_multicast.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%                 if redistribute_route.source_protocol is arista.avd.defined %}
 {%                     set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                     if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
+{%                         if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                         endif %}
+{%                         if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                         endif %}
+{%                         if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                         endif %}
+{%                     endif %}
 {%                     if redistribute_route.include_leaked is arista.avd.defined and redistribute_route.source_protocol == "isis" %}
 {%                         set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
 {%                     endif %}
@@ -1863,6 +1951,17 @@ router bgp {{ router_bgp.as }}
 {%             for redistribute_route in vrf.address_family_ipv6.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%                 if redistribute_route.source_protocol is arista.avd.defined %}
 {%                     set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                     if redistribute_route.source_protocol == "ospfv3" %}
+{%                         if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                         endif %}
+{%                         if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                         endif %}
+{%                         if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                         endif %}
+{%                     endif %}
 {%                     if redistribute_route.source_protocol == "bgp" %}
 {%                         set redistribute_route_cli = redistribute_route_cli ~ " leaked" %}
 {%                     elif redistribute_route.include_leaked is arista.avd.defined %}
@@ -1912,6 +2011,17 @@ router bgp {{ router_bgp.as }}
 {%             for redistribute_route in vrf.address_family_ipv6_multicast.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%                 if redistribute_route.source_protocol is arista.avd.defined %}
 {%                     set redistribute_route_cli = "redistribute " ~ redistribute_route.source_protocol %}
+{%                     if redistribute_route.source_protocol in ["ospf", "ospfv3"] %}
+{%                         if redistribute_route.ospf_match_internal is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match internal" %}
+{%                         endif %}
+{%                         if redistribute_route.ospf_match_external is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match external" %}
+{%                         endif %}
+{%                         if redistribute_route.ospf_match_nssa_external is arista.avd.defined %}
+{%                             set redistribute_route_cli = redistribute_route_cli ~ " match " ~ redistribute_route.ospf_match_nssa_external %}
+{%                         endif %}
+{%                     endif %}
 {%                     if redistribute_route.include_leaked is arista.avd.defined and redistribute_route.source_protocol == "isis" %}
 {%                         set redistribute_route_cli = redistribute_route_cli ~ " include leaked" %}
 {%                     endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -35342,25 +35342,17 @@
                           "type": "boolean",
                           "title": "Include Leaked"
                         },
-                        "ospf_match_internal": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from internal sources.",
-                          "title": "OSPF Match Internal"
-                        },
-                        "ospf_match_external": {
-                          "type": "boolean",
-                          "description": "OSPF routes learned from external sources.",
-                          "title": "OSPF Match External"
-                        },
-                        "ospf_match_nssa_external": {
+                        "ospf_route_type": {
                           "type": "string",
-                          "description": "OSPF routes learned from external NSSA sources.",
                           "enum": [
+                            "external",
+                            "internal",
                             "nssa-external",
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "title": "OSPF Match Nssa External"
+                          "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                          "title": "OSPF Route Type"
                         }
                       },
                       "additionalProperties": false,
@@ -36515,25 +36507,17 @@
                               "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.",
                               "title": "RCF"
                             },
-                            "ospf_match_internal": {
-                              "type": "boolean",
-                              "description": "OSPF routes learned from internal sources.",
-                              "title": "OSPF Match Internal"
-                            },
-                            "ospf_match_external": {
-                              "type": "boolean",
-                              "description": "OSPF routes learned from external sources.",
-                              "title": "OSPF Match External"
-                            },
-                            "ospf_match_nssa_external": {
+                            "ospf_route_type": {
                               "type": "string",
-                              "description": "OSPF routes learned from external NSSA sources.",
                               "enum": [
+                                "external",
+                                "internal",
                                 "nssa-external",
                                 "nssa-external 1",
                                 "nssa-external 2"
                               ],
-                              "title": "OSPF Match Nssa External"
+                              "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                              "title": "OSPF Route Type"
                             }
                           },
                           "additionalProperties": false,
@@ -36648,25 +36632,17 @@
                               "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                               "title": "RCF"
                             },
-                            "ospf_match_internal": {
-                              "type": "boolean",
-                              "description": "OSPF routes learned from internal sources.",
-                              "title": "OSPF Match Internal"
-                            },
-                            "ospf_match_external": {
-                              "type": "boolean",
-                              "description": "OSPF routes learned from external sources.",
-                              "title": "OSPF Match External"
-                            },
-                            "ospf_match_nssa_external": {
+                            "ospf_route_type": {
                               "type": "string",
-                              "description": "OSPF routes learned from external NSSA sources.",
                               "enum": [
+                                "external",
+                                "internal",
                                 "nssa-external",
                                 "nssa-external 1",
                                 "nssa-external 2"
                               ],
-                              "title": "OSPF Match Nssa External"
+                              "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                              "title": "OSPF Route Type"
                             }
                           },
                           "additionalProperties": false,
@@ -36925,25 +36901,17 @@
                               "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.",
                               "title": "RCF"
                             },
-                            "ospf_match_internal": {
-                              "type": "boolean",
-                              "description": "OSPF routes learned from internal sources.",
-                              "title": "OSPF Match Internal"
-                            },
-                            "ospf_match_external": {
-                              "type": "boolean",
-                              "description": "OSPF routes learned from external sources.",
-                              "title": "OSPF Match External"
-                            },
-                            "ospf_match_nssa_external": {
+                            "ospf_route_type": {
                               "type": "string",
-                              "description": "OSPF routes learned from external NSSA sources.",
                               "enum": [
+                                "external",
+                                "internal",
                                 "nssa-external",
                                 "nssa-external 1",
                                 "nssa-external 2"
                               ],
-                              "title": "OSPF Match Nssa External"
+                              "description": "The `ospf_route_type` is required with source_protocols 'ospfv3'.",
+                              "title": "OSPF Route Type"
                             }
                           },
                           "additionalProperties": false,
@@ -37132,25 +37100,17 @@
                               "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                               "title": "RCF"
                             },
-                            "ospf_match_internal": {
-                              "type": "boolean",
-                              "description": "OSPF routes learned from internal sources.",
-                              "title": "OSPF Match Internal"
-                            },
-                            "ospf_match_external": {
-                              "type": "boolean",
-                              "description": "OSPF routes learned from external sources.",
-                              "title": "OSPF Match External"
-                            },
-                            "ospf_match_nssa_external": {
+                            "ospf_route_type": {
                               "type": "string",
-                              "description": "OSPF routes learned from external NSSA sources.",
                               "enum": [
+                                "external",
+                                "internal",
                                 "nssa-external",
                                 "nssa-external 1",
                                 "nssa-external 2"
                               ],
-                              "title": "OSPF Match Nssa External"
+                              "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                              "title": "OSPF Route Type"
                             }
                           },
                           "additionalProperties": false,
@@ -38711,25 +38671,17 @@
                                 "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                                 "title": "RCF"
                               },
-                              "ospf_match_internal": {
-                                "type": "boolean",
-                                "description": "OSPF routes learned from internal sources.",
-                                "title": "OSPF Match Internal"
-                              },
-                              "ospf_match_external": {
-                                "type": "boolean",
-                                "description": "OSPF routes learned from external sources.",
-                                "title": "OSPF Match External"
-                              },
-                              "ospf_match_nssa_external": {
+                              "ospf_route_type": {
                                 "type": "string",
-                                "description": "OSPF routes learned from external NSSA sources.",
                                 "enum": [
+                                  "external",
+                                  "internal",
                                   "nssa-external",
                                   "nssa-external 1",
                                   "nssa-external 2"
                                 ],
-                                "title": "OSPF Match Nssa External"
+                                "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                                "title": "OSPF Route Type"
                               }
                             },
                             "additionalProperties": false,
@@ -39036,25 +38988,17 @@
                                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                                     "title": "RCF"
                                   },
-                                  "ospf_match_internal": {
-                                    "type": "boolean",
-                                    "description": "OSPF routes learned from internal sources.",
-                                    "title": "OSPF Match Internal"
-                                  },
-                                  "ospf_match_external": {
-                                    "type": "boolean",
-                                    "description": "OSPF routes learned from external sources.",
-                                    "title": "OSPF Match External"
-                                  },
-                                  "ospf_match_nssa_external": {
+                                  "ospf_route_type": {
                                     "type": "string",
-                                    "description": "OSPF routes learned from external NSSA sources.",
                                     "enum": [
+                                      "external",
+                                      "internal",
                                       "nssa-external",
                                       "nssa-external 1",
                                       "nssa-external 2"
                                     ],
-                                    "title": "OSPF Match Nssa External"
+                                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                                    "title": "OSPF Route Type"
                                   }
                                 },
                                 "additionalProperties": false,
@@ -39285,25 +39229,17 @@
                                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                                     "title": "RCF"
                                   },
-                                  "ospf_match_internal": {
-                                    "type": "boolean",
-                                    "description": "OSPF routes learned from internal sources.",
-                                    "title": "OSPF Match Internal"
-                                  },
-                                  "ospf_match_external": {
-                                    "type": "boolean",
-                                    "description": "OSPF routes learned from external sources.",
-                                    "title": "OSPF Match External"
-                                  },
-                                  "ospf_match_nssa_external": {
+                                  "ospf_route_type": {
                                     "type": "string",
-                                    "description": "OSPF routes learned from external NSSA sources.",
                                     "enum": [
+                                      "external",
+                                      "internal",
                                       "nssa-external",
                                       "nssa-external 1",
                                       "nssa-external 2"
                                     ],
-                                    "title": "OSPF Match Nssa External"
+                                    "description": "The `ospf_route_type` is required with source_protocols 'ospfv3'.",
+                                    "title": "OSPF Route Type"
                                   }
                                 },
                                 "additionalProperties": false,
@@ -39468,25 +39404,17 @@
                                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                                     "title": "RCF"
                                   },
-                                  "ospf_match_internal": {
-                                    "type": "boolean",
-                                    "description": "OSPF routes learned from internal sources.",
-                                    "title": "OSPF Match Internal"
-                                  },
-                                  "ospf_match_external": {
-                                    "type": "boolean",
-                                    "description": "OSPF routes learned from external sources.",
-                                    "title": "OSPF Match External"
-                                  },
-                                  "ospf_match_nssa_external": {
+                                  "ospf_route_type": {
                                     "type": "string",
-                                    "description": "OSPF routes learned from external NSSA sources.",
                                     "enum": [
+                                      "external",
+                                      "internal",
                                       "nssa-external",
                                       "nssa-external 1",
                                       "nssa-external 2"
                                     ],
-                                    "title": "OSPF Match Nssa External"
+                                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                                    "title": "OSPF Route Type"
                                   }
                                 },
                                 "additionalProperties": false,
@@ -39650,25 +39578,17 @@
                                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                                     "title": "RCF"
                                   },
-                                  "ospf_match_internal": {
-                                    "type": "boolean",
-                                    "description": "OSPF routes learned from internal sources.",
-                                    "title": "OSPF Match Internal"
-                                  },
-                                  "ospf_match_external": {
-                                    "type": "boolean",
-                                    "description": "OSPF routes learned from external sources.",
-                                    "title": "OSPF Match External"
-                                  },
-                                  "ospf_match_nssa_external": {
+                                  "ospf_route_type": {
                                     "type": "string",
-                                    "description": "OSPF routes learned from external NSSA sources.",
                                     "enum": [
+                                      "external",
+                                      "internal",
                                       "nssa-external",
                                       "nssa-external 1",
                                       "nssa-external 2"
                                     ],
-                                    "title": "OSPF Match Nssa External"
+                                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                                    "title": "OSPF Route Type"
                                   }
                                 },
                                 "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -35341,6 +35341,26 @@
                         "include_leaked": {
                           "type": "boolean",
                           "title": "Include Leaked"
+                        },
+                        "ospf_match_internal": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from internal sources.",
+                          "title": "OSPF Match Internal"
+                        },
+                        "ospf_match_external": {
+                          "type": "boolean",
+                          "description": "OSPF routes learned from external sources.",
+                          "title": "OSPF Match External"
+                        },
+                        "ospf_match_nssa_external": {
+                          "type": "string",
+                          "description": "OSPF routes learned from external NSSA sources.",
+                          "enum": [
+                            "nssa-external",
+                            "nssa-external 1",
+                            "nssa-external 2"
+                          ],
+                          "title": "OSPF Match Nssa External"
                         }
                       },
                       "additionalProperties": false,
@@ -36494,6 +36514,26 @@
                               "type": "string",
                               "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.",
                               "title": "RCF"
+                            },
+                            "ospf_match_internal": {
+                              "type": "boolean",
+                              "description": "OSPF routes learned from internal sources.",
+                              "title": "OSPF Match Internal"
+                            },
+                            "ospf_match_external": {
+                              "type": "boolean",
+                              "description": "OSPF routes learned from external sources.",
+                              "title": "OSPF Match External"
+                            },
+                            "ospf_match_nssa_external": {
+                              "type": "string",
+                              "description": "OSPF routes learned from external NSSA sources.",
+                              "enum": [
+                                "nssa-external",
+                                "nssa-external 1",
+                                "nssa-external 2"
+                              ],
+                              "title": "OSPF Match Nssa External"
                             }
                           },
                           "additionalProperties": false,
@@ -36607,6 +36647,26 @@
                               "type": "string",
                               "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                               "title": "RCF"
+                            },
+                            "ospf_match_internal": {
+                              "type": "boolean",
+                              "description": "OSPF routes learned from internal sources.",
+                              "title": "OSPF Match Internal"
+                            },
+                            "ospf_match_external": {
+                              "type": "boolean",
+                              "description": "OSPF routes learned from external sources.",
+                              "title": "OSPF Match External"
+                            },
+                            "ospf_match_nssa_external": {
+                              "type": "string",
+                              "description": "OSPF routes learned from external NSSA sources.",
+                              "enum": [
+                                "nssa-external",
+                                "nssa-external 1",
+                                "nssa-external 2"
+                              ],
+                              "title": "OSPF Match Nssa External"
                             }
                           },
                           "additionalProperties": false,
@@ -36864,6 +36924,26 @@
                               "type": "string",
                               "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly used if `source_protocol` is one of `connected`, `static`, `isis`, `user`, `dynamic`.",
                               "title": "RCF"
+                            },
+                            "ospf_match_internal": {
+                              "type": "boolean",
+                              "description": "OSPF routes learned from internal sources.",
+                              "title": "OSPF Match Internal"
+                            },
+                            "ospf_match_external": {
+                              "type": "boolean",
+                              "description": "OSPF routes learned from external sources.",
+                              "title": "OSPF Match External"
+                            },
+                            "ospf_match_nssa_external": {
+                              "type": "string",
+                              "description": "OSPF routes learned from external NSSA sources.",
+                              "enum": [
+                                "nssa-external",
+                                "nssa-external 1",
+                                "nssa-external 2"
+                              ],
+                              "title": "OSPF Match Nssa External"
                             }
                           },
                           "additionalProperties": false,
@@ -37051,6 +37131,26 @@
                               "type": "string",
                               "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                               "title": "RCF"
+                            },
+                            "ospf_match_internal": {
+                              "type": "boolean",
+                              "description": "OSPF routes learned from internal sources.",
+                              "title": "OSPF Match Internal"
+                            },
+                            "ospf_match_external": {
+                              "type": "boolean",
+                              "description": "OSPF routes learned from external sources.",
+                              "title": "OSPF Match External"
+                            },
+                            "ospf_match_nssa_external": {
+                              "type": "string",
+                              "description": "OSPF routes learned from external NSSA sources.",
+                              "enum": [
+                                "nssa-external",
+                                "nssa-external 1",
+                                "nssa-external 2"
+                              ],
+                              "title": "OSPF Match Nssa External"
                             }
                           },
                           "additionalProperties": false,
@@ -38610,6 +38710,26 @@
                                 "type": "string",
                                 "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                                 "title": "RCF"
+                              },
+                              "ospf_match_internal": {
+                                "type": "boolean",
+                                "description": "OSPF routes learned from internal sources.",
+                                "title": "OSPF Match Internal"
+                              },
+                              "ospf_match_external": {
+                                "type": "boolean",
+                                "description": "OSPF routes learned from external sources.",
+                                "title": "OSPF Match External"
+                              },
+                              "ospf_match_nssa_external": {
+                                "type": "string",
+                                "description": "OSPF routes learned from external NSSA sources.",
+                                "enum": [
+                                  "nssa-external",
+                                  "nssa-external 1",
+                                  "nssa-external 2"
+                                ],
+                                "title": "OSPF Match Nssa External"
                               }
                             },
                             "additionalProperties": false,
@@ -38915,6 +39035,26 @@
                                     "type": "string",
                                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                                     "title": "RCF"
+                                  },
+                                  "ospf_match_internal": {
+                                    "type": "boolean",
+                                    "description": "OSPF routes learned from internal sources.",
+                                    "title": "OSPF Match Internal"
+                                  },
+                                  "ospf_match_external": {
+                                    "type": "boolean",
+                                    "description": "OSPF routes learned from external sources.",
+                                    "title": "OSPF Match External"
+                                  },
+                                  "ospf_match_nssa_external": {
+                                    "type": "string",
+                                    "description": "OSPF routes learned from external NSSA sources.",
+                                    "enum": [
+                                      "nssa-external",
+                                      "nssa-external 1",
+                                      "nssa-external 2"
+                                    ],
+                                    "title": "OSPF Match Nssa External"
                                   }
                                 },
                                 "additionalProperties": false,
@@ -39144,6 +39284,26 @@
                                     "type": "string",
                                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is one of `connected`, `dynamic`, `isis`, `static` and `user`.",
                                     "title": "RCF"
+                                  },
+                                  "ospf_match_internal": {
+                                    "type": "boolean",
+                                    "description": "OSPF routes learned from internal sources.",
+                                    "title": "OSPF Match Internal"
+                                  },
+                                  "ospf_match_external": {
+                                    "type": "boolean",
+                                    "description": "OSPF routes learned from external sources.",
+                                    "title": "OSPF Match External"
+                                  },
+                                  "ospf_match_nssa_external": {
+                                    "type": "string",
+                                    "description": "OSPF routes learned from external NSSA sources.",
+                                    "enum": [
+                                      "nssa-external",
+                                      "nssa-external 1",
+                                      "nssa-external 2"
+                                    ],
+                                    "title": "OSPF Match Nssa External"
                                   }
                                 },
                                 "additionalProperties": false,
@@ -39307,6 +39467,26 @@
                                     "type": "string",
                                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                                     "title": "RCF"
+                                  },
+                                  "ospf_match_internal": {
+                                    "type": "boolean",
+                                    "description": "OSPF routes learned from internal sources.",
+                                    "title": "OSPF Match Internal"
+                                  },
+                                  "ospf_match_external": {
+                                    "type": "boolean",
+                                    "description": "OSPF routes learned from external sources.",
+                                    "title": "OSPF Match External"
+                                  },
+                                  "ospf_match_nssa_external": {
+                                    "type": "string",
+                                    "description": "OSPF routes learned from external NSSA sources.",
+                                    "enum": [
+                                      "nssa-external",
+                                      "nssa-external 1",
+                                      "nssa-external 2"
+                                    ],
+                                    "title": "OSPF Match Nssa External"
                                   }
                                 },
                                 "additionalProperties": false,
@@ -39469,6 +39649,26 @@
                                     "type": "string",
                                     "description": "RCF function name with parenthesis.\nExample: MyFunction(myarg).\n`route_map` and `rcf` are mutually exclusive. `route_map` takes precedence.\nOnly applicable if `source_protocol` is `isis`.",
                                     "title": "RCF"
+                                  },
+                                  "ospf_match_internal": {
+                                    "type": "boolean",
+                                    "description": "OSPF routes learned from internal sources.",
+                                    "title": "OSPF Match Internal"
+                                  },
+                                  "ospf_match_external": {
+                                    "type": "boolean",
+                                    "description": "OSPF routes learned from external sources.",
+                                    "title": "OSPF Match External"
+                                  },
+                                  "ospf_match_nssa_external": {
+                                    "type": "string",
+                                    "description": "OSPF routes learned from external NSSA sources.",
+                                    "enum": [
+                                      "nssa-external",
+                                      "nssa-external 1",
+                                      "nssa-external 2"
+                                    ],
+                                    "title": "OSPF Match Nssa External"
                                   }
                                 },
                                 "additionalProperties": false,

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -35351,7 +35351,7 @@
                             "nssa-external 1",
                             "nssa-external 2"
                           ],
-                          "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                          "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                           "title": "OSPF Route Type"
                         }
                       },
@@ -36516,7 +36516,7 @@
                                 "nssa-external 1",
                                 "nssa-external 2"
                               ],
-                              "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                              "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                               "title": "OSPF Route Type"
                             }
                           },
@@ -36641,7 +36641,7 @@
                                 "nssa-external 1",
                                 "nssa-external 2"
                               ],
-                              "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                              "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                               "title": "OSPF Route Type"
                             }
                           },
@@ -36910,7 +36910,7 @@
                                 "nssa-external 1",
                                 "nssa-external 2"
                               ],
-                              "description": "The `ospf_route_type` is required with source_protocols 'ospfv3'.",
+                              "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospfv3'.\n",
                               "title": "OSPF Route Type"
                             }
                           },
@@ -37109,7 +37109,7 @@
                                 "nssa-external 1",
                                 "nssa-external 2"
                               ],
-                              "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                              "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                               "title": "OSPF Route Type"
                             }
                           },
@@ -38680,7 +38680,7 @@
                                   "nssa-external 1",
                                   "nssa-external 2"
                                 ],
-                                "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                                "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                                 "title": "OSPF Route Type"
                               }
                             },
@@ -38997,7 +38997,7 @@
                                       "nssa-external 1",
                                       "nssa-external 2"
                                     ],
-                                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                                    "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                                     "title": "OSPF Route Type"
                                   }
                                 },
@@ -39238,7 +39238,7 @@
                                       "nssa-external 1",
                                       "nssa-external 2"
                                     ],
-                                    "description": "The `ospf_route_type` is required with source_protocols 'ospfv3'.",
+                                    "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospfv3'.\n",
                                     "title": "OSPF Route Type"
                                   }
                                 },
@@ -39413,7 +39413,7 @@
                                       "nssa-external 1",
                                       "nssa-external 2"
                                     ],
-                                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                                    "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                                     "title": "OSPF Route Type"
                                   }
                                 },
@@ -39587,7 +39587,7 @@
                                       "nssa-external 1",
                                       "nssa-external 2"
                                     ],
-                                    "description": "The `ospf_route_type` is required with source_protocols 'ospf' and 'ospfv3'.",
+                                    "description": "Routes learned by the OSPF protocol.\nThe `ospf_route_type` is valid for source_protocols 'ospf' and 'ospfv3'.\n",
                                     "title": "OSPF Route Type"
                                   }
                                 },


### PR DESCRIPTION
## Change Summary

Add knob for ospf_type when redistributing ospf into bgp.

## Related Issue(s)

Fixes #4014 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## How to test
Check config on CLI

## Checklist
### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
