### PR TITLE
Feat(eos_designs): Add support to enable BGP peering with wan provider

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-prefix-list-definition-cv-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-prefix-list-definition-cv-pathfinder.yml
@@ -1,0 +1,88 @@
+---
+# Testing cv-pathfinder
+wan_mode: cv-pathfinder
+# Have all the router in the examples use eBGP as underlay routing protocol -
+# the default is "none" for WAN routers"
+underlay_routing_protocol: ebgp
+
+wan_ipsec_profiles:
+  control_plane:
+    shared_key: ABCDEF1234567890
+  data_plane:
+    shared_key: ABCDEF1234567890666
+
+cv_pathfinder_regions:
+  - name: AVD_Land_West
+    id: 42
+    description: AVD Region
+    sites:
+      - name: Site422
+        id: 422
+        location: Somewhere
+
+bgp_peer_groups:
+  wan_overlay_peers:
+    password: "htm4AZe9mIQOO1uiMuGgYQ=="
+    listen_range_prefixes:
+      - 192.168.142.0/24
+
+ipv4_prefix_list_catalog:
+  - name: ALLOW-DEFAULT
+    sequence_numbers:
+      - sequence: 10
+        action: permit 0.0.0.0/0
+  - name: PL2
+    sequence_numbers:
+      - sequence: 10
+        action: permit 5.0.0.0/0
+      - sequence: 20
+        action: deny 10.00.0.0/24
+
+default_node_types:
+  - node_type: wan_router
+    match_hostnames:
+      - missing-prefix-list-definition-cv-pathfinder
+
+wan_router:
+  defaults:
+    loopback_ipv4_pool: 192.168.42.0/24
+    vtep_loopback_ipv4_pool: 192.168.142.0/24
+    bgp_as: 65000
+  # Testing HA and disabling HA
+  node_groups:
+    # SITE_HA_DISABLED
+    - group: Site511
+      uplink_type: p2p-vrfs
+      cv_pathfinder_region: AVD_Land_West
+      cv_pathfinder_site: Site422
+      wan_ha:
+        enabled: False
+      nodes:
+        - name: missing-prefix-list-definition-cv-pathfinder
+          id: 1
+          uplink_switch_interfaces: [Ethernet1]
+          l3_interfaces:
+            - name: Ethernet1
+              peer: peer3
+              peer_interface: Ethernet42
+              wan_carrier: Comcast
+              wan_circuit_id: 666
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+              flow_tracking:
+                enabled: true
+              peer_ip: 172.16.9.4
+              bgp:
+                peer_as: 64520
+                ipv4_prefix_list_in: PL1
+
+wan_path_groups:
+  - name: INET
+    id: 101
+
+wan_carriers:
+  - name: Comcast
+    path_group: INET
+    trusted: true
+
+expected_error_message: "ipv4_prefix_list_catalog[name=PL1]"

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-prefix-list-in-cv-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-prefix-list-in-cv-pathfinder.yml
@@ -1,0 +1,87 @@
+---
+# Testing cv-pathfinder
+wan_mode: cv-pathfinder
+# Have all the router in the examples use eBGP as underlay routing protocol -
+# the default is "none" for WAN routers"
+underlay_routing_protocol: ebgp
+
+wan_ipsec_profiles:
+  control_plane:
+    shared_key: ABCDEF1234567890
+  data_plane:
+    shared_key: ABCDEF1234567890666
+
+cv_pathfinder_regions:
+  - name: AVD_Land_West
+    id: 42
+    description: AVD Region
+    sites:
+      - name: Site422
+        id: 422
+        location: Somewhere
+
+bgp_peer_groups:
+  wan_overlay_peers:
+    password: "htm4AZe9mIQOO1uiMuGgYQ=="
+    listen_range_prefixes:
+      - 192.168.142.0/24
+
+ipv4_prefix_list_catalog:
+  - name: ALLOW-DEFAULT
+    sequence_numbers:
+      - sequence: 10
+        action: permit 0.0.0.0/0
+  - name: PL2
+    sequence_numbers:
+      - sequence: 10
+        action: permit 5.0.0.0/0
+      - sequence: 20
+        action: deny 10.00.0.0/24
+
+default_node_types:
+  - node_type: wan_router
+    match_hostnames:
+      - missing-prefix-list-in-cv-pathfinder
+
+wan_router:
+  defaults:
+    loopback_ipv4_pool: 192.168.42.0/24
+    vtep_loopback_ipv4_pool: 192.168.142.0/24
+    bgp_as: 65000
+  # Testing HA and disabling HA
+  node_groups:
+    # SITE_HA_DISABLED
+    - group: Site511
+      uplink_type: p2p-vrfs
+      cv_pathfinder_region: AVD_Land_West
+      cv_pathfinder_site: Site422
+      wan_ha:
+        enabled: False
+      nodes:
+        - name: missing-prefix-list-in-cv-pathfinder
+          id: 1
+          uplink_switch_interfaces: [Ethernet1]
+          l3_interfaces:
+            - name: Ethernet1
+              peer: peer3
+              peer_interface: Ethernet42
+              wan_carrier: Comcast
+              wan_circuit_id: 666
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+              flow_tracking:
+                enabled: true
+              peer_ip: 172.16.9.4
+              bgp:
+                peer_as: 64520
+
+wan_path_groups:
+  - name: INET
+    id: 101
+
+wan_carriers:
+  - name: Comcast
+    path_group: INET
+    trusted: true
+
+expected_error_message: "BGP is enabled but 'bgp.ipv4_prefix_list_in' is not configured for l3_interfaces[Ethernet1]"

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -101,6 +101,8 @@ all:
             ipv4-acl-in-missing-on-wan-interface:
             ipv4-acls:
             missing-avt-id-cv-pathfinder:
+            missing-prefix-list-in-cv-pathfinder:
+            missing-prefix-list-definition-cv-pathfinder:
             missing-data-plane_cpu-allocation-max:
             ntp-settings-server-vrf-missing-mgmt-ip:
             ntp-settings-server-vrf-missing-inband-mgmt-interface:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -500,6 +500,9 @@ ip routing vrf PROD
 !
 ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.1:511
 !
+ip prefix-list ALLOW-DEFAULT
+   seq 10 permit 0.0.0.0/0
+!
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.42.0/24 eq 32
 !
@@ -515,6 +518,21 @@ ip route 10.50.9.1/32 172.20.20.21 name IE-ZSCALER-TER
 !
 ip nat pool PORT-ONLY-POOL port-only
    port range 1500 65535
+!
+route-map RM-BGP-172.16.5.4-IN permit 10
+   match ip address prefix-list ALLOW-DEFAULT
+   set community no-advertise additive
+!
+route-map RM-BGP-172.16.5.4-OUT permit 10
+   match ip address prefix-list ALLOW-DEFAULT
+!
+route-map RM-BGP-172.16.5.4-OUT deny 20
+!
+route-map RM-BGP-172.16.9.4-IN permit 10
+   match ip address prefix-list ALLOW-DEFAULT
+   set community no-advertise additive
+!
+route-map RM-BGP-172.16.9.4-OUT deny 10
 !
 route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
@@ -561,6 +579,14 @@ router bgp 65000
    neighbor WAN-OVERLAY-PEERS password 7 htm4AZe9mIQOO1uiMuGgYQ==
    neighbor WAN-OVERLAY-PEERS send-community
    neighbor WAN-OVERLAY-PEERS maximum-routes 0
+   neighbor 172.16.5.4 remote-as 64520
+   neighbor 172.16.5.4 description Colt_10555
+   neighbor 172.16.5.4 route-map RM-BGP-172.16.5.4-IN in
+   neighbor 172.16.5.4 route-map RM-BGP-172.16.5.4-OUT out
+   neighbor 172.16.9.4 remote-as 64520
+   neighbor 172.16.9.4 description ATT_666_peer3_Ethernet42
+   neighbor 172.16.9.4 route-map RM-BGP-172.16.9.4-IN in
+   neighbor 172.16.9.4 route-map RM-BGP-172.16.9.4-OUT out
    neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.0.0 remote-as 65199
    neighbor 172.17.0.0 description site-ha-disabled-leaf_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -344,6 +344,18 @@ interface Ethernet3
    dhcp client accept default-route
    ip nat service-profile IE-DIRECT-NAT
 !
+interface Ethernet4
+   no shutdown
+   no switchport
+   ip address dhcp
+   dhcp client accept default-route
+!
+interface Ethernet5
+   no shutdown
+   no switchport
+   ip address dhcp
+   dhcp client accept default-route
+!
 interface Ethernet52
    description P2P_LINK_TO_SITE-HA-DISABLED-LEAF_Ethernet2
    no shutdown
@@ -565,6 +577,13 @@ ip routing vrf PROD
 !
 ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.2:511
 !
+ip prefix-list ALLOW-DEFAULT
+   seq 10 permit 0.0.0.0/0
+!
+ip prefix-list PL2
+   seq 10 permit 5.0.0.0/0
+   seq 20 deny 10.00.0.0/24
+!
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.42.0/24 eq 32
 !
@@ -574,6 +593,19 @@ ip route 10.50.9.1/32 172.31.0.1 name IE-ZSCALER-TER
 !
 ip nat pool PORT-ONLY-POOL port-only
    port range 1500 65535
+!
+route-map RM-BGP-172.28.0.14-OUT permit 10
+   match ip address prefix-list PL2
+!
+route-map RM-BGP-172.28.0.14-OUT deny 20
+!
+route-map RM-BGP-172.29.0.13-IN permit 10
+   match ip address prefix-list PL2
+!
+route-map RM-BGP-172.29.0.13-OUT permit 10
+   match ip address prefix-list ALLOW-DEFAULT
+!
+route-map RM-BGP-172.29.0.13-OUT deny 20
 !
 route-map RM-BGP-UNDERLAY-PEERS-IN permit 40
    description Mark prefixes originated from the LAN
