### PR TITLE
Refactor(plugins): Deprecate various unused Ansible plugins

### DIFF
--- a/ansible_collections/arista/avd/docs/plugins/Filter_plugins/generate_esi.md
+++ b/ansible_collections/arista/avd/docs/plugins/Filter_plugins/generate_esi.md
@@ -13,6 +13,9 @@ title: arista.avd.generate_esi
 !!! note
     Always use the FQCN (Fully Qualified Collection Name) `arista.avd.generate_esi` when using this plugin.
 
+!!! danger "This plugin is **deprecated**"
+    This  will be removed in version 5.0.0.
+
 Transforms short_esi `0303:0202:0101` to EVPN ESI format `0000:0000:0303:0202:0101`
 
 ## Synopsis

--- a/ansible_collections/arista/avd/docs/plugins/Filter_plugins/generate_lacp_id.md
+++ b/ansible_collections/arista/avd/docs/plugins/Filter_plugins/generate_lacp_id.md
@@ -13,6 +13,9 @@ title: arista.avd.generate_lacp_id
 !!! note
     Always use the FQCN (Fully Qualified Collection Name) `arista.avd.generate_lacp_id` when using this plugin.
 
+!!! danger "This plugin is **deprecated**"
+    This  will be removed in version 5.0.0.
+
 Transforms short_esi `0303:0202:0101` to LACP ID format `0303.0202.0101`
 
 ## Synopsis

--- a/ansible_collections/arista/avd/docs/plugins/Filter_plugins/generate_route_target.md
+++ b/ansible_collections/arista/avd/docs/plugins/Filter_plugins/generate_route_target.md
@@ -13,6 +13,9 @@ title: arista.avd.generate_route_target
 !!! note
     Always use the FQCN (Fully Qualified Collection Name) `arista.avd.generate_route_target` when using this plugin.
 
+!!! danger "This plugin is **deprecated**"
+    This  will be removed in version 5.0.0.
+
 Transforms short_esi `0303:0202:0101` to route-target format `03:03:02:02:01:01`
 
 ## Synopsis

--- a/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/batch_template.md
+++ b/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/batch_template.md
@@ -13,6 +13,9 @@ title: arista.avd.batch_template
 !!! note
     Always use the FQCN (Fully Qualified Collection Name) `arista.avd.batch_template` when using this plugin.
 
+!!! danger "This plugin is **deprecated**"
+    This module will be removed in version 5.0.0.
+
 Render Jinja2 template on multiple items and write result to individual files.
 
 ## Synopsis

--- a/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/validate_and_template.md
+++ b/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/validate_and_template.md
@@ -13,6 +13,9 @@ title: arista.avd.validate_and_template
 !!! note
     Always use the FQCN (Fully Qualified Collection Name) `arista.avd.validate_and_template` when using this plugin.
 
+!!! danger "This plugin is **deprecated**"
+    This module will be removed in version 5.0.0.
+
 Validate input data according to Schema, render Jinja2 template and write result to a file.
 
 ## Synopsis

--- a/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/yaml_templates_to_facts.md
+++ b/ansible_collections/arista/avd/docs/plugins/Modules_and_action_plugins/yaml_templates_to_facts.md
@@ -13,6 +13,9 @@ title: arista.avd.yaml_templates_to_facts
 !!! note
     Always use the FQCN (Fully Qualified Collection Name) `arista.avd.yaml_templates_to_facts` when using this plugin.
 
+!!! danger "This plugin is **deprecated**"
+    This module will be removed in version 5.0.0.
+
 Set facts from YAML via Jinja2 templates
 
 ## Synopsis

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -28,6 +28,27 @@ For these reasons, the route-map was removed as a bug fix.
 
 To keep the broken route-map, `structured_config` can be used.
 
