### PR TITLE
Feat(eos_designs): Add support to add access-groups on l3-interfaces through network-services

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -122,6 +122,8 @@ interface Ethernet8
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.10.10/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8 out
 !
 interface Ethernet9
    description test
@@ -130,6 +132,8 @@ interface Ethernet9
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.20.20/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9 out
 !
 interface Ethernet10
    description test-DC1-BL1A
@@ -138,6 +142,8 @@ interface Ethernet10
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.30.10/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10 out
 !
 interface Ethernet11
    description DC1-BL1A descriptions preferred over single description
@@ -219,6 +225,27 @@ event-handler evpn-blacklist-recovery
    action bash FastCli -p 15 -c "clear bgp evpn host-flap"
    delay 300
    asynchronous
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
+   15 deny ip any host 10.10.10.10
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
+   15 deny ip any host 10.10.20.20
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
+   15 deny ip any host 10.10.30.10
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.10.10 any
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.20.20 any
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.30.10 any
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -158,14 +158,18 @@ interface Ethernet12
    ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12 out
 !
 interface Ethernet13
+   no shutdown
+   no switchport
+!
+interface Ethernet13.10
    description test l3 interfaces acls
    no shutdown
    mtu 9000
-   no switchport
+   encapsulation dot1q vlan 10
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.40.20/24
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13 in
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13 out
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13.10 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13.10 out
 !
 interface Ethernet4000
    description My test
@@ -243,14 +247,14 @@ event-handler evpn-blacklist-recovery
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
    15 deny ip any host 10.10.40.10
 !
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13.10
    15 deny ip any host 10.10.40.20
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.40.10 any
 !
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13.10
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.40.20 any
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -151,6 +151,26 @@ interface Ethernet11
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.30.10/24
 !
+interface Ethernet12
+   description test l3 interfaces acls
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_A_L3_VRF_Zone
+   ip address 10.10.40.10/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12 out
+!
+interface Ethernet13
+   description test l3 interfaces acls
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_A_L3_VRF_Zone
+   ip address 10.10.40.20/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13 out
+!
 interface Ethernet4000
    description My test
    no shutdown
@@ -230,6 +250,12 @@ ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
    15 deny ip any host 10.10.20.20
 !
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
+   15 deny ip any host 10.10.40.10
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+   15 deny ip any host 10.10.40.20
+!
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.10.10 any
@@ -237,6 +263,14 @@ ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.20.20 any
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.40.10 any
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.40.20 any
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -122,8 +122,6 @@ interface Ethernet8
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.10.10/24
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8 in
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8 out
 !
 interface Ethernet9
    description test
@@ -132,8 +130,6 @@ interface Ethernet9
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.20.20/24
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9 in
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9 out
 !
 interface Ethernet10
    description test-DC1-BL1A
@@ -244,25 +240,11 @@ event-handler evpn-blacklist-recovery
    delay 300
    asynchronous
 !
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
-   15 deny ip any host 10.10.10.10
-!
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
-   15 deny ip any host 10.10.20.20
-!
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
    15 deny ip any host 10.10.40.10
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
    15 deny ip any host 10.10.40.20
-!
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
-   remark Some remark will not require source and destination fields.
-   permit ip host 10.10.10.10 any
-!
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
-   remark Some remark will not require source and destination fields.
-   permit ip host 10.10.20.20 any
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
    remark Some remark will not require source and destination fields.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -142,8 +142,6 @@ interface Ethernet10
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.30.10/24
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10 in
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10 out
 !
 interface Ethernet11
    description DC1-BL1A descriptions preferred over single description
@@ -232,9 +230,6 @@ ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
    15 deny ip any host 10.10.20.20
 !
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
-   15 deny ip any host 10.10.30.10
-!
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.10.10 any
@@ -242,10 +237,6 @@ ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.20.20 any
-!
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
-   remark Some remark will not require source and destination fields.
-   permit ip host 10.10.30.10 any
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -113,8 +113,6 @@ interface Ethernet8
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.30.10/24
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8 in
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8 out
 !
 interface Ethernet9
    description test
@@ -123,8 +121,6 @@ interface Ethernet9
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.40.20/24
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9 in
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9 out
 !
 interface Ethernet10
    description test-DC1-BL1B
@@ -225,25 +221,11 @@ hardware tcam
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
-   15 deny ip any host 10.10.30.10
-!
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
-   15 deny ip any host 10.10.40.20
-!
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
    15 deny ip any host 10.10.50.10
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
    15 deny ip any host 10.10.50.20
-!
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
-   remark Some remark will not require source and destination fields.
-   permit ip host 10.10.30.10 any
-!
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
-   remark Some remark will not require source and destination fields.
-   permit ip host 10.10.40.20 any
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
    remark Some remark will not require source and destination fields.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -149,14 +149,18 @@ interface Ethernet12
    ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12 out
 !
 interface Ethernet13
+   no shutdown
+   no switchport
+!
+interface Ethernet13.10
    description test l3 interfaces acls
    no shutdown
    mtu 9000
-   no switchport
+   encapsulation dot1q vlan 10
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.50.20/24
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13 in
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13 out
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13.10 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13.10 out
 !
 interface Ethernet4000
    description My second test
@@ -224,14 +228,14 @@ ip virtual-router mac-address 00:dc:00:00:00:0a
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
    15 deny ip any host 10.10.50.10
 !
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13.10
    15 deny ip any host 10.10.50.20
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.50.10 any
 !
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13.10
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.50.20 any
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -142,6 +142,26 @@ interface Ethernet11
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.40.20/24
 !
+interface Ethernet12
+   description test l3 interfaces acls
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_A_L3_VRF_Zone
+   ip address 10.10.50.10/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12 out
+!
+interface Ethernet13
+   description test l3 interfaces acls
+   no shutdown
+   mtu 9000
+   no switchport
+   vrf Tenant_A_L3_VRF_Zone
+   ip address 10.10.50.20/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13 out
+!
 interface Ethernet4000
    description My second test
    no shutdown
