### PR TITLE
Doc: Deprecate the eos_designs and eos_cli_config_gen jsonschema.json…

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -42,6 +42,8 @@ Pull request:
 - AVD version 5.0.0 will drop support for Python version 3.9. The decision has been taken to remove Python version 3.9 support in AVD collection to anticipate its removal in `ansible-core`.
   `ansible-core` version 2.15 End-Of-Life is scheduled for November 2024 and it will be the last `ansible-core` version supporting Python version 3.9 as documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix.
 
+- In AVD version 5.0.0, the `eos_designs.jsonschema.json` and `eos_cli_config_gen.jsonschema.json` will not be generated anymore. These schemas are not being used and have never been complete.
+
 - The following Ansible plugins are no longer being used by AVD and have been deprecated for removal in AVD 5.0.0. See the plugin docs for possible replacements.
 
   Filters:

--- a/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/4.x.x.md
@@ -12,7 +12,12 @@ title: Release Notes for AVD 4.x.x
 
 - Documentation for AVD version `4.x.x` [available here](https://www.avd.sh/en/stable/)
 
-<!-- Release notes generated using configuration in .github/release.yml at devel -->
+## Release 4.10.0
+
+### Deprecations
+
+- In AVD version 5.0.0, the `eos_designs.jsonschema.json` and `eos_cli_config_gen.jsonschema.json` will no longer be generated. These schemas are not being used and have never been complete.
+
 ## Release 4.9.0
 
 ### Breaking or behavioral changes in eos_designs
@@ -41,8 +46,6 @@ Pull request:
 
 - AVD version 5.0.0 will drop support for Python version 3.9. The decision has been taken to remove Python version 3.9 support in AVD collection to anticipate its removal in `ansible-core`.
   `ansible-core` version 2.15 End-Of-Life is scheduled for November 2024 and it will be the last `ansible-core` version supporting Python version 3.9 as documented here: https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix.
-
-- In AVD version 5.0.0, the `eos_designs.jsonschema.json` and `eos_cli_config_gen.jsonschema.json` will not be generated anymore. These schemas are not being used and have never been complete.
 
 - The following Ansible plugins are no longer being used by AVD and have been deprecated for removal in AVD 5.0.0. See the plugin docs for possible replacements.
 


### PR DESCRIPTION
## Change Summary

Announce in the release notes that the `eos_cli_config_gen.jsonschema.json` and `eos_designs.jsonschema.json` files won't be generated starting AVD 5.0.0

## Component(s) name

`arista.avd.eos_designs`
`arista.avd.eos_cli_config_gen`

## Proposed changes

deprecation message in release_notes 4.x.x

## How to test

no test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