+### Changes to requirements
+
+- The Ansible collection `arista.avd.` now only requires `pyavd[ansible]` which will install all other Python dependencies.<br>
+  Note that the version of `pyavd` **must** match the version of the `arista.avd` collection.
+
+### Deprecations
+
+- The following Ansible plugins are no longer being used by AVD and have been deprecated for removal in AVD 5.0.0. See the plugin docs for possible replacements.
+
+  Filters:
+
+  - `arista.avd.generate_esi`
+  - `arista.avd.generate_lacp_id`
+  - `arista.avd.generate_route_target`
+
+  Action plugins / Modules:
+
+  - `arista.avd.batch_template`
+  - `arista.avd.validate_and_template`
+  - `arista.avd.yaml_templates_to_facts`
+
 ## Release 4.8.0
 
 ### Changes to requirements

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -30,7 +30,7 @@ To keep the broken route-map, `structured_config` can be used.
 
 ### Changes to requirements
 
-- The Ansible collection `arista.avd.` now only requires `pyavd[ansible]` which will install all other Python dependencies.<br>
+- The Ansible collection `arista.avd` now only requires `pyavd[ansible]` which will install all other Python dependencies.<br>
   Note that the version of `pyavd` **must** match the version of the `arista.avd` collection.
 
 ### Deprecations

--- a/ansible_collections/arista/avd/docs/templates/plugin-docs.j2
+++ b/ansible_collections/arista/avd/docs/templates/plugin-docs.j2
@@ -65,7 +65,6 @@ title: {{ collection | default("arista.avd", true) ~ "." ~ module }}
 
 !!! danger "This plugin is **deprecated**"
     This {{ plugin_type }} will be removed in version {{ deprecated['removed_in'] | default('') }}.
