### PR TITLE
Refactor(plugins): Move jinja filter code for arista.avd.generate_esi to PyAVD

### DIFF
--- a/ansible_collections/arista/avd/plugins/filter/generate_esi.py
+++ b/ansible_collections/arista/avd/plugins/filter/generate_esi.py
@@ -5,6 +5,23 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
+from ansible.errors import AnsibleFilterError
+
+from ansible_collections.arista.avd.plugins.plugin_utils.pyavd_wrappers import RaiseOnUse, wrap_filter
+
+PLUGIN_NAME = "arista.avd.generate_esi"
+
+try:
+    from pyavd.j2filters.generate_esi import generate_esi
+except ImportError as e:
+    generate_esi = RaiseOnUse(
+        AnsibleFilterError(
+            f"The '{PLUGIN_NAME}' plugin requires the 'pyavd' Python library. Got import error",
+            orig_exc=e,
+        )
+    )
+
+
 DOCUMENTATION = r"""
 ---
 name: generate_esi
@@ -38,12 +55,8 @@ _value:
 """
 
 
-def generate_esi(esi_short, esi_prefix="0000:0000:"):
-    return esi_prefix + esi_short
-
-
 class FilterModule(object):
     def filters(self):
         return {
-            "generate_esi": generate_esi,
+            "generate_esi": wrap_filter(PLUGIN_NAME)(generate_esi),
         }

--- a/ansible_collections/arista/avd/tests/unit/filters/test_esi_management.py
+++ b/ansible_collections/arista/avd/tests/unit/filters/test_esi_management.py
@@ -5,23 +5,12 @@ from __future__ import absolute_import, division, print_function
 
 __metaclass__ = type
 
-from ansible_collections.arista.avd.plugins.filter.generate_esi import generate_esi
 from ansible_collections.arista.avd.plugins.filter.generate_lacp_id import generate_lacp_id
 
-ESI_SHORT = "0303:0202:0101"
-ESI_PREFIX = "1111:1111"
 ESI_SHORT_1 = "0404:0202:0101"
 
 
 class TestEsiManagementFilter:
-    def test_generate_esi_without_prefix(self):
-        resp = generate_esi(ESI_SHORT)
-        assert resp == "0000:0000:" + ESI_SHORT
-
-    def test_generate_esi_with_prefix(self):
-        assert ESI_PREFIX is not None and ESI_PREFIX != ""
-        resp = generate_esi(ESI_SHORT, ESI_PREFIX)
-        assert resp == ESI_PREFIX + ESI_SHORT
 
     def test_lacp_id(self):
         assert ESI_SHORT_1 is not None and ESI_SHORT_1 != ""

--- a/python-avd/Makefile
+++ b/python-avd/Makefile
@@ -98,6 +98,7 @@ fix-libs: ## Fix/remove various Ansible specifics things from python files
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.generate_route_target/$(PYAVD_FILTER_IMPORT)\.generate_route_target/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.hide_passwords/$(PYAVD_FILTER_IMPORT)\.hide_passwords/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.list_compress/$(PYAVD_FILTER_IMPORT)\.list_compress/g' {} +
+	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.generate_esi/$(PYAVD_FILTER_IMPORT)\.generate_esi/g' {} +
 
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter/$(VENDOR_IMPORT)\.j2\.filter/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.roles\.eos_designs\.python_modules/$(VENDOR_IMPORT)\.eos_designs/g' {} +

--- a/python-avd/Makefile
+++ b/python-avd/Makefile
@@ -95,10 +95,10 @@ fix-libs: ## Fix/remove various Ansible specifics things from python files
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.convert_dicts/$(PYAVD_FILTER_IMPORT)\.convert_dicts/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.default/$(PYAVD_FILTER_IMPORT)\.default/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.natural_sort/$(PYAVD_FILTER_IMPORT)\.natural_sort/g' {} +
+	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.generate_esi/$(PYAVD_FILTER_IMPORT)\.generate_esi/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.generate_route_target/$(PYAVD_FILTER_IMPORT)\.generate_route_target/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.hide_passwords/$(PYAVD_FILTER_IMPORT)\.hide_passwords/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.list_compress/$(PYAVD_FILTER_IMPORT)\.list_compress/g' {} +
-	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter.generate_esi/$(PYAVD_FILTER_IMPORT)\.generate_esi/g' {} +
 
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.plugins\.filter/$(VENDOR_IMPORT)\.j2\.filter/g' {} +
 	find $(PACKAGE_DIR) -name '*.py' -exec sed -i -e 's/ansible_collections\.arista\.avd\.roles\.eos_designs\.python_modules/$(VENDOR_IMPORT)\.eos_designs/g' {} +

