### PR TITLE
Feat(eos_designs): MLAG secondary should use short-esi from MLAG primary

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -171,6 +171,10 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
+   evpn ethernet-segment
+      identifier 0000:0000:ca01:5ba3:6ffb
+      route-target import ca:01:5b:a3:6f:fb
+   lacp system-id ca01.5ba3.6ffb
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -171,10 +171,6 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   evpn ethernet-segment
-      identifier 0000:0000:ca01:5ba3:6ffb
-      route-target import ca:01:5b:a3:6f:fb
-   lacp system-id ca01.5ba3.6ffb
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
 !
@@ -201,6 +197,17 @@ interface Port-Channel26
    switchport phone vlan 211
    switchport phone trunk untagged
    switchport mode trunk phone
+!
+interface Port-Channel30
+   description DC1_L2LEAF6_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:a8be:743c:0a1a
+      route-target import a8:be:74:3c:0a:1a
+   lacp system-id a8be.743c.0a1a
 !
 interface Port-Channel141
    description DC1_L2LEAF5_Po1
@@ -331,6 +338,11 @@ interface Ethernet26
    description PHONE03_port_channel_Eth0
    no shutdown
    channel-group 26 mode active
+!
+interface Ethernet30
+   description DC1.L2LEAF6A_Ethernet1
+   no shutdown
+   channel-group 30 mode active
 !
 interface Ethernet49/1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet3/1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -171,6 +171,10 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
+   evpn ethernet-segment
+      identifier 0000:0000:ca01:5ba3:6ffb
+      route-target import ca:01:5b:a3:6f:fb
+   lacp system-id ca01.5ba3.6ffb
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -171,10 +171,6 @@ interface Port-Channel11
    mtu 1600
    switchport
    switchport access vlan 110
-   evpn ethernet-segment
-      identifier 0000:0000:ca01:5ba3:6ffb
-      route-target import ca:01:5b:a3:6f:fb
-   lacp system-id ca01.5ba3.6ffb
    spanning-tree bpduguard enable
    spanning-tree bpdufilter enable
 !
@@ -201,6 +197,17 @@ interface Port-Channel26
    switchport phone vlan 211
    switchport phone trunk untagged
    switchport mode trunk phone
+!
+interface Port-Channel30
+   description DC1_L2LEAF6_Po1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
+   switchport mode trunk
+   evpn ethernet-segment
+      identifier 0000:0000:a8be:743c:0a1a
+      route-target import a8:be:74:3c:0a:1a
+   lacp system-id a8be.743c.0a1a
 !
 interface Port-Channel141
    description DC1_L2LEAF5_Po1
@@ -295,6 +302,11 @@ interface Ethernet26
    description PHONE03_port_channel_Eth1
    no shutdown
    channel-group 26 mode active
+!
+interface Ethernet31
+   description DC1.L2LEAF6B_Ethernet1
+   no shutdown
+   channel-group 30 mode active
 !
 interface Ethernet49/1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet5/1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6A.cfg
@@ -1,0 +1,176 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1.L2LEAF6A
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+ip name-server vrf MGMT 2001:db8::1
+ip name-server vrf MGMT 2001:db8::2
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+ntp server vrf MGMT 2001:db8::3
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1.L2LEAF6A
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4091
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+no username admin
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 410
+   name Tenant_D_v6_OP_Zone_1
+!
+vlan 411
+   name Tenant_D_v6_OP_Zone_2
+!
+vlan 412
+   name Tenant_D_v6_OP_Zone_1
+!
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
+vlan 450
+   name Tenant_D_v6_WAN_Zone_1
+!
+vlan 451
+   name Tenant_D_v6_WAN_Zone_2
+!
+vlan 452
+   name Tenant_D_v6_WAN_Zone_3
+!
+vlan 4091
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_LEAF2_Po11
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_DC1.L2LEAF6B_Po3
+   no shutdown
+   switchport
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description DC1-LEAF2A_Ethernet11
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_DC1.L2LEAF6B_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_DC1.L2LEAF6B_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.122/24
+!
+interface Vlan4091
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.30/31
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id DC1_L2LEAF6
+   local-interface Vlan4091
+   peer-address 10.255.252.31
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6A.cfg
@@ -112,7 +112,7 @@ vlan 4091
 vrf instance MGMT
 !
 interface Port-Channel1
-   description DC1_LEAF2_Po11
+   description DC1_LEAF2_Po30
    no shutdown
    switchport
    switchport trunk allowed vlan 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
@@ -127,7 +127,7 @@ interface Port-Channel3
    switchport trunk group MLAG
 !
 interface Ethernet1