@@ -618,6 +650,11 @@ router bgp 65000
    neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.0.2 remote-as 65199
    neighbor 172.17.0.2 description site-ha-disabled-leaf_Ethernet2
+   neighbor 172.28.0.14 remote-as 64520
+   neighbor 172.28.0.14 route-map RM-BGP-172.28.0.14-OUT out
+   neighbor 172.29.0.13 remote-as 64520
+   neighbor 172.29.0.13 route-map RM-BGP-172.29.0.13-IN in
+   neighbor 172.29.0.13 route-map RM-BGP-172.29.0.13-OUT out
    neighbor 192.168.144.2 peer group WAN-OVERLAY-PEERS
    neighbor 192.168.144.2 description cv-pathfinder-pathfinder1
    neighbor 192.168.144.3 peer group WAN-OVERLAY-PEERS

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -47,6 +47,16 @@ router_bgp:
     remote_as: '65199'
     peer: site-ha-disabled-leaf
     description: site-ha-disabled-leaf_Ethernet1
+  - ip_address: 172.16.9.4
+    remote_as: '64520'
+    description: ATT_666_peer3_Ethernet42
+    route_map_in: RM-BGP-172.16.9.4-IN
+    route_map_out: RM-BGP-172.16.9.4-OUT
+  - ip_address: 172.16.5.4
+    remote_as: '64520'
+    description: Colt_10555
+    route_map_in: RM-BGP-172.16.5.4-IN
+    route_map_out: RM-BGP-172.16.5.4-OUT
   - ip_address: 192.168.144.1
     peer_group: WAN-OVERLAY-PEERS
     peer: cv-pathfinder-pathfinder
@@ -254,6 +264,10 @@ prefix_lists:
   sequence_numbers:
   - sequence: 10
     action: permit 192.168.42.0/24 eq 32
+- name: ALLOW-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 0.0.0.0/0
 - name: PL-STATIC-VRF-DEFAULT
   sequence_numbers:
   - sequence: 10
@@ -274,6 +288,34 @@ route_maps:
     description: Mark prefixes originated from the LAN
     set:
     - extcommunity soo 192.168.42.1:511 additive
+- name: RM-BGP-172.16.9.4-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list ALLOW-DEFAULT
+    set:
+    - community no-advertise additive
+- name: RM-BGP-172.16.9.4-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: deny
+- name: RM-BGP-172.16.5.4-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list ALLOW-DEFAULT
+    set:
+    - community no-advertise additive
+- name: RM-BGP-172.16.5.4-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list ALLOW-DEFAULT
+  - sequence: 20
+    type: deny
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -44,6 +44,13 @@ router_bgp:
     remote_as: '65199'
     peer: site-ha-disabled-leaf
     description: site-ha-disabled-leaf_Ethernet2
+  - ip_address: 172.29.0.13
+    remote_as: '64520'
+    route_map_in: RM-BGP-172.29.0.13-IN
+    route_map_out: RM-BGP-172.29.0.13-OUT
+  - ip_address: 172.28.0.14
+    remote_as: '64520'
+    route_map_out: RM-BGP-172.28.0.14-OUT
   - ip_address: 192.168.144.2
     peer_group: WAN-OVERLAY-PEERS
     peer: cv-pathfinder-pathfinder1
@@ -236,6 +243,18 @@ ethernet_interfaces:
   dhcp_client_accept_default_route: true
   ip_nat:
     service_profile: IE-DIRECT-NAT
+- name: Ethernet4
+  peer_type: l3_interface
+  ip_address: dhcp
+  shutdown: false
+  type: routed
+  dhcp_client_accept_default_route: true
+- name: Ethernet5
+  peer_type: l3_interface
+  ip_address: dhcp
+  shutdown: false
+  type: routed
+  dhcp_client_accept_default_route: true
 - name: Ethernet1/49
   type: routed
   peer_type: l3_interface
@@ -250,6 +269,16 @@ prefix_lists:
   sequence_numbers:
   - sequence: 10
     action: permit 192.168.42.0/24 eq 32
+- name: PL2
+  sequence_numbers:
+  - sequence: 10
+    action: permit 5.0.0.0/0
+  - sequence: 20
+    action: deny 10.00.0.0/24
+- name: ALLOW-DEFAULT
+  sequence_numbers:
+  - sequence: 10
+    action: permit 0.0.0.0/0
 route_maps:
 - name: RM-CONN-2-BGP
   sequence_numbers:
@@ -266,6 +295,28 @@ route_maps:
     description: Mark prefixes originated from the LAN
     set:
     - extcommunity soo 192.168.42.2:511 additive
+- name: RM-BGP-172.29.0.13-IN
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL2
+- name: RM-BGP-172.29.0.13-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list ALLOW-DEFAULT
+  - sequence: 20
+    type: deny
+- name: RM-BGP-172.28.0.14-OUT
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL2
+  - sequence: 20
+    type: deny
 - name: RM-EVPN-SOO-IN
   sequence_numbers:
   - sequence: 10
