### PR TITLE
Fix(containers): Add "remoteUser": "avd" to devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,5 +12,6 @@
     // The dev entrypoint is used to install Ansible collections and requirements, as they are not included with the dev version.
     // "true" is required to exit "postStartCommand" without entering ZSH.
     // the script must be executed ONLY if Ansible is not installed
-    "postStartCommand": "/bin/entrypoint.sh true"
+    "postStartCommand": "/bin/entrypoint.sh true",
+    "remoteUser": "avd"
 }


### PR DESCRIPTION
## Change Summary

In some cases vs code starts using your local user account and causes the dev container not to build.
Adding `"remoteUser": "avd"` parameter to the dev container config file resolves this issue.