### PR TITLE
Doc(eos_cli_config_gen): Include docs for router segment-security

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -905,6 +905,12 @@ roles/eos_cli_config_gen/docs/tables/router-ospf.md
 roles/eos_cli_config_gen/docs/tables/router-path-selection.md
 --8<--
 
+### Router segment-security
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/router-segment-security.md
+--8<--
+
 ### Router service-insertion
 
 --8<--

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -905,12 +905,6 @@ roles/eos_cli_config_gen/docs/tables/router-ospf.md
 roles/eos_cli_config_gen/docs/tables/router-path-selection.md
 --8<--
 
-### Router segment-security
-
---8<--
-roles/eos_cli_config_gen/docs/tables/router-segment-security.md
---8<--
-
 ### Router service-insertion
 
 --8<--
@@ -959,6 +953,12 @@ roles/eos_cli_config_gen/docs/tables/vrfs.md
 
 --8<--
 roles/eos_cli_config_gen/docs/tables/ip-security.md
+--8<--
+
+### Router segment-security
+
+--8<--
+roles/eos_cli_config_gen/docs/tables/router-segment-security.md
 --8<--
 
 ## Switching


### PR DESCRIPTION
## Change Summary

Fix missing documentation table for router segment-security.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Include router-segment-security.md table in input-variables.md

## How to test
Verify Router segment-security section appears in docs for `eos_cli_config_gen`.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
