### PR TITLE
Feat(eos_cli_config_gen): Adding option for arp cache persistent and arp persistent refresh-delay

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
@@ -39,6 +39,10 @@ interface Management1
 
 ### ARP
 
+ARP cache persistency is enabled.
+
+ARP cache is refresh delay is 700 seconds after reboot.
+
 Global ARP timeout: 300
 
 #### ARP Static Entries
@@ -56,6 +60,8 @@ Global ARP timeout: 300
 
 ```eos
 !
+arp cache persistent
+arp persistent refresh-delay 700
 arp aging timeout default 300
 arp vrf BLAH 42.42.42.42 DEAD.BEEF.CAFE arpa
 arp vrf defauls 42.42.42.42 DEAD.BEEF.CAFE arpa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/arp.md
@@ -39,9 +39,7 @@ interface Management1
 
 ### ARP
 
-ARP cache persistency is enabled.
-
-ARP cache is refresh delay is 700 seconds after reboot.
+ARP cache persistency is enabled. The refresh-delay is 700 seconds after reboot.
 
 Global ARP timeout: 300
 
@@ -60,7 +58,6 @@ Global ARP timeout: 300
 
 ```eos
 !
-arp cache persistent
 arp persistent refresh-delay 700
 arp aging timeout default 300
 arp vrf BLAH 42.42.42.42 DEAD.BEEF.CAFE arpa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
@@ -12,6 +12,8 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
+arp cache persistent
+arp persistent refresh-delay 700
 arp aging timeout default 300
 arp vrf BLAH 42.42.42.42 DEAD.BEEF.CAFE arpa
 arp vrf defauls 42.42.42.42 DEAD.BEEF.CAFE arpa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/arp.cfg
@@ -12,7 +12,6 @@ interface Management1
    vrf MGMT
    ip address 10.73.255.122/24
 !
-arp cache persistent
 arp persistent refresh-delay 700
 arp aging timeout default 300
 arp vrf BLAH 42.42.42.42 DEAD.BEEF.CAFE arpa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
@@ -1,5 +1,7 @@
 # test arp
 arp:
+  cache_persistent: true
+  persistent_refresh_delay: 700
   aging:
     timeout_default: 300
   static_entries:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
@@ -1,6 +1,6 @@
 # test arp
 arp:
-  persistent: 
+  persistent:
     enabled: true
     refresh_delay: 700
   aging:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/arp.yml
@@ -1,7 +1,8 @@
 # test arp
 arp:
-  cache_persistent: true
-  persistent_refresh_delay: 700
+  persistent: 
+    enabled: true
+    refresh_delay: 700
   aging:
     timeout_default: 300
   static_entries:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
