### PR TITLE
Refactor(plugins): Move jinja filter code for arista.avd.natural_sort to PyAVD

### DIFF
--- a/ansible_collections/arista/avd/plugins/filter/default.py
+++ b/ansible_collections/arista/avd/plugins/filter/default.py
@@ -16,7 +16,6 @@ PLUGIN_NAME = "arista.avd.default"
 
 try:
     from pyavd.j2filters.default import default
-
 except ImportError as e:
     default = RaiseOnUse(
         AnsibleFilterError(

--- a/ansible_collections/arista/avd/plugins/filter/default.py
+++ b/ansible_collections/arista/avd/plugins/filter/default.py
@@ -8,16 +8,22 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from ansible.errors import AnsibleFilterError
 
-from ansible_collections.arista.avd.plugins.plugin_utils.pyavd_wrappers import wrap_filter
+from ansible_collections.arista.avd.plugins.plugin_utils.pyavd_wrappers import RaiseOnUse, wrap_filter
+
+PLUGIN_NAME = "arista.avd.default"
 
 try:
     from pyavd.j2filters.default import default
 
-    PYAVD_IMPORT_EXCEPTION = None
 except ImportError as e:
-    default = None
-    PYAVD_IMPORT_EXCEPTION = e
+    default = RaiseOnUse(
+        AnsibleFilterError(
+            f"The '{PLUGIN_NAME}' plugin requires the 'pyavd' Python library. Got import error",
+            orig_exc=e,
+        )
+    )
 
 DOCUMENTATION = r"""
 ---
@@ -59,5 +65,5 @@ _value:
 class FilterModule(object):
     def filters(self):
         return {
-            "default": wrap_filter("arista.avd.default", PYAVD_IMPORT_EXCEPTION)(default),
+            "default": wrap_filter(PLUGIN_NAME)(default),
         }

--- a/ansible_collections/arista/avd/plugins/filter/natural_sort.py
+++ b/ansible_collections/arista/avd/plugins/filter/natural_sort.py
@@ -8,10 +8,15 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-import re
+from ansible_collections.arista.avd.plugins.plugin_utils.pyavd_wrappers import wrap_filter
 
-from jinja2.runtime import Undefined
-from jinja2.utils import Namespace
+try:
+    from pyavd.j2filters.natural_sort import natural_sort
+
+    PYAVD_IMPORT_EXCEPTION = None
+except ImportError as e:
+    natural_sort = None
+    PYAVD_IMPORT_EXCEPTION = e
 
 DOCUMENTATION = r"""
 ---
@@ -55,27 +60,8 @@ _value:
 """
 
 
-def convert(text):
-    return int(text) if text.isdigit() else text.lower()
-
-
-def natural_sort(iterable, sort_key=None):
-    if isinstance(iterable, Undefined) or iterable is None:
-        return []
-
-    def alphanum_key(key):
-        if sort_key is not None and isinstance(key, dict):
-            return [convert(c) for c in re.split("([0-9]+)", str(key.get(sort_key, key)))]
-        elif sort_key is not None and isinstance(key, Namespace):
-            return [convert(c) for c in re.split("([0-9]+)", getattr(key, sort_key))]
-        else:
-            return [convert(c) for c in re.split("([0-9]+)", str(key))]
-
-    return sorted(iterable, key=alphanum_key)
-
-
 class FilterModule(object):
     def filters(self):
         return {
-            "natural_sort": natural_sort,
+            "natural_sort": wrap_filter("arista.avd.natural_sort", PYAVD_IMPORT_EXCEPTION)(natural_sort),
         }

--- a/ansible_collections/arista/avd/plugins/filter/natural_sort.py
+++ b/ansible_collections/arista/avd/plugins/filter/natural_sort.py
@@ -8,15 +8,21 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible_collections.arista.avd.plugins.plugin_utils.pyavd_wrappers import wrap_filter
+from ansible.errors import AnsibleFilterError
+
+from ansible_collections.arista.avd.plugins.plugin_utils.pyavd_wrappers import RaiseOnUse, wrap_filter
+
+PLUGIN_NAME = "arista.avd.natural_sort"
 
 try:
     from pyavd.j2filters.natural_sort import natural_sort
-
-    PYAVD_IMPORT_EXCEPTION = None
 except ImportError as e:
-    natural_sort = None
-    PYAVD_IMPORT_EXCEPTION = e
+    natural_sort = RaiseOnUse(
+        AnsibleFilterError(
+            f"The '{PLUGIN_NAME}' plugin requires the 'pyavd' Python library. Got import error",
+            orig_exc=e,
+        )
+    )
 
 DOCUMENTATION = r"""
 ---
@@ -63,5 +69,5 @@ _value:
 class FilterModule(object):
     def filters(self):
         return {
-            "natural_sort": wrap_filter("arista.avd.natural_sort", PYAVD_IMPORT_EXCEPTION)(natural_sort),
+            "natural_sort": wrap_filter(PLUGIN_NAME)(natural_sort),
         }

--- a/python-avd/Makefile
+++ b/python-avd/Makefile
@@ -11,6 +11,7 @@ SCRIPTS_DIR = $(CURRENT_DIR)/scripts
 EOS_CLI_CONFIG_GEN_TEMPLATE_DIR = $(VENDOR_DIR)/templates
 SCHEMAS_DIR = $(VENDOR_DIR)/schemas
 EOS_DESIGNS_MODULES_DIR = $(VENDOR_DIR)/eos_designs
+PYAVD_FILTER_IMPORT = $(PACKAGE_DIR).j2filters
 # export PYTHONPATH=$(CURRENT_DIR) # Uncomment to test from source
 
 .PHONY: help
@@ -88,6 +89,10 @@ fix-libs: ## Fix/remove various Ansible specifics things from python files
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.plugin_utils\.eos_designs_shared_utils/$(VENDOR_IMPORT)\.eos_designs\.eos_designs_shared_utils/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.plugin_utils/$(VENDOR_IMPORT)/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.module_utils/$(VENDOR_IMPORT)/g' {} +
+
+# For each moved filter make sure to override the default translation.
+	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.natural_sort/$(PYAVD_FILTER_IMPORT)\.natural_sort/g' {} +
+
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter/$(VENDOR_IMPORT)\.j2\.filter/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.roles\.eos_designs\.python_modules/$(VENDOR_IMPORT)\.eos_designs/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/from ansible\.utils\.display/from $(VENDOR_IMPORT)\.utils\.display/g' {} +

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -11,7 +11,7 @@ def convert(text: str) -> int | str:
     return int(text) if text.isdigit() else text.lower()
 
 
-def natural_sort(iterable, sort_key=None):
+def natural_sort(iterable: list | dict | str | None, sort_key: str | None = None) -> list:
     if isinstance(iterable, Undefined) or iterable is None:
         return []
 

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -2,6 +2,7 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 from __future__ import annotations
+
 import re
 
 from jinja2.runtime import Undefined

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -7,7 +7,7 @@ from jinja2.runtime import Undefined
 from jinja2.utils import Namespace
 
 
-def convert(text):
+def convert(text: str) -> int | str:
     return int(text) if text.isdigit() else text.lower()
 
 

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -7,21 +7,21 @@ import re
 from jinja2.runtime import Undefined
 from jinja2.utils import Namespace
 
-
 def convert(text):
     return int(text) if text.isdigit() else text.lower()
-
+    
 
 def natural_sort(iterable, sort_key=None):
     if isinstance(iterable, Undefined) or iterable is None:
         return []
 
     def alphanum_key(key):
+        pattern = r"(\d+)"
         if sort_key is not None and isinstance(key, dict):
-            return [convert(c) for c in re.split("([0-9]+)", str(key.get(sort_key, key)))]
+            return [convert(c) for c in re.split(pattern, str(key.get(sort_key, key)))]
         elif sort_key is not None and isinstance(key, Namespace):
-            return [convert(c) for c in re.split("([0-9]+)", getattr(key, sort_key))]
+            return [convert(c) for c in re.split(pattern, getattr(key, sort_key))]
         else:
-            return [convert(c) for c in re.split("([0-9]+)", str(key))]
+            return [convert(c) for c in re.split(pattern, str(key))]
 
     return sorted(iterable, key=alphanum_key)

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -20,9 +20,8 @@ def natural_sort(iterable, sort_key=None):
         pattern = r"(\d+)"
         if sort_key is not None and isinstance(key, dict):
             return [convert(c) for c in re.split(pattern, str(key.get(sort_key, key)))]
-        elif sort_key is not None and isinstance(key, Namespace):
+        if sort_key is not None and isinstance(key, Namespace):
             return [convert(c) for c in re.split(pattern, getattr(key, sort_key))]
-        else:
-            return [convert(c) for c in re.split(pattern, str(key))]
+        return [convert(c) for c in re.split(pattern, str(key))]
 
     return sorted(iterable, key=alphanum_key)

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -10,10 +10,25 @@ from jinja2.utils import Namespace
 
 
 def convert(text: str) -> int | str:
+    """
+    Converts the string to an integer if it is a digit, otherwise converts it to lower case.
+    Args:
+        text (str): Input string.
+    Returns:
+        int | str: Converted string.
+    """
     return int(text) if text.isdigit() else text.lower()
 
 
 def natural_sort(iterable: list | dict | str | None, sort_key: str | None = None) -> list:
+    """
+    Sorts an iterable in a natural (alphanumeric) order.
+    Args:
+        iterable (list | dict | str | None): Input iterable.
+        sort_key (str | None, optional): Key to sort by, defaults to None.
+    Returns:
+        list: Sorted iterable.
+    """
     if isinstance(iterable, Undefined) or iterable is None:
         return []
 

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
+from __future__ import annotations
 import re
 
 from jinja2.runtime import Undefined

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -1,0 +1,27 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+
+import re
+
+from jinja2.runtime import Undefined
+from jinja2.utils import Namespace
+
+
+def convert(text):
+    return int(text) if text.isdigit() else text.lower()
+
+
+def natural_sort(iterable, sort_key=None):
+    if isinstance(iterable, Undefined) or iterable is None:
+        return []
+
+    def alphanum_key(key):
+        if sort_key is not None and isinstance(key, dict):
+            return [convert(c) for c in re.split("([0-9]+)", str(key.get(sort_key, key)))]
+        elif sort_key is not None and isinstance(key, Namespace):
+            return [convert(c) for c in re.split("([0-9]+)", getattr(key, sort_key))]
+        else:
+            return [convert(c) for c in re.split("([0-9]+)", str(key))]
+
+    return sorted(iterable, key=alphanum_key)

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
-
 import re
 
 from jinja2.runtime import Undefined

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -7,9 +7,10 @@ import re
 from jinja2.runtime import Undefined
 from jinja2.utils import Namespace
 
+
 def convert(text):
     return int(text) if text.isdigit() else text.lower()
-    
+
 
 def natural_sort(iterable, sort_key=None):
     if isinstance(iterable, Undefined) or iterable is None:

--- a/python-avd/pyavd/templater.py
+++ b/python-avd/pyavd/templater.py
@@ -5,6 +5,7 @@ from jinja2 import ChoiceLoader, Environment, FileSystemLoader, ModuleLoader, St
 
 from .constants import JINJA2_EXTENSIONS, JINJA2_PRECOMPILED_TEMPLATE_PATH
 from .j2filters.default import default
+from .j2filters.natural_sort import natural_sort
 
 
 class Undefined(StrictUndefined):
@@ -57,7 +58,6 @@ class Templar:
         from .vendor.j2.filter.encrypt import encrypt
         from .vendor.j2.filter.hide_passwords import hide_passwords
         from .vendor.j2.filter.list_compress import list_compress
-        from .vendor.j2.filter.natural_sort import natural_sort
         from .vendor.j2.filter.range_expand import range_expand
         from .vendor.j2.test.contains import contains
         from .vendor.j2.test.defined import defined

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -21,6 +21,7 @@ class TestNaturalSortFilter:
             ([], None, []),  # test with blank list
             ({}, "", []),  # test with blank dict
             ("", None, []),  # test with blank string
+            ("access_list", None, ['_', 'a', 'c', 'c', 'e', 'i', 'l', 's', 's', 's', 't']), # test with string
             (["1,2,3,4", "11,2,3,4", "5.6.7.8"], None, ["1,2,3,4", "5.6.7.8", "11,2,3,4"]),  # test with list of integers
             ({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, None, ["a1", "a2", "a10", "a11"]),  # test with dict
             (

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -7,12 +7,9 @@ __metaclass__ = type
 
 import pytest
 from jinja2.runtime import Undefined
-
-from ansible_collections.arista.avd.plugins.filter.natural_sort import FilterModule, convert
-from ansible_collections.arista.avd.plugins.filter.natural_sort import natural_sort as _natural_sort
-from ansible_collections.arista.avd.tests.unit.filters.filter_utils import natural_sort
-
-f = FilterModule()
+from natsort import os_sorted
+from pyavd.j2filters.natural_sort import convert
+from pyavd.j2filters.natural_sort import natural_sort as _natural_sort
 
 STRINGS_VALID = ["100", "200", "ABC"]
 ITEMS_TO_NATURAL_SORT = [None, [], {}, "", ["1,2,3,4", "11,2,3,4", "5.6.7.8"], {"a1": 123, "a2": 2, "a10": 333, "a11": 4456}]
@@ -28,15 +25,10 @@ class TestNaturalSortFilter:
             assert resp == STRING_VALID.lower()
 
     @pytest.mark.parametrize("ITEM_TO_NATURAL_SORT", ITEMS_TO_NATURAL_SORT)
-    def test_natural_sort_invalid(self, ITEM_TO_NATURAL_SORT):
+    def test_natural_sort(self, ITEM_TO_NATURAL_SORT):
         resp = _natural_sort(ITEM_TO_NATURAL_SORT)
         if ITEM_TO_NATURAL_SORT is None or isinstance(ITEM_TO_NATURAL_SORT, Undefined):
             resp == []
         else:
-            resp_natsort = natural_sort(ITEM_TO_NATURAL_SORT)
+            resp_natsort = os_sorted(ITEM_TO_NATURAL_SORT)
             assert resp == resp_natsort
-
-    def test_natural_sort_filter(self):
-        resp = f.filters()
-        assert isinstance(resp, dict)
-        assert "natural_sort" in resp.keys()

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -6,13 +6,17 @@ from pyavd.j2filters.natural_sort import convert, natural_sort
 
 
 class TestNaturalSortFilter:
-    @pytest.mark.parametrize("item_to_convert", ["100", "200", "ABC"])
-    def test_convert_function(self, item_to_convert):
+    @pytest.mark.parametrize(
+        "item_to_convert, converted_item",
+        [
+            ("100", 100),
+            ("200", 200),
+            ("ABC", "abc"),
+        ],
+    )
+    def test_convert(self, item_to_convert, converted_item):
         resp = convert(item_to_convert)
-        if item_to_convert.isdigit():
-            assert resp == int(item_to_convert)
-        else:
-            assert resp == item_to_convert.lower()
+        assert resp == converted_item
 
     @pytest.mark.parametrize(
         "item_to_natural_sort, sort_key, sorted_list",

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -2,7 +2,6 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 import pytest
-
 from pyavd.j2filters.natural_sort import convert, natural_sort
 
 

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -21,12 +21,12 @@ class TestNaturalSortFilter:
     @pytest.mark.parametrize(
         "item_to_natural_sort, sort_key, expected_output",
         [
-            (None, None, []), # test with None 
-            ([], None, []), # test with blank list
-            ({}, "", []), # test with blank dict
-            ("", None, []), # test with blank string
-            (["1,2,3,4", "11,2,3,4", "5.6.7.8"], None, ["1,2,3,4", "5.6.7.8", "11,2,3,4"]), # test with list of integers
-            ({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, None, ["a1", "a2", "a10", "a11"]), # test with dict
+            (None, None, []),  # test with None
+            ([], None, []),  # test with blank list
+            ({}, "", []),  # test with blank dict
+            ("", None, []),  # test with blank string
+            (["1,2,3,4", "11,2,3,4", "5.6.7.8"], None, ["1,2,3,4", "5.6.7.8", "11,2,3,4"]),  # test with list of integers
+            ({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, None, ["a1", "a2", "a10", "a11"]),  # test with dict
             (
                 [
                     {"name": "ACL-10", "counters_per_entry": True},
@@ -38,7 +38,7 @@ class TestNaturalSortFilter:
                     {"name": "ACL-01", "counters_per_entry": True},
                     {"name": "ACL-05", "counters_per_entry": False},
                     {"name": "ACL-10", "counters_per_entry": True},
-                ], # test list of dict with "name" as sort_key
+                ],  # test list of dict with "name" as sort_key
             ),
         ],
     )

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -1,11 +1,8 @@
 # Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
-from __future__ import absolute_import, division, print_function
-
-__metaclass__ = type
-
 import pytest
+
 from pyavd.j2filters.natural_sort import convert, natural_sort
 
 
@@ -19,7 +16,7 @@ class TestNaturalSortFilter:
             assert resp == item_to_convert.lower()
 
     @pytest.mark.parametrize(
-        "item_to_natural_sort, sort_key, expected_output",
+        "item_to_natural_sort, sort_key, sorted_list",
         [
             (None, None, []),  # test with None
             ([], None, []),  # test with blank list
@@ -42,6 +39,6 @@ class TestNaturalSortFilter:
             ),
         ],
     )
-    def test_natural_sort(self, item_to_natural_sort, sort_key, expected_output):
+    def test_natural_sort(self, item_to_natural_sort, sort_key, sorted_list):
         resp = natural_sort(item_to_natural_sort, sort_key)
-        assert resp == expected_output
+        assert resp == sorted_list

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -19,16 +19,29 @@ class TestNaturalSortFilter:
             assert resp == item_to_convert.lower()
 
     @pytest.mark.parametrize(
-        "item_to_natural_sort, expected_output",
+        "item_to_natural_sort, sort_key, expected_output",
         [
-            (None, []),
-            ([], []),
-            ({}, []),
-            ("", []),
-            (["1,2,3,4", "11,2,3,4", "5.6.7.8"], ["1,2,3,4", "5.6.7.8", "11,2,3,4"]),
-            ({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, ["a1", "a2", "a10", "a11"]),
+            (None, None, []), # test with None 
+            ([], None, []), # test with blank list
+            ({}, "", []), # test with blank dict
+            ("", None, []), # test with blank string
+            (["1,2,3,4", "11,2,3,4", "5.6.7.8"], None, ["1,2,3,4", "5.6.7.8", "11,2,3,4"]), # test with list of integers
+            ({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, None, ["a1", "a2", "a10", "a11"]), # test with dict
+            (
+                [
+                    {"name": "ACL-10", "counters_per_entry": True},
+                    {"name": "ACL-01", "counters_per_entry": True},
+                    {"name": "ACL-05", "counters_per_entry": False},
+                ],
+                "name",
+                [
+                    {"name": "ACL-01", "counters_per_entry": True},
+                    {"name": "ACL-05", "counters_per_entry": False},
+                    {"name": "ACL-10", "counters_per_entry": True},
+                ], # test list of dict with "name" as sort_key
+            ),
         ],
     )
-    def test_natural_sort(self, item_to_natural_sort, expected_output):
-        resp = natural_sort(item_to_natural_sort)
+    def test_natural_sort(self, item_to_natural_sort, sort_key, expected_output):
+        resp = natural_sort(item_to_natural_sort, sort_key)
         assert resp == expected_output

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -29,6 +29,6 @@ class TestNaturalSortFilter:
             ({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, ["a1", "a2", "a10", "a11"]),
         ],
     )
-    def test_natural_sort(self, item_to_natural_sort , expected_output):
+    def test_natural_sort(self, item_to_natural_sort, expected_output):
         resp = natural_sort(item_to_natural_sort)
         assert resp == expected_output

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -21,7 +21,7 @@ class TestNaturalSortFilter:
             ([], None, []),  # test with blank list
             ({}, "", []),  # test with blank dict
             ("", None, []),  # test with blank string
-            ("access_list", None, ['_', 'a', 'c', 'c', 'e', 'i', 'l', 's', 's', 's', 't']), # test with string
+            ("access_list", None, ["_", "a", "c", "c", "e", "i", "l", "s", "s", "s", "t"]),  # test with string
             (["1,2,3,4", "11,2,3,4", "5.6.7.8"], None, ["1,2,3,4", "5.6.7.8", "11,2,3,4"]),  # test with list of integers
             ({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, None, ["a1", "a2", "a10", "a11"]),  # test with dict
             (

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -41,6 +41,34 @@ class TestNaturalSortFilter:
                     {"name": "ACL-10", "counters_per_entry": True},
                 ],  # test list of dict with "name" as sort_key
             ),
+            (
+                [
+                    {"name": "ACL-10", "counters_per_entry": True},
+                    {"sequence_numbers": {"sequence": 10}},
+                    {"counters_per_entry": False},
+                    {"name": "ACL-05", "counters_per_entry": False},
+                ],
+                "name",
+                [
+                    {"name": "ACL-05", "counters_per_entry": False},
+                    {"name": "ACL-10", "counters_per_entry": True},
+                    {"counters_per_entry": False},
+                    {"sequence_numbers": {"sequence": 10}},
+                ],  # test list of dict without "name" sort_key in some entries
+            ),
+            (
+                [
+                    {"sequence_numbers": {"sequence": 10}},
+                    {"counters_per_entry": False},
+                    {"action": "action_command"},
+                ],
+                "name",
+                [
+                    {"action": "action_command"},
+                    {"counters_per_entry": False},
+                    {"sequence_numbers": {"sequence": 10}},
+                ],
+            ),  # test test list of dict without "name" sort_key in all entries
         ],
     )
     def test_natural_sort(self, item_to_natural_sort, sort_key, sorted_list):

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -6,17 +6,11 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import pytest
-from jinja2.runtime import Undefined
-from natsort import os_sorted
-from pyavd.j2filters.natural_sort import convert
-from pyavd.j2filters.natural_sort import natural_sort as _natural_sort
-
-STRINGS_VALID = ["100", "200", "ABC"]
-ITEMS_TO_NATURAL_SORT = [None, [], {}, "", ["1,2,3,4", "11,2,3,4", "5.6.7.8"], {"a1": 123, "a2": 2, "a10": 333, "a11": 4456}]
+from pyavd.j2filters.natural_sort import convert, natural_sort
 
 
 class TestNaturalSortFilter:
-    @pytest.mark.parametrize("STRING_VALID", STRINGS_VALID)
+    @pytest.mark.parametrize("STRING_VALID", ["100", "200", "ABC"])
     def test_convert_function(self, STRING_VALID):
         resp = convert(STRING_VALID)
         if STRING_VALID.isdigit():
@@ -24,11 +18,17 @@ class TestNaturalSortFilter:
         else:
             assert resp == STRING_VALID.lower()
 
-    @pytest.mark.parametrize("ITEM_TO_NATURAL_SORT", ITEMS_TO_NATURAL_SORT)
-    def test_natural_sort(self, ITEM_TO_NATURAL_SORT):
-        resp = _natural_sort(ITEM_TO_NATURAL_SORT)
-        if ITEM_TO_NATURAL_SORT is None or isinstance(ITEM_TO_NATURAL_SORT, Undefined):
-            resp == []
-        else:
-            resp_natsort = os_sorted(ITEM_TO_NATURAL_SORT)
-            assert resp == resp_natsort
+    @pytest.mark.parametrize(
+        "ITEM_TO_NATURAL_SORT, EXPECTED_OUTPUT",
+        [
+            (None, []),
+            ([], []),
+            ({}, []),
+            ("", []),
+            (["1,2,3,4", "11,2,3,4", "5.6.7.8"], ["1,2,3,4", "5.6.7.8", "11,2,3,4"]),
+            ({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, ["a1", "a2", "a10", "a11"]),
+        ],
+    )
+    def test_natural_sort(self, ITEM_TO_NATURAL_SORT, EXPECTED_OUTPUT):
+        resp = natural_sort(ITEM_TO_NATURAL_SORT)
+        assert resp == EXPECTED_OUTPUT

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -10,16 +10,16 @@ from pyavd.j2filters.natural_sort import convert, natural_sort
 
 
 class TestNaturalSortFilter:
-    @pytest.mark.parametrize("STRING_VALID", ["100", "200", "ABC"])
-    def test_convert_function(self, STRING_VALID):
-        resp = convert(STRING_VALID)
-        if STRING_VALID.isdigit():
-            assert resp == int(STRING_VALID)
+    @pytest.mark.parametrize("item_to_convert", ["100", "200", "ABC"])
+    def test_convert_function(self, item_to_convert):
+        resp = convert(item_to_convert)
+        if item_to_convert.isdigit():
+            assert resp == int(item_to_convert)
         else:
-            assert resp == STRING_VALID.lower()
+            assert resp == item_to_convert.lower()
 
     @pytest.mark.parametrize(
-        "ITEM_TO_NATURAL_SORT, EXPECTED_OUTPUT",
+        "item_to_natural_sort, expected_output",
         [
             (None, []),
             ([], []),
@@ -29,6 +29,6 @@ class TestNaturalSortFilter:
             ({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, ["a1", "a2", "a10", "a11"]),
         ],
     )
-    def test_natural_sort(self, ITEM_TO_NATURAL_SORT, EXPECTED_OUTPUT):
-        resp = natural_sort(ITEM_TO_NATURAL_SORT)
-        assert resp == EXPECTED_OUTPUT
+    def test_natural_sort(self, item_to_natural_sort , expected_output):
+        resp = natural_sort(item_to_natural_sort)
+        assert resp == expected_output


### PR DESCRIPTION
## Change Summary

Move arista.avd.natural_sort code to PyAVD

## Related Issue(s)

Fixes #4070 

## Component(s) name

Filter
- `arista.avd.natural_sort`

## Proposed changes
Moving the code and unit tests for  arista.avd.natural_sort filter to PyAVD

## How to test

CI should catch things.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