@@ -977,6 +1028,14 @@ metadata:
         value: ATT
       - name: Circuit
         value: '404'
+    - interface: Ethernet4
+      tags:
+      - name: Type
+        value: lan
+    - interface: Ethernet5
+      tags:
+      - name: Type
+        value: lan
     - interface: Ethernet1/49
       tags:
       - name: Type

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -5,6 +5,18 @@ wan_mode: cv-pathfinder
 # the default is "none" for WAN routers"
 underlay_routing_protocol: ebgp
 
+ipv4_prefix_list_catalog:
+  - name: ALLOW-DEFAULT
+    sequence_numbers:
+      - sequence: 10
+        action: permit 0.0.0.0/0
+  - name: PL2
+    sequence_numbers:
+      - sequence: 10
+        action: permit 5.0.0.0/0
+      - sequence: 20
+        action: deny 10.00.0.0/24
+
 cv_pathfinder_regions:
   - name: AVD_Land_West
     id: 42
@@ -104,6 +116,10 @@ wan_router:
               ip_address: dhcp
               flow_tracking:
                 enabled: true
+              peer_ip: 172.16.9.4
+              bgp:
+                peer_as: 64520
+                ipv4_prefix_list_in: ALLOW-DEFAULT
             - name: Ethernet2
               wan_carrier: Colt
               wan_circuit_id: 10555
@@ -114,6 +130,10 @@ wan_router:
               cv_pathfinder_internet_exit:
                 policies:
                   - name: DIRECT-EXIT-POLICY-1
+              bgp:
+                peer_as: 64520
+                ipv4_prefix_list_in: ALLOW-DEFAULT
+                ipv4_prefix_list_out: ALLOW-DEFAULT
             - name: Ethernet2/1
               wan_carrier: Colt
               wan_circuit_id: 10555
@@ -167,6 +187,21 @@ wan_router:
                     tunnel_interface_numbers: 110-112
                   - name: DIRECT-EXIT-POLICY-1
                   - name: DIRECT-EXIT-POLICY-2