@@ -10,7 +10,7 @@
     | [<samp>arp</samp>](## "arp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;persistent</samp>](## "arp.persistent") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "arp.persistent.enabled") | Boolean | Required |  |  | Restore the ARP cache after reboot |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;refresh_delay</samp>](## "arp.persistent.refresh_delay") | Integer |  | `600` | Min: 600<br>Max: 3600 | Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;refresh_delay</samp>](## "arp.persistent.refresh_delay") | Integer |  |  | Min: 600<br>Max: 3600 | Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600). |
     | [<samp>&nbsp;&nbsp;aging</samp>](## "arp.aging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timeout_default</samp>](## "arp.aging.timeout_default") | Integer |  |  | Min: 60<br>Max: 65535 | Timeout in seconds. |
     | [<samp>&nbsp;&nbsp;static_entries</samp>](## "arp.static_entries") | List, items: Dictionary |  |  |  | Static ARP entries. |
@@ -28,7 +28,7 @@
         enabled: <bool; required>
 
         # Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).
-        refresh_delay: <int; 600-3600; default=600>
+        refresh_delay: <int; 600-3600>
       aging:
 
         # Timeout in seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
@@ -8,8 +8,9 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>arp</samp>](## "arp") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;cache_persistent</samp>](## "arp.cache_persistent") | Boolean |  |  |  | Restore the ARP cache after reboot |
-    | [<samp>&nbsp;&nbsp;persistent_refresh_delay</samp>](## "arp.persistent_refresh_delay") | Integer |  | `600` | Min: 600<br>Max: 3600 | Time to wait in seconds before refreshing the ARP cache after reboot. |
+    | [<samp>&nbsp;&nbsp;persistent</samp>](## "arp.persistent") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "arp.persistent.enabled") | Boolean | Required |  |  | Restore the ARP cache after reboot |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;refresh_delay</samp>](## "arp.persistent.refresh_delay") | Integer |  | `600` | Min: 600<br>Max: 3600 | Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600). |
     | [<samp>&nbsp;&nbsp;aging</samp>](## "arp.aging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timeout_default</samp>](## "arp.aging.timeout_default") | Integer |  |  | Min: 60<br>Max: 65535 | Timeout in seconds. |
     | [<samp>&nbsp;&nbsp;static_entries</samp>](## "arp.static_entries") | List, items: Dictionary |  |  |  | Static ARP entries. |
@@ -21,12 +22,13 @@
 
     ```yaml
     arp:
+      persistent:
 
-      # Restore the ARP cache after reboot
-      cache_persistent: <bool>
+        # Restore the ARP cache after reboot
+        enabled: <bool; required>
 
-      # Time to wait in seconds before refreshing the ARP cache after reboot.
-      persistent_refresh_delay: <int; 600-3600; default=600>
+        # Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).
+        refresh_delay: <int; 600-3600; default=600>
       aging:
 
         # Timeout in seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
@@ -9,7 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>arp</samp>](## "arp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;persistent</samp>](## "arp.persistent") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "arp.persistent.enabled") | Boolean | Required |  |  | Restore the ARP cache after reboot |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "arp.persistent.enabled") | Boolean | Required |  |  | Restore the ARP cache after reboot. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;refresh_delay</samp>](## "arp.persistent.refresh_delay") | Integer |  |  | Min: 600<br>Max: 3600 | Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600). |
     | [<samp>&nbsp;&nbsp;aging</samp>](## "arp.aging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timeout_default</samp>](## "arp.aging.timeout_default") | Integer |  |  | Min: 60<br>Max: 65535 | Timeout in seconds. |
@@ -24,7 +24,7 @@
     arp:
       persistent:
 
-        # Restore the ARP cache after reboot
+        # Restore the ARP cache after reboot.
         enabled: <bool; required>
 
         # Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/arp.md
@@ -8,6 +8,8 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>arp</samp>](## "arp") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;cache_persistent</samp>](## "arp.cache_persistent") | Boolean |  |  |  | Restore the ARP cache after reboot |
+    | [<samp>&nbsp;&nbsp;persistent_refresh_delay</samp>](## "arp.persistent_refresh_delay") | Integer |  | `600` | Min: 600<br>Max: 3600 | Time to wait in seconds before refreshing the ARP cache after reboot. |
     | [<samp>&nbsp;&nbsp;aging</samp>](## "arp.aging") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;timeout_default</samp>](## "arp.aging.timeout_default") | Integer |  |  | Min: 60<br>Max: 65535 | Timeout in seconds. |
     | [<samp>&nbsp;&nbsp;static_entries</samp>](## "arp.static_entries") | List, items: Dictionary |  |  |  | Static ARP entries. |
@@ -19,6 +21,12 @@
 
     ```yaml
     arp:
+
+      # Restore the ARP cache after reboot
+      cache_persistent: <bool>
+
+      # Time to wait in seconds before refreshing the ARP cache after reboot.
+      persistent_refresh_delay: <int; 600-3600; default=600>
       aging:
 
         # Timeout in seconds.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1125,7 +1125,6 @@
             "refresh_delay": {
               "type": "integer",
               "description": "Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).",
-              "default": 600,
               "minimum": 600,
               "maximum": 3600,
               "title": "Refresh Delay"

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1119,7 +1119,7 @@
           "properties": {
             "enabled": {
               "type": "boolean",
-              "description": "Restore the ARP cache after reboot",
+              "description": "Restore the ARP cache after reboot.",
               "title": "Enabled"
             },
             "refresh_delay": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1114,6 +1114,19 @@
     "arp": {
       "type": "object",
       "properties": {
+        "cache_persistent": {
+          "type": "boolean",
+          "description": "Restore the ARP cache after reboot",
+          "title": "Cache Persistent"
+        },
+        "persistent_refresh_delay": {
+          "type": "integer",
+          "description": "Time to wait in seconds before refreshing the ARP cache after reboot.",
+          "default": 600,
+          "minimum": 600,
+          "maximum": 3600,
+          "title": "Persistent Refresh Delay"
+        },
         "aging": {
           "type": "object",
           "properties": {

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.jsonschema.json
@@ -1114,18 +1114,31 @@
     "arp": {
       "type": "object",
       "properties": {
-        "cache_persistent": {
-          "type": "boolean",
-          "description": "Restore the ARP cache after reboot",
-          "title": "Cache Persistent"
-        },
-        "persistent_refresh_delay": {
-          "type": "integer",
-          "description": "Time to wait in seconds before refreshing the ARP cache after reboot.",
-          "default": 600,
-          "minimum": 600,
-          "maximum": 3600,
-          "title": "Persistent Refresh Delay"
+        "persistent": {
+          "type": "object",
+          "properties": {
+            "enabled": {
+              "type": "boolean",
+              "description": "Restore the ARP cache after reboot",
+              "title": "Enabled"
+            },
+            "refresh_delay": {
+              "type": "integer",
+              "description": "Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).",
+              "default": 600,
+              "minimum": 600,
+              "maximum": 3600,
+              "title": "Refresh Delay"
+            }
+          },
+          "required": [
+            "enabled"
+          ],
+          "additionalProperties": false,
+          "patternProperties": {
+            "^_.+$": {}
+          },
+          "title": "Persistent"
         },
         "aging": {
           "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -626,6 +626,18 @@ keys:
   arp:
     type: dict
     keys:
+      cache_persistent:
+        type: bool
+        description: Restore the ARP cache after reboot
+      persistent_refresh_delay:
+        type: int
+        description: Time to wait in seconds before refreshing the ARP cache after
+          reboot.
+        default: 600
+        min: 600
+        max: 3600
+        convert_types:
+        - str
       aging:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -632,7 +632,7 @@ keys:
           enabled:
             type: bool
             required: true
-            description: Restore the ARP cache after reboot
+            description: Restore the ARP cache after reboot.
           refresh_delay:
             type: int
             description: Time to wait in seconds before refreshing the ARP cache after

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -626,18 +626,22 @@ keys:
   arp:
     type: dict
     keys:
-      cache_persistent:
-        type: bool
-        description: Restore the ARP cache after reboot
-      persistent_refresh_delay:
-        type: int
-        description: Time to wait in seconds before refreshing the ARP cache after
-          reboot.
-        default: 600
-        min: 600
-        max: 3600
-        convert_types:
-        - str
+      persistent:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+            required: true
+            description: Restore the ARP cache after reboot
+          refresh_delay:
+            type: int
+            description: Time to wait in seconds before refreshing the ARP cache after
+              reboot (EOS default 600).
+            default: 600
+            min: 600
+            max: 3600
+            convert_types:
+            - str
       aging:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/eos_cli_config_gen.schema.yml
@@ -637,7 +637,6 @@ keys:
             type: int
             description: Time to wait in seconds before refreshing the ARP cache after
               reboot (EOS default 600).
-            default: 600
             min: 600
             max: 3600
             convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -9,17 +9,21 @@ keys:
   arp:
     type: dict
     keys:
-      cache_persistent:
-        type: bool
-        description: Restore the ARP cache after reboot
-      persistent_refresh_delay:
-        type: int
-        description: Time to wait in seconds before refreshing the ARP cache after reboot.
-        default: 600
-        min: 600
-        max: 3600
-        convert_types:
-          - str
+      persistent:
+        type: dict
+        keys:
+          enabled:
+            type: bool
+            required: true
+            description: Restore the ARP cache after reboot
+          refresh_delay:
+            type: int
+            description: Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).
+            default: 600
+            min: 600
+            max: 3600
+            convert_types:
+              - str
       aging:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -15,7 +15,7 @@ keys:
           enabled:
             type: bool
             required: true
-            description: Restore the ARP cache after reboot
+            description: Restore the ARP cache after reboot.
           refresh_delay:
             type: int
             description: Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -9,6 +9,17 @@ keys:
   arp:
     type: dict
     keys:
+      cache_persistent:
+        type: bool
+        description: Restore the ARP cache after reboot
+      persistent_refresh_delay:
+        type: int
+        description: Time to wait in seconds before refreshing the ARP cache after reboot.
+        default: 600
+        min: 600
+        max: 3600
+        convert_types:
+          - str
       aging:
         type: dict
         keys:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/schemas/schema_fragments/arp.schema.yml
@@ -19,7 +19,6 @@ keys:
           refresh_delay:
             type: int
             description: Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).
-            default: 600
             min: 600
             max: 3600
             convert_types:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
@@ -4,17 +4,16 @@
  that can be found in the LICENSE file.
 #}
 {# doc - arp #}
-{% if arp.aging.timeout_default is arista.avd.defined or arp.static_entries is arista.avd.defined or arp.cache_persistent is arista.avd.defined or
-    arp.persistent_refresh_delay is arista.avd.defined %}
+{% if arp.aging.timeout_default is arista.avd.defined or arp.static_entries is arista.avd.defined or arp.persistent is arista.avd.defined %}
 
 ### ARP
-{%     if arp.cache_persistent is arista.avd.defined(true) %}
+{%     if arp.persistent.enabled is arista.avd.defined(true) %}
+{%         set persistent_doc = "ARP cache persistency is enabled." %}
+{%         if arp.persistent.refresh_delay is arista.avd.defined %}
+{%             set persistent_doc = persistent_doc ~ " The refresh-delay is " ~ arp.persistent.refresh_delay ~ " seconds after reboot." %}
+{%         endif %}
 
-ARP cache persistency is enabled.
-{%     endif %}
-{%     if arp.persistent_refresh_delay is arista.avd.defined() %}
-
-ARP cache is refresh delay is {{ arp.persistent_refresh_delay }} seconds after reboot.
+{{ persistent_doc }}
 {%     endif %}
 {%     if arp.aging.timeout_default is arista.avd.defined %}
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/documentation/arp.j2
@@ -4,9 +4,18 @@
  that can be found in the LICENSE file.
 #}
 {# doc - arp #}
-{% if arp.aging.timeout_default is arista.avd.defined or arp.static_entries is arista.avd.defined %}
+{% if arp.aging.timeout_default is arista.avd.defined or arp.static_entries is arista.avd.defined or arp.cache_persistent is arista.avd.defined or
+    arp.persistent_refresh_delay is arista.avd.defined %}
 
 ### ARP
+{%     if arp.cache_persistent is arista.avd.defined(true) %}
+
+ARP cache persistency is enabled.
+{%     endif %}
+{%     if arp.persistent_refresh_delay is arista.avd.defined() %}
+
+ARP cache is refresh delay is {{ arp.persistent_refresh_delay }} seconds after reboot.
+{%     endif %}
 {%     if arp.aging.timeout_default is arista.avd.defined %}
 
 Global ARP timeout: {{ arp.aging.timeout_default }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
@@ -4,14 +4,14 @@
  that can be found in the LICENSE file.
 #}
 {# eos - arp #}
-{% if arp.aging.timeout_default is arista.avd.defined or arp.static_entries is arista.avd.defined or arp.cache_persistent is arista.avd.defined or
-    arp.persistent_refresh_delay is arista.avd.defined %}
+{% if arp.aging.timeout_default is arista.avd.defined or arp.static_entries is arista.avd.defined or arp.persistent is arista.avd.defined %}
 !
-{%     if arp.cache_persistent is arista.avd.defined(true) %}
-arp cache persistent
-{%     endif %}
-{%     if arp.persistent_refresh_delay is arista.avd.defined() %}
-arp persistent refresh-delay {{ arp.persistent_refresh_delay }}
+{%     if arp.persistent.enabled is arista.avd.defined(true) %}
+{%         set persistent_cli = "arp persistent" %}
+{%         if arp.persistent.refresh_delay is arista.avd.defined %}
+{%             set persistent_cli = persistent_cli ~ " refresh-delay " ~ arp.persistent.refresh_delay %}
+{%         endif %}
+{{ persistent_cli }}
 {%     endif %}
 {%     if arp.aging.timeout_default is arista.avd.defined %}
 arp aging timeout default {{ arp.aging.timeout_default }}

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/templates/eos/arp.j2
@@ -4,25 +4,34 @@
  that can be found in the LICENSE file.
 #}
 {# eos - arp #}
-{% if arp.aging.timeout_default is arista.avd.defined %}
+{% if arp.aging.timeout_default is arista.avd.defined or arp.static_entries is arista.avd.defined or arp.cache_persistent is arista.avd.defined or
+    arp.persistent_refresh_delay is arista.avd.defined %}
 !
+{%     if arp.cache_persistent is arista.avd.defined(true) %}
+arp cache persistent
+{%     endif %}
+{%     if arp.persistent_refresh_delay is arista.avd.defined() %}
+arp persistent refresh-delay {{ arp.persistent_refresh_delay }}
+{%     endif %}
+{%     if arp.aging.timeout_default is arista.avd.defined %}
 arp aging timeout default {{ arp.aging.timeout_default }}
-{% endif %}
-{% if arp.static_entries is arista.avd.defined %}
+{%     endif %}
+{%     if arp.static_entries is arista.avd.defined %}
 {# TODO - remove when dropping support for ansible 2.12.6 and its jinja2 hack #}
-{%     for entry in arp.static_entries %}
-{%         if entry.vrf is not arista.avd.defined %}
-{%             do entry.update({"vrf": "default"}) %}
-{%         endif %}
-{%     endfor %}
-{%     for vrf, entries in arp.static_entries | groupby("vrf") | arista.avd.natural_sort %}
-{# TODO {%     for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %} #}
-{%         for entry in entries | arista.avd.natural_sort("ipv4_address") %}
-{%             set arp_entry_prefix = "arp" %}
-{%             if vrf != "default" %}
-{%                 set arp_entry_prefix = arp_entry_prefix ~ " vrf " ~ vrf %}
+{%         for entry in arp.static_entries %}
+{%             if entry.vrf is not arista.avd.defined %}
+{%                 do entry.update({"vrf": "default"}) %}
 {%             endif %}
-{{ arp_entry_prefix }} {{ entry.ipv4_address }} {{ entry.mac_address }} arpa
 {%         endfor %}
-{%     endfor %}
+{%         for vrf, entries in arp.static_entries | groupby("vrf") | arista.avd.natural_sort %}
+{# TODO {%     for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %} #}
+{%             for entry in entries | arista.avd.natural_sort("ipv4_address") %}
+{%                 set arp_entry_prefix = "arp" %}
+{%                 if vrf != "default" %}
+{%                     set arp_entry_prefix = arp_entry_prefix ~ " vrf " ~ vrf %}
+{%                 endif %}
+{{ arp_entry_prefix }} {{ entry.ipv4_address }} {{ entry.mac_address }} arpa
+{%             endfor %}
+{%         endfor %}
+{%     endif %}
 {% endif %}

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -18973,6 +18973,19 @@
               "arp": {
                 "type": "object",
                 "properties": {
+                  "cache_persistent": {
+                    "type": "boolean",
+                    "description": "Restore the ARP cache after reboot",
+                    "title": "Cache Persistent"
+                  },
+                  "persistent_refresh_delay": {
+                    "type": "integer",
+                    "description": "Time to wait in seconds before refreshing the ARP cache after reboot.",
+                    "default": 600,
+                    "minimum": 600,
+                    "maximum": 3600,
+                    "title": "Persistent Refresh Delay"
+                  },
                   "aging": {
                     "type": "object",
                     "properties": {

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -18984,7 +18984,6 @@
                       "refresh_delay": {
                         "type": "integer",
                         "description": "Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).",
-                        "default": 600,
                         "minimum": 600,
                         "maximum": 3600,
                         "title": "Refresh Delay"

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -18973,18 +18973,31 @@
               "arp": {
                 "type": "object",
                 "properties": {
-                  "cache_persistent": {
-                    "type": "boolean",
-                    "description": "Restore the ARP cache after reboot",
-                    "title": "Cache Persistent"
-                  },
-                  "persistent_refresh_delay": {
-                    "type": "integer",
-                    "description": "Time to wait in seconds before refreshing the ARP cache after reboot.",
-                    "default": 600,
-                    "minimum": 600,
-                    "maximum": 3600,
-                    "title": "Persistent Refresh Delay"
+                  "persistent": {
+                    "type": "object",
+                    "properties": {
+                      "enabled": {
+                        "type": "boolean",
+                        "description": "Restore the ARP cache after reboot",
+                        "title": "Enabled"
+                      },
+                      "refresh_delay": {
+                        "type": "integer",
+                        "description": "Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).",
+                        "default": 600,
+                        "minimum": 600,
+                        "maximum": 3600,
+                        "title": "Refresh Delay"
+                      }
+                    },
+                    "required": [
+                      "enabled"
+                    ],
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "title": "Persistent"
                   },
                   "aging": {
                     "type": "object",

--- a/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
+++ b/ansible_collections/arista/avd/roles/eos_designs/schemas/eos_designs.jsonschema.json
@@ -18978,7 +18978,7 @@
                     "properties": {
                       "enabled": {
                         "type": "boolean",
-                        "description": "Restore the ARP cache after reboot",
+                        "description": "Restore the ARP cache after reboot.",
                         "title": "Enabled"
                       },
                       "refresh_delay": {


### PR DESCRIPTION
## Change Summary

Adding option for `arp cache persistent` and `arp persistent refresh-delay`

## Related Issue(s)

Fixes #4106 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Under the existing key "arp" two new options are added:

```
arp:
    type: dict
    keys:
      persistent:
        type: dict
        keys:
          enabled:
            type: bool
            required: true
            description: Restore the ARP cache after reboot
          refresh_delay:
            type: int
            description: Time to wait in seconds before refreshing the ARP cache after reboot (EOS default 600).
            default: 600
            min: 600
            max: 3600
            convert_types:
              - str
```


## How to test

```
arp:
  persistent: 
    enabled: true
    refresh_delay: 700
```

## Checklist

### User Checklist
- N/A

### Repository Checklist

- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
