### PR TITLE
Fix(eos_designs): core_interfaces generates invalid config if ASN is not defined for the p2p_links/p2p_links_profiles

### DIFF
--- a/.github/requirements-ci.txt
+++ b/.github/requirements-ci.txt
@@ -1,5 +1,5 @@
 # Installing PyAVD as editable install.
 # The -e path is relative to the repo root and will only work if the pip install is executed from there.
--e python-avd
+-e ./python-avd
 # The -r path is relative to this file.
 -r ../ansible_collections/arista/avd/requirements.txt

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/core-interfaces-p2p-links-as.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/core-interfaces-p2p-links-as.yml
@@ -1,0 +1,50 @@
+# Testing "core_interfaces.p2p_links_profiles.[].as" not defined error
+
+# Fabric node type keys
+node_type_keys:
+  - key: core_router
+    type: core_router
+    default_evpn_role: none
+    mpls_lsr: true
+
+bgp_as: 65000
+
+# Nodes
+type: core_router
+core_router:
+  defaults:
+    loopback_ipv4_pool: 10.0.0.0/24
+    loopback_ipv6_pool: "2000:1234:ffff:ffff::/64"
+    node_sid_base: 200
+    isis_system_id_prefix: "0000.0001"
+  nodes:
+    - name: core-interfaces-p2p-links-as
+      id: 1
+
+core_interfaces:
+  p2p_links_ip_pools:
+    - name: underlay_pool
+      ipv4_pool: 100.64.48.0/24
+    - name: some_other_pool
+      ipv4_pool: 100.123.123.0/24
+  p2p_links_profiles:
+    - name: isis_bb_profile
+      speed: "forced 1000full"
+      mtu: 1500
+      isis_hello_padding: false
+      isis_metric: 60
+      ip_pool: underlay_pool
+      isis_circuit_type: level-2
+      ipv6_enable: true
+      isis_authentication_mode: md5
+      isis_authentication_key: $1c$sTNAlR6rKSw=
+  p2p_links:
+    # P2P core links with underlay_multicast(pim-sparse) enabled.
+    - nodes: [ core-interfaces-p2p-links-as, peer1 ]
+      id: 10
+      interfaces: [ Ethernet1, Ethernet1 ]
+      include_in_underlay_protocol: true
+      underlay_multicast: true
+      ip_pool: underlay_pool
+
+expected_error_message: "core_interfaces.p2p_links.[].as or core_interfaces.p2p_links_profiles.[].as"

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/core-interfaces-p2p-links-as.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/core-interfaces-p2p-links-as.yml
@@ -1,11 +1,9 @@
-# Testing "core_interfaces.p2p_links_profiles.[].as" not defined error
+# Testing "core_interfaces.p2p_links.[].as" not defined
 
 # Fabric node type keys
 node_type_keys:
   - key: core_router
     type: core_router
-    default_evpn_role: none
-    mpls_lsr: true
 
 bgp_as: 65000
 
@@ -15,36 +13,20 @@ core_router:
   defaults:
     loopback_ipv4_pool: 10.0.0.0/24
     loopback_ipv6_pool: "2000:1234:ffff:ffff::/64"
-    node_sid_base: 200
-    isis_system_id_prefix: "0000.0001"
   nodes:
     - name: core-interfaces-p2p-links-as
       id: 1
 
 core_interfaces:
-  p2p_links_ip_pools:
-    - name: underlay_pool
-      ipv4_pool: 100.64.48.0/24
-    - name: some_other_pool
-      ipv4_pool: 100.123.123.0/24
   p2p_links_profiles:
     - name: isis_bb_profile
       speed: "forced 1000full"
       mtu: 1500
-      isis_hello_padding: false
-      isis_metric: 60
-      ip_pool: underlay_pool
-      isis_circuit_type: level-2
-      ipv6_enable: true
-      isis_authentication_mode: md5
-      isis_authentication_key: $1c$sTNAlR6rKSw=
   p2p_links:
-    # P2P core links with underlay_multicast(pim-sparse) enabled.
     - nodes: [ core-interfaces-p2p-links-as, peer1 ]
       id: 10
       interfaces: [ Ethernet1, Ethernet1 ]
       include_in_underlay_protocol: true
       underlay_multicast: true
