### PR TITLE
CI: Avoid latest pylint and set latest docker version as minimum

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -96,7 +96,7 @@ repos:
         exclude: ^ansible_collections/arista/avd/plugins/plugin_utils/cv_client/api/
 
   - repo: https://github.com/pycqa/pylint
-    rev: "v3.2.2"
+    rev: "v3.1.1"
     hooks:
       - id: pylint # Use pylintrc file in repository
         name: Check for Linting errors on Python files

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -3,12 +3,13 @@ ansible-lint>=6.21.0,<24.5.0
 codespell>=2.2.6
 pycodestyle
 flake8
-pylint>=2.16.1
+# Hitting various pylint bugs for 'possibly-used-before-assignment' introduced in 3.2.0
+pylint>=2.16.1,<3.2.0
 twine
 pre-commit>=3.2.0
 pre-commit-hooks>=3.3.0
 identify>=1.4.20
-docker
+docker>=7.1.0
 molecule>=6.0
 molecule-plugins[docker]>=23.4.0
 yamllint
@@ -16,7 +17,7 @@ treelib>=1.5.5
 md-toc>=8.1.0
 natsort
 jsonschema>=4.10.3
-referencing>=0.35.0
+referencing>=0.35.
 deepmerge>=1.1.0
 isort==5.13.2
 black==24.4.2

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -17,7 +17,7 @@ treelib>=1.5.5
 md-toc>=8.1.0
 natsort
 jsonschema>=4.10.3
-referencing>=0.35.
+referencing>=0.35.0
 deepmerge>=1.1.0
 isort==5.13.2
 black==24.4.2


### PR DESCRIPTION
- Hitting pylint bugs with a new check in 3.2 so capping it <3.2.
- Latest `docker` version resolves incompatibility with latest `requests`.

Open source is fun...