-
 {% else %}
 {%     set module_states = {
      "preview": {"message": "not guaranteed to have a backwards compatible interface", "level": "warning"},

--- a/ansible_collections/arista/avd/meta/runtime.yml
+++ b/ansible_collections/arista/avd/meta/runtime.yml
@@ -7,6 +7,18 @@ plugin_routing:
       deprecation:
         removal_version: 5.0.0
         warning_text: Use arista.avd.snmp_hash instead
+    generate_esi:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use Jinja string concatenation instead like `{{ <esi_prefix> ~ <short_esi> }}`
+    generate_lacp_id:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: Use the builtin `replace` filter instead like `{{ <short_esi> | replace(':', '.') }}`
+    generate_route_target:
+      deprecation:
+        removal_version: 5.0.0
+        warning_test: Use the builtin `ansible.builtin.regex_replace` filter instead like `{{ <short_esi> | ansible.builtin.regex_replace('(\\d{2})(\\d{2}):(\\d{2})(\\d{2}):(\\d{2})(\\d{2})', '\\1:\\2:\\3:\\4:\\5:\\6') }}`
   modules:
     deploy_to_cv:
       deprecation:
@@ -15,6 +27,24 @@ plugin_routing:
           The preview module 'arista.avd.deploy_to_cv' has been released under the new name 'arista.avd.cv_workflow'.
           The module will be redirected automatically until AVD version 5.0.0 after which it will be removed.
       redirect: arista.avd.cv_workflow
+    batch_template:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: |-
+          The internal 'arista.avd.batch_template' action plugin is no longer used by AVD.
+          The plugin is released as open source, so it can be copied and reused according to the license and copyright.
+    validate_and_template:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: |-
+          The internal 'arista.avd.validate_and_template' action plugin is no longer used by AVD.
+          The plugin is released as open source, so it can be copied and reused according to the license and copyright.
+    yaml_templates_to_facts:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: |-
+          The internal 'arista.avd.yaml_templates_to_facts' action plugin is no longer used by AVD.
+          The plugin is released as open source, so it can be copied and reused according to the license and copyright.
   action:
     deploy_to_cv:
       deprecation:
@@ -23,3 +53,21 @@ plugin_routing:
           The preview module 'arista.avd.deploy_to_cv' has been released under the new name 'arista.avd.cv_workflow'.
           The module will be redirected automatically until AVD version 5.0.0 after which it will be removed.
       redirect: arista.avd.cv_workflow
+    batch_template:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: |-
+          The internal 'arista.avd.batch_template' action plugin is no longer used by AVD.
+          The plugin is released as open source, so it can be copied and reused according to the license and copyright.
+    validate_and_template:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: |-
+          The internal 'arista.avd.validate_and_template' action plugin is no longer used by AVD.
+          The plugin is released as open source, so it can be copied and reused according to the license and copyright.
+    yaml_templates_to_facts:
+      deprecation:
+        removal_version: 5.0.0
+        warning_text: |-
+          The internal 'arista.avd.yaml_templates_to_facts' action plugin is no longer used by AVD.
+          The plugin is released as open source, so it can be copied and reused according to the license and copyright.

--- a/ansible_collections/arista/avd/meta/runtime.yml
+++ b/ansible_collections/arista/avd/meta/runtime.yml
@@ -18,7 +18,7 @@ plugin_routing:
     generate_route_target:
       deprecation:
         removal_version: 5.0.0
-        warning_test: Use the builtin `ansible.builtin.regex_replace` filter instead like `{{ <short_esi> | ansible.builtin.regex_replace('(\\d{2})(\\d{2}):(\\d{2})(\\d{2}):(\\d{2})(\\d{2})', '\\1:\\2:\\3:\\4:\\5:\\6') }}`
+        warning_text: Use the builtin `ansible.builtin.regex_replace` filter instead like `{{ <short_esi> | ansible.builtin.regex_replace('(\\d{2})(\\d{2}):(\\d{2})(\\d{2}):(\\d{2})(\\d{2})', '\\1:\\2:\\3:\\4:\\5:\\6') }}`
   modules:
     deploy_to_cv:
       deprecation:

--- a/ansible_collections/arista/avd/plugins/filter/generate_esi.py
+++ b/ansible_collections/arista/avd/plugins/filter/generate_esi.py
@@ -40,6 +40,10 @@ options:
     description: ESI prefix value. Will be concatenated with the `short_esi`.
     type: string
     default: "0000:0000:"
+deprecated:
+    removed_in: "5.0.0"
+    why: This filter is no longer used by AVD and is very simple to replace with generic Jinja syntax.
+    alternative: Use Jinja string concatenation instead like `{{ <esi_prefix> ~ <short_esi> }}`
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/plugins/filter/generate_lacp_id.py
+++ b/ansible_collections/arista/avd/plugins/filter/generate_lacp_id.py
@@ -35,6 +35,10 @@ options:
     description: Short ESI value as per AVD definition in eos_designs.
     type: string
     required: true
+deprecated:
+    removed_in: "5.0.0"
+    why: This filter is no longer used by AVD and is very simple to replace with a generic Jinja filter.
+    alternative: Use the builtin `replace` filter instead like `{{ <short_esi> | replace(':', '.') }}`
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/plugins/filter/generate_route_target.py
+++ b/ansible_collections/arista/avd/plugins/filter/generate_route_target.py
@@ -35,6 +35,12 @@ options:
     description: Short ESI value as per AVD definition in eos_designs.
     type: string
     required: true
+deprecated:
+    removed_in: "5.0.0"
+    why: This filter is no longer used by AVD and is very simple to replace with a generic Jinja filter.
+    alternative: |-
+      Use the builtin `ansible.builtin.regex_replace` filter instead like
+      `{{ <short_esi> | ansible.builtin.regex_replace('(\\d{2})(\\d{2}):(\\d{2})(\\d{2}):(\\d{2})(\\d{2})', '\\1:\\2:\\3:\\4:\\5:\\6') }}`
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/plugins/modules/batch_template.py
+++ b/ansible_collections/arista/avd/plugins/modules/batch_template.py
@@ -28,7 +28,7 @@ options:
 deprecated:
   removed_in: "5.0.0"
   why: The internal 'arista.avd.batch_template' action plugin is no longer used by AVD.
-  alternatives: The plugin is released as open source, so it can be copied and reused according to the license and copyright.
+  alternative: The plugin is released as open source, so it can be copied and reused according to the license and copyright.
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/plugins/modules/batch_template.py
+++ b/ansible_collections/arista/avd/plugins/modules/batch_template.py
@@ -25,6 +25,10 @@ options:
     required: true
     type: list
     elements: str
+deprecated:
+  removed_in: "5.0.0"
+  why: The internal 'arista.avd.batch_template' action plugin is no longer used by AVD.
+  alternatives: The plugin is released as open source, so it can be copied and reused according to the license and copyright.
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/plugins/modules/validate_and_template.py
+++ b/ansible_collections/arista/avd/plugins/modules/validate_and_template.py
@@ -84,7 +84,7 @@ options:
 deprecated:
   removed_in: "5.0.0"
   why: The internal 'arista.avd.validate_and_template' action plugin is no longer used by AVD.
-  alternatives: The plugin is released as open source, so it can be copied and reused according to the license and copyright.
+  alternative: The plugin is released as open source, so it can be copied and reused according to the license and copyright.
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/plugins/modules/validate_and_template.py
+++ b/ansible_collections/arista/avd/plugins/modules/validate_and_template.py
@@ -81,6 +81,10 @@ options:
       - Running cprofile will slow down performance in itself, so only set this while troubleshooting.
     required: false
     type: str
+deprecated:
+  removed_in: "5.0.0"
+  why: The internal 'arista.avd.validate_and_template' action plugin is no longer used by AVD.
+  alternatives: The plugin is released as open source, so it can be copied and reused according to the license and copyright.
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
@@ -126,7 +126,7 @@ options:
 deprecated:
   removed_in: "5.0.0"
   why: The internal 'arista.avd.yaml_templates_to_facts' action plugin is no longer used by AVD.
-  alternatives: The plugin is released as open source, so it can be copied and reused according to the license and copyright.
+  alternative: The plugin is released as open source, so it can be copied and reused according to the license and copyright.
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
+++ b/ansible_collections/arista/avd/plugins/modules/yaml_templates_to_facts.py
@@ -123,6 +123,10 @@ options:
     required: false
     type: bool
     default: true
+deprecated:
+  removed_in: "5.0.0"
+  why: The internal 'arista.avd.yaml_templates_to_facts' action plugin is no longer used by AVD.
+  alternatives: The plugin is released as open source, so it can be copied and reused according to the license and copyright.
 """
 
 EXAMPLES = r"""

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -1019,9 +1019,9 @@ Both data models support variable inheritance from profiles defined under [`port
     To help provide consistency when configuring EVPN A/A ESI values, arista.avd provides an abstraction in the form of a `short_esi` key.
     `short_esi` is an abbreviated 3 octets value to encode [Ethernet Segment ID](https://tools.ietf.org/html/rfc7432#section-8.3.1) and LACP ID.
 
-    Transformation from abstraction to network values provides the following result:
+    The abstracted `short_esi: "0303:0202:0101"` is transformed into the following network values:
 
-    - *EVPN ESI*: 000:000:0303:0202:0101
+    - *EVPN ESI*: 0000:0000:0303:0202:0101
     - *LACP ID*: 0303.0202.0101
     - *Route Target*: 03:03:02:02:01:01
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -1018,13 +1018,8 @@ Both data models support variable inheritance from profiles defined under [`port
 
     To help provide consistency when configuring EVPN A/A ESI values, arista.avd provides an abstraction in the form of a `short_esi` key.
     `short_esi` is an abbreviated 3 octets value to encode [Ethernet Segment ID](https://tools.ietf.org/html/rfc7432#section-8.3.1) and LACP ID.
-    Transformation from abstraction to network values is managed by the following Ansible filter plugins:
 
-    - [`arista.avd.generate_esi`](../../../docs/plugins/Filter_plugins/generate_esi.md)
-    - [`arista.avd.generate_lacp_id`](../../../docs/plugins/Filter_plugins/generate_lacp_id.md).
-    - [`arista.avd.generate_route_target`](../../../docs/plugins/Filter_plugins/generate_route_target.md).
-
-    The plugins provides the following result:
+    Transformation from abstraction to network values provides the following result:
 
     - *EVPN ESI*: 000:000:0303:0202:0101
     - *LACP ID*: 0303.0202.0101

--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/port_channel_interfaces.py
@@ -8,7 +8,7 @@ from collections import ChainMap
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from ...._utils import append_if_not_duplicate, get, strip_null_from_data
+from ...._utils import append_if_not_duplicate, get, short_esi_to_route_target, strip_null_from_data
 from ....j2filters import range_expand
 from ...interface_descriptions import InterfaceDescriptionData
 from .utils import UtilsMixin
@@ -219,7 +219,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
         ) is not None:
             port_channel_interface["evpn_ethernet_segment"] = {
                 "identifier": f"{self.shared_utils.evpn_short_esi_prefix}{short_esi}",
-                "route_target": re.sub(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})", r"\1:\2:\3:\4:\5:\6", short_esi),
+                "route_target": short_esi_to_route_target(short_esi),
             }
 
         return strip_null_from_data(port_channel_interface, strip_values_tuple=(None, ""))

--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/utils.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING
 
 from ...._errors import AristaAvdError
 from ...._utils import get, get_item
-from ....j2filters import convert_dicts, generate_esi, generate_route_target
+from ....j2filters import convert_dicts
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigConnectedEndpoints
@@ -157,9 +157,9 @@ class UtilsMixin:
 
         adapter_ethernet_segment: dict = adapter.get("ethernet_segment", {})
         evpn_ethernet_segment = {
-            "identifier": generate_esi(short_esi, self.shared_utils.evpn_short_esi_prefix),
+            "identifier": f"{self.shared_utils.evpn_short_esi_prefix}{short_esi}",
             "redundancy": adapter_ethernet_segment.get("redundancy", default_redundancy),
-            "route_target": generate_route_target(short_esi),
+            "route_target": re.sub(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})", r"\1:\2:\3:\4:\5:\6", short_esi),
         }
         if (designated_forwarder_algorithm := adapter_ethernet_segment.get("designated_forwarder_algorithm", default_df_algo)) is None:
             return evpn_ethernet_segment

--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/utils.py
@@ -9,7 +9,7 @@ from hashlib import sha256
 from typing import TYPE_CHECKING
 
 from ...._errors import AristaAvdError
-from ...._utils import get, get_item
+from ...._utils import get, get_item, short_esi_to_route_target
 from ....j2filters import convert_dicts
 
 if TYPE_CHECKING:
@@ -159,7 +159,7 @@ class UtilsMixin:
         evpn_ethernet_segment = {
             "identifier": f"{self.shared_utils.evpn_short_esi_prefix}{short_esi}",
             "redundancy": adapter_ethernet_segment.get("redundancy", default_redundancy),
-            "route_target": re.sub(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})", r"\1:\2:\3:\4:\5:\6", short_esi),
+            "route_target": short_esi_to_route_target(short_esi),
         }
         if (designated_forwarder_algorithm := adapter_ethernet_segment.get("designated_forwarder_algorithm", default_df_algo)) is None:
             return evpn_ethernet_segment

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/port_channel_interfaces.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING
 
 from ...._utils import append_if_not_duplicate, get