-      ip_pool: underlay_pool
 
 expected_error_message: "core_interfaces.p2p_links.[].as or core_interfaces.p2p_links_profiles.[].as"

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -60,66 +60,6 @@ all:
             downlink-pools-duplicate-spine:
             downlink-pools-duplicate-l3leaf:
     EOS_DESIGNS_FAILURES: # Add cases that fail during 'eos_designs_structured_config' phase
-      hosts:
-        failure-port-channel:
-        connected-endpoints-mismatched-descriptions:
-        connected-endpoints-missing-profile-lacp-fallback:
-        connected-endpoints-wrong-profile-lacp-fallback:
-        connected-endpoints-phone-vlan-mode:
-        connected-endpoints-phone-vlan-vlans:
-        connected-endpoints-monitor-sessions-mismatch-direction:
-        duplicate-vlans-l2vlans:
-        duplicate-vlans-svi-id:
-        duplicate-vrfs-duplicate-svi-name-conflict:
-        duplicate-vrfs-id-conflict:
-        duplicate-vrfs-vni-conflict:
-        duplicate-vrfs-tenant-igmp-snooping-conflict:
-        duplicate-interface-l3-edge:
-        duplicate-l3-interfaces-network-services:
-        duplicate-interfaces-point-to-point-services-1:
-        duplicate-interfaces-point-to-point-services-2:
-        duplicate-interfaces-point-to-point-services-3:
-        duplicate-interfaces-point-to-point-services-4:
-        duplicate-interfaces-connected-endpoints:
-        duplicate-interfaces-core-interfaces:
-        duplicate-interfaces-core-interfaces-with-port-channel:
-        duplicate-vni-vxlan-interface:
-        duplicate-vni-l3-interfaces-in-vxlan-interface:
-        duplicate-vni-l2vlans-vxlan-interface:
-        duplicate-interfaces-underlay:
-        duplicate-ip-address-uplink-switch-router-bgp:
-        duplicate-tunnel-interface-internet-exit:
-        failure-missing-evpn-vlan-bundle:
-        failure-missing-evpn-vlan-bundle_svi:
-        failure-missing-evpn-multicast-l3-with-pim:
-        failure-missing-evpn-multicast-peg-rps:
-        failure-duplicate-evpn-vlan-bundle-name:
-        failure-no-local-path-group-in-default-policy:
-        ipv4-acl-in-missing-on-wan-interface:
-        ipv4-acls:
-        missing-avt-id-cv-pathfinder:
-        missing-data-plane_cpu-allocation-max:
-        ntp-settings-server-vrf-missing-mgmt-ip:
-        ntp-settings-server-vrf-missing-inband-mgmt-interface:
-        source-interfaces-domain-lookup-duplicate-vrf:
-        source-interfaces-domain-lookup-missing-inband-mgmt-interface:
-        source-interfaces-domain-lookup-missing-mgmt-ip:
-        source-interfaces-http-client-duplicate-vrf:
-        source-interfaces-http-client-missing-inband-mgmt-interface:
-        source-interfaces-http-client-missing-mgmt-ip:
-        source-interfaces-radius-duplicate-vrf:
-        source-interfaces-radius-missing-inband-mgmt-interface:
-        source-interfaces-radius-missing-mgmt-ip:
-        source-interfaces-ssh-client-duplicate-vrf:
-        source-interfaces-ssh-client-missing-inband-mgmt-interface:
-        source-interfaces-ssh-client-missing-mgmt-ip:
-        source-interfaces-tacacs-duplicate-vrf:
-        source-interfaces-tacacs-missing-inband-mgmt-interface:
-        source-interfaces-tacacs-missing-mgmt-ip:
-        ul-filter-evpn-default-vrf-services:
-        sflow-settings-missing-inband-mgmt-interface:
-        sflow-settings-missing-mgmt-ip:
-        core-interfaces-p2p-links-as:
       children:
         EOS_DESIGNS_FAILURES_INCLUDED:
           hosts:

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -60,6 +60,66 @@ all:
             downlink-pools-duplicate-spine:
             downlink-pools-duplicate-l3leaf:
     EOS_DESIGNS_FAILURES: # Add cases that fail during 'eos_designs_structured_config' phase
