### PR TITLE
Doc: Fix mkdocs broken requirement links in roles

### DIFF
--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/README.md
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/README.md
@@ -101,7 +101,7 @@ ansible-playbook playbook.to.deploy.with.cvp.yml --tags "provision"
 
 ## Requirements
 
-Requirements are located here: [avd-requirements](../../README.md#Requirements)
+Requirements are located here: [avd-requirements](../../docs/installation/collection-installation.md#additional-python-libraries-required)
 
 ## License
 

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/README.md
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/README.md
@@ -128,7 +128,7 @@ custom_structured_configuration_daemon_terminattr:
 
 ## Requirements
 
-Requirements are located here: [avd-requirements](../../README.md#Requirements)
+Requirements are located here: [avd-requirements](../../docs/installation/collection-installation.md#additional-python-libraries-required)
 
 ## License
 

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/README.md
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_cvp/README.md
@@ -303,7 +303,7 @@ ansible-playbook playbook.to.deploy.with.cvp.yml --skip-tags "containers,apply"
 
 ## Requirements
 
-Requirements are located here: [avd-requirements](../../README.md#Requirements)
+Requirements are located here: [avd-requirements](../../docs/installation/collection-installation.md#additional-python-libraries-required)
 
 ## License
 

--- a/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/README.md
+++ b/ansible_collections/arista/avd/roles/eos_config_deploy_eapi/README.md
@@ -53,7 +53,7 @@ roles/eos_config_deploy_eapi/defaults/main.yml
 
 ## Requirements
 
-Requirements are located here: [avd-requirements](../../README.md#Requirements)
+Requirements are located here: [avd-requirements](../../docs/installation/collection-installation.md#additional-python-libraries-required)
 
 ## License
 

--- a/ansible_collections/arista/avd/roles/eos_snapshot/README.md
+++ b/ansible_collections/arista/avd/roles/eos_snapshot/README.md
@@ -74,7 +74,7 @@ commands_list:
 
 ## Requirements
 
-Requirements are located here: [avd-requirements](../../README.md#Requirements)
+Requirements are located here: [avd-requirements](../../docs/installation/collection-installation.md#additional-python-libraries-required)
 
 ## Example Playbook
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -124,7 +124,7 @@ The variable validation_role.only_failed_tests is used to limit the number of te
 
 ## Requirements
 
-Requirements are located here: [avd-requirements](../../README.md#Requirements)
+Requirements are located here: [avd-requirements](../../docs/installation/collection-installation.md#additional-python-libraries-required)
 
 ## Example Playbook
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -3,6 +3,9 @@ site_name: Arista AVD
 site_author: Arista Ansible Team
 site_description: Arista Validated Designs documentation
 copyright: Copyright &copy; 2019 - 2023 Arista Networks
+strict: true
+exclude_docs: |
+  /README.md
 
 # Repository information
 repo_name: AVD on Github


### PR DESCRIPTION
## Change Summary

We broke some links, this unbroke the links

## Component(s) name

`documentation`

## Proposed changes

* fix the links
* turns mkdocs warnings into errors to prevent this to ever happening agin

## How to test

doc builds without warning, anyway now warnings are errors so this is better!\


## Checklist

### User Checklist

* click the links and marvel

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
