### PR TITLE
Fix(cvp_configlet_upload): Add tag always to main's generic task triggering v1/v3

### DIFF
--- a/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/main.yml
@@ -25,4 +25,5 @@
   register: cvp_vars
 
 - name: "Execute upload with collection in version {{ cv_collection }}"
+  tags: [always]
   ansible.builtin.include_tasks: "cv_collection_{{ cv_collection }}.yml"


### PR DESCRIPTION
## Change Summary

Add `[always]` tag to main's `Execute upload with collection in version {{ cv_collection }}` task so that it triggers respective v1/v3 sub-tasks when playbook execution is using explicit `--tags` arg

## Related Issue(s)

Fixes #4081 

## Component(s) name

`arista.avd.cvp_configlet_upload`

## Proposed changes

Add `tags: [always]`

## How to test

```
# ./playbooks/issue-4081.yml

---

- name: Engage arista.avd.cvp_configlet_upload to push configlet
  hosts: CLOUD_VISION_SERVERS
  connection: local
  gather_facts: false

  tasks:

    - name: Upload cvp configlets
      ansible.builtin.import_role:
          name: arista.avd.cvp_configlet_upload
      vars:
        configlet_directory: 'configlets/'
        file_extension: 'txt'
        configlets_cvp_prefix: 'DC1-AVD'
        execute_tasks: false
        cv_collection: v3
```

Run:
 - `ansible-playbook -i inventory.yml -i ../cvp_inventory.yml  playbooks/issue-4081.yml -e @../vault.yml --ask-vault-pass`
 - `ansible-playbook -i inventory.yml -i ../cvp_inventory.yml  playbooks/issue-4081.yml -e @../vault.yml --ask-vault-pass --tags apply`
 - `ansible-playbook -i inventory.yml -i ../cvp_inventory.yml  playbooks/issue-4081.yml -e @../vault.yml --ask-vault-pass --tags provision`

All 3 playbook runs above should trigger execution of respective tasks from `ansible_collections/arista/avd/roles/cvp_configlet_upload/tasks/cv_collection_v3.yml` 

Testing environment:
- python: 3.11.9
- ansible-core: 2.16.7
- arista.avd: devel

## Checklist

- N/A

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ x] My code has been rebased from devel before I start
- [ x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