@@ -211,6 +231,12 @@ ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
    15 deny ip any host 10.10.40.20
 !
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
+   15 deny ip any host 10.10.50.10
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+   15 deny ip any host 10.10.50.20
+!
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.30.10 any
@@ -218,6 +244,14 @@ ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
    remark Some remark will not require source and destination fields.
    permit ip host 10.10.40.20 any
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.50.10 any
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.50.20 any
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -113,6 +113,8 @@ interface Ethernet8
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.30.10/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8 out
 !
 interface Ethernet9
    description test
@@ -121,6 +123,8 @@ interface Ethernet9
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.40.20/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9 out
 !
 interface Ethernet10
    description test-DC1-BL1B
@@ -129,6 +133,8 @@ interface Ethernet10
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.40.20/24
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10 in
+   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10 out
 !
 interface Ethernet11
    description DC1-BL1B descriptions preferred over single description
@@ -200,6 +206,27 @@ hardware tcam
    system profile vxlan-routing
 !
 ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
+   15 deny ip any host 10.10.10.10
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
+   15 deny ip any host 10.10.20.20
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
+   15 deny ip any host 10.10.30.10
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.10.10 any
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.20.20 any
+!
+ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
+   remark Some remark will not require source and destination fields.
+   permit ip host 10.10.30.10 any
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -133,8 +133,6 @@ interface Ethernet10
    no switchport
    vrf Tenant_A_L3_VRF_Zone
    ip address 10.10.40.20/24
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10 in
-   ip access-group TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10 out
 !
 interface Ethernet11
    description DC1-BL1B descriptions preferred over single description
@@ -208,25 +206,18 @@ hardware tcam
 ip virtual-router mac-address 00:dc:00:00:00:0a
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
-   15 deny ip any host 10.10.10.10
+   15 deny ip any host 10.10.30.10
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
-   15 deny ip any host 10.10.20.20
-!
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
-   15 deny ip any host 10.10.30.10
+   15 deny ip any host 10.10.40.20
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
    remark Some remark will not require source and destination fields.
-   permit ip host 10.10.10.10 any
+   permit ip host 10.10.30.10 any
 !
 ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
    remark Some remark will not require source and destination fields.
-   permit ip host 10.10.20.20 any
-!
-ip access-list TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
-   remark Some remark will not require source and destination fields.
-   permit ip host 10.10.30.10 any
+   permit ip host 10.10.40.20 any
 !
 ip routing
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -450,6 +450,8 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet9
@@ -458,6 +460,8 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet10
@@ -466,6 +470,8 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test-DC1-BL1A
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet11
@@ -558,6 +564,49 @@ vlans:
 - id: 350
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
+ip_access_lists:
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.10.10
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.20.20
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.30.10
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.10.10
+    destination: any
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.20.20
+    destination: any
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.30.10
+    destination: any
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -480,6 +480,26 @@ ethernet_interfaces:
   description: DC1-BL1A descriptions preferred over single description
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
+- name: Ethernet12
+  peer_type: l3_interface
+  ip_address: 10.10.40.10/24
+  mtu: 9000
+  shutdown: false
+  description: test l3 interfaces acls
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
+  type: routed
+  vrf: Tenant_A_L3_VRF_Zone
+- name: Ethernet13
+  peer_type: l3_interface
+  ip_address: 10.10.40.20/24
+  mtu: 9000
+  shutdown: false
+  description: test l3 interfaces acls
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+  type: routed
+  vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet7
   peer_type: l3_interface
   ip_address: 10.10.10.10/24
@@ -577,6 +597,20 @@ ip_access_lists:
     protocol: ip
     source: any
     destination: 10.10.20.20
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.40.10
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.40.20
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
   entries:
   - remark: Some remark will not require source and destination fields.
@@ -590,6 +624,20 @@ ip_access_lists:
   - action: permit
     protocol: ip
     source: 10.10.20.20
+    destination: any
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.40.10
+    destination: any
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.40.20
     destination: any
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -450,8 +450,6 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test
-  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
-  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet9
@@ -460,8 +458,6 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test
-  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
-  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet10
@@ -583,20 +579,6 @@ vlans:
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
 ip_access_lists:
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
-  entries:
-  - sequence: 15
-    action: deny
-    protocol: ip
-    source: any
-    destination: 10.10.10.10
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
-  entries:
-  - sequence: 15
-    action: deny
-    protocol: ip
-    source: any
-    destination: 10.10.20.20
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
   entries:
   - sequence: 15
@@ -611,20 +593,6 @@ ip_access_lists:
     protocol: ip
     source: any
     destination: 10.10.40.20
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
-  entries:
-  - remark: Some remark will not require source and destination fields.
-  - action: permit
-    protocol: ip
-    source: 10.10.10.10
-    destination: any
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
-  entries:
-  - remark: Some remark will not require source and destination fields.
-  - action: permit
-    protocol: ip
-    source: 10.10.20.20
-    destination: any
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
   entries:
   - remark: Some remark will not require source and destination fields.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -486,15 +486,16 @@ ethernet_interfaces:
   access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
-- name: Ethernet13
+- name: Ethernet13.10
   peer_type: l3_interface
   ip_address: 10.10.40.20/24
   mtu: 9000
   shutdown: false
   description: test l3 interfaces acls
-  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
-  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
-  type: routed
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13.10
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13.10
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 10
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet7
   peer_type: l3_interface
@@ -515,6 +516,10 @@ ethernet_interfaces:
   - id: 2
     hash_algorithm: sha512
     key: AQQvKeimxJu+uGQ/yYvv9w==
+- name: Ethernet13
+  type: routed
+  peer_type: l3_interface
+  shutdown: false
 - name: Ethernet4000
   description: My test
   ip_address: 10.3.2.1/21