-   description DC1-LEAF2A_Ethernet11
+   description DC1-LEAF2A_Ethernet30
    no shutdown
    channel-group 1 mode active
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6B.cfg
@@ -1,0 +1,176 @@
+!RANCID-CONTENT-TYPE: arista
+!
+boot secret sha512 a153de6290ff1409257ade45f
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+no ip igmp snooping vlan 120
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname DC1.L2LEAF6B
+ip name-server vrf MGMT 8.8.8.8
+ip name-server vrf MGMT 192.168.200.5
+ip name-server vrf MGMT 2001:db8::1
+ip name-server vrf MGMT 2001:db8::2
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 192.168.200.5 prefer
+ntp server vrf MGMT 2001:db8::3
+!
+snmp-server contact example@example.com
+snmp-server location EOS_DESIGNS_UNIT_TESTS rackE DC1.L2LEAF6B
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4091
+spanning-tree mst 0 priority 16384
+!
+no enable password
+no aaa root
+!
+no username admin
+username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
+username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vlan 111
+   name Tenant_A_OP_Zone_2
+!
+vlan 112
+   name Tenant_A_OP_Zone_3
+!
+vlan 120
+   name Tenant_A_WEB_Zone_1
+!
+vlan 121
+   name Tenant_A_WEBZone_2
+!
+vlan 130
+   name Tenant_A_APP_Zone_1
+!
+vlan 131
+   name Tenant_A_APP_Zone_2
+!
+vlan 140
+   name Tenant_A_DB_BZone_1
+!
+vlan 141
+   name Tenant_A_DB_Zone_2
+!
+vlan 160
+   name Tenant_A_VMOTION
+!
+vlan 161
+   name Tenant_A_NFS
+!
+vlan 210
+   name Tenant_B_OP_Zone_1
+!
+vlan 211
+   name Tenant_B_OP_Zone_2
+!
+vlan 310
+   name Tenant_C_OP_Zone_1
+!
+vlan 311
+   name Tenant_C_OP_Zone_2
+!
+vlan 410
+   name Tenant_D_v6_OP_Zone_1
+!
+vlan 411
+   name Tenant_D_v6_OP_Zone_2
+!
+vlan 412
+   name Tenant_D_v6_OP_Zone_1
+!
+vlan 413
+   name Tenant_D_v6_OP_Zone_3
+!
+vlan 450
+   name Tenant_D_v6_WAN_Zone_1
+!
+vlan 451
+   name Tenant_D_v6_WAN_Zone_2
+!
+vlan 452
+   name Tenant_D_v6_WAN_Zone_3
+!
+vlan 4091
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description DC1_LEAF2_Po11
+   no shutdown
+   switchport
+   switchport trunk allowed vlan 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_DC1.L2LEAF6A_Po3
+   no shutdown
+   switchport
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description DC1-LEAF2B_Ethernet12
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_DC1.L2LEAF6A_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_DC1.L2LEAF6A_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.123/24
+!
+interface Vlan4091
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 10.255.252.31/31
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id DC1_L2LEAF6
+   local-interface Vlan4091
+   peer-address 10.255.252.30
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.5
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6B.cfg
@@ -112,7 +112,7 @@ vlan 4091
 vrf instance MGMT
 !
 interface Port-Channel1
-   description DC1_LEAF2_Po11
+   description DC1_LEAF2_Po30
    no shutdown
    switchport
    switchport trunk allowed vlan 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
@@ -127,7 +127,7 @@ interface Port-Channel3
    switchport trunk group MLAG
 !
 interface Ethernet1
-   description DC1-LEAF2B_Ethernet12
+   description DC1-LEAF2B_Ethernet31
    no shutdown
    channel-group 1 mode active
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -491,17 +491,6 @@ ethernet_interfaces:
   channel_group:
     id: 9
     mode: active
-- name: Ethernet11
-  peer: server01_MTU_PROFILE_MLAG
-  peer_interface: Eth4
-  peer_type: server
-  description: server01_MTU_PROFILE_MLAG_Eth4
-  shutdown: false
-  type: port-channel-member
-  channel_group:
-    id: 11
-    mode: active
-  port_profile: TENANT_A_MTU
 - name: Ethernet13
   peer: DC1-L2LEAF4A
   peer_interface: Ethernet1
@@ -531,6 +520,16 @@ ethernet_interfaces:
   type: port-channel-member
   channel_group:
     id: 141
+    mode: active
+- name: Ethernet30
+  peer: DC1.L2LEAF6A
+  peer_interface: Ethernet1
+  peer_type: l2leaf
+  description: DC1.L2LEAF6A_Ethernet1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 30
     mode: active
 - name: Ethernet49/1
   peer: DC1-SPINE1
@@ -687,6 +686,17 @@ ethernet_interfaces:
   channel_group:
     id: 10
     mode: active
+- name: Ethernet11
+  peer: server01_MTU_PROFILE_MLAG
+  peer_interface: Eth4
+  peer_type: server
+  port_profile: TENANT_A_MTU
+  description: server01_MTU_PROFILE_MLAG_Eth4
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 11
+    mode: active
 - name: Ethernet12
   peer: server01_MTU_ADAPTOR_MLAG
   peer_interface: Eth6
