### PR TITLE
Doc: Add notes about using cv_deploy for CV Pathfinder

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -38,6 +38,13 @@ Please familiarize yourself with the Arista WAN terminology before proceeding:
 - VRF `default` is being configured by default on all WAN devices with a `wan_vni` of 1. To override this, it is necessary to configure VRF `default` in a tenant in `network_services`.
 - Path-group ID `65535` is reserved for the path-group called `LAN_HA`.
 
+!!! info "CV Pathfinder & CloudVision"
+
+    When deploying CV Pathfinder with CloudVision, it is necessary to leverage
+    `arista.avd.cv_deploy` role and not `arista.avd.eos_config_deploy_cvp` as
+    CloudVision relies on metadata sent by AVD for visualization and to generate
+    and deliver to devices certificates for STUN.
+
 ### Features in PREVIEW
 
 - WAN HA is in PREVIEW

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -41,9 +41,9 @@ Please familiarize yourself with the Arista WAN terminology before proceeding:
 !!! info "CV Pathfinder & CloudVision"
 
     When deploying CV Pathfinder with CloudVision, it is necessary to leverage
-    `arista.avd.cv_deploy` role and not `arista.avd.eos_config_deploy_cvp` as
-    CloudVision relies on metadata sent by AVD for visualization and to generate
-    and deliver to devices certificates for STUN.
+    the `arista.avd.cv_deploy` role and not the `arista.avd.eos_config_deploy_cvp`
+    role, as CloudVision relies on metadata sent by AVD for visualization and to
+    generate and deliver certificates for STUN to devices.
 
 ### Features in PREVIEW
 


### PR DESCRIPTION
## Change Summary

cf title

## Related Issue(s)

Field issue - some users have tried to use `arista.avd.eos_config_deploy_cvp` which led to empty metadata on CV and so no visualization and issues with STUN.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

cf title

## How to test

Read doc.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