-from ....j2filters import generate_esi, generate_lacp_id, generate_route_target, natural_sort
+from ....j2filters import natural_sort
 from .utils import UtilsMixin
 
 if TYPE_CHECKING:
@@ -67,13 +67,13 @@ class PortChannelInterfacesMixin(UtilsMixin):
                                 parent_interface.update(
                                     {
                                         "evpn_ethernet_segment": {
-                                            "identifier": generate_esi(short_esi, self.shared_utils.evpn_short_esi_prefix),
-                                            "route_target": generate_route_target(short_esi),
+                                            "identifier": f"{self.shared_utils.evpn_short_esi_prefix}{short_esi}",
+                                            "route_target": re.sub(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})", r"\1:\2:\3:\4:\5:\6", short_esi),
                                         }
                                     }
                                 )
                                 if port_channel_mode == "active":
-                                    parent_interface["lacp_id"] = generate_lacp_id(short_esi)
+                                    parent_interface["lacp_id"] = short_esi.replace(":", ".")
 
                         subif_parent_interfaces.append(parent_interface)
 
@@ -123,13 +123,13 @@ class PortChannelInterfacesMixin(UtilsMixin):
                                 interface.update(
                                     {
                                         "evpn_ethernet_segment": {
-                                            "identifier": generate_esi(short_esi, self.shared_utils.evpn_short_esi_prefix),
-                                            "route_target": generate_route_target(short_esi),
+                                            "identifier": f"{self.shared_utils.evpn_short_esi_prefix}{short_esi}",
+                                            "route_target": re.sub(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})", r"\1:\2:\3:\4:\5:\6", short_esi),
                                         }
                                     }
                                 )
                                 if port_channel_mode == "active":
