### PR TITLE
Feat(eos_cli_config_gen): Add Patch-Panel Connector commands

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/patch-panel.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/patch-panel.md
@@ -40,16 +40,18 @@ interface Management1
 
 ### Patch Panel Summary
 
-| Patch Name | Enabled | Connector A Type | Connector A Endpoint | Connector B Type | Connector B Endpoint |
-| ---------- | ------- | ---------------- | -------------------- | ---------------- | -------------------- |
-| TEN_B_site2_site5_eline | True | Interface | Ethernet5 | Pseudowire | bgp vpws TENANT_A pseudowire TEN_B_site2_site5_eline |
-| TEN_A_site2_site5_eline | False | Interface | Ethernet6 dot1q vlan 123 | Pseudowire | ldp LDP_PW_1 |
-
 Patch Panel Connector Interface Recovery Review Delay Min: 10
 
 Patch Panel Connector Interface Recovery Review Delay Max: 900
 
 Patch Panel Connector Interface Path BGP VPWS Remote Failure Errdisable is enabled.
+
+#### Patch Panel Connections
+
+| Patch Name | Enabled | Connector A Type | Connector A Endpoint | Connector B Type | Connector B Endpoint |
+| ---------- | ------- | ---------------- | -------------------- | ---------------- | -------------------- |
+| TEN_B_site2_site5_eline | True | Interface | Ethernet5 | Pseudowire | bgp vpws TENANT_A pseudowire TEN_B_site2_site5_eline |
+| TEN_A_site2_site5_eline | False | Interface | Ethernet6 dot1q vlan 123 | Pseudowire | ldp LDP_PW_1 |
 
 ### Patch Panel Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/patch-panel.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/patch-panel.md
@@ -45,11 +45,19 @@ interface Management1
 | TEN_B_site2_site5_eline | True | Interface | Ethernet5 | Pseudowire | bgp vpws TENANT_A pseudowire TEN_B_site2_site5_eline |
 | TEN_A_site2_site5_eline | False | Interface | Ethernet6 dot1q vlan 123 | Pseudowire | ldp LDP_PW_1 |
 
+Patch Panel Connector Interface Recovery Review Delay Min: 10
+
+Patch Panel Connector Interface Recovery Review Delay Max: 900
+
+Patch Panel Connector Interface Path BGP VPWS Remote Failure Errdisable is enabled.
 ### Patch Panel Device Configuration
 
 ```eos
 !
 patch panel
+   connector interface recovery review delay 10 900
+   connector interface patch bgp vpws remote-failure errdisable
+   !
    patch TEN_B_site2_site5_eline
       connector 1 interface Ethernet5
       connector 2 pseudowire bgp vpws TENANT_A pseudowire TEN_B_site2_site5_eline

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/patch-panel.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/patch-panel.md
@@ -50,6 +50,7 @@ Patch Panel Connector Interface Recovery Review Delay Min: 10
 Patch Panel Connector Interface Recovery Review Delay Max: 900
 
 Patch Panel Connector Interface Path BGP VPWS Remote Failure Errdisable is enabled.
+
 ### Patch Panel Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/patch-panel.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/patch-panel.cfg
@@ -13,6 +13,9 @@ interface Management1
    ip address 10.73.255.122/24
 !
 patch panel
+   connector interface recovery review delay 10 900
+   connector interface patch bgp vpws remote-failure errdisable
+   !
    patch TEN_B_site2_site5_eline
       connector 1 interface Ethernet5
       connector 2 pseudowire bgp vpws TENANT_A pseudowire TEN_B_site2_site5_eline

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/patch-panel.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/patch-panel.yml
@@ -1,4 +1,12 @@
 patch_panel:
+  connector:
+    interface:
+      patch:
+        bgp_vpws_remote_failure_errdisable: true
+      recovery:
+        review_delay:
+          min: 10
+          max: 900
   patches:
   - name: TEN_B_site2_site5_eline
     connectors:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -814,6 +814,8 @@ mpls ldp
 
 ### Patch Panel Summary
 
+#### Patch Panel Connections
+
 | Patch Name | Enabled | Connector A Type | Connector A Endpoint | Connector B Type | Connector B Endpoint |
 | ---------- | ------- | ---------------- | -------------------- | ---------------- | -------------------- |
 | TEN_A_site2_site5_eline_port_based | True | Interface | Ethernet6 | Pseudowire | bgp vpws TENANT_A pseudowire TEN_A_site2_site5_eline_port_based |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -818,6 +818,8 @@ mpls ldp
 
 ### Patch Panel Summary
 
+#### Patch Panel Connections
+
 | Patch Name | Enabled | Connector A Type | Connector A Endpoint | Connector B Type | Connector B Endpoint |
 | ---------- | ------- | ---------------- | -------------------- | ---------------- | -------------------- |
 | TEN_B_site3_site5_eline_vlan_based_1000 | True | Interface | Port-Channel3.1000 | Pseudowire | bgp vpws TENANT_B pseudowire TEN_B_site3_site5_eline_vlan_based_1000 |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -929,6 +929,8 @@ mpls ldp
 
 ### Patch Panel Summary
 
+#### Patch Panel Connections
+
 | Patch Name | Enabled | Connector A Type | Connector A Endpoint | Connector B Type | Connector B Endpoint |
 | ---------- | ------- | ---------------- | -------------------- | ---------------- | -------------------- |
 | TEN_A_site2_site5_eline_port_based | True | Interface | Ethernet7 | Pseudowire | bgp vpws TENANT_A pseudowire TEN_A_site2_site5_eline_port_based |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/patch-panel.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/patch-panel.md
@@ -8,6 +8,14 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>patch_panel</samp>](## "patch_panel") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;connector</samp>](## "patch_panel.connector") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "patch_panel.connector.interface") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;patch</samp>](## "patch_panel.connector.interface.patch") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp_vpws_remote_failure_errdisable</samp>](## "patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;recovery</samp>](## "patch_panel.connector.interface.recovery") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;review_delay</samp>](## "patch_panel.connector.interface.recovery.review_delay") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min</samp>](## "patch_panel.connector.interface.recovery.review_delay.min") | Integer | Required |  | Min: 10 | Minimum delay (10-600). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;max</samp>](## "patch_panel.connector.interface.recovery.review_delay.max") | Integer | Required |  | Min: 15 | Maximum delay (15-900). |
     | [<samp>&nbsp;&nbsp;patches</samp>](## "patch_panel.patches") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "patch_panel.patches.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "patch_panel.patches.[].enabled") | Boolean |  |  |  |  |
@@ -20,6 +28,18 @@
 
     ```yaml
     patch_panel:
+      connector:
+        interface:
+          patch:
+            bgp_vpws_remote_failure_errdisable: <bool>
+          recovery:
+            review_delay:
+
+              # Minimum delay (10-600).
+              min: <int; >=10; required>
+
+              # Maximum delay (15-900).
+              max: <int; >=15; required>
       patches:
         - name: <str; required; unique>
           enabled: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -13069,6 +13069,76 @@
     "patch_panel": {
       "type": "object",
       "properties": {
+        "connector": {
+          "type": "object",
+          "properties": {
+            "interface": {
+              "type": "object",
+              "properties": {
+                "patch": {
+                  "type": "object",
+                  "properties": {
+                    "bgp_vpws_remote_failure_errdisable": {
+                      "type": "boolean",
+                      "title": "BGP Vpws Remote Failure Errdisable"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Patch"
+                },
+                "recovery": {
+                  "type": "object",
+                  "properties": {
+                    "review_delay": {
+                      "type": "object",
+                      "properties": {
+                        "min": {
+                          "type": "integer",
+                          "minimum": 10,
+                          "description": "Minimum delay (10-600).",
+                          "title": "Min"
+                        },
+                        "max": {
+                          "type": "integer",
+                          "minimum": 15,
+                          "description": "Maximum delay (15-900).",
+                          "title": "Max"
+                        }
+                      },
+                      "required": [
+                        "min",
+                        "max"
+                      ],
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Review Delay"
+                    }
+                  },
+                  "additionalProperties": false,
+                  "patternProperties": {
+                    "^_.+$": {}
+                  },
+                  "title": "Recovery"
+                }
+              },
+              "additionalProperties": false,
+              "patternProperties": {
+                "^_.+$": {}
+              },
+              "title": "Interface"
+            }
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Connector"
+        },
         "patches": {
           "type": "array",
           "items": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -7737,6 +7737,37 @@ keys:
   patch_panel:
     type: dict
     keys:
+      connector:
+        type: dict
+        keys:
+          interface:
+            type: dict
+            keys:
+              patch:
+                type: dict
+                keys:
+                  bgp_vpws_remote_failure_errdisable:
+                    type: bool
+              recovery:
+                type: dict
+                keys:
+                  review_delay:
+                    type: dict
+                    keys:
+                      min:
+                        type: int
+                        required: true
+                        min: 10
+                        convert_types:
+                        - str
+                        description: Minimum delay (10-600).
+                      max:
+                        type: int
+                        required: true
+                        min: 15
+                        convert_types:
+                        - str
+                        description: Maximum delay (15-900).
       patches:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
@@ -9,6 +9,37 @@ keys:
   patch_panel:
     type: dict
     keys:
+      connector:
+        type: dict
+        keys:
+          interface:
+            type: dict
+            keys:
+              patch:
+                type: dict
+                keys:
+                  bgp_vpws_remote_failure_errdisable:
+                    type: bool
+              recovery:
+                type: dict
+                keys:
+                  review_delay:
+                    type: dict
+                    keys:
+                      min:
+                        type: int
+                        required: true
+                        min: 10
+                        convert_types:
+                          - str
+                        description: Minimum delay (10-600).
+                      max:
+                        type: int
+                        required: true
+                        min: 15
+                        convert_types:
+                          - str
+                        description: Maximum delay (15-900).
       patches:
         type: list
         primary_key: name

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/patch_panel.schema.yml
@@ -44,7 +44,7 @@ keys:
         type: list
         primary_key: name
         convert_types:
-        - dict
+          - dict
         items:
           type: dict
           keys:
@@ -56,7 +56,7 @@ keys:
               type: list
               primary_key: id
               convert_types:
-              - dict
+                - dict
               min_length: 2
               max_length: 2
               description: Must have exactly two connectors to a patch of which at least one must be of type "interface".
@@ -66,12 +66,12 @@ keys:
                   id:
                     type: str
                     convert_types:
-                    - int
+                      - int
                   type:
                     type: str
                     valid_values:
-                    - interface
-                    - pseudowire
+                      - interface
+                      - pseudowire
                     required: true
                   endpoint:
                     type: str

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
@@ -39,6 +39,7 @@ Patch Panel Connector Interface Recovery Review Delay Max: {{ patch_panel.connec
 {%     if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable  is arista.avd.defined(true) %}
 
 Patch Panel Connector Interface Path BGP VPWS Remote Failure Errdisable is enabled.
+
 {%     endif %}
 ### Patch Panel Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
@@ -28,7 +28,18 @@
 | {{ patch.name }} | {{ patch_panel_patch.enabled }} | {{ patch_panel_patch.connector_a_type }} | {{ patch_panel_patch.connector_a_endpoint }} | {{ patch_panel_patch.connector_b_type }} | {{ patch_panel_patch.connector_b_endpoint }} |
 {%         endif %}
 {%     endfor %}
+{%     if patch_panel.connector.interface.recovery.review_delay.min is arista.avd.defined %}
 
+Patch Panel Connector Interface Recovery Review Delay Min: {{ patch_panel.connector.interface.recovery.review_delay.min }}
+{%     endif %}
+{%     if patch_panel.connector.interface.recovery.review_delay.max is arista.avd.defined %}
+
+Patch Panel Connector Interface Recovery Review Delay Max: {{ patch_panel.connector.interface.recovery.review_delay.max }}
+{%     endif %}
+{%     if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable  is arista.avd.defined(true) %}
+
+Patch Panel Connector Interface Path BGP VPWS Remote Failure Errdisable is enabled.
+{%     endif %}
 ### Patch Panel Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
@@ -17,7 +17,7 @@ Patch Panel Connector Interface Recovery Review Delay Min: {{ patch_panel.connec
 
 Patch Panel Connector Interface Recovery Review Delay Max: {{ patch_panel.connector.interface.recovery.review_delay.max }}
 {%     endif %}
-{%     if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable  is arista.avd.defined(true) %}
+{%     if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable is arista.avd.defined(true) %}
 
 Patch Panel Connector Interface Path BGP VPWS Remote Failure Errdisable is enabled.
 {%     endif %}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/patch-panel.j2
@@ -9,6 +9,20 @@
 ## Patch Panel
 
 ### Patch Panel Summary
+{%     if patch_panel.connector.interface.recovery.review_delay.min is arista.avd.defined %}
+
+Patch Panel Connector Interface Recovery Review Delay Min: {{ patch_panel.connector.interface.recovery.review_delay.min }}
+{%     endif %}
+{%     if patch_panel.connector.interface.recovery.review_delay.max is arista.avd.defined %}
+
+Patch Panel Connector Interface Recovery Review Delay Max: {{ patch_panel.connector.interface.recovery.review_delay.max }}
+{%     endif %}
+{%     if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable  is arista.avd.defined(true) %}
+
+Patch Panel Connector Interface Path BGP VPWS Remote Failure Errdisable is enabled.
+{%     endif %}
+
+#### Patch Panel Connections
 
 | Patch Name | Enabled | Connector A Type | Connector A Endpoint | Connector B Type | Connector B Endpoint |
 | ---------- | ------- | ---------------- | -------------------- | ---------------- | -------------------- |
@@ -28,19 +42,7 @@
 | {{ patch.name }} | {{ patch_panel_patch.enabled }} | {{ patch_panel_patch.connector_a_type }} | {{ patch_panel_patch.connector_a_endpoint }} | {{ patch_panel_patch.connector_b_type }} | {{ patch_panel_patch.connector_b_endpoint }} |
 {%         endif %}
 {%     endfor %}
-{%     if patch_panel.connector.interface.recovery.review_delay.min is arista.avd.defined %}
 
-Patch Panel Connector Interface Recovery Review Delay Min: {{ patch_panel.connector.interface.recovery.review_delay.min }}
-{%     endif %}
-{%     if patch_panel.connector.interface.recovery.review_delay.max is arista.avd.defined %}
-
-Patch Panel Connector Interface Recovery Review Delay Max: {{ patch_panel.connector.interface.recovery.review_delay.max }}
-{%     endif %}
-{%     if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable  is arista.avd.defined(true) %}
-
-Patch Panel Connector Interface Path BGP VPWS Remote Failure Errdisable is enabled.
-
-{%     endif %}
 ### Patch Panel Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/patch-panel.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/patch-panel.j2
@@ -7,13 +7,15 @@
 {% if patch_panel is arista.avd.defined %}
 !
 patch panel
-{%     if patch_panel.connector.interface.recovery.review_delay.min is arista.avd.defined and patch_panel.connector.interface.recovery.review_delay.max is arista.avd.defined %}
+{%     if patch_panel.connector.interface is arista.avd.defined %}
+{%         if patch_panel.connector.interface.recovery.review_delay.min is arista.avd.defined and patch_panel.connector.interface.recovery.review_delay.max is arista.avd.defined %}
    connector interface recovery review delay {{ patch_panel.connector.interface.recovery.review_delay.min }} {{ patch_panel.connector.interface.recovery.review_delay.max }}
-{%     endif %}
-{%     if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable is arista.avd.defined(true) %}
+{%         endif %}
+{%         if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable is arista.avd.defined(true) %}
    connector interface patch bgp vpws remote-failure errdisable
-{%     endif %}
+{%         endif %}
    !
+{%     endif %}
 {%     for patch in patch_panel.patches | arista.avd.default([]) %}
 {%         if patch.name is arista.avd.defined %}
    patch {{ patch.name }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/patch-panel.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/patch-panel.j2
@@ -7,6 +7,27 @@
 {% if patch_panel is arista.avd.defined %}
 !
 patch panel
+{%     if patch_panel.connector is arista.avd.defined %}
+{%         set pp_connector_cli = "connector " %}
+{%         if patch_panel.connector.interface is arista.avd.defined %}
+{%             set pp_connector_cli = pp_connector_cli ~ "interface " %}
+{%             if patch_panel.connector.interface.recovery is arista.avd.defined %}
+{%                 set pp_connector_cli_recovery = pp_connector_cli ~ "recovery " %}
+{%                 if patch_panel.connector.interface.recovery.review_delay.min is arista.avd.defined and patch_panel.connector.interface.recovery.review_delay.max is arista.avd.defined %}
+{%                     set pp_connector_cli_recovery = pp_connector_cli_recovery ~ "review delay " ~ patch_panel.connector.interface.recovery.review_delay.min ~ " " ~ patch_panel.connector.interface.recovery.review_delay.max %}
+   {{ pp_connector_cli_recovery }}
+{%                 endif %}
+{%             endif %}
+{%             if patch_panel.connector.interface.patch is arista.avd.defined %}
+{%                 set pp_connector_cli_patch = pp_connector_cli ~ "patch " %}
+{%                 if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable is arista.avd.defined(true) %}
+{%                     set pp_connector_cli_patch = pp_connector_cli_patch ~ "bgp vpws remote-failure errdisable" %}
+   {{ pp_connector_cli_patch }}
+{%                 endif %}
+{%             endif %}
+{%         endif %}
+   !
+{%     endif %}
 {%     for patch in patch_panel.patches | arista.avd.default([]) %}
 {%         if patch.name is arista.avd.defined %}
    patch {{ patch.name }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/patch-panel.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/patch-panel.j2
@@ -7,27 +7,13 @@
 {% if patch_panel is arista.avd.defined %}
 !
 patch panel
-{%     if patch_panel.connector is arista.avd.defined %}
-{%         set pp_connector_cli = "connector " %}
-{%         if patch_panel.connector.interface is arista.avd.defined %}
-{%             set pp_connector_cli = pp_connector_cli ~ "interface " %}
-{%             if patch_panel.connector.interface.recovery is arista.avd.defined %}
-{%                 set pp_connector_cli_recovery = pp_connector_cli ~ "recovery " %}
-{%                 if patch_panel.connector.interface.recovery.review_delay.min is arista.avd.defined and patch_panel.connector.interface.recovery.review_delay.max is arista.avd.defined %}
-{%                     set pp_connector_cli_recovery = pp_connector_cli_recovery ~ "review delay " ~ patch_panel.connector.interface.recovery.review_delay.min ~ " " ~ patch_panel.connector.interface.recovery.review_delay.max %}
-   {{ pp_connector_cli_recovery }}
-{%                 endif %}
-{%             endif %}
-{%             if patch_panel.connector.interface.patch is arista.avd.defined %}
-{%                 set pp_connector_cli_patch = pp_connector_cli ~ "patch " %}
-{%                 if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable is arista.avd.defined(true) %}
-{%                     set pp_connector_cli_patch = pp_connector_cli_patch ~ "bgp vpws remote-failure errdisable" %}
-   {{ pp_connector_cli_patch }}
-{%                 endif %}
-{%             endif %}
-{%         endif %}
-   !
+{%     if patch_panel.connector.interface.recovery.review_delay.min is arista.avd.defined and patch_panel.connector.interface.recovery.review_delay.max is arista.avd.defined %}
+   connector interface recovery review delay {{ patch_panel.connector.interface.recovery.review_delay.min }} {{ patch_panel.connector.interface.recovery.review_delay.max }}
 {%     endif %}
+{%     if patch_panel.connector.interface.patch.bgp_vpws_remote_failure_errdisable is arista.avd.defined(true) %}
+   connector interface patch bgp vpws remote-failure errdisable
+{%     endif %}
+   !
 {%     for patch in patch_panel.patches | arista.avd.default([]) %}
 {%         if patch.name is arista.avd.defined %}
    patch {{ patch.name }}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -30127,6 +30127,76 @@
               "patch_panel": {
                 "type": "object",
                 "properties": {
+                  "connector": {
+                    "type": "object",
+                    "properties": {
+                      "interface": {
+                        "type": "object",
+                        "properties": {
+                          "patch": {
+                            "type": "object",
+                            "properties": {
+                              "bgp_vpws_remote_failure_errdisable": {
+                                "type": "boolean",
+                                "title": "BGP Vpws Remote Failure Errdisable"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Patch"
+                          },
+                          "recovery": {
+                            "type": "object",
+                            "properties": {
+                              "review_delay": {
+                                "type": "object",
+                                "properties": {
+                                  "min": {
+                                    "type": "integer",
+                                    "minimum": 10,
+                                    "description": "Minimum delay (10-600).",
+                                    "title": "Min"
+                                  },
+                                  "max": {
+                                    "type": "integer",
+                                    "minimum": 15,
+                                    "description": "Maximum delay (15-900).",
+                                    "title": "Max"
+                                  }
+                                },
+                                "required": [
+                                  "min",
+                                  "max"
+                                ],
+                                "additionalProperties": false,
+                                "patternProperties": {
+                                  "^_.+$": {}
+                                },
+                                "title": "Review Delay"
+                              }
+                            },
+                            "additionalProperties": false,
+                            "patternProperties": {
+                              "^_.+$": {}
+                            },
+                            "title": "Recovery"
+                          }
+                        },
+                        "additionalProperties": false,
+                        "patternProperties": {
+                          "^_.+$": {}
+                        },
+                        "title": "Interface"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Connector"
+                  },
                   "patches": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
## Change Summary

Extend existing Patch-Panel template by adding "connector" global commands.

```
patch_panel:
  connector:
    interface:
      patch:
        bgp_vpws_remote_failure_errdisable: <bool>
      recovery:
        review_delay: 
          min: <10-600>
          max:  <15-900>
```

## Related Issue(s)

Fixes #<N/A>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add connector interface
 - patch
 - recovery

with currently featured sub-commands

## How to test
extended existing molecule test

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