@@ -750,19 +760,6 @@ port_channel_interfaces:
     identifier: 0000:0000:0606:0707:0808
     route_target: 06:06:07:07:08:08
   lacp_id: 0606.0707.0808
-- name: Port-Channel11
-  description: server01_MTU_PROFILE_MLAG_PortChanne1
-  type: switched
-  shutdown: false
-  mode: access
-  vlans: '110'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:ca01:5ba3:6ffb
-    route_target: ca:01:5b:a3:6f:fb
-  lacp_id: ca01.5ba3.6ffb
-  mtu: 1600
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
 - name: Port-Channel1013
   description: DC1-L2LEAF4A_Po1001
   type: switched
@@ -783,6 +780,16 @@ port_channel_interfaces:
     identifier: 0000:0000:fa91:ce62:ce95
     route_target: fa:91:ce:62:ce:95
   lacp_id: fa91.ce62.ce95
+- name: Port-Channel30
+  description: DC1_L2LEAF6_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
+  evpn_ethernet_segment:
+    identifier: 0000:0000:a8be:743c:0a1a
+    route_target: a8:be:74:3c:0a:1a
+  lacp_id: a8be.743c.0a1a
 - name: Port-Channel10
   description: server01_MLAG_PortChanne1
   type: switched
@@ -791,6 +798,15 @@ port_channel_interfaces:
   vlans: 210-211
   spanning_tree_bpdufilter: disabled
   spanning_tree_bpduguard: disabled
+- name: Port-Channel11
+  description: server01_MTU_PROFILE_MLAG_PortChanne1
+  type: switched
+  shutdown: false
+  mtu: 1600
+  mode: access
+  vlans: '110'
+  spanning_tree_bpdufilter: enabled
+  spanning_tree_bpduguard: enabled
 - name: Port-Channel12
   description: server01_MTU_ADAPTOR_MLAG_PortChanne1
   type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -491,6 +491,17 @@ ethernet_interfaces:
   channel_group:
     id: 9
     mode: active
+- name: Ethernet11
+  peer: server01_MTU_PROFILE_MLAG
+  peer_interface: Eth4
+  peer_type: server
+  description: server01_MTU_PROFILE_MLAG_Eth4
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 11
+    mode: active
+  port_profile: TENANT_A_MTU
 - name: Ethernet13
   peer: DC1-L2LEAF4A
   peer_interface: Ethernet1
@@ -676,17 +687,6 @@ ethernet_interfaces:
   channel_group:
     id: 10
     mode: active
-- name: Ethernet11
-  peer: server01_MTU_PROFILE_MLAG
-  peer_interface: Eth4
-  peer_type: server
-  port_profile: TENANT_A_MTU
-  description: server01_MTU_PROFILE_MLAG_Eth4
-  shutdown: false
-  type: port-channel-member
-  channel_group:
-    id: 11
-    mode: active
 - name: Ethernet12
   peer: server01_MTU_ADAPTOR_MLAG
   peer_interface: Eth6
@@ -750,6 +750,19 @@ port_channel_interfaces:
     identifier: 0000:0000:0606:0707:0808
     route_target: 06:06:07:07:08:08
   lacp_id: 0606.0707.0808
+- name: Port-Channel11
+  description: server01_MTU_PROFILE_MLAG_PortChanne1
+  type: switched
+  shutdown: false
+  mode: access
+  vlans: '110'
+  evpn_ethernet_segment:
+    identifier: 0000:0000:ca01:5ba3:6ffb
+    route_target: ca:01:5b:a3:6f:fb
+  lacp_id: ca01.5ba3.6ffb
+  mtu: 1600
+  spanning_tree_bpdufilter: enabled
+  spanning_tree_bpduguard: enabled
 - name: Port-Channel1013
   description: DC1-L2LEAF4A_Po1001
   type: switched
@@ -778,15 +791,6 @@ port_channel_interfaces:
   vlans: 210-211
   spanning_tree_bpdufilter: disabled
   spanning_tree_bpduguard: disabled
-- name: Port-Channel11
-  description: server01_MTU_PROFILE_MLAG_PortChanne1
-  type: switched
-  shutdown: false
-  mtu: 1600
-  mode: access
-  vlans: '110'
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
 - name: Port-Channel12
   description: server01_MTU_ADAPTOR_MLAG_PortChanne1
   type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -491,16 +491,6 @@ ethernet_interfaces:
   channel_group:
     id: 9
     mode: active
-- name: Ethernet12
-  peer: server01_MTU_ADAPTOR_MLAG
-  peer_interface: Eth7
-  peer_type: server
-  description: server01_MTU_ADAPTOR_MLAG_Eth7
-  shutdown: false
-  type: port-channel-member
-  channel_group:
-    id: 12
-    mode: active
 - name: Ethernet13
   peer: DC1-L2LEAF4A
   peer_interface: Ethernet2