--- a/python-avd/pyavd/j2filters/generate_esi.py
+++ b/python-avd/pyavd/j2filters/generate_esi.py
@@ -1,0 +1,10 @@
+# Copyright (c) 2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+
+def generate_esi(esi_short: str, esi_prefix: str = "0000:0000:") -> str:
+    return esi_prefix + esi_short

--- a/python-avd/pyavd/j2filters/generate_esi.py
+++ b/python-avd/pyavd/j2filters/generate_esi.py
@@ -6,5 +6,16 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 
-def generate_esi(esi_short: str, esi_prefix: str = "0000:0000:") -> str:
-    return esi_prefix + esi_short
+def generate_esi(short_esi: str, esi_prefix: str = "0000:0000:") -> str:
+    """
+    Transforms short_esi to EVPN ESI format.
+    0303:0202:0101 (short_esi) -> 0000:0000:0303:0202:0101 (EVPN ESI).
+
+    Args:
+        esi_short (str): Short ESI value as per AVD definition in eos_designs
+        esi_prefix (str): ESI prefix value, will be concatenated with the `short_esi`
+    Returns:
+        str: Concatenated string of `esi_prefix` and `short_esi` like `0000:0000:0303:0202:0101`
+
+    """
+    return esi_prefix + short_esi

--- a/python-avd/pyavd/j2filters/generate_esi.py
+++ b/python-avd/pyavd/j2filters/generate_esi.py
@@ -12,10 +12,10 @@ def generate_esi(short_esi: str, esi_prefix: str = "0000:0000:") -> str:
     0303:0202:0101 (short_esi) -> 0000:0000:0303:0202:0101 (EVPN ESI).
 
     Args:
-        esi_short (str): Short ESI value as per AVD definition in eos_designs
-        esi_prefix (str): ESI prefix value, will be concatenated with the `short_esi`
+        esi_short: Short ESI value as per AVD definition in eos_designs
+        esi_prefix: ESI prefix value, will be concatenated with the `short_esi`
     Returns:
-        str: Concatenated string of `esi_prefix` and `short_esi` like `0000:0000:0303:0202:0101`
+        Concatenated string of `esi_prefix` and `short_esi` like `0000:0000:0303:0202:0101`
 
     """
     return esi_prefix + short_esi

--- a/python-avd/pyavd/templater.py
+++ b/python-avd/pyavd/templater.py
@@ -7,6 +7,7 @@ from .constants import JINJA2_EXTENSIONS, JINJA2_PRECOMPILED_TEMPLATE_PATH
 from .j2filters.add_md_toc import add_md_toc
 from .j2filters.convert_dicts import convert_dicts
 from .j2filters.default import default
+from .j2filters.generate_esi import generate_esi
 from .j2filters.generate_route_target import generate_route_target
 from .j2filters.hide_passwords import hide_passwords
 from .j2filters.list_compress import list_compress
@@ -73,6 +74,7 @@ class Templar:
                 "arista.avd.decrypt": decrypt,
                 "arista.avd.default": default,
                 "arista.avd.encrypt": encrypt,
+                "arista.avd.generate_esi": generate_esi,
                 "arista.avd.generate_route_target": generate_route_target,
                 "arista.avd.hide_passwords": hide_passwords,
                 "arista.avd.list_compress": list_compress,

--- a/python-avd/tests/pyavd/j2filters/test_esi_management.py
+++ b/python-avd/tests/pyavd/j2filters/test_esi_management.py
@@ -34,6 +34,6 @@ class TestEsiManagementFilter:
 
     @pytest.mark.parametrize("esi_short, esi_prefix, esi", GENERATE_ESI_TEST_CASES)
     def test_generate_esi(self, esi_short, esi_prefix, esi):
-        esi_prefix = esi_prefix if esi_prefix else DEFAULT_ESI_PREFIX
+        esi_prefix = esi_prefix or DEFAULT_ESI_PREFIX
         resp = generate_esi(esi_short, esi_prefix)
         assert resp == esi

--- a/python-avd/tests/pyavd/j2filters/test_esi_management.py
+++ b/python-avd/tests/pyavd/j2filters/test_esi_management.py
@@ -6,6 +6,7 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import pytest
+from pyavd.j2filters.generate_esi import generate_esi
 from pyavd.j2filters.generate_route_target import generate_route_target
 
 ESI_TO_RT_TEST_CASES = [
@@ -17,9 +18,22 @@ ESI_TO_RT_TEST_CASES = [
     ("3", ""),
 ]
 
+DEFAULT_ESI_PREFIX = "0000:0000:"
+GENERATE_ESI_TEST_CASES = [
+    # (<esi_short>, <esi_prefix>, <esi>)
+    ("0303:0202:0101", "", "0000:0000:0303:0202:0101"),  # without prefix
+    ("0303:0202:0101", "1111:1111:", "1111:1111:0303:0202:0101"),  # with prefix
+]
+
 
 class TestEsiManagementFilter:
     @pytest.mark.parametrize("esi_short, route_target", ESI_TO_RT_TEST_CASES)
     def test_generate_route_target(self, esi_short, route_target):
         resp = generate_route_target(esi_short)
         assert resp == route_target
+
+    @pytest.mark.parametrize("esi_short, esi_prefix, esi", GENERATE_ESI_TEST_CASES)
+    def test_generate_esi(self, esi_short, esi_prefix, esi):
+        esi_prefix = esi_prefix if esi_prefix else DEFAULT_ESI_PREFIX
+        resp = generate_esi(esi_short, esi_prefix)
+        assert resp == esi

--- a/python-avd/tests/pyavd/j2filters/test_generate_esi.py
+++ b/python-avd/tests/pyavd/j2filters/test_generate_esi.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from pyavd.j2filters.generate_esi import generate_esi
+
+DEFAULT_ESI_PREFIX = "0000:0000:"
+GENERATE_ESI_TEST_CASES = [
+    # (<esi_short>, <esi_prefix>, <esi>)
+    ("0303:0202:0101", "", "0000:0000:0303:0202:0101"),  # without prefix
+    ("0303:0202:0101", "1111:1111:", "1111:1111:0303:0202:0101"),  # with prefix
+]
+
+
+class TestGenerateEsiFilter:
+    @pytest.mark.parametrize("esi_short, esi_prefix, esi", GENERATE_ESI_TEST_CASES)
+    def test_generate_esi(self, esi_short, esi_prefix, esi):
+        esi_prefix = esi_prefix or DEFAULT_ESI_PREFIX
+        resp = generate_esi(esi_short, esi_prefix)
+        assert resp == esi

--- a/python-avd/tests/pyavd/j2filters/test_generate_route_target.py
+++ b/python-avd/tests/pyavd/j2filters/test_generate_route_target.py
@@ -6,7 +6,6 @@ from __future__ import absolute_import, division, print_function
 __metaclass__ = type
 
 import pytest
-from pyavd.j2filters.generate_esi import generate_esi
 from pyavd.j2filters.generate_route_target import generate_route_target
 
 ESI_TO_RT_TEST_CASES = [
@@ -18,22 +17,9 @@ ESI_TO_RT_TEST_CASES = [
     ("3", ""),
 ]
 
-DEFAULT_ESI_PREFIX = "0000:0000:"
-GENERATE_ESI_TEST_CASES = [
-    # (<esi_short>, <esi_prefix>, <esi>)
-    ("0303:0202:0101", "", "0000:0000:0303:0202:0101"),  # without prefix
-    ("0303:0202:0101", "1111:1111:", "1111:1111:0303:0202:0101"),  # with prefix
-]
 
-
-class TestEsiManagementFilter:
+class TestGenerateRouteTargetFilter:
     @pytest.mark.parametrize("esi_short, route_target", ESI_TO_RT_TEST_CASES)
     def test_generate_route_target(self, esi_short, route_target):
         resp = generate_route_target(esi_short)
         assert resp == route_target
-
-    @pytest.mark.parametrize("esi_short, esi_prefix, esi", GENERATE_ESI_TEST_CASES)
-    def test_generate_esi(self, esi_short, esi_prefix, esi):
-        esi_prefix = esi_prefix or DEFAULT_ESI_PREFIX
-        resp = generate_esi(esi_short, esi_prefix)
-        assert resp == esi


### PR DESCRIPTION
## Change Summary

Move jinja filter code for arista.avd.generate_esi to PyAVD

## Related Issue(s)

Fixes #4113 

## Component(s) name

`arista.avd.generate_esi`

## Proposed changes
Moving the code and unit tests for arista.avd.generate_esi filter to PyAVD

## How to test
CI should catch things.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