+            - name: Ethernet4
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+              peer_ip: 172.29.0.13
+              bgp:
+                peer_as: 64520
+                ipv4_prefix_list_in: PL2
+                ipv4_prefix_list_out: ALLOW-DEFAULT
+            - name: Ethernet5
+              dhcp_accept_default_route: true
+              ip_address: dhcp
+              peer_ip: 172.28.0.14
+              bgp:
+                peer_as: 64520
+                ipv4_prefix_list_out: PL2
     # SITE_HA_ENABLED
     - group: Site423
       cv_pathfinder_region: AVD_Land_West

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-l3-interfaces-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-l3-interfaces-configuration.md
@@ -23,6 +23,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].peer") | String |  |  |  | The peer device name. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].peer_interface") | String |  |  |  | The peer device interface. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].peer_ip") | String |  |  |  | The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].bgp") | Dictionary |  |  |  | Enforce IPv4 BGP peering for the peer |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_as</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].bgp.peer_as") | String | Required |  |  | BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_in</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].bgp.ipv4_prefix_list_in") | String |  |  |  | Prefix List Name. Accept routes for only these prefixes from the peer.<br>Required for wan interfaces. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_out</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].bgp.ipv4_prefix_list_out") | String |  |  |  | Prefix List Name. Advertise routes for only these prefixes.<br>If not specified, nothing would be advertised. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".<br>Required for all WAN interfaces (`wan_carrier` is set) unless the carrier is marked as 'trusted' under `wan_carriers`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<node_type_keys.key>.defaults.l3_interfaces.[].static_routes") | List, items: Dictionary |  |  | Min Length: 1 | Configure IPv4 static routes pointing to `peer_ip`. |
@@ -58,6 +62,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].peer") | String |  |  |  | The peer device name. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].peer_interface") | String |  |  |  | The peer device interface. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].peer_ip") | String |  |  |  | The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].bgp") | Dictionary |  |  |  | Enforce IPv4 BGP peering for the peer |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_as</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].bgp.peer_as") | String | Required |  |  | BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_in</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].bgp.ipv4_prefix_list_in") | String |  |  |  | Prefix List Name. Accept routes for only these prefixes from the peer.<br>Required for wan interfaces. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_out</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].bgp.ipv4_prefix_list_out") | String |  |  |  | Prefix List Name. Advertise routes for only these prefixes.<br>If not specified, nothing would be advertised. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".<br>Required for all WAN interfaces (`wan_carrier` is set) unless the carrier is marked as 'trusted' under `wan_carriers`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].l3_interfaces.[].static_routes") | List, items: Dictionary |  |  | Min Length: 1 | Configure IPv4 static routes pointing to `peer_ip`. |
@@ -89,6 +97,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].peer") | String |  |  |  | The peer device name. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].peer_interface") | String |  |  |  | The peer device interface. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].peer_ip") | String |  |  |  | The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].bgp") | Dictionary |  |  |  | Enforce IPv4 BGP peering for the peer |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_as</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].bgp.peer_as") | String | Required |  |  | BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_in</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].bgp.ipv4_prefix_list_in") | String |  |  |  | Prefix List Name. Accept routes for only these prefixes from the peer.<br>Required for wan interfaces. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_out</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].bgp.ipv4_prefix_list_out") | String |  |  |  | Prefix List Name. Advertise routes for only these prefixes.<br>If not specified, nothing would be advertised. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".<br>Required for all WAN interfaces (`wan_carrier` is set) unless the carrier is marked as 'trusted' under `wan_carriers`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<node_type_keys.key>.node_groups.[].l3_interfaces.[].static_routes") | List, items: Dictionary |  |  | Min Length: 1 | Configure IPv4 static routes pointing to `peer_ip`. |
@@ -122,6 +134,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].peer") | String |  |  |  | The peer device name. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].peer_interface") | String |  |  |  | The peer device interface. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].peer_ip") | String |  |  |  | The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].bgp") | Dictionary |  |  |  | Enforce IPv4 BGP peering for the peer |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_as</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].bgp.peer_as") | String | Required |  |  | BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_in</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].bgp.ipv4_prefix_list_in") | String |  |  |  | Prefix List Name. Accept routes for only these prefixes from the peer.<br>Required for wan interfaces. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_out</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].bgp.ipv4_prefix_list_out") | String |  |  |  | Prefix List Name. Advertise routes for only these prefixes.<br>If not specified, nothing would be advertised. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".<br>Required for all WAN interfaces (`wan_carrier` is set) unless the carrier is marked as 'trusted' under `wan_carriers`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<node_type_keys.key>.nodes.[].l3_interfaces.[].static_routes") | List, items: Dictionary |  |  | Min Length: 1 | Configure IPv4 static routes pointing to `peer_ip`. |
@@ -153,6 +169,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer</samp>](## "l3_interface_profiles.[].peer") | String |  |  |  | The peer device name. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_interface</samp>](## "l3_interface_profiles.[].peer_interface") | String |  |  |  | The peer device interface. Used for description and documentation. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;peer_ip</samp>](## "l3_interface_profiles.[].peer_ip") | String |  |  |  | The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bgp</samp>](## "l3_interface_profiles.[].bgp") | Dictionary |  |  |  | Enforce IPv4 BGP peering for the peer |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;peer_as</samp>](## "l3_interface_profiles.[].bgp.peer_as") | String | Required |  |  | BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".<br>For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_in</samp>](## "l3_interface_profiles.[].bgp.ipv4_prefix_list_in") | String |  |  |  | Prefix List Name. Accept routes for only these prefixes from the peer.<br>Required for wan interfaces. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_prefix_list_out</samp>](## "l3_interface_profiles.[].bgp.ipv4_prefix_list_out") | String |  |  |  | Prefix List Name. Advertise routes for only these prefixes.<br>If not specified, nothing would be advertised. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "l3_interface_profiles.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".<br>Required for all WAN interfaces (`wan_carrier` is set) unless the carrier is marked as 'trusted' under `wan_carriers`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "l3_interface_profiles.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "l3_interface_profiles.[].static_routes") | List, items: Dictionary |  |  | Min Length: 1 | Configure IPv4 static routes pointing to `peer_ip`. |
@@ -235,6 +255,21 @@
 
             # The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address.
             peer_ip: <str>
+
+            # Enforce IPv4 BGP peering for the peer
+            bgp:
+
+              # BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".
+              # For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number.
+              peer_as: <str; required>
+
+              # Prefix List Name. Accept routes for only these prefixes from the peer.
+              # Required for wan interfaces.
+              ipv4_prefix_list_in: <str>
+
+              # Prefix List Name. Advertise routes for only these prefixes.
+              # If not specified, nothing would be advertised.
+              ipv4_prefix_list_out: <str>
 
             # Name of the IPv4 access-list to be assigned in the ingress direction.
             # The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".
@@ -362,6 +397,21 @@
                   # The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address.
                   peer_ip: <str>
 
+                  # Enforce IPv4 BGP peering for the peer
+                  bgp:
+
+                    # BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".
+                    # For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number.
+                    peer_as: <str; required>
+
+                    # Prefix List Name. Accept routes for only these prefixes from the peer.
+                    # Required for wan interfaces.
+                    ipv4_prefix_list_in: <str>
+
+                    # Prefix List Name. Advertise routes for only these prefixes.
+                    # If not specified, nothing would be advertised.
+                    ipv4_prefix_list_out: <str>
+
                   # Name of the IPv4 access-list to be assigned in the ingress direction.
                   # The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".
                   # Required for all WAN interfaces (`wan_carrier` is set) unless the carrier is marked as 'trusted' under `wan_carriers`.
@@ -474,6 +524,21 @@
 
               # The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address.
               peer_ip: <str>
+
+              # Enforce IPv4 BGP peering for the peer
+              bgp:
+
+                # BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".
+                # For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number.
+                peer_as: <str; required>
+
+                # Prefix List Name. Accept routes for only these prefixes from the peer.
+                # Required for wan interfaces.
+                ipv4_prefix_list_in: <str>
+
+                # Prefix List Name. Advertise routes for only these prefixes.
+                # If not specified, nothing would be advertised.
+                ipv4_prefix_list_out: <str>
 
               # Name of the IPv4 access-list to be assigned in the ingress direction.
               # The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".
@@ -594,6 +659,21 @@
               # The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address.
               peer_ip: <str>
 
+              # Enforce IPv4 BGP peering for the peer
+              bgp:
+
+                # BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".
+                # For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number.
+                peer_as: <str; required>
+
+                # Prefix List Name. Accept routes for only these prefixes from the peer.
+                # Required for wan interfaces.
+                ipv4_prefix_list_in: <str>
+
+                # Prefix List Name. Advertise routes for only these prefixes.
+                # If not specified, nothing would be advertised.
+                ipv4_prefix_list_out: <str>
+
               # Name of the IPv4 access-list to be assigned in the ingress direction.
               # The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".
               # Required for all WAN interfaces (`wan_carrier` is set) unless the carrier is marked as 'trusted' under `wan_carriers`.
@@ -706,6 +786,21 @@
 
         # The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address.
         peer_ip: <str>
+
+        # Enforce IPv4 BGP peering for the peer
+        bgp:
+
+          # BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".
+          # For asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number.
+          peer_as: <str; required>
+
+          # Prefix List Name. Accept routes for only these prefixes from the peer.
+          # Required for wan interfaces.
+          ipv4_prefix_list_in: <str>
+
+          # Prefix List Name. Advertise routes for only these prefixes.
+          # If not specified, nothing would be advertised.
+          ipv4_prefix_list_out: <str>
 
         # Name of the IPv4 access-list to be assigned in the ingress direction.
         # The access-list must be defined under `ipv4_acls` and supports field substitution for "interface_ip" and "peer_ip".

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ipv4_prefix_lists.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ipv4_prefix_lists.schema.yml
@@ -1,0 +1,42 @@
+# Copyright (c) 2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ipv4_prefix_list_catalog:
+    type: list
+    primary_key: name
+    description: |-
+      IPv4 prefix-list catalog.
+    convert_types:
+      - dict
+    items:
+      type: dict
+      keys:
+        name:
+          type: str
+          description: Prefix-list Name.
+        sequence_numbers:
+          type: list
+          primary_key: sequence
+          required: true
+          convert_types:
+            - dict
+          items:
+            type: dict
+            keys:
+              sequence:
+                type: int
+                required: true
+                description: Sequence ID.
+                convert_types:
+                  - str
+              action:
+                type: str
+                required: true
+                description: |
+                  Action as string.
+                  Example: "permit 10.255.0.0/27 eq 32"

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ipv4_prefix_lists.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/schema_fragments/ipv4_prefix_lists.schema.yml
@@ -9,8 +9,7 @@ keys:
   ipv4_prefix_list_catalog:
     type: list
     primary_key: name
-    description: |-
-      IPv4 prefix-list catalog.
+    description: IPv4 prefix-list catalog.
     convert_types:
       - dict
     items:
@@ -37,6 +36,6 @@ keys:
               action:
                 type: str
                 required: true
-                description: |
+                description: |-
                   Action as string.
                   Example: "permit 10.255.0.0/27 eq 32"

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -8264,6 +8264,35 @@
             "description": "The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address.",
             "title": "Peer IP"
           },