@@ -530,6 +520,16 @@ ethernet_interfaces:
   type: port-channel-member
   channel_group:
     id: 141
+    mode: active
+- name: Ethernet31
+  peer: DC1.L2LEAF6B
+  peer_interface: Ethernet1
+  peer_type: l2leaf
+  description: DC1.L2LEAF6B_Ethernet1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 30
     mode: active
 - name: Ethernet49/1
   peer: DC1-SPINE1
@@ -641,6 +641,16 @@ ethernet_interfaces:
   channel_group:
     id: 11
     mode: active
+- name: Ethernet12
+  peer: server01_MTU_ADAPTOR_MLAG
+  peer_interface: Eth7
+  peer_type: server
+  description: server01_MTU_ADAPTOR_MLAG_Eth7
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 12
+    mode: active
 - name: Ethernet20
   peer: FIREWALL01
   peer_interface: E1
@@ -694,19 +704,6 @@ port_channel_interfaces:
     identifier: 0000:0000:0606:0707:0808
     route_target: 06:06:07:07:08:08
   lacp_id: 0606.0707.0808
-- name: Port-Channel11
-  description: server01_MTU_PROFILE_MLAG_PortChanne1
-  type: switched
-  shutdown: false
-  mode: access
-  vlans: '110'
-  evpn_ethernet_segment:
-    identifier: 0000:0000:ca01:5ba3:6ffb
-    route_target: ca:01:5b:a3:6f:fb
-  lacp_id: ca01.5ba3.6ffb
-  mtu: 1600
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
 - name: Port-Channel1013
   description: DC1-L2LEAF4A_Po1001
   type: switched
@@ -727,6 +724,16 @@ port_channel_interfaces:
     identifier: 0000:0000:fa91:ce62:ce95
     route_target: fa:91:ce:62:ce:95
   lacp_id: fa91.ce62.ce95
+- name: Port-Channel30
+  description: DC1_L2LEAF6_Po1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
+  evpn_ethernet_segment:
+    identifier: 0000:0000:a8be:743c:0a1a
+    route_target: a8:be:74:3c:0a:1a
+  lacp_id: a8be.743c.0a1a
 - name: Port-Channel10
   description: server01_MLAG_PortChanne1
   type: switched
@@ -735,6 +742,15 @@ port_channel_interfaces:
   vlans: 210-211
   spanning_tree_bpdufilter: disabled
   spanning_tree_bpduguard: disabled
+- name: Port-Channel11
+  description: server01_MTU_PROFILE_MLAG_PortChanne1
+  type: switched
+  shutdown: false
+  mtu: 1600
+  mode: access
+  vlans: '110'
+  spanning_tree_bpdufilter: enabled
+  spanning_tree_bpduguard: enabled
 - name: Port-Channel12
   description: server01_MTU_ADAPTOR_MLAG_PortChanne1
   type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -491,6 +491,16 @@ ethernet_interfaces:
   channel_group:
     id: 9
     mode: active
+- name: Ethernet12
+  peer: server01_MTU_ADAPTOR_MLAG
+  peer_interface: Eth7
+  peer_type: server
+  description: server01_MTU_ADAPTOR_MLAG_Eth7
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 12
+    mode: active
 - name: Ethernet13
   peer: DC1-L2LEAF4A
   peer_interface: Ethernet2
@@ -631,16 +641,6 @@ ethernet_interfaces:
   channel_group:
     id: 11
     mode: active
-- name: Ethernet12
-  peer: server01_MTU_ADAPTOR_MLAG
-  peer_interface: Eth7
-  peer_type: server
-  description: server01_MTU_ADAPTOR_MLAG_Eth7
-  shutdown: false
-  type: port-channel-member
-  channel_group:
-    id: 12
-    mode: active
 - name: Ethernet20
   peer: FIREWALL01
   peer_interface: E1
@@ -694,6 +694,19 @@ port_channel_interfaces:
     identifier: 0000:0000:0606:0707:0808
     route_target: 06:06:07:07:08:08
   lacp_id: 0606.0707.0808
+- name: Port-Channel11
+  description: server01_MTU_PROFILE_MLAG_PortChanne1
+  type: switched
+  shutdown: false
+  mode: access
+  vlans: '110'
+  evpn_ethernet_segment:
+    identifier: 0000:0000:ca01:5ba3:6ffb
+    route_target: ca:01:5b:a3:6f:fb
+  lacp_id: ca01.5ba3.6ffb
+  mtu: 1600
+  spanning_tree_bpdufilter: enabled
+  spanning_tree_bpduguard: enabled
 - name: Port-Channel1013
   description: DC1-L2LEAF4A_Po1001
   type: switched
