### PR TITLE
CI: Ignored warning of useless object instantiation of "Tablesort"

### DIFF
--- a/ansible_collections/arista/avd/docs/stylesheets/tables.js
+++ b/ansible_collections/arista/avd/docs/stylesheets/tables.js
@@ -2,5 +2,6 @@
 document$.subscribe(function() {
   var tables = document.querySelectorAll("article table:not([class])")
   tables.forEach(function(table) {
+    new Tablesort(table) // NOSONAR
   })
 })

--- a/ansible_collections/arista/avd/docs/stylesheets/tables.js
+++ b/ansible_collections/arista/avd/docs/stylesheets/tables.js
@@ -2,6 +2,5 @@
 document$.subscribe(function() {
   var tables = document.querySelectorAll("article table:not([class])")
   tables.forEach(function(table) {
-    new Tablesort(table)
   })
 })


### PR DESCRIPTION
## Change Summary

Ignored warning of useless object instantiation of "Tablesort".

## Related Issue(s)

Fixes #<ISSUE ID>
https://sonarcloud.io/project/issues?fileUuids=AY-cQzMFgsw4bnlWrqY4&resolved=false&id=aristanetworks_avd&open=AY-cQzlzgsw4bnlWrqf6&tab=code

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
Added ignore of useless object instantiation of "Tablesort".

## How to test
NA

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