-                                    interface["lacp_id"] = generate_lacp_id(short_esi)
+                                    interface["lacp_id"] = short_esi.replace(":", ".")
 
                         append_if_not_duplicate(
                             list_of_dicts=port_channel_interfaces,

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/port_channel_interfaces.py
@@ -7,7 +7,7 @@ import re
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from ...._utils import append_if_not_duplicate, get
+from ...._utils import append_if_not_duplicate, get, short_esi_to_route_target
 from ....j2filters import natural_sort
 from .utils import UtilsMixin
 
@@ -68,7 +68,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
                                     {
                                         "evpn_ethernet_segment": {
                                             "identifier": f"{self.shared_utils.evpn_short_esi_prefix}{short_esi}",
-                                            "route_target": re.sub(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})", r"\1:\2:\3:\4:\5:\6", short_esi),
+                                            "route_target": short_esi_to_route_target(short_esi),
                                         }
                                     }
                                 )
@@ -124,7 +124,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
                                     {
                                         "evpn_ethernet_segment": {
                                             "identifier": f"{self.shared_utils.evpn_short_esi_prefix}{short_esi}",
-                                            "route_target": re.sub(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})", r"\1:\2:\3:\4:\5:\6", short_esi),
+                                            "route_target": short_esi_to_route_target(short_esi),
                                         }
                                     }
                                 )

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
@@ -3,11 +3,10 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-import re
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from ...._utils import get
+from ...._utils import get, short_esi_to_route_target
 from ...interface_descriptions.models import InterfaceDescriptionData
 from .utils import UtilsMixin
 