@@ -722,15 +735,6 @@ port_channel_interfaces:
   vlans: 210-211
   spanning_tree_bpdufilter: disabled
   spanning_tree_bpduguard: disabled
-- name: Port-Channel11
-  description: server01_MTU_PROFILE_MLAG_PortChanne1
-  type: switched
-  shutdown: false
-  mtu: 1600
-  mode: access
-  vlans: '110'
-  spanning_tree_bpdufilter: enabled
-  spanning_tree_bpduguard: enabled
 - name: Port-Channel12
   description: server01_MTU_ADAPTOR_MLAG_PortChanne1
   type: switched

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6A.yml
@@ -1,0 +1,219 @@
+hostname: DC1.L2LEAF6A
+is_deployed: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.5
+service_routing_protocols_model: multi-agent
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.200.11:9910
+  cvauth:
+    method: key
+    key: telarista
+  cvvrf: MGMT
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+  ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+  disable_aaa: false
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+ip_name_servers:
+- ip_address: 192.168.200.5
+  vrf: MGMT
+- ip_address: 8.8.8.8
+  vrf: MGMT
+- ip_address: 2001:db8::1
+  vrf: MGMT
+- ip_address: 2001:db8::2
+  vrf: MGMT
+spanning_tree:
+  mode: mstp
+  mst_instances:
+  - id: '0'
+    priority: 16384
+  no_spanning_tree_vlan: '4091'
+local_users:
+- name: admin
+  disabled: true
+  privilege: 15
+  role: network-admin
+  no_password: true
+- name: cvpadmin
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+  ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU=
+    cvpadmin@hostmachine.local
+  secondary_ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz=
+    cvpadmin@hostmachine.local
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_interfaces:
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.122/24
+  gateway: 192.168.200.5
+  type: oob
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+  default_services: false
+ntp:
+  local_interface:
+    name: Management1
+    vrf: MGMT
+  servers:
+  - name: 192.168.200.5
+    vrf: MGMT
+    preferred: true
+  - name: 2001:db8::3
+    vrf: MGMT
+snmp_server:
+  contact: example@example.com
+  location: EOS_DESIGNS_UNIT_TESTS rackE DC1.L2LEAF6A
+vlans:
+- id: 4091
+  tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+- id: 130
+  name: Tenant_A_APP_Zone_1
+  tenant: Tenant_A
+- id: 131
+  name: Tenant_A_APP_Zone_2
+  tenant: Tenant_A
+- id: 140
+  name: Tenant_A_DB_BZone_1
+  tenant: Tenant_A
+- id: 141
+  name: Tenant_A_DB_Zone_2
+  tenant: Tenant_A
+- id: 110
+  name: Tenant_A_OP_Zone_1
+  tenant: Tenant_A
+- id: 111
+  name: Tenant_A_OP_Zone_2
+  tenant: Tenant_A
+- id: 112
+  name: Tenant_A_OP_Zone_3
+  tenant: Tenant_A
+- id: 120
+  name: Tenant_A_WEB_Zone_1
+  tenant: Tenant_A
+- id: 121
+  name: Tenant_A_WEBZone_2
+  tenant: Tenant_A
+- id: 160
+  name: Tenant_A_VMOTION
+  tenant: Tenant_A
+- id: 161
+  name: Tenant_A_NFS
+  tenant: Tenant_A
+- id: 210
+  name: Tenant_B_OP_Zone_1
+  tenant: Tenant_B
+- id: 211
+  name: Tenant_B_OP_Zone_2
+  tenant: Tenant_B
+- id: 310
+  name: Tenant_C_OP_Zone_1
+  tenant: Tenant_C
+- id: 311
+  name: Tenant_C_OP_Zone_2
+  tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
+- id: 410
+  name: Tenant_D_v6_OP_Zone_1
+  tenant: Tenant_D
+- id: 411
+  name: Tenant_D_v6_OP_Zone_2
+  tenant: Tenant_D
+- id: 412
+  name: Tenant_D_v6_OP_Zone_1
+  tenant: Tenant_D
+- id: 413
+  name: Tenant_D_v6_OP_Zone_3
+  tenant: Tenant_D
+vlan_interfaces:
+- name: Vlan4091
+  description: MLAG_PEER
+  shutdown: false
+  no_autostate: true
+  mtu: 1500
+  ip_address: 10.255.252.30/31
+port_channel_interfaces:
+- name: Port-Channel3
+  description: MLAG_PEER_DC1.L2LEAF6B_Po3
+  type: switched
+  shutdown: false
+  mode: trunk
+  trunk_groups:
+  - MLAG
+- name: Port-Channel1
+  description: DC1_LEAF2_Po11
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
+  mlag: 1
+ethernet_interfaces:
+- name: Ethernet3
+  peer: DC1.L2LEAF6B
+  peer_interface: Ethernet3
+  peer_type: mlag_peer
+  description: MLAG_PEER_DC1.L2LEAF6B_Ethernet3
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+- name: Ethernet4
+  peer: DC1.L2LEAF6B
+  peer_interface: Ethernet4
+  peer_type: mlag_peer
+  description: MLAG_PEER_DC1.L2LEAF6B_Ethernet4
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+- name: Ethernet1
+  peer: DC1-LEAF2A
+  peer_interface: Ethernet11
+  peer_type: l3leaf
+  description: DC1-LEAF2A_Ethernet11
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 1
+    mode: active
+mlag_configuration:
+  domain_id: DC1_L2LEAF6
+  local_interface: Vlan4091
+  peer_address: 10.255.252.31
+  peer_link: Port-Channel3
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
+ip_igmp_snooping:
+  globally_enabled: true
+  vlans:
+  - id: 120
+    enabled: false
+metadata:
+  platform: vEOS-LAB

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6A.yml
@@ -166,7 +166,7 @@ port_channel_interfaces:
   trunk_groups:
   - MLAG
 - name: Port-Channel1