@@ -586,7 +591,7 @@ ip_access_lists:
     protocol: ip
     source: any
     destination: 10.10.40.10
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13.10
   entries:
   - sequence: 15
     action: deny
@@ -600,7 +605,7 @@ ip_access_lists:
     protocol: ip
     source: 10.10.40.10
     destination: any
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13.10
   entries:
   - remark: Some remark will not require source and destination fields.
   - action: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -470,8 +470,6 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test-DC1-BL1A
-  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
-  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet11
@@ -579,13 +577,6 @@ ip_access_lists:
     protocol: ip
     source: any
     destination: 10.10.20.20
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
-  entries:
-  - sequence: 15
-    action: deny
-    protocol: ip
-    source: any
-    destination: 10.10.30.10
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
   entries:
   - remark: Some remark will not require source and destination fields.
@@ -599,13 +590,6 @@ ip_access_lists:
   - action: permit
     protocol: ip
     source: 10.10.20.20
-    destination: any
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
-  entries:
-  - remark: Some remark will not require source and destination fields.
-  - action: permit
-    protocol: ip
-    source: 10.10.30.10
     destination: any
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -458,8 +458,6 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test-DC1-BL1B
-  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
-  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet11
@@ -544,41 +542,27 @@ ip_access_lists:
     action: deny
     protocol: ip
     source: any
-    destination: 10.10.10.10
+    destination: 10.10.30.10
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
   entries:
   - sequence: 15
     action: deny
     protocol: ip
     source: any
-    destination: 10.10.20.20
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
-  entries:
-  - sequence: 15
-    action: deny
-    protocol: ip
-    source: any
-    destination: 10.10.30.10
+    destination: 10.10.40.20
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
   entries:
   - remark: Some remark will not require source and destination fields.
   - action: permit
     protocol: ip
-    source: 10.10.10.10
+    source: 10.10.30.10
     destination: any
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
   entries:
   - remark: Some remark will not require source and destination fields.
   - action: permit
     protocol: ip
-    source: 10.10.20.20
-    destination: any
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
-  entries:
-  - remark: Some remark will not require source and destination fields.
-  - action: permit
-    protocol: ip
-    source: 10.10.30.10
+    source: 10.10.40.20
     destination: any
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -474,15 +474,16 @@ ethernet_interfaces:
   access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
-- name: Ethernet13
+- name: Ethernet13.10
   peer_type: l3_interface
   ip_address: 10.10.50.20/24
   mtu: 9000
   shutdown: false
   description: test l3 interfaces acls
-  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
-  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
-  type: routed
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13.10
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13.10
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 10
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet7
   peer_type: l3_interface
@@ -492,6 +493,10 @@ ethernet_interfaces:
   description: test
   type: routed
   vrf: Tenant_A_WAN_Zone
+- name: Ethernet13
+  type: routed
+  peer_type: l3_interface
+  shutdown: false
 - name: Ethernet4000
   description: My second test
   ip_address: 10.1.2.3/12
@@ -559,7 +564,7 @@ ip_access_lists:
     protocol: ip
     source: any
     destination: 10.10.50.10
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13.10
   entries:
   - sequence: 15
     action: deny
@@ -573,7 +578,7 @@ ip_access_lists:
     protocol: ip
     source: 10.10.50.10
     destination: any
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13.10
   entries:
   - remark: Some remark will not require source and destination fields.
   - action: permit

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -438,6 +438,8 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet9
@@ -446,6 +448,8 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet10
@@ -454,6 +458,8 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test-DC1-BL1B
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet11
@@ -531,6 +537,49 @@ vlans:
 - id: 350
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
+ip_access_lists:
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.10.10
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.20.20
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet10
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.30.10
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.10.10
+    destination: any
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.20.20
+    destination: any
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet10
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.30.10
+    destination: any
 ip_igmp_snooping:
   globally_enabled: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -438,8 +438,6 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test
-  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
-  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet9
@@ -448,8 +446,6 @@ ethernet_interfaces:
   mtu: 9000
   shutdown: false
   description: test
-  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
-  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet10
@@ -556,20 +552,6 @@ vlans:
   name: Tenant_C_WAN_Zone_1
   tenant: Tenant_C
 ip_access_lists:
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet8
-  entries:
-  - sequence: 15
-    action: deny
-    protocol: ip
-    source: any
-    destination: 10.10.30.10
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet9
-  entries:
-  - sequence: 15
-    action: deny
-    protocol: ip
-    source: any
-    destination: 10.10.40.20
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
   entries:
   - sequence: 15
@@ -584,20 +566,6 @@ ip_access_lists:
     protocol: ip
     source: any
     destination: 10.10.50.20
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
-  entries:
-  - remark: Some remark will not require source and destination fields.
-  - action: permit
-    protocol: ip
-    source: 10.10.30.10
-    destination: any
-- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet9
-  entries:
-  - remark: Some remark will not require source and destination fields.
-  - action: permit
-    protocol: ip
-    source: 10.10.40.20
-    destination: any
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
   entries:
   - remark: Some remark will not require source and destination fields.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -468,6 +468,26 @@ ethernet_interfaces:
   description: DC1-BL1B descriptions preferred over single description
   type: routed
   vrf: Tenant_A_L3_VRF_Zone
+- name: Ethernet12
+  peer_type: l3_interface
+  ip_address: 10.10.50.10/24
+  mtu: 9000
+  shutdown: false
+  description: test l3 interfaces acls
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
+  type: routed
+  vrf: Tenant_A_L3_VRF_Zone
+- name: Ethernet13
+  peer_type: l3_interface
+  ip_address: 10.10.50.20/24
+  mtu: 9000
+  shutdown: false
+  description: test l3 interfaces acls
+  access_group_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+  access_group_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+  type: routed
+  vrf: Tenant_A_L3_VRF_Zone
 - name: Ethernet7
   peer_type: l3_interface
   ip_address: 10.10.20.20/24