@@ -73,7 +72,7 @@ class PortChannelInterfacesMixin(UtilsMixin):
             if (short_esi := link.get("short_esi")) is not None:
                 port_channel_interface["evpn_ethernet_segment"] = {
                     "identifier": f"{self.shared_utils.evpn_short_esi_prefix}{short_esi}",
-                    "route_target": re.sub(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})", r"\1:\2:\3:\4:\5:\6", short_esi),
+                    "route_target": short_esi_to_route_target(short_esi),
                 }
                 port_channel_interface["lacp_id"] = short_esi.replace(":", ".")
 

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
@@ -3,11 +3,11 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
+import re
 from functools import cached_property
 from typing import TYPE_CHECKING
 
 from ...._utils import get
-from ....j2filters import generate_esi, generate_lacp_id, generate_route_target
 from ...interface_descriptions.models import InterfaceDescriptionData
 from .utils import UtilsMixin
 
@@ -72,10 +72,10 @@ class PortChannelInterfacesMixin(UtilsMixin):
 
             if (short_esi := link.get("short_esi")) is not None:
                 port_channel_interface["evpn_ethernet_segment"] = {
-                    "identifier": generate_esi(short_esi, self.shared_utils.evpn_short_esi_prefix),
-                    "route_target": generate_route_target(short_esi),
+                    "identifier": f"{self.shared_utils.evpn_short_esi_prefix}{short_esi}",
+                    "route_target": re.sub(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})", r"\1:\2:\3:\4:\5:\6", short_esi),
                 }
-                port_channel_interface["lacp_id"] = generate_lacp_id(short_esi)
+                port_channel_interface["lacp_id"] = short_esi.replace(":", ".")
 
             # PTP
             if get(link, "ptp.enable") is True:

--- a/python-avd/pyavd/_utils/__init__.py
+++ b/python-avd/pyavd/_utils/__init__.py
@@ -14,6 +14,7 @@ from .groupby import groupby
 from .load_python_class import load_python_class
 from .merge import merge
 from .replace_or_append_item import replace_or_append_item
+from .short_esi_to_route_target import short_esi_to_route_target
 from .strip_empties import strip_empties_from_dict, strip_empties_from_list, strip_null_from_data
 from .template import template
 from .template_var import template_var