-  description: DC1_LEAF2_Po11
+  description: DC1_LEAF2_Po30
   type: switched
   shutdown: false
   mode: trunk
@@ -195,9 +195,9 @@ ethernet_interfaces:
     mode: active
 - name: Ethernet1
   peer: DC1-LEAF2A
-  peer_interface: Ethernet11
+  peer_interface: Ethernet30
   peer_type: l3leaf
-  description: DC1-LEAF2A_Ethernet11
+  description: DC1-LEAF2A_Ethernet30
   shutdown: false
   type: port-channel-member
   channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6B.yml
@@ -166,7 +166,7 @@ port_channel_interfaces:
   trunk_groups:
   - MLAG
 - name: Port-Channel1
-  description: DC1_LEAF2_Po11
+  description: DC1_LEAF2_Po30
   type: switched
   shutdown: false
   mode: trunk
@@ -195,9 +195,9 @@ ethernet_interfaces:
     mode: active
 - name: Ethernet1
   peer: DC1-LEAF2B
-  peer_interface: Ethernet12
+  peer_interface: Ethernet31
   peer_type: l3leaf
-  description: DC1-LEAF2B_Ethernet12
+  description: DC1-LEAF2B_Ethernet31
   shutdown: false
   type: port-channel-member
   channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6B.yml