@@ -550,6 +570,20 @@ ip_access_lists:
     protocol: ip
     source: any
     destination: 10.10.40.20
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet12
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.50.10
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN_Ethernet13
+  entries:
+  - sequence: 15
+    action: deny
+    protocol: ip
+    source: any
+    destination: 10.10.50.20
 - name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet8
   entries:
   - remark: Some remark will not require source and destination fields.
@@ -563,6 +597,20 @@ ip_access_lists:
   - action: permit
     protocol: ip
     source: 10.10.40.20
+    destination: any
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet12
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.50.10
+    destination: any
+- name: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT_Ethernet13
+  entries:
+  - remark: Some remark will not require source and destination fields.
+  - action: permit
+    protocol: ip
+    source: 10.10.50.20
     destination: any
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -242,8 +242,6 @@ tenant_a:
             mtu: 9000
             enabled: True
             description: "test"
-            ipv4_acl_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN
-            ipv4_acl_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT
           - interfaces: [Ethernet10, Ethernet10]
             ip_addresses: [10.10.30.10/24, 10.10.40.20/24]
             nodes: [DC1-BL1A, DC1-BL1B]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -257,6 +257,14 @@ tenant_a:
             enabled: True
             description: "Single description"
             descriptions: ["DC1-BL1A descriptions preferred over single description", "DC1-BL1B descriptions preferred over single description"]
+          - interfaces: [Ethernet12, Ethernet13, Ethernet12, Ethernet13]
+            ip_addresses: [10.10.40.10/24, 10.10.40.20/24, 10.10.50.10/24, 10.10.50.20/24]
+            nodes: [DC1-BL1A, DC1-BL1A, DC1-BL1B, DC1-BL1B]
+            mtu: 9000
+            enabled: True
+            description: "test l3 interfaces acls"
+            ipv4_acl_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN
+            ipv4_acl_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT
             # no description nor descriptions is tested in Tenant_OSPF below
       - name: Tenant_A_OSPF
         vrf_id: 16

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -248,8 +248,6 @@ tenant_a:
             ip_addresses: [10.10.30.10/24, 10.10.40.20/24]
             nodes: [DC1-BL1A, DC1-BL1B]
             mtu: 9000
-            ipv4_acl_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN
-            ipv4_acl_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT
             enabled: True
             descriptions: ["test-DC1-BL1A", "test-DC1-BL1B"]
           - interfaces: [Ethernet11, Ethernet11]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -255,7 +255,7 @@ tenant_a:
             enabled: True
             description: "Single description"
             descriptions: ["DC1-BL1A descriptions preferred over single description", "DC1-BL1B descriptions preferred over single description"]
-          - interfaces: [Ethernet12, Ethernet13, Ethernet12, Ethernet13]
+          - interfaces: [Ethernet12, Ethernet13.10, Ethernet12, Ethernet13.10]
             ip_addresses: [10.10.40.10/24, 10.10.40.20/24, 10.10.50.10/24, 10.10.50.20/24]
             nodes: [DC1-BL1A, DC1-BL1A, DC1-BL1B, DC1-BL1B]
             mtu: 9000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -242,10 +242,14 @@ tenant_a:
             mtu: 9000
             enabled: True
             description: "test"
+            ipv4_acl_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN
+            ipv4_acl_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT
           - interfaces: [Ethernet10, Ethernet10]
             ip_addresses: [10.10.30.10/24, 10.10.40.20/24]
             nodes: [DC1-BL1A, DC1-BL1B]
             mtu: 9000
+            ipv4_acl_in: TEST-IPV4-ACL-WITH-IP-FIELDS-IN
+            ipv4_acl_out: TEST-IPV4-ACL-WITH-IP-FIELDS-OUT
             enabled: True
             descriptions: ["test-DC1-BL1A", "test-DC1-BL1B"]
           - interfaces: [Ethernet11, Ethernet11]

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
@@ -25,6 +25,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].descriptions.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].mtu") | Integer |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv4_acl_in") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv4_acl_out") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ospf") | Dictionary |  |  |  | OSPF interface configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ospf.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;point_to_point</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ospf.point_to_point") | Boolean |  | `False` |  |  |
@@ -91,6 +93,8 @@
                   - <str>
                 enabled: <bool>
                 mtu: <int>
+                ipv4_acl_in: <str>
+                ipv4_acl_out: <str>
 
                 # OSPF interface configuration.
                 ospf:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -6367,8 +6367,12 @@ $defs:
                       - str
                     ipv4_acl_in:
                       type: str
+                      convert_types:
+                      - int
                     ipv4_acl_out:
                       type: str
+                      convert_types:
+                      - int
                     ospf:
                       type: dict
                       description: OSPF interface configuration.

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -6365,6 +6365,10 @@ $defs:
                       type: int
                       convert_types:
                       - str
+                    ipv4_acl_in:
+                      type: str
+                    ipv4_acl_out:
+                      type: str
                     ospf:
                       type: dict
                       description: OSPF interface configuration.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -693,12 +693,12 @@ $defs:
                         - str
                     ipv4_acl_in:
                       type: str
-                      # convert_type:
-                      #   - int
+                      convert_types:
+                        - int
                     ipv4_acl_out:
                       type: str
-                      # convert_type:
-                      #   - int
+                      convert_types:
+                        - int
                     ospf:
                       type: dict
                       description: OSPF interface configuration.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -691,6 +691,14 @@ $defs:
                       type: int
                       convert_types:
                         - str