+      hosts:
+        failure-port-channel:
+        connected-endpoints-mismatched-descriptions:
+        connected-endpoints-missing-profile-lacp-fallback:
+        connected-endpoints-wrong-profile-lacp-fallback:
+        connected-endpoints-phone-vlan-mode:
+        connected-endpoints-phone-vlan-vlans:
+        connected-endpoints-monitor-sessions-mismatch-direction:
+        duplicate-vlans-l2vlans:
+        duplicate-vlans-svi-id:
+        duplicate-vrfs-duplicate-svi-name-conflict:
+        duplicate-vrfs-id-conflict:
+        duplicate-vrfs-vni-conflict:
+        duplicate-vrfs-tenant-igmp-snooping-conflict:
+        duplicate-interface-l3-edge:
+        duplicate-l3-interfaces-network-services:
+        duplicate-interfaces-point-to-point-services-1:
+        duplicate-interfaces-point-to-point-services-2:
+        duplicate-interfaces-point-to-point-services-3:
+        duplicate-interfaces-point-to-point-services-4:
+        duplicate-interfaces-connected-endpoints:
+        duplicate-interfaces-core-interfaces:
+        duplicate-interfaces-core-interfaces-with-port-channel:
+        duplicate-vni-vxlan-interface:
+        duplicate-vni-l3-interfaces-in-vxlan-interface:
+        duplicate-vni-l2vlans-vxlan-interface:
+        duplicate-interfaces-underlay:
+        duplicate-ip-address-uplink-switch-router-bgp:
+        duplicate-tunnel-interface-internet-exit:
+        failure-missing-evpn-vlan-bundle:
+        failure-missing-evpn-vlan-bundle_svi:
+        failure-missing-evpn-multicast-l3-with-pim:
+        failure-missing-evpn-multicast-peg-rps:
+        failure-duplicate-evpn-vlan-bundle-name:
+        failure-no-local-path-group-in-default-policy:
+        ipv4-acl-in-missing-on-wan-interface:
+        ipv4-acls:
+        missing-avt-id-cv-pathfinder:
+        missing-data-plane_cpu-allocation-max:
+        ntp-settings-server-vrf-missing-mgmt-ip:
+        ntp-settings-server-vrf-missing-inband-mgmt-interface:
+        source-interfaces-domain-lookup-duplicate-vrf:
+        source-interfaces-domain-lookup-missing-inband-mgmt-interface:
+        source-interfaces-domain-lookup-missing-mgmt-ip:
+        source-interfaces-http-client-duplicate-vrf:
+        source-interfaces-http-client-missing-inband-mgmt-interface:
+        source-interfaces-http-client-missing-mgmt-ip:
+        source-interfaces-radius-duplicate-vrf:
+        source-interfaces-radius-missing-inband-mgmt-interface:
+        source-interfaces-radius-missing-mgmt-ip:
+        source-interfaces-ssh-client-duplicate-vrf:
+        source-interfaces-ssh-client-missing-inband-mgmt-interface:
+        source-interfaces-ssh-client-missing-mgmt-ip:
+        source-interfaces-tacacs-duplicate-vrf:
+        source-interfaces-tacacs-missing-inband-mgmt-interface:
+        source-interfaces-tacacs-missing-mgmt-ip:
+        ul-filter-evpn-default-vrf-services:
+        sflow-settings-missing-inband-mgmt-interface:
+        sflow-settings-missing-mgmt-ip:
+        core-interfaces-p2p-links-as:
       children:
         EOS_DESIGNS_FAILURES_INCLUDED:
           hosts:
@@ -121,6 +181,7 @@ all:
             ul-filter-evpn-default-vrf-services:
             sflow-settings-missing-inband-mgmt-interface:
             sflow-settings-missing-mgmt-ip:
+            core-interfaces-p2p-links-as:
 
           children:
             duplicate-vlans-mlag:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-4-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-4-multicast.cfg