@@ -35,6 +36,7 @@ __all__ = [
     "load_python_class",
     "merge",
     "replace_or_append_item",
+    "short_esi_to_route_target",
     "strip_empties_from_dict",
     "strip_empties_from_list",
     "strip_null_from_data",

--- a/python-avd/pyavd/_utils/short_esi_to_route_target.py
+++ b/python-avd/pyavd/_utils/short_esi_to_route_target.py
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file.
 import re
 
-MATCH_PATTERN = re.compile(r"([0-9a-fA-F]{2})([0-9a-fA-F]{2}):([0-9a-fA-F]{2})([0-9a-fA-F]{2}):([0-9a-fA-F]{2})([0-9a-fA-F]{2})")
+MATCH_PATTERN = re.compile(r"^([0-9a-fA-F]{2})([0-9a-fA-F]{2}):([0-9a-fA-F]{2})([0-9a-fA-F]{2}):([0-9a-fA-F]{2})([0-9a-fA-F]{2})$")
 REPL = r"\1:\2:\3:\4:\5:\6"
 
 

--- a/python-avd/pyavd/_utils/short_esi_to_route_target.py
+++ b/python-avd/pyavd/_utils/short_esi_to_route_target.py
@@ -4,8 +4,8 @@
 import re
 
 MATCH_PATTERN = re.compile(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})")
-REPLACE_PATTERN = re.compile(r"\1:\2:\3:\4:\5:\6")
+REPL = r"\1:\2:\3:\4:\5:\6"
 
 
 def short_esi_to_route_target(short_esi: str) -> str:
-    return re.sub(MATCH_PATTERN, REPLACE_PATTERN, short_esi)
+    return re.sub(MATCH_PATTERN, REPL, short_esi)

--- a/python-avd/pyavd/_utils/short_esi_to_route_target.py
+++ b/python-avd/pyavd/_utils/short_esi_to_route_target.py
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file.
 import re
 
-MATCH_PATTERN = re.compile(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})")
+MATCH_PATTERN = re.compile(r"([0-9a-fA-F]{2})([0-9a-fA-F]{2}):([0-9a-fA-F]{2})([0-9a-fA-F]{2}):([0-9a-fA-F]{2})([0-9a-fA-F]{2})")
 REPL = r"\1:\2:\3:\4:\5:\6"
 
 

--- a/python-avd/pyavd/_utils/short_esi_to_route_target.py
+++ b/python-avd/pyavd/_utils/short_esi_to_route_target.py
@@ -1,0 +1,11 @@
+# Copyright (c) 2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+import re
+
+MATCH_PATTERN = re.compile(r"(\n{2})(\n{2}):(\n{2})(\n{2}):(\n{2})(\n{2})")
+REPLACE_PATTERN = re.compile(r"\1:\2:\3:\4:\5:\6")
+
+
+def short_esi_to_route_target(short_esi: str) -> str:
+    return re.sub(MATCH_PATTERN, REPLACE_PATTERN, short_esi)

--- a/python-avd/tests/pyavd/utils/test_short_esi_to_route_target.py
+++ b/python-avd/tests/pyavd/utils/test_short_esi_to_route_target.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import absolute_import, division, print_function
+
+__metaclass__ = type
+
+import pytest
+from pyavd._utils import short_esi_to_route_target
+
+ESI_TO_RT_TEST_CASES = [
+    # (<short_esi>, <route_target>)
+    ("0303:0202:0101", "03:03:02:02:01:01"),
+    ("0303:0202:0101  ", "0303:0202:0101  "),
+    ("ESI_SHORT", "ESI_SHORT"),
+    ("", ""),
+    ("3", "3"),
+]
+
+
+class TestGenerateRouteTargetFilter:
+    @pytest.mark.parametrize("short_esi, route_target", ESI_TO_RT_TEST_CASES)
+    def test_short_esi_to_route_target(self, short_esi, route_target):
+        resp = short_esi_to_route_target(short_esi)
+        assert resp == route_target


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Deprecate various unused Ansible plugins

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- The following Ansible plugins are no longer being used by AVD and have been deprecated for removal in AVD 5.0.0. See the plugin docs for possible replacements.

  Filters:

  - `arista.avd.generate_esi`
  - `arista.avd.generate_lacp_id`
  - `arista.avd.generate_route_target`

  Action plugins / Modules:

  - `arista.avd.batch_template`
  - `arista.avd.validate_and_template`
  - `arista.avd.yaml_templates_to_facts`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Hopefully no changes. The plugins are not being removed. Just deprecated.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