+                    ipv4_acl_in:
+                      type: str
+                      # convert_type:
+                      #   - int
+                    ipv4_acl_out:
+                      type: str
+                      # convert_type:
+                      #   - int
                     ospf:
                       type: dict
                       description: OSPF interface configuration.

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -78,12 +78,8 @@ class EthernetInterfacesMixin(UtilsMixin):
                             if self._l3_interface_acls is not None:
                                 interface.update(
                                     {
-                                        "access_group_in": get(
-                                            self._l3_interface_acls, f"{interface_name}..ipv4_acl_in..name", separator=".."
-                                            ),
-                                        "access_group_out": get(
-                                            self._l3_interface_acls, f"{interface_name}..ipv4_acl_out..name", separator=".."
-                                            ),
+                                        "access_group_in": get(self._l3_interface_acls, f"{interface_name}..ipv4_acl_in..name", separator=".."),
+                                        "access_group_out": get(self._l3_interface_acls, f"{interface_name}..ipv4_acl_out..name", separator=".."),
                                     }
                                 )
 

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -70,12 +70,18 @@ class EthernetInterfacesMixin(UtilsMixin):
                                 "mtu": l3_interface.get("mtu") if self.shared_utils.platform_settings_feature_support_per_interface_mtu else None,
                                 "shutdown": not l3_interface.get("enabled", True),
                                 "description": interface_description,
-                                "access_group_in": get(self._l3_interface_acls, f"{interface_name}.ipv4_acl_in.name"),
-                                "access_group_out": get(self._l3_interface_acls, f"{interface_name}.ipv4_acl_out.name"),
                                 "eos_cli": l3_interface.get("raw_eos_cli"),
                                 "struct_cfg": l3_interface.get("structured_config"),
                                 "flow_tracker": self.shared_utils.get_flow_tracker(l3_interface, "l3_interfaces"),
                             }
+
+                            if get(self._l3_interface_acls, self.shared_utils.hostname):
+                                interface.update(
+                                    {
+                                "access_group_in": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}.ipv4_acl_in.name"),
+                                "access_group_out": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}.ipv4_acl_out.name"),
+                                }
+                                )
 
                             if "." in interface_name:
                                 # This is a subinterface so we need to ensure that the parent is created

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -70,6 +70,8 @@ class EthernetInterfacesMixin(UtilsMixin):
                                 "mtu": l3_interface.get("mtu") if self.shared_utils.platform_settings_feature_support_per_interface_mtu else None,
                                 "shutdown": not l3_interface.get("enabled", True),
                                 "description": interface_description,
+                                "access_group_in": get(self._l3_interface_acls, f"{interface_name}.ipv4_acl_in.name"),
+                                "access_group_out": get(self._l3_interface_acls, f"{interface_name}.ipv4_acl_out.name"),
                                 "eos_cli": l3_interface.get("raw_eos_cli"),
                                 "struct_cfg": l3_interface.get("structured_config"),
                                 "flow_tracker": self.shared_utils.get_flow_tracker(l3_interface, "l3_interfaces"),

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -78,9 +78,9 @@ class EthernetInterfacesMixin(UtilsMixin):
                             if get(self._l3_interface_acls, self.shared_utils.hostname):
                                 interface.update(
                                     {
-                                "access_group_in": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}.ipv4_acl_in.name"),
-                                "access_group_out": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}.ipv4_acl_out.name"),
-                                }
+                                        "access_group_in": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}.ipv4_acl_in.name"),
+                                        "access_group_out": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}.ipv4_acl_out.name"),
+                                    }
                                 )
 
                             if "." in interface_name:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -78,8 +78,12 @@ class EthernetInterfacesMixin(UtilsMixin):
                             if get(self._l3_interface_acls, self.shared_utils.hostname):
                                 interface.update(
                                     {
-                                        "access_group_in": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}..ipv4_acl_in..name", separator=".."),
-                                        "access_group_out": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}..ipv4_acl_out..name", separator=".."),
+                                        "access_group_in": get(
+                                            self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}..ipv4_acl_in..name", separator=".."
+                                        ),
+                                        "access_group_out": get(
+                                            self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}..ipv4_acl_out..name", separator=".."
+                                        ),
                                     }
                                 )
 

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -78,8 +78,8 @@ class EthernetInterfacesMixin(UtilsMixin):
                             if get(self._l3_interface_acls, self.shared_utils.hostname):
                                 interface.update(
                                     {
-                                        "access_group_in": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}.ipv4_acl_in.name"),
-                                        "access_group_out": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}.ipv4_acl_out.name"),
+                                        "access_group_in": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}..ipv4_acl_in..name", separator=".."),
+                                        "access_group_out": get(self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}..ipv4_acl_out..name", separator=".."),
                                     }
                                 )
 

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -75,15 +75,15 @@ class EthernetInterfacesMixin(UtilsMixin):
                                 "flow_tracker": self.shared_utils.get_flow_tracker(l3_interface, "l3_interfaces"),
                             }
 
-                            if get(self._l3_interface_acls, self.shared_utils.hostname):
+                            if self._l3_interface_acls is not None:
                                 interface.update(
                                     {
                                         "access_group_in": get(
-                                            self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}..ipv4_acl_in..name", separator=".."
-                                        ),
+                                            self._l3_interface_acls, f"{interface_name}..ipv4_acl_in..name", separator=".."
+                                            ),
                                         "access_group_out": get(
-                                            self._l3_interface_acls[self.shared_utils.hostname], f"{interface_name}..ipv4_acl_out..name", separator=".."
-                                        ),
+                                            self._l3_interface_acls, f"{interface_name}..ipv4_acl_out..name", separator=".."
+                                            ),
                                     }
                                 )
 

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
@@ -113,7 +113,7 @@ class IpAccesslistsMixin(UtilsMixin):
 
         if self._l3_interface_acls:
             l3_interface_acls = self._l3_interface_acls
-            for l3_interface_acl in l3_interface_acls[self.shared_utils.hostname].values():
+            for l3_interface_acl in l3_interface_acls.values():
                 for acl in l3_interface_acl.values():
                     append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for L3 interface", context_keys=["name"])
 

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
@@ -113,7 +113,7 @@ class IpAccesslistsMixin(UtilsMixin):
 
         if self._l3_interface_acls:
             l3_interface_acls = self._l3_interface_acls