@@ -74,16 +74,16 @@ router bgp 65000
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 100.64.48.19 peer group IPv4-UNDERLAY-PEERS
-   neighbor 100.64.48.19 remote-as None
-   neighbor 100.64.48.19 local-as None no-prepend replace-as
+   neighbor 100.64.48.19 remote-as 65002
+   neighbor 100.64.48.19 local-as 65001 no-prepend replace-as
    neighbor 100.64.48.19 description peer1
    neighbor 100.64.48.21 peer group IPv4-UNDERLAY-PEERS
-   neighbor 100.64.48.21 remote-as None
-   neighbor 100.64.48.21 local-as None no-prepend replace-as
+   neighbor 100.64.48.21 remote-as 65003
+   neighbor 100.64.48.21 local-as 65001 no-prepend replace-as
    neighbor 100.64.48.21 description peer2
    neighbor 100.64.48.23 peer group IPv4-UNDERLAY-PEERS
-   neighbor 100.64.48.23 remote-as None
-   neighbor 100.64.48.23 local-as None no-prepend replace-as
+   neighbor 100.64.48.23 remote-as 65004
+   neighbor 100.64.48.23 local-as 65001 no-prepend replace-as
    neighbor 100.64.48.23 description peer3
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-4-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-4-multicast.yml
@@ -29,23 +29,23 @@ router_bgp:
     route_map: RM-CONN-2-BGP
   neighbors:
   - ip_address: 100.64.48.19
-    remote_as: None
+    remote_as: '65002'
     peer: peer1
     description: peer1
     peer_group: IPv4-UNDERLAY-PEERS
-    local_as: None
+    local_as: '65001'
   - ip_address: 100.64.48.21
-    remote_as: None
+    remote_as: '65003'
     peer: peer2
     description: peer2
     peer_group: IPv4-UNDERLAY-PEERS
-    local_as: None
+    local_as: '65001'
   - ip_address: 100.64.48.23
-    remote_as: None
+    remote_as: '65004'
     peer: peer3
     description: peer3
     peer_group: IPv4-UNDERLAY-PEERS
-    local_as: None
+    local_as: '65001'
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CORE_UNIT_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CORE_UNIT_TESTS.yml
@@ -149,6 +149,7 @@ core_interfaces:
     # P2P core links with underlay_multicast(pim-sparse) enabled.
     - nodes: [ core-4-multicast, peer1 ]
       id: 10
+      as: [65001, 65002]
       interfaces: [ Ethernet1, Ethernet1 ]
       include_in_underlay_protocol: true
       underlay_multicast: true
@@ -157,6 +158,7 @@ core_interfaces:
      # P2P core links with underlay_multicast(pim-sparse) disabled.
     - nodes: [ core-4-multicast, peer2 ]
       id: 11
+      as: [65001, 65003]
       interfaces: [ Ethernet2, Ethernet2 ]
       include_in_underlay_protocol: true
       underlay_multicast: false
@@ -165,6 +167,7 @@ core_interfaces:
     # P2P core links with underlay_multicast(pim-sparse) default.
     - nodes: [ core-4-multicast, peer3 ]
       id: 12
+      as: [65001, 65004]
       interfaces: [ Ethernet3, Ethernet3 ]
       include_in_underlay_protocol: true
       ip_pool: underlay_pool

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
@@ -32,7 +32,7 @@ class RouterBgpMixin(UtilsMixin):
                 continue
 
             if p2p_link["data"]["bgp_as"] is None or p2p_link["data"]["peer_bgp_as"] is None:
-                raise AristaAvdMissingVariableError("l3_edge.p2p_links.[].as")
+                raise AristaAvdMissingVariableError(f"{self.data_model}.p2p_links.[].as or {self.data_model}.p2p_links_profiles.[].as")
 
             neighbor = {
                 "remote_as": p2p_link["data"]["peer_bgp_as"],
@@ -48,7 +48,7 @@ class RouterBgpMixin(UtilsMixin):
 
             # Regular BGP Neighbors
             if p2p_link["data"]["ip"] is None or p2p_link["data"]["peer_ip"] is None:
-                raise AristaAvdMissingVariableError("l3_edge.p2p_links.[].ip, .subnet or .ip_pool")
+                raise AristaAvdMissingVariableError(f"{self.data_model}.p2p_links.[].ip, .subnet or .ip_pool")
 
             neighbor["bfd"] = p2p_link.get("bfd")
             if p2p_link["data"]["bgp_as"] != self.shared_utils.bgp_as:

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
@@ -32,7 +32,7 @@ class RouterBgpMixin(UtilsMixin):
                 continue
 
             if p2p_link["data"]["bgp_as"] is None or p2p_link["data"]["peer_bgp_as"] is None:
-                raise AristaAvdMissingVariableError(f"{self.data_model}.p2p_links.[].as or core_interfaces.p2p_links_profiles.[].as")
+                raise AristaAvdMissingVariableError(f"{self.data_model}.p2p_links.[].as or {self.data_model}.p2p_links_profiles.[].as")
 
             neighbor = {
                 "remote_as": p2p_link["data"]["peer_bgp_as"],

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/router_bgp.py
@@ -32,7 +32,7 @@ class RouterBgpMixin(UtilsMixin):
                 continue
 
             if p2p_link["data"]["bgp_as"] is None or p2p_link["data"]["peer_bgp_as"] is None:
-                raise AristaAvdMissingVariableError(f"{self.data_model}.p2p_links.[].as or {self.data_model}.p2p_links_profiles.[].as")
+                raise AristaAvdMissingVariableError(f"{self.data_model}.p2p_links.[].as or core_interfaces.p2p_links_profiles.[].as")
 
             neighbor = {
                 "remote_as": p2p_link["data"]["peer_bgp_as"],

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
@@ -151,8 +151,8 @@ class UtilsMixin:
             "peer_type": peer_type,
             "ip": ip[index],
             "peer_ip": ip[peer_index],
-            "bgp_as": str(bgp_as[index]),
-            "peer_bgp_as": str(bgp_as[peer_index]),
+            "bgp_as": (str(bgp_as[index]) if bgp_as[index] is not None else None),
+            "peer_bgp_as": str(bgp_as[peer_index] if bgp_as[peer_index] is not None else None),
             "description": descriptions[index],
         }
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
@@ -151,8 +151,8 @@ class UtilsMixin:
             "peer_type": peer_type,
             "ip": ip[index],
             "peer_ip": ip[peer_index],
-            "bgp_as": (str(bgp_as[index]) if bgp_as[index] else None),
-            "peer_bgp_as": str(bgp_as[peer_index] if bgp_as[peer_index] else None),
+            "bgp_as": str(bgp_as[index]) if index < len(bgp_as) and bgp_as[index] else None,
+            "peer_bgp_as": str(bgp_as[peer_index]) if peer_index < len(bgp_as) and bgp_as[peer_index] else None,
             "description": descriptions[index],
         }
 

--- a/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
+++ b/ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py
@@ -151,8 +151,8 @@ class UtilsMixin:
             "peer_type": peer_type,
             "ip": ip[index],
             "peer_ip": ip[peer_index],
-            "bgp_as": (str(bgp_as[index]) if bgp_as[index] is not None else None),
-            "peer_bgp_as": str(bgp_as[peer_index] if bgp_as[peer_index] is not None else None),
+            "bgp_as": (str(bgp_as[index]) if bgp_as[index] else None),
+            "peer_bgp_as": str(bgp_as[peer_index] if bgp_as[peer_index] else None),
             "description": descriptions[index],
         }
 


### PR DESCRIPTION
## Change Summary

Current code is converting the `bgp_as` value to `string`, where `None` value is also getting converted to type `string`, which is revoking the check for None value to raise the `AristaAvdMissingVariableError` even if `core_interfaces.p2p_links.[].as` is not defined.

Fixing the code and tests for the same.

## Related Issue(s)

Fixes #3596 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Fixing the type conversion in `ansible_collections/arista/avd/roles/eos_designs/python_modules/core_interfaces_and_l3_edge/utils.py`

## How to test

Test by not defining `core_interfaces.p2p_links.[].as` in input and run the eos_designs role. `AristaAvdMissingVariableError` is expected.

Check the test added in `eos_designs_negative_unit_tests` molecule scenario.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