@@ -1,0 +1,219 @@
+hostname: DC1.L2LEAF6B
+is_deployed: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.5
+service_routing_protocols_model: multi-agent
+daemon_terminattr:
+  cvaddrs:
+  - 192.168.200.11:9910
+  cvauth:
+    method: key
+    key: telarista
+  cvvrf: MGMT
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+  ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+  disable_aaa: false
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+ip_name_servers:
+- ip_address: 192.168.200.5
+  vrf: MGMT
+- ip_address: 8.8.8.8
+  vrf: MGMT
+- ip_address: 2001:db8::1
+  vrf: MGMT
+- ip_address: 2001:db8::2
+  vrf: MGMT
+spanning_tree:
+  mode: mstp
+  mst_instances:
+  - id: '0'
+    priority: 16384
+  no_spanning_tree_vlan: '4091'
+local_users:
+- name: admin
+  disabled: true
+  privilege: 15
+  role: network-admin
+  no_password: true
+- name: cvpadmin
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
+  ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU=
+    cvpadmin@hostmachine.local
+  secondary_ssh_key: ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz=
+    cvpadmin@hostmachine.local
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_interfaces:
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.123/24
+  gateway: 192.168.200.5
+  type: oob
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+  default_services: false
+ntp:
+  local_interface:
+    name: Management1
+    vrf: MGMT
+  servers:
+  - name: 192.168.200.5
+    vrf: MGMT
+    preferred: true
+  - name: 2001:db8::3
+    vrf: MGMT
+snmp_server:
+  contact: example@example.com
+  location: EOS_DESIGNS_UNIT_TESTS rackE DC1.L2LEAF6B
+vlans:
+- id: 4091
+  tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+- id: 130
+  name: Tenant_A_APP_Zone_1
+  tenant: Tenant_A
+- id: 131
+  name: Tenant_A_APP_Zone_2
+  tenant: Tenant_A
+- id: 140
+  name: Tenant_A_DB_BZone_1
+  tenant: Tenant_A
+- id: 141
+  name: Tenant_A_DB_Zone_2
+  tenant: Tenant_A
+- id: 110
+  name: Tenant_A_OP_Zone_1
+  tenant: Tenant_A
+- id: 111
+  name: Tenant_A_OP_Zone_2
+  tenant: Tenant_A
+- id: 112
+  name: Tenant_A_OP_Zone_3
+  tenant: Tenant_A
+- id: 120
+  name: Tenant_A_WEB_Zone_1
+  tenant: Tenant_A
+- id: 121
+  name: Tenant_A_WEBZone_2
+  tenant: Tenant_A
+- id: 160
+  name: Tenant_A_VMOTION
+  tenant: Tenant_A
+- id: 161
+  name: Tenant_A_NFS
+  tenant: Tenant_A
+- id: 210
+  name: Tenant_B_OP_Zone_1
+  tenant: Tenant_B
+- id: 211
+  name: Tenant_B_OP_Zone_2
+  tenant: Tenant_B
+- id: 310
+  name: Tenant_C_OP_Zone_1
+  tenant: Tenant_C
+- id: 311
+  name: Tenant_C_OP_Zone_2
+  tenant: Tenant_C
+- id: 450
+  name: Tenant_D_v6_WAN_Zone_1
+  tenant: Tenant_D
+- id: 451
+  name: Tenant_D_v6_WAN_Zone_2
+  tenant: Tenant_D
+- id: 452
+  name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
+- id: 410
+  name: Tenant_D_v6_OP_Zone_1
+  tenant: Tenant_D
+- id: 411
+  name: Tenant_D_v6_OP_Zone_2
+  tenant: Tenant_D
+- id: 412
+  name: Tenant_D_v6_OP_Zone_1
+  tenant: Tenant_D
+- id: 413
+  name: Tenant_D_v6_OP_Zone_3
+  tenant: Tenant_D
+vlan_interfaces:
+- name: Vlan4091
+  description: MLAG_PEER
+  shutdown: false
+  no_autostate: true
+  mtu: 1500
+  ip_address: 10.255.252.31/31
+port_channel_interfaces:
+- name: Port-Channel3
+  description: MLAG_PEER_DC1.L2LEAF6A_Po3
+  type: switched
+  shutdown: false
+  mode: trunk
+  trunk_groups:
+  - MLAG
+- name: Port-Channel1
+  description: DC1_LEAF2_Po11
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: 110-112,120-121,130-131,140-141,160-161,210-211,310-311,410-413,450-452
+  mlag: 1
+ethernet_interfaces:
+- name: Ethernet3
+  peer: DC1.L2LEAF6A
+  peer_interface: Ethernet3
+  peer_type: mlag_peer
+  description: MLAG_PEER_DC1.L2LEAF6A_Ethernet3
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+- name: Ethernet4
+  peer: DC1.L2LEAF6A
+  peer_interface: Ethernet4
+  peer_type: mlag_peer
+  description: MLAG_PEER_DC1.L2LEAF6A_Ethernet4
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+- name: Ethernet1
+  peer: DC1-LEAF2B
+  peer_interface: Ethernet12
+  peer_type: l3leaf
+  description: DC1-LEAF2B_Ethernet12
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 1
+    mode: active
+mlag_configuration:
+  domain_id: DC1_L2LEAF6
+  local_interface: Vlan4091
+  peer_address: 10.255.252.30
+  peer_link: Port-Channel3
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
+ip_igmp_snooping:
+  globally_enabled: true
+  vlans:
+  - id: 120
+    enabled: false
+metadata:
+  platform: vEOS-LAB

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -368,6 +368,20 @@ l2leaf:
         - name: DC1.L2LEAF5B
           id: 15
           mgmt_ip: 192.168.200.121/24
+    # Example for issue 4124
+    - group: DC1_L2LEAF6
+      short_esi: auto # Test Auto ESI to MLAG pair
+      nodes:
+        - name: DC1.L2LEAF6A
+          id: 16
+          mgmt_ip: 192.168.200.122/24
+          uplink_switches: [ DC1-LEAF2A ]
+          uplink_switch_interfaces: [ Ethernet11 ]
+        - name: DC1.L2LEAF6B
+          id: 17
+          mgmt_ip: 192.168.200.123/24
+          uplink_switches: [ DC1-LEAF2B ]
+          uplink_switch_interfaces: [ Ethernet12 ]
 
 # Update p2p mtu 9000 -> 1500
 p2p_uplinks_mtu: 1500

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -376,12 +376,12 @@ l2leaf:
           id: 16
           mgmt_ip: 192.168.200.122/24
           uplink_switches: [ DC1-LEAF2A ]
-          uplink_switch_interfaces: [ Ethernet11 ]
+          uplink_switch_interfaces: [ Ethernet30 ]
         - name: DC1.L2LEAF6B
           id: 17
           mgmt_ip: 192.168.200.123/24
           uplink_switches: [ DC1-LEAF2B ]
-          uplink_switch_interfaces: [ Ethernet12 ]
+          uplink_switch_interfaces: [ Ethernet31 ]
 
 # Update p2p mtu 9000 -> 1500
 p2p_uplinks_mtu: 1500

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -514,6 +514,12 @@ all:
                           ansible_host: 192.168.200.120
                         DC1.L2LEAF5B:
                           ansible_host: 192.168.200.121