-            if self.shared_utils.hostname in l3_interface_acls.keys():
+            if self.shared_utils.hostname in l3_interface_acls:
                 for l3_interface_acl in l3_interface_acls[self.shared_utils.hostname].values():
                     for acl in l3_interface_acl.values():
                         append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for L3 interface", context_keys=["name"])

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
@@ -112,9 +112,11 @@ class IpAccesslistsMixin(UtilsMixin):
                     append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for SVI", context_keys=["name"])
 
         if self._l3_interface_acls:
-            for l3_interface_acl in self._l3_interface_acls.values():
-                for acl in l3_interface_acl.values():
-                    append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for L3 interface", context_keys=["name"])
+            l3_interface_acls = self._l3_interface_acls
+            if self.shared_utils.hostname in l3_interface_acls.keys():
+                for l3_interface_acl in l3_interface_acls[self.shared_utils.hostname].values():
+                    for acl in l3_interface_acl.values():
+                        append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for L3 interface", context_keys=["name"])
 
         for ie_policy_type in self._filtered_internet_exit_policy_types:
             acls = self._acl_internet_exit(ie_policy_type)

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
@@ -111,6 +111,11 @@ class IpAccesslistsMixin(UtilsMixin):
                 for acl in interface_acls.values():
                     append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for SVI", context_keys=["name"])
 
+        if self._l3_interface_acls:
+            for l3_interface_acl in self._l3_interface_acls.values():
+                for acl in l3_interface_acl.values():
+                    append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for L3 interface", context_keys=["name"])
+
         for ie_policy_type in self._filtered_internet_exit_policy_types:
             acls = self._acl_internet_exit(ie_policy_type)
             if acls:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
@@ -113,10 +113,9 @@ class IpAccesslistsMixin(UtilsMixin):
 
         if self._l3_interface_acls:
             l3_interface_acls = self._l3_interface_acls
-            if self.shared_utils.hostname in l3_interface_acls:
-                for l3_interface_acl in l3_interface_acls[self.shared_utils.hostname].values():
-                    for acl in l3_interface_acl.values():
-                        append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for L3 interface", context_keys=["name"])
+            for l3_interface_acl in l3_interface_acls[self.shared_utils.hostname].values():
+                for acl in l3_interface_acl.values():
+                    append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for L3 interface", context_keys=["name"])
 
         for ie_policy_type in self._filtered_internet_exit_policy_types:
             acls = self._acl_internet_exit(ie_policy_type)

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_access_lists.py
@@ -112,8 +112,7 @@ class IpAccesslistsMixin(UtilsMixin):
                     append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for SVI", context_keys=["name"])
 
         if self._l3_interface_acls:
-            l3_interface_acls = self._l3_interface_acls
-            for l3_interface_acl in l3_interface_acls.values():
+            for l3_interface_acl in self._l3_interface_acls.values():
                 for acl in l3_interface_acl.values():
                     append_if_not_duplicate(ip_access_lists, "name", acl, context="IPv4 Access lists for L3 interface", context_keys=["name"])
 

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -690,12 +690,14 @@ class UtilsMixin(UtilsZscalerMixin):
     def _l3_interface_acls(self: AvdStructuredConfigNetworkServices):
         """
         Returns a dict of
-            <interface_name>: {
+            <hostname> : {
+                <interface_name>: {
                 "ipv4_acl_in": <generated_ipv4_acl>,
                 "ipv4_acl_out": <generated_ipv4_acl>,
+                }
             }
         Only contains interfaces with ACLs and only the ACLs that are set,
-        so use `get(self._l3_interface_acls, f"{interface_name}.ipv4_acl_in")` to get the value.
+        so use `get(self._l3_interface_acls, f"{hostname}.{interface_name}.ipv4_acl_in")` to get the value.
         """
 
         if not self.shared_utils.network_services_l3:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -713,8 +713,9 @@ class UtilsMixin(UtilsZscalerMixin):
                         interface_name = interface
                         interface_idx = l3_interface["interfaces"].index(interface_name)
                         interface_ip: str | None = l3_interface["ip_addresses"][interface_idx]
-                        if interface_ip is not None and "/" in interface_ip:
-                            interface_ip = interface_ip.split("/", maxsplit=1)[0]
+                        if interface_ip is None:
+                            continue
+                        interface_ip = str(ipaddress.ip_interface(interface_ip).ip)
 
                         if ipv4_acl_in is not None:
                             l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -689,15 +689,15 @@ class UtilsMixin(UtilsZscalerMixin):
     @cached_property
     def _l3_interface_acls(self: AvdStructuredConfigNetworkServices):
         """
-        Returns a dict of
-            <hostname> : {
+        Returns a dict of interfaces and acls assigned to the interfaces.
+            {
                 <interface_name>: {
                 "ipv4_acl_in": <generated_ipv4_acl>,
                 "ipv4_acl_out": <generated_ipv4_acl>,
                 }
             }
         Only contains interfaces with ACLs and only the ACLs that are set,
-        so use `get(self._l3_interface_acls, f"{hostname}.{interface_name}..ipv4_acl_in", separator="..")` to get the value.
+        so use `get(self._l3_interface_acls, f"{interface_name}..ipv4_acl_in", separator="..")` to get the value.
         """
 
         if not self.shared_utils.network_services_l3:
@@ -717,21 +717,21 @@ class UtilsMixin(UtilsZscalerMixin):
                         interface_ip = str(ipaddress.ip_interface(interface_ip).ip)
                         node = l3_interface["nodes"][interface_idx]
                         if node == self.shared_utils.hostname:
-                            if node not in l3_interface_acls:
-                                l3_interface_acls[node] = {}
+                            # if node not in l3_interface_acls:
+                            #     l3_interface_acls[node] = {}
                             if ipv4_acl_in is not None:
-                                l3_interface_acls[node].setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
+                                l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
                                     name=ipv4_acl_in,
                                     interface_name=interface_name,
                                     interface_ip=interface_ip,
                                 )
                             if ipv4_acl_out is not None:
-                                l3_interface_acls[node].setdefault(interface_name, {})["ipv4_acl_out"] = self.shared_utils.get_ipv4_acl(
+                                l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_out"] = self.shared_utils.get_ipv4_acl(
                                     name=ipv4_acl_out,
                                     interface_name=interface_name,
                                     interface_ip=interface_ip,
                                 )
-            return l3_interface_acls
+        return l3_interface_acls
 
     @cached_property
     def _filtered_internet_exit_policies(self: AvdStructuredConfigNetworkServices) -> list:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -705,26 +705,25 @@ class UtilsMixin(UtilsZscalerMixin):
         for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant["vrfs"]:
                 for l3_interface in vrf["l3_interfaces"]:
-                    for interface in l3_interface["interfaces"]:
+                    for interface_idx, interface in enumerate(l3_interface["interfaces"]):
                         ipv4_acl_in = get(l3_interface, "ipv4_acl_in")
                         ipv4_acl_out = get(l3_interface, "ipv4_acl_out")
                         if ipv4_acl_in is None and ipv4_acl_out is None:
                             continue
                         interface_name = interface
-                        interface_idx = l3_interface["interfaces"].index(interface_name)
                         interface_ip: str | None = l3_interface["ip_addresses"][interface_idx]
-                        if interface_ip is None:
-                            continue
                         interface_ip = str(ipaddress.ip_interface(interface_ip).ip)
-
+                        node = l3_interface["nodes"][interface_idx]
+                        if node not in l3_interface_acls.keys():
+                            l3_interface_acls[node] = {}
                         if ipv4_acl_in is not None:
-                            l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
+                            l3_interface_acls[node].setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
                                 name=ipv4_acl_in,
                                 interface_name=interface_name,
                                 interface_ip=interface_ip,
                             )
                         if ipv4_acl_out is not None:
-                            l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_out"] = self.shared_utils.get_ipv4_acl(
+                            l3_interface_acls[node].setdefault(interface_name, {})["ipv4_acl_out"] = self.shared_utils.get_ipv4_acl(
                                 name=ipv4_acl_out,
                                 interface_name=interface_name,
                                 interface_ip=interface_ip,

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -714,7 +714,7 @@ class UtilsMixin(UtilsZscalerMixin):
                         interface_ip: str | None = l3_interface["ip_addresses"][interface_idx]
                         interface_ip = str(ipaddress.ip_interface(interface_ip).ip)
                         node = l3_interface["nodes"][interface_idx]
-                        if node not in l3_interface_acls.keys():
+                        if node not in l3_interface_acls:
                             l3_interface_acls[node] = {}
                         if ipv4_acl_in is not None:
                             l3_interface_acls[node].setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -708,6 +708,9 @@ class UtilsMixin(UtilsZscalerMixin):
             for vrf in tenant["vrfs"]:
                 for l3_interface in vrf["l3_interfaces"]:
                     for interface_idx, interface in enumerate(l3_interface["interfaces"]):
+                        if l3_interface["nodes"][interface_idx] != self.shared_utils.hostname:
+                            continue
+                            
                         ipv4_acl_in = get(l3_interface, "ipv4_acl_in")
                         ipv4_acl_out = get(l3_interface, "ipv4_acl_out")
                         if ipv4_acl_in is None and ipv4_acl_out is None:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -710,7 +710,7 @@ class UtilsMixin(UtilsZscalerMixin):
                     for interface_idx, interface in enumerate(l3_interface["interfaces"]):
                         if l3_interface["nodes"][interface_idx] != self.shared_utils.hostname:
                             continue
-                            
+
                         ipv4_acl_in = get(l3_interface, "ipv4_acl_in")
                         ipv4_acl_out = get(l3_interface, "ipv4_acl_out")
                         if ipv4_acl_in is None and ipv4_acl_out is None:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -718,20 +718,18 @@ class UtilsMixin(UtilsZscalerMixin):
                         interface_name = interface
                         interface_ip: str | None = l3_interface["ip_addresses"][interface_idx]
                         interface_ip = str(ipaddress.ip_interface(interface_ip).ip)
-                        node = l3_interface["nodes"][interface_idx]
-                        if node == self.shared_utils.hostname:
-                            if ipv4_acl_in is not None:
-                                l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
-                                    name=ipv4_acl_in,
-                                    interface_name=interface_name,
-                                    interface_ip=interface_ip,
-                                )
-                            if ipv4_acl_out is not None:
-                                l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_out"] = self.shared_utils.get_ipv4_acl(
-                                    name=ipv4_acl_out,
-                                    interface_name=interface_name,
-                                    interface_ip=interface_ip,
-                                )
+                        if ipv4_acl_in is not None:
+                            l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
+                                name=ipv4_acl_in,
+                                interface_name=interface_name,
+                                interface_ip=interface_ip,
+                            )
+                        if ipv4_acl_out is not None:
+                            l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_out"] = self.shared_utils.get_ipv4_acl(
+                                name=ipv4_acl_out,
+                                interface_name=interface_name,
+                                interface_ip=interface_ip,
+                            )
         return l3_interface_acls
 
     @cached_property

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -687,7 +687,7 @@ class UtilsMixin(UtilsZscalerMixin):
         return sorted(set(internet_exit_policy["type"] for internet_exit_policy in self._filtered_internet_exit_policies))
 
     @cached_property
-    def _l3_interface_acls(self: AvdStructuredConfigNetworkServices):
+    def _l3_interface_acls(self: AvdStructuredConfigNetworkServices) -> dict | None:
         """
         Returns a dict of interfaces and ACLs set on the interfaces.
             {

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -697,7 +697,7 @@ class UtilsMixin(UtilsZscalerMixin):
                 }
             }
         Only contains interfaces with ACLs and only the ACLs that are set,
-        so use `get(self._l3_interface_acls, f"{hostname}.{interface_name}.ipv4_acl_in")` to get the value.
+        so use `get(self._l3_interface_acls, f"{hostname}.{interface_name}..ipv4_acl_in", separator="..")` to get the value.
         """
 
         if not self.shared_utils.network_services_l3:
@@ -716,21 +716,22 @@ class UtilsMixin(UtilsZscalerMixin):
                         interface_ip: str | None = l3_interface["ip_addresses"][interface_idx]
                         interface_ip = str(ipaddress.ip_interface(interface_ip).ip)
                         node = l3_interface["nodes"][interface_idx]
-                        if node not in l3_interface_acls:
-                            l3_interface_acls[node] = {}
-                        if ipv4_acl_in is not None:
-                            l3_interface_acls[node].setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
-                                name=ipv4_acl_in,
-                                interface_name=interface_name,
-                                interface_ip=interface_ip,
-                            )
-                        if ipv4_acl_out is not None:
-                            l3_interface_acls[node].setdefault(interface_name, {})["ipv4_acl_out"] = self.shared_utils.get_ipv4_acl(
-                                name=ipv4_acl_out,
-                                interface_name=interface_name,
-                                interface_ip=interface_ip,
-                            )
-        return l3_interface_acls
+                        if node == self.shared_utils.hostname:
+                            if node not in l3_interface_acls:
+                                l3_interface_acls[node] = {}
+                            if ipv4_acl_in is not None:
+                                l3_interface_acls[node].setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
+                                    name=ipv4_acl_in,
+                                    interface_name=interface_name,
+                                    interface_ip=interface_ip,
+                                )
+                            if ipv4_acl_out is not None:
+                                l3_interface_acls[node].setdefault(interface_name, {})["ipv4_acl_out"] = self.shared_utils.get_ipv4_acl(
+                                    name=ipv4_acl_out,
+                                    interface_name=interface_name,
+                                    interface_ip=interface_ip,
+                                )
+            return l3_interface_acls
 
     @cached_property
     def _filtered_internet_exit_policies(self: AvdStructuredConfigNetworkServices) -> list:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -689,7 +689,7 @@ class UtilsMixin(UtilsZscalerMixin):
     @cached_property
     def _l3_interface_acls(self: AvdStructuredConfigNetworkServices):
         """
-        Returns a dict of interfaces and acls assigned to the interfaces.
+        Returns a dict of interfaces and ACLs set on the interfaces.
             {
                 <interface_name>: {
                 "ipv4_acl_in": <generated_ipv4_acl>,
@@ -717,8 +717,6 @@ class UtilsMixin(UtilsZscalerMixin):
                         interface_ip = str(ipaddress.ip_interface(interface_ip).ip)
                         node = l3_interface["nodes"][interface_idx]
                         if node == self.shared_utils.hostname:
-                            # if node not in l3_interface_acls:
-                            #     l3_interface_acls[node] = {}
                             if ipv4_acl_in is not None:
                                 l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
                                     name=ipv4_acl_in,

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -687,6 +687,50 @@ class UtilsMixin(UtilsZscalerMixin):
         return sorted(set(internet_exit_policy["type"] for internet_exit_policy in self._filtered_internet_exit_policies))
 
     @cached_property
+    def _l3_interface_acls(self: AvdStructuredConfigNetworkServices):
+        """
+        Returns a dict of
+            <interface_name>: {
+                "ipv4_acl_in": <generated_ipv4_acl>,
+                "ipv4_acl_out": <generated_ipv4_acl>,
+            }
+        Only contains interfaces with ACLs and only the ACLs that are set,
+        so use `get(self._l3_interface_acls, f"{interface_name}.ipv4_acl_in")` to get the value.
+        """
+
+        if not self.shared_utils.network_services_l3:
+            return None
+
+        l3_interface_acls = {}
+        for tenant in self.shared_utils.filtered_tenants:
+            for vrf in tenant["vrfs"]:
+                for l3_interface in vrf["l3_interfaces"]:
+                    for interface in l3_interface["interfaces"]:
+                        ipv4_acl_in = get(l3_interface, "ipv4_acl_in")
+                        ipv4_acl_out = get(l3_interface, "ipv4_acl_out")
+                        if ipv4_acl_in is None and ipv4_acl_out is None:
+                            continue
+                        interface_name = interface
+                        interface_idx = l3_interface["interfaces"].index(interface_name)
+                        interface_ip: str | None = l3_interface["ip_addresses"][interface_idx]
+                        if interface_ip is not None and "/" in interface_ip:
+                            interface_ip = interface_ip.split("/", maxsplit=1)[0]
+
+                        if ipv4_acl_in is not None:
+                            l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_in"] = self.shared_utils.get_ipv4_acl(
+                                name=ipv4_acl_in,
+                                interface_name=interface_name,
+                                interface_ip=interface_ip,
+                            )
+                        if ipv4_acl_out is not None:
+                            l3_interface_acls.setdefault(interface_name, {})["ipv4_acl_out"] = self.shared_utils.get_ipv4_acl(
+                                name=ipv4_acl_out,
+                                interface_name=interface_name,
+                                interface_ip=interface_ip,
+                            )
+        return l3_interface_acls
+
+    @cached_property
     def _filtered_internet_exit_policies(self: AvdStructuredConfigNetworkServices) -> list:
         """
         Only supported for CV Pathfinder Edge routers. Returns an empty list for pathfinders.


### PR DESCRIPTION
## Change Summary
Add support to add access-groups on l3-interfaces through network-services

## Related Issue(s)

Fixes #3534
Only address the L3 interfaec but not the SVIs as it was already implemented in https://github.com/aristanetworks/avd/pull/4096.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Initial ask
> It would be nice when defining a L3 / SVI in network services to also be able to add an access group right there. That was the tags take care of only adding the L3/SVI as it already does but also only add the access group to the devices that need it.

This PR covers the L3 interfaces part in network services - SVIs was done in https://github.com/aristanetworks/avd/pull/4096

## How to test


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
