### PR TITLE
Fix(eos_cli_config_gen): Fix MSDP template typo for sa_filter.out_list

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-msdp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-msdp.md
@@ -85,7 +85,7 @@ router msdp
          local-interface Loopback13
          keepalive 5 15
          sa-filter in list ACL3
-         sa-filter out list ACL3
+         sa-filter out list ACL4
          description Some other kind of MSDP Peer
          sa-limit 100
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-msdp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-msdp.cfg
@@ -46,7 +46,7 @@ router msdp
          local-interface Loopback13
          keepalive 5 15
          sa-filter in list ACL3
-         sa-filter out list ACL3
+         sa-filter out list ACL4
          description Some other kind of MSDP Peer
          sa-limit 100
 !

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-msdp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-msdp.j2
@@ -106,7 +106,7 @@ router msdp
          sa-filter in list {{ peer.sa_filter.in_list }}
 {%                     endif %}
 {%                     if peer.sa_filter.out_list is arista.avd.defined %}
-         sa-filter out list {{ peer.sa_filter.in_list }}
+         sa-filter out list {{ peer.sa_filter.out_list }}
 {%                     endif %}
 {%                     if peer.description is arista.avd.defined %}
          description {{ peer.description }}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix MSDP template typo for SA filters

## Related Issue(s)

Fixes #4159 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
typo fix in template

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
