### PR TITLE
Test(eos_designs): Have multiple wan_route_servers on one edge device for idempotency

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -162,14 +162,17 @@ router path-selection
       ipsec profile CP-PROFILE
       !
       local interface Ethernet3
-         stun server-profile INET-cv-pathfinder-pathfinder-Ethernet1 INET-cv-pathfinder-pathfinder-Ethernet3
+         stun server-profile INET-cv-pathfinder-pathfinder1-Ethernet1 INET-cv-pathfinder-pathfinder2-Ethernet1
       !
       peer dynamic
       !
-      peer static router-ip 192.168.144.1
-         name cv-pathfinder-pathfinder
-         ipv4 address 172.17.7.7
-         ipv4 address 10.9.9.9
+      peer static router-ip 192.168.144.2
+         name cv-pathfinder-pathfinder1
+         ipv4 address 10.8.8.8
+      !
+      peer static router-ip 192.168.144.3
+         name cv-pathfinder-pathfinder2
+         ipv4 address 10.9.9.6
    !
    path-group Satellite id 104
       ipsec profile CP-PROFILE
@@ -478,7 +481,7 @@ application traffic recognition
       42.42.42.0/24
    !
    field-set ipv4 prefix PFX-PATHFINDERS
-      192.168.144.1/32
+      192.168.144.2/32 192.168.144.3/32
    !
    field-set l4-port TCP-DEST-2
       666, 777
@@ -617,8 +620,10 @@ router bgp 65000
    neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.0.2 remote-as 65199
    neighbor 172.17.0.2 description site-ha-disabled-leaf_Ethernet2
-   neighbor 192.168.144.1 peer group WAN-OVERLAY-PEERS
-   neighbor 192.168.144.1 description cv-pathfinder-pathfinder
+   neighbor 192.168.144.2 peer group WAN-OVERLAY-PEERS
+   neighbor 192.168.144.2 description cv-pathfinder-pathfinder1
+   neighbor 192.168.144.3 peer group WAN-OVERLAY-PEERS
+   neighbor 192.168.144.3 description cv-pathfinder-pathfinder2
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -695,11 +700,11 @@ management security
 !
 stun
    client
-      server-profile INET-cv-pathfinder-pathfinder-Ethernet1
-         ip address 172.17.7.7
+      server-profile INET-cv-pathfinder-pathfinder1-Ethernet1
+         ip address 10.8.8.8
          ssl profile profileA
-      server-profile INET-cv-pathfinder-pathfinder-Ethernet3
-         ip address 10.9.9.9
+      server-profile INET-cv-pathfinder-pathfinder2-Ethernet1
+         ip address 10.9.9.6
          ssl profile profileA
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -45,10 +45,14 @@ router_bgp:
     remote_as: '65199'
     peer: site-ha-disabled-leaf
     description: site-ha-disabled-leaf_Ethernet2
-  - ip_address: 192.168.144.1
+  - ip_address: 192.168.144.2
     peer_group: WAN-OVERLAY-PEERS
-    peer: cv-pathfinder-pathfinder
-    description: cv-pathfinder-pathfinder
+    peer: cv-pathfinder-pathfinder1
+    description: cv-pathfinder-pathfinder1
+  - ip_address: 192.168.144.3
+    peer_group: WAN-OVERLAY-PEERS
+    peer: cv-pathfinder-pathfinder2
+    description: cv-pathfinder-pathfinder2
   vrfs:
   - name: IT
     router_id: 192.168.42.2
@@ -510,16 +514,19 @@ router_path_selection:
     - name: Ethernet3
       stun:
         server_profiles:
-        - INET-cv-pathfinder-pathfinder-Ethernet1
-        - INET-cv-pathfinder-pathfinder-Ethernet3
+        - INET-cv-pathfinder-pathfinder1-Ethernet1
+        - INET-cv-pathfinder-pathfinder2-Ethernet1
     dynamic_peers:
       enabled: true
     static_peers:
-    - router_ip: 192.168.144.1
-      name: cv-pathfinder-pathfinder
+    - router_ip: 192.168.144.2
+      name: cv-pathfinder-pathfinder1
       ipv4_addresses:
-      - 172.17.7.7
-      - 10.9.9.9
+      - 10.8.8.8
+    - router_ip: 192.168.144.3
+      name: cv-pathfinder-pathfinder2
+      ipv4_addresses:
+      - 10.9.9.6
     ipsec_profile: CP-PROFILE
   load_balance_policies:
   - name: LB-DEFAULT-AVT-POLICY-CONTROL-PLANE
@@ -558,11 +565,11 @@ router_traffic_engineering:
 stun:
   client:
     server_profiles:
-    - name: INET-cv-pathfinder-pathfinder-Ethernet1
-      ip_address: 172.17.7.7
+    - name: INET-cv-pathfinder-pathfinder1-Ethernet1
+      ip_address: 10.8.8.8
       ssl_profile: profileA
-    - name: INET-cv-pathfinder-pathfinder-Ethernet3
-      ip_address: 10.9.9.9
+    - name: INET-cv-pathfinder-pathfinder2-Ethernet1
+      ip_address: 10.9.9.6
       ssl_profile: profileA
 application_traffic_recognition:
   application_profiles:
@@ -615,7 +622,8 @@ application_traffic_recognition:
       - 6.6.6.0/24
     - name: PFX-PATHFINDERS
       prefix_values:
-      - 192.168.144.1/32
+      - 192.168.144.2/32
+      - 192.168.144.3/32
 ip_access_lists:
 - name: ALLOW-ALL
   entries:
@@ -918,7 +926,8 @@ metadata:
       circuit_id: '404'
       pathgroup: INET
     pathfinders:
-    - vtep_ip: 192.168.144.1
+    - vtep_ip: 192.168.144.2
+    - vtep_ip: 192.168.144.3
   cv_tags:
     device_tags:
     - name: Role

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge1.yml
@@ -6,3 +6,8 @@
 # serial_number: mockZscaler
 # cv_server: "www.cv-play.corp.arista.io"
 # zscaler_endpoints: null
+
+# Testing multiple pathinfders on one device
+wan_route_servers:
+  - hostname: cv-pathfinder-pathfinder1
+  - hostname: cv-pathfinder-pathfinder2


### PR DESCRIPTION
## Related Issue(s)

Add a test regarding #4065 - not sure this is an AVD issue yet but at least a test would exist now

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Adding a test

## How to test

Test passes

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