+          "bgp": {
+            "type": "object",
+            "description": "Enforce IPv4 BGP peering for the peer",
+            "properties": {
+              "peer_as": {
+                "type": "string",
+                "description": "BGP AS <1-4294967295> or AS number in asdot notation \"<1-65535>.<0-65535>\".\nFor asdot notation in YAML inputs, the value must be put in quotes, to prevent it from being interpreted as a float number.",
+                "title": "Peer As"
+              },
+              "ipv4_prefix_list_in": {
+                "type": "string",
+                "description": "Prefix List Name. Accept routes for only these prefixes from the peer.\nRequired for wan interfaces.",
+                "title": "IPv4 Prefix List In"
+              },
+              "ipv4_prefix_list_out": {
+                "type": "string",
+                "description": "Prefix List Name. Advertise routes for only these prefixes.\nIf not specified, nothing would be advertised.",
+                "title": "IPv4 Prefix List Out"
+              }
+            },
+            "required": [
+              "peer_as"
+            ],
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "BGP"
+          },
           "ipv4_acl_in": {
             "description": "Name of the IPv4 access-list to be assigned in the ingress direction.\nThe access-list must be defined under `ipv4_acls` and supports field substitution for \"interface_ip\" and \"peer_ip\".\nRequired for all WAN interfaces (`wan_carrier` is set) unless the carrier is marked as 'trusted' under `wan_carriers`.",
             "type": "string",

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -8909,6 +8909,30 @@ $defs:
           type: str
           description: The peer device IPv4 address (no mask). Used as default route
             gateway if `set_default_route` is true and `ip` is an IP address.
+        bgp:
+          type: dict
+          description: Enforce IPv4 BGP peering for the peer
+          keys:
+            peer_as:
+              type: str
+              required: true
+              convert_types:
+              - int
+              description: 'BGP AS <1-4294967295> or AS number in asdot notation "<1-65535>.<0-65535>".
+
+                For asdot notation in YAML inputs, the value must be put in quotes,
+                to prevent it from being interpreted as a float number.'
+            ipv4_prefix_list_in:
+              type: str
+              description: 'Prefix List Name. Accept routes for only these prefixes
+                from the peer.
+
+                Required for wan interfaces.'
+            ipv4_prefix_list_out:
+              type: str
+              description: 'Prefix List Name. Advertise routes for only these prefixes.
+
+                If not specified, nothing would be advertised.'
         ipv4_acl_in:
           description: 'Name of the IPv4 access-list to be assigned in the ingress
             direction.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type_l3_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type_l3_interfaces.schema.yml
@@ -77,6 +77,31 @@ $defs:
           type: str
           description: |-
             The peer device IPv4 address (no mask). Used as default route gateway if `set_default_route` is true and `ip` is an IP address.
+        bgp:
+          type: dict
+          description: |-
+            Enforce IPv4 BGP peering for the peer
+          keys:
+            peer_as:
+              type: str
+              required: true
+              convert_types:
+                - int
+              description: 'BGP AS <1-4294967295> or AS number in asdot notation
+                "<1-65535>.<0-65535>".
+
+                For asdot notation in YAML inputs, the value must be put in
+                quotes, to prevent it from being interpreted as a float number.'
+            ipv4_prefix_list_in:
+              type: str
+              description: |-
+                Prefix List Name. Accept routes for only these prefixes from the peer.
+                Required for wan interfaces.
+            ipv4_prefix_list_out:
+              type: str
+              description: |-
+                Prefix List Name. Advertise routes for only these prefixes.
+                If not specified, nothing would be advertised.
         ipv4_acl_in:
           description: |-
             Name of the IPv4 access-list to be assigned in the ingress direction.

--- a/python-avd/pyavd/_eos_designs/shared_utils/l3_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/l3_interfaces.py
@@ -109,8 +109,8 @@ class L3InterfacesMixin:
             if is_intf_wan:
                 neighbor["set_no_advertise"] = True
 
-            if prefix_list_in:
-                # In route map is used only if there is a prefix list
+            # The inbound route-map is only used if there is a prefix list or no-advertise
+            if neighbor["ipv4_prefix_list_in"] or neighbor["set_no_advertise"]:
                 neighbor["route_map_in"] = f"RM-BGP-{neighbor['ip_address']}-IN"
             neighbor["route_map_out"] = f"RM-BGP-{neighbor['ip_address']}-OUT"
 

--- a/python-avd/pyavd/_eos_designs/shared_utils/l3_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/l3_interfaces.py
@@ -110,7 +110,7 @@ class L3InterfacesMixin:
                 neighbor["set_no_advertise"] = True
 
             # The inbound route-map is only used if there is a prefix list or no-advertise
-            if neighbor["ipv4_prefix_list_in"] or neighbor["set_no_advertise"]:
+            if neighbor["ipv4_prefix_list_in"] or neighbor.get("set_no_advertise") is True:
                 neighbor["route_map_in"] = f"RM-BGP-{neighbor['ip_address']}-IN"
             neighbor["route_map_out"] = f"RM-BGP-{neighbor['ip_address']}-OUT"
 

--- a/python-avd/pyavd/_eos_designs/shared_utils/l3_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/l3_interfaces.py
@@ -6,8 +6,8 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from ..._utils import get, get_item, merge
 from ..._errors import AristaAvdMissingVariableError
+from ..._utils import get, get_item, merge
 from ..interface_descriptions import InterfaceDescriptionData
 
 if TYPE_CHECKING:

--- a/python-avd/pyavd/_eos_designs/shared_utils/misc.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/misc.py
@@ -418,3 +418,7 @@ class MiscMixin:
             return value
 
         return field_value
+
+    @cached_property
+    def ipv4_prefix_list_catalog(self: SharedUtils) -> list:
+        return get(self.hostvars, "ipv4_prefix_list_catalog", default=[])

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/prefix_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/prefix_lists.py
@@ -8,7 +8,6 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 from ...._utils import get, get_item
-
 from .utils import UtilsMixin
 
 if TYPE_CHECKING:

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/prefix_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/prefix_lists.py
@@ -87,8 +87,7 @@ class PrefixListsMixin(UtilsMixin):
         return prefix_lists
 
     def _get_prefix_list(self, name: str):
-        pfx_list = get_item(self.shared_utils.ipv4_prefix_list_catalog, "name", name, required=True, var_name=f"ipv4_prefix_list_catalog[name={name}]")
-        return pfx_list
+        return get_item(self.shared_utils.ipv4_prefix_list_catalog, "name", name, required=True, var_name=f"ipv4_prefix_list_catalog[name={name}]")
 
     @cached_property
     def ipv6_prefix_lists(self: AvdStructuredConfigUnderlay) -> list | None:

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/route_maps.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/route_maps.py
@@ -143,8 +143,8 @@ class RouteMapsMixin(UtilsMixin):
                 route_maps.append({"name": "RM-BGP-UNDERLAY-PEERS-OUT", "sequence_numbers": sequence_numbers})
 
         for neighbor in self.shared_utils.l3_interfaces_bgp_neighbors:
+            # RM-BGP-<PEER-IP>-IN
             if prefix_list_in := get(neighbor, "ipv4_prefix_list_in"):
-                # RM-BGP-<PEER-IP>-IN
                 sequence_numbers = [
                     {
                         "sequence": 10,
@@ -159,6 +159,7 @@ class RouteMapsMixin(UtilsMixin):
 
                 route_maps.append({"name": neighbor["route_map_in"], "sequence_numbers": sequence_numbers})
 
+            # RM-BGP-<PEER-IP>-OUT
             if prefix_list_out := get(neighbor, "ipv4_prefix_list_out"):
                 sequence_numbers = [
                     {
@@ -172,7 +173,6 @@ class RouteMapsMixin(UtilsMixin):
                     },
                 ]
             else:
-                # RM-BGP-<PEER-IP>-OUT
                 sequence_numbers = [
                     {
                         "sequence": 10,

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/route_maps.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/route_maps.py
@@ -7,7 +7,6 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 from ...._utils import get
-
 from .utils import UtilsMixin
 
 if TYPE_CHECKING:

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/route_maps.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/route_maps.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from ...._utils import get
+
 from .utils import UtilsMixin
 
 if TYPE_CHECKING:
@@ -140,6 +142,46 @@ class RouteMapsMixin(UtilsMixin):
                     },
                 ]
                 route_maps.append({"name": "RM-BGP-UNDERLAY-PEERS-OUT", "sequence_numbers": sequence_numbers})
+
+        for neighbor in self.shared_utils.l3_interfaces_bgp_neighbors:
+            if prefix_list_in := get(neighbor, "ipv4_prefix_list_in"):
+                # RM-BGP-<PEER-IP>-IN
+                sequence_numbers = [
+                    {
+                        "sequence": 10,
+                        "type": "permit",
+                        "match": [f"ip address prefix-list {prefix_list_in}"],
+                    },
+                ]
+                # set no advertise is set only for wan neighbors, which will also have
+                # prefix_list_in
+                if neighbor.get("set_no_advertise"):
+                    sequence_numbers[0]["set"] = ["community no-advertise additive"]
+
+                route_maps.append({"name": neighbor["route_map_in"], "sequence_numbers": sequence_numbers})
+
+            if prefix_list_out := get(neighbor, "ipv4_prefix_list_out"):
+                sequence_numbers = [
+                    {
+                        "sequence": 10,
+                        "type": "permit",
+                        "match": [f"ip address prefix-list {prefix_list_out}"],
+                    },
+                    {
+                        "sequence": 20,
+                        "type": "deny",
+                    },
+                ]
+            else:
+                # RM-BGP-<PEER-IP>-OUT
+                sequence_numbers = [
+                    {
+                        "sequence": 10,
+                        "type": "deny",
+                    },
+                ]
+
+            route_maps.append({"name": neighbor["route_map_out"], "sequence_numbers": sequence_numbers})
 
         if route_maps:
             return route_maps

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_bgp.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_bgp.py
@@ -174,6 +174,17 @@ class RouterBgpMixin(UtilsMixin):
             if neighbors:
                 router_bgp["neighbors"] = neighbors
 
+        for neighbor_info in self.shared_utils.l3_interfaces_bgp_neighbors:
+            neighbor = {
+                "ip_address": get(neighbor_info, "ip_address"),
+                "remote_as": get(neighbor_info, "remote_as"),
+                "description": get(neighbor_info, "description"),
+                "route_map_in": get(neighbor_info, "route_map_in"),
+                "route_map_out": get(neighbor_info, "route_map_out"),
+            }
+
+            router_bgp.setdefault("neighbors", []).append(strip_empties_from_dict(neighbor))
+
         if vrfs_dict:
             router_bgp["vrfs"] = list(vrfs_dict.values())
 


### PR DESCRIPTION
## Change Summary
Allow BGP peering ( IPv4 ) for WAN providers by adding knobs in node_type_l3_interfaces

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

## How to test
molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