+                    DC1_L2LEAF6:
+                      hosts:
+                        DC1.L2LEAF6A:
+                          ansible_host: 192.168.200.122
+                        DC1.L2LEAF6B:
+                          ansible_host: 192.168.200.123
                     TESTS:
                       hosts:
                         mgmt_interface_default:

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/short_esi.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/short_esi.py
@@ -27,12 +27,12 @@ class ShortEsiMixin:
         If short_esi is set to "auto" we will use sha256 to create a
         unique short_esi value based on various uplink information.
         """
+        if self.shared_utils.mlag_role == "secondary":
+            # On the MLAG Secondary use short-esi from MLAG primary
+            if (peer_short_esi := self.shared_utils.mlag_peer_facts._short_esi) is not None:
+                return peer_short_esi
         short_esi = get(self.shared_utils.switch_data_combined, "short_esi")
         if short_esi == "auto":
-            if self.shared_utils.mlag_role == "secondary":
-                # On the MLAG Secondary use short-esi from MLAG primary
-                if (peer_short_esi := self.shared_utils.mlag_peer_facts._short_esi) is not None:
-                    return peer_short_esi
             esi_seed_1 = "".join(self.shared_utils.uplink_switches[:2])
             esi_seed_2 = "".join(self.shared_utils.uplink_switch_interfaces[:2])
             esi_seed_3 = "".join(default(self.shared_utils.uplink_interfaces, [])[:2])

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/short_esi.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/short_esi.py
@@ -29,6 +29,10 @@ class ShortEsiMixin:
         """
         short_esi = get(self.shared_utils.switch_data_combined, "short_esi")
         if short_esi == "auto":
+            if self.shared_utils.mlag_role == "secondary":
+                # On the MLAG Secondary use short-esi from MLAG primary
+                if (peer_short_esi := self.shared_utils.mlag_peer_facts._short_esi) is not None:
+                    return peer_short_esi
             esi_seed_1 = "".join(self.shared_utils.uplink_switches[:2])
             esi_seed_2 = "".join(self.shared_utils.uplink_switch_interfaces[:2])
             esi_seed_3 = "".join(default(self.shared_utils.uplink_interfaces, [])[:2])

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/short_esi.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/short_esi.py
@@ -26,6 +26,9 @@ class ShortEsiMixin:
         """
         If short_esi is set to "auto" we will use sha256 to create a
         unique short_esi value based on various uplink information.
+
+        Note: Secondary MLAG switch should have the same short-esi value
+        as primary MLAG switch.
         """
         if self.shared_utils.mlag_role == "secondary":
             # On the MLAG Secondary use short-esi from MLAG primary

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/uplinks.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/uplinks.py
@@ -301,7 +301,8 @@ class UplinksMixin:
 
         if self.shared_utils.mlag_role == "secondary":
             # On the MLAG Secondary use short-esi from MLAG primary
-            uplink["peer_short_esi"] = self.shared_utils.mlag_peer_facts._short_esi
+            if (peer_short_esi := self.shared_utils.mlag_peer_facts._short_esi) is not None:
+                uplink["peer_short_esi"] = peer_short_esi
         elif self._short_esi is not None:
             uplink["peer_short_esi"] = self._short_esi
 

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/uplinks.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/uplinks.py
@@ -299,7 +299,10 @@ class UplinksMixin:
         if uplink_native_vlan := get(self.shared_utils.switch_data_combined, "uplink_native_vlan"):
             uplink["native_vlan"] = uplink_native_vlan
 
-        if self._short_esi is not None:
+        if self.shared_utils.mlag_role == "secondary":
+            # On the MLAG Secondary use short-esi from MLAG primary
+            uplink["peer_short_esi"] = self.shared_utils.mlag_peer_facts._short_esi
+        elif self._short_esi is not None:
             uplink["peer_short_esi"] = self._short_esi
 
         if self.shared_utils.link_tracking_groups is not None:

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/uplinks.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/uplinks.py
@@ -299,11 +299,7 @@ class UplinksMixin:
         if uplink_native_vlan := get(self.shared_utils.switch_data_combined, "uplink_native_vlan"):
             uplink["native_vlan"] = uplink_native_vlan
 
-        if self.shared_utils.mlag_role == "secondary":
-            # On the MLAG Secondary use short-esi from MLAG primary
-            if (peer_short_esi := self.shared_utils.mlag_peer_facts._short_esi) is not None:
-                uplink["peer_short_esi"] = peer_short_esi
-        elif self._short_esi is not None:
+        if self._short_esi is not None:
             uplink["peer_short_esi"] = self._short_esi
 
         if self.shared_utils.link_tracking_groups is not None:


### PR DESCRIPTION
## Change Summary
MLAG secondary should use short-esi from MLAG primary.

## Related Issue(s)

Fixes #4124 

## Component(s) name

`arista.avd.eos_designs`

## How to test
CI will check

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
