### PR TITLE
Feat(eos_designs): Add keys to set mlag_peer_ipv4 and mlag_peer_l3_ipv4 directly

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -622,7 +622,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.6/31
+   ip address 192.168.44.41/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -737,7 +737,7 @@ interface Vlan3008
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.6/31
+   ip address 192.168.44.41/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
@@ -751,55 +751,55 @@ interface Vlan3011
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.6/31
+   ip address 192.168.44.41/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.6/31
+   ip address 192.168.44.41/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WAN_Zone
-   ip address 10.255.251.6/31
+   ip address 192.168.44.41/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.6/31
+   ip address 192.168.44.41/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_WAN_Zone
-   ip address 10.255.251.6/31
+   ip address 192.168.44.41/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_C_WAN_Zone
-   ip address 10.255.251.6/31
+   ip address 192.168.44.41/31
 !
 interface Vlan4090
    description MLAG_PEER_L3_PEERING
    no shutdown
    mtu 1500
-   ip address 10.255.251.6/31
+   ip address 192.168.44.41/31
 !
 interface Vlan4092
    description MLAG_PEER
    no shutdown
    mtu 1500
    no autostate
-   ip address 10.255.252.6/31
+   ip address 192.168.44.41/31
 !
 interface Vxlan1
    description DC1-SVC3A_VTEP
@@ -875,13 +875,13 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.168.254.0/24 eq 32
 !
 ip prefix-list PL-MLAG-PEER-VRFS
-   seq 10 permit 10.255.251.6/31
-   seq 20 permit 172.31.11.6/31
+   seq 10 permit 172.31.11.6/31
+   seq 20 permit 192.168.44.40/31
 !
 mlag configuration
    domain-id custom_mlag_domain_id
    local-interface Vlan4092
-   peer-address 10.255.252.7
+   peer-address 192.168.44.42
    peer-link Port-Channel2000
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -928,8 +928,6 @@ router bgp 65103
    neighbor UNDERLAY-PEERS password 7 0nsCUm70mvSTxVO0ldytrg==
    neighbor UNDERLAY-PEERS send-community
    neighbor UNDERLAY-PEERS maximum-routes 12000
-   neighbor 10.255.251.7 peer group MLAG-PEERS
-   neighbor 10.255.251.7 description DC1-SVC3B
    neighbor 172.31.254.96 peer group UNDERLAY-PEERS
    neighbor 172.31.254.96 remote-as 65001
    neighbor 172.31.254.96 description DC1-SPINE1_Ethernet7/1
@@ -942,6 +940,8 @@ router bgp 65103
    neighbor 172.31.254.102 peer group UNDERLAY-PEERS
    neighbor 172.31.254.102 remote-as 65001
    neighbor 172.31.254.102 description DC1-SPINE4_Ethernet7/1
+   neighbor 192.168.44.42 peer group MLAG-PEERS
+   neighbor 192.168.44.42 description DC1-SVC3B
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -1037,7 +1037,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.12
       update wait-install
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 192.168.44.42 peer group MLAG-PEERS
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_DB_Zone
@@ -1046,7 +1046,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.12
       update wait-install
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 192.168.44.42 peer group MLAG-PEERS
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_OP_Zone
@@ -1055,7 +1055,7 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.12
       update wait-install
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 192.168.44.42 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1066,7 +1066,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.12
       update wait-install
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 192.168.44.42 peer group MLAG-PEERS
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_WEB_Zone
@@ -1084,7 +1084,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.12
       update wait-install
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 192.168.44.42 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1093,7 +1093,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.12
       update wait-install
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 192.168.44.42 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1102,7 +1102,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.12
       update wait-install
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 192.168.44.42 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1111,7 +1111,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.12
       update wait-install
-      neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 192.168.44.42 peer group MLAG-PEERS
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -588,7 +588,7 @@ interface Vlan2
    no shutdown
    mtu 1500
    vrf Tenant_C_OP_Zone
-   ip address 10.255.251.7/31
+   ip address 192.168.44.42/31
 !
 interface Vlan110
    description Tenant_A_OP_Zone_1
@@ -703,7 +703,7 @@ interface Vlan3008
    no shutdown
    mtu 1500
    vrf Tenant_A_OP_Zone
-   ip address 10.255.251.7/31
+   ip address 192.168.44.42/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
@@ -717,55 +717,55 @@ interface Vlan3011
    no shutdown
    mtu 1500
    vrf Tenant_A_APP_Zone
-   ip address 10.255.251.7/31
+   ip address 192.168.44.42/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_DB_Zone
-   ip address 10.255.251.7/31
+   ip address 192.168.44.42/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_A_WAN_Zone
-   ip address 10.255.251.7/31
+   ip address 192.168.44.42/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_OP_Zone
-   ip address 10.255.251.7/31
+   ip address 192.168.44.42/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_B_WAN_Zone
-   ip address 10.255.251.7/31
+   ip address 192.168.44.42/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
    no shutdown
    mtu 1500
    vrf Tenant_C_WAN_Zone
-   ip address 10.255.251.7/31
+   ip address 192.168.44.42/31
 !
 interface Vlan4090
    description MLAG_PEER_L3_PEERING
    no shutdown
    mtu 1500
-   ip address 10.255.251.7/31
+   ip address 192.168.44.42/31
 !
 interface Vlan4092
    description MLAG_PEER
    no shutdown
    mtu 1500
    no autostate
-   ip address 10.255.252.7/31
+   ip address 192.168.44.42/31
 !
 interface Vxlan1
    description DC1-SVC3B_VTEP
@@ -840,13 +840,13 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 20 permit 192.168.254.0/24 eq 32
 !
 ip prefix-list PL-MLAG-PEER-VRFS
-   seq 10 permit 10.255.251.6/31
-   seq 20 permit 172.31.11.6/31
+   seq 10 permit 172.31.11.6/31
+   seq 20 permit 192.168.44.42/31
 !
 mlag configuration
    domain-id custom_mlag_domain_id
    local-interface Vlan4092
-   peer-address 10.255.252.6
+   peer-address 192.168.44.41
    peer-link Port-Channel2000
    reload-delay mlag 300
    reload-delay non-mlag 330
@@ -893,8 +893,6 @@ router bgp 65103
    neighbor UNDERLAY-PEERS password 7 0nsCUm70mvSTxVO0ldytrg==
    neighbor UNDERLAY-PEERS send-community
    neighbor UNDERLAY-PEERS maximum-routes 12000
-   neighbor 10.255.251.6 peer group MLAG-PEERS
-   neighbor 10.255.251.6 description DC1-SVC3A
    neighbor 172.31.254.128 peer group UNDERLAY-PEERS
    neighbor 172.31.254.128 remote-as 65001
    neighbor 172.31.254.128 description DC1-SPINE1_Ethernet9/1
@@ -907,6 +905,8 @@ router bgp 65103
    neighbor 172.31.254.134 peer group UNDERLAY-PEERS
    neighbor 172.31.254.134 remote-as 65001
    neighbor 172.31.254.134 description DC1-SPINE4_Ethernet9/1
+   neighbor 192.168.44.41 peer group MLAG-PEERS
+   neighbor 192.168.44.41 description DC1-SVC3A
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1
@@ -1002,7 +1002,7 @@ router bgp 65103
       route-target export evpn 12:12
       router-id 192.168.255.13
       update wait-install
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 192.168.44.41 peer group MLAG-PEERS
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_DB_Zone
@@ -1011,7 +1011,7 @@ router bgp 65103
       route-target export evpn 13:13
       router-id 192.168.255.13
       update wait-install
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 192.168.44.41 peer group MLAG-PEERS
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_OP_Zone
@@ -1020,7 +1020,7 @@ router bgp 65103
       route-target export evpn 9:9
       router-id 192.168.255.13
       update wait-install
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 192.168.44.41 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1031,7 +1031,7 @@ router bgp 65103
       route-target export evpn 65000:789
       router-id 192.168.255.13
       update wait-install
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 192.168.44.41 peer group MLAG-PEERS
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_WEB_Zone
@@ -1049,7 +1049,7 @@ router bgp 65103
       route-target export evpn 20:20
       router-id 192.168.255.13
       update wait-install
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 192.168.44.41 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1058,7 +1058,7 @@ router bgp 65103
       route-target export evpn 21:21
       router-id 192.168.255.13
       update wait-install
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 192.168.44.41 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1067,7 +1067,7 @@ router bgp 65103
       route-target export evpn 30:30
       router-id 192.168.255.13
       update wait-install
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 192.168.44.41 peer group MLAG-PEERS
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1076,7 +1076,7 @@ router bgp 65103
       route-target export evpn 31:31
       router-id 192.168.255.13
       update wait-install
-      neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 192.168.44.41 peer group MLAG-PEERS
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -45,7 +45,7 @@ router_bgp:
     - name: EVPN-OVERLAY-PEERS
       activate: false
   neighbors:
-  - ip_address: 10.255.251.7
+  - ip_address: 192.168.44.42
     peer_group: MLAG-PEERS
     peer: DC1-SVC3B
     description: DC1-SVC3B
@@ -118,7 +118,7 @@ router_bgp:
     - source_protocol: connected
       route_map: RM-CONN-2-BGP-VRFS
     neighbors:
-    - ip_address: 10.255.251.7
+    - ip_address: 192.168.44.42
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -138,7 +138,7 @@ router_bgp:
     - source_protocol: connected
       route_map: RM-CONN-2-BGP-VRFS
     neighbors:
-    - ip_address: 10.255.251.7
+    - ip_address: 192.168.44.42
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -157,7 +157,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.7
+    - ip_address: 192.168.44.42
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -179,7 +179,7 @@ router_bgp:
     - source_protocol: connected
       route_map: RM-CONN-2-BGP-VRFS
     neighbors:
-    - ip_address: 10.255.251.7
+    - ip_address: 192.168.44.42
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -218,7 +218,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.7
+    - ip_address: 192.168.44.42
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -237,7 +237,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.7
+    - ip_address: 192.168.44.42
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -256,7 +256,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.7
+    - ip_address: 192.168.44.42
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -275,7 +275,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.7
+    - ip_address: 192.168.44.42
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -593,13 +593,13 @@ vlan_interfaces:
   description: MLAG_PEER_L3_PEERING
   shutdown: false
   mtu: 1500
-  ip_address: 10.255.251.6/31
+  ip_address: 192.168.44.41/31
 - name: Vlan4092
   description: MLAG_PEER
   shutdown: false
   no_autostate: true
   mtu: 1500
-  ip_address: 10.255.252.6/31
+  ip_address: 192.168.44.41/31
 - name: Vlan130
   tenant: Tenant_A
   tags:
@@ -624,7 +624,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
   vrf: Tenant_A_APP_Zone
   mtu: 1500
-  ip_address: 10.255.251.6/31
+  ip_address: 192.168.44.41/31
 - name: Vlan140
   tenant: Tenant_A
   tags:
@@ -649,7 +649,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
   vrf: Tenant_A_DB_Zone
   mtu: 1500
-  ip_address: 10.255.251.6/31
+  ip_address: 192.168.44.41/31
 - name: Vlan110
   tenant: Tenant_A
   tags:
@@ -691,7 +691,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
   vrf: Tenant_A_OP_Zone
   mtu: 1500
-  ip_address: 10.255.251.6/31
+  ip_address: 192.168.44.41/31
 - name: Vlan150
   tenant: Tenant_A
   tags:
@@ -712,7 +712,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
   vrf: Tenant_A_WAN_Zone
   mtu: 1500
-  ip_address: 10.255.251.6/31
+  ip_address: 192.168.44.41/31
 - name: Vlan120
   tenant: Tenant_A
   tags:
@@ -769,7 +769,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
   vrf: Tenant_B_OP_Zone
   mtu: 1500
-  ip_address: 10.255.251.6/31
+  ip_address: 192.168.44.41/31
 - name: Vlan250
   tenant: Tenant_B
   tags:
@@ -785,7 +785,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
   vrf: Tenant_B_WAN_Zone
   mtu: 1500
-  ip_address: 10.255.251.6/31
+  ip_address: 192.168.44.41/31
 - name: Vlan310
   tenant: Tenant_C
   tags:
@@ -809,7 +809,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
   vrf: Tenant_C_OP_Zone
   mtu: 1500
-  ip_address: 10.255.251.6/31
+  ip_address: 192.168.44.41/31
 - name: Vlan350
   tenant: Tenant_C
   tags:
@@ -825,7 +825,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
   vrf: Tenant_C_WAN_Zone
   mtu: 1500
-  ip_address: 10.255.251.6/31
+  ip_address: 192.168.44.41/31
 port_channel_interfaces:
 - name: Port-Channel2000
   description: MLAG_PEER_DC1-SVC3B_Po2000
@@ -1492,7 +1492,7 @@ ethernet_interfaces:
 mlag_configuration:
   domain_id: custom_mlag_domain_id
   local_interface: Vlan4092
-  peer_address: 10.255.252.7
+  peer_address: 192.168.44.42
   peer_link: Port-Channel2000
   reload_delay_mlag: '300'
   reload_delay_non_mlag: '330'
@@ -1542,9 +1542,9 @@ prefix_lists:
 - name: PL-MLAG-PEER-VRFS
   sequence_numbers:
   - sequence: 10
-    action: permit 10.255.251.6/31
-  - sequence: 20
     action: permit 172.31.11.6/31
+  - sequence: 20
+    action: permit 192.168.44.40/31
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -45,7 +45,7 @@ router_bgp:
     - name: EVPN-OVERLAY-PEERS
       activate: false
   neighbors:
-  - ip_address: 10.255.251.6
+  - ip_address: 192.168.44.41
     peer_group: MLAG-PEERS
     peer: DC1-SVC3A
     description: DC1-SVC3A
@@ -118,7 +118,7 @@ router_bgp:
     - source_protocol: connected
       route_map: RM-CONN-2-BGP-VRFS
     neighbors:
-    - ip_address: 10.255.251.6
+    - ip_address: 192.168.44.41
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -138,7 +138,7 @@ router_bgp:
     - source_protocol: connected
       route_map: RM-CONN-2-BGP-VRFS
     neighbors:
-    - ip_address: 10.255.251.6
+    - ip_address: 192.168.44.41
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -157,7 +157,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.6
+    - ip_address: 192.168.44.41
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -179,7 +179,7 @@ router_bgp:
     - source_protocol: connected
       route_map: RM-CONN-2-BGP-VRFS
     neighbors:
-    - ip_address: 10.255.251.6
+    - ip_address: 192.168.44.41
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -218,7 +218,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.6
+    - ip_address: 192.168.44.41
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -237,7 +237,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.6
+    - ip_address: 192.168.44.41
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -256,7 +256,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.6
+    - ip_address: 192.168.44.41
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -275,7 +275,7 @@ router_bgp:
     redistribute_routes:
     - source_protocol: connected
     neighbors:
-    - ip_address: 10.255.251.6
+    - ip_address: 192.168.44.41
       peer_group: MLAG-PEERS
     updates:
       wait_install: true
@@ -593,13 +593,13 @@ vlan_interfaces:
   description: MLAG_PEER_L3_PEERING
   shutdown: false
   mtu: 1500
-  ip_address: 10.255.251.7/31
+  ip_address: 192.168.44.42/31
 - name: Vlan4092
   description: MLAG_PEER
   shutdown: false
   no_autostate: true
   mtu: 1500
-  ip_address: 10.255.252.7/31
+  ip_address: 192.168.44.42/31
 - name: Vlan130
   tenant: Tenant_A
   tags:
@@ -624,7 +624,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone'
   vrf: Tenant_A_APP_Zone
   mtu: 1500
-  ip_address: 10.255.251.7/31
+  ip_address: 192.168.44.42/31
 - name: Vlan140
   tenant: Tenant_A
   tags:
@@ -649,7 +649,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone'
   vrf: Tenant_A_DB_Zone
   mtu: 1500
-  ip_address: 10.255.251.7/31
+  ip_address: 192.168.44.42/31
 - name: Vlan110
   tenant: Tenant_A
   tags:
@@ -691,7 +691,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone'
   vrf: Tenant_A_OP_Zone
   mtu: 1500
-  ip_address: 10.255.251.7/31
+  ip_address: 192.168.44.42/31
 - name: Vlan150
   tenant: Tenant_A
   tags:
@@ -712,7 +712,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone'
   vrf: Tenant_A_WAN_Zone
   mtu: 1500
-  ip_address: 10.255.251.7/31
+  ip_address: 192.168.44.42/31
 - name: Vlan120
   tenant: Tenant_A
   tags:
@@ -769,7 +769,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone'
   vrf: Tenant_B_OP_Zone
   mtu: 1500
-  ip_address: 10.255.251.7/31
+  ip_address: 192.168.44.42/31
 - name: Vlan250
   tenant: Tenant_B
   tags:
@@ -785,7 +785,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone'
   vrf: Tenant_B_WAN_Zone
   mtu: 1500
-  ip_address: 10.255.251.7/31
+  ip_address: 192.168.44.42/31
 - name: Vlan310
   tenant: Tenant_C
   tags:
@@ -809,7 +809,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone'
   vrf: Tenant_C_OP_Zone
   mtu: 1500
-  ip_address: 10.255.251.7/31
+  ip_address: 192.168.44.42/31
 - name: Vlan350
   tenant: Tenant_C
   tags:
@@ -825,7 +825,7 @@ vlan_interfaces:
   description: 'MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone'
   vrf: Tenant_C_WAN_Zone
   mtu: 1500
-  ip_address: 10.255.251.7/31
+  ip_address: 192.168.44.42/31
 port_channel_interfaces:
 - name: Port-Channel2000
   description: MLAG_PEER_DC1-SVC3A_Po2000
@@ -1444,7 +1444,7 @@ ethernet_interfaces:
 mlag_configuration:
   domain_id: custom_mlag_domain_id
   local_interface: Vlan4092
-  peer_address: 10.255.252.6
+  peer_address: 192.168.44.41
   peer_link: Port-Channel2000
   reload_delay_mlag: '300'
   reload_delay_non_mlag: '330'
@@ -1494,9 +1494,9 @@ prefix_lists:
 - name: PL-MLAG-PEER-VRFS
   sequence_numbers:
   - sequence: 10
-    action: permit 10.255.251.6/31
-  - sequence: 20
     action: permit 172.31.11.6/31
+  - sequence: 20
+    action: permit 192.168.44.42/31
 router_bfd:
   multihop:
     interval: 1200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -142,11 +142,15 @@ l3leaf:
           id: 4
           mgmt_ip: 192.168.200.108/24
           mac_address: '0c:1d:c0:1d:62:01'
+          mlag_peer_ipv4_address: 192.168.44.41
+          mlag_peer_l3_ipv4_address: 192.168.44.41
           # Commented out for automatic downlink allocation on spine
           # uplink_switch_interfaces: [ Ethernet4, Ethernet4, Ethernet4, Ethernet4 ]
         - name: DC1-SVC3B
           id: 5
           mgmt_ip: 192.168.200.109/24
+          mlag_peer_ipv4_address: 192.168.44.42
+          mlag_peer_l3_ipv4_address: 192.168.44.42
           # Commented out for automatic downlink allocation on spine
           # uplink_switch_interfaces: [ Ethernet5, Ethernet5, Ethernet5, Ethernet5 ]
     - group: DC1_BL1

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-l2-mlag-configuration.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-l2-mlag-configuration.md
@@ -20,10 +20,12 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "<node_type_keys.key>.defaults.mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_vlan</samp>](## "<node_type_keys.key>.defaults.mlag_peer_l3_vlan") | Integer |  | `4093` | Min: 0<br>Max: 4094 | Underlay L3 peering SVI interface id.<br>If set to 0 or the same vlan as mlag_peer_vlan, the mlag_peer_vlan will be used for L3 peering.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_ipv4_pool</samp>](## "<node_type_keys.key>.defaults.mlag_peer_l3_ipv4_pool") | String |  |  | Format: ipv4_cidr | IP address pool used for MLAG underlay L3 peering. IP is derived from the node id.<br>Required when MLAG leafs present in topology and they are using a separate L3 peering VLAN.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_ipv4_address</samp>](## "<node_type_keys.key>.defaults.mlag_peer_l3_ipv4_address") | String |  |  | Format: ipv4 | IPv4 address without mask used for MLAG underlay L3 peering.<br>When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.<br>Note: AVD does not check for validity of the IPv4 address and does not catch duplicates. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_vlan</samp>](## "<node_type_keys.key>.defaults.mlag_peer_vlan") | Integer |  | `4094` | Min: 1<br>Max: 4094 | MLAG Peer Link (control link) SVI interface id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_link_allowed_vlans</samp>](## "<node_type_keys.key>.defaults.mlag_peer_link_allowed_vlans") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_address_family</samp>](## "<node_type_keys.key>.defaults.mlag_peer_address_family") | String |  | `ipv4` | Valid Values:<br>- <code>ipv4</code><br>- <code>ipv6</code> | IP address family used to establish MLAG Peer Link (control link).<br>`ipv6` requires EOS version 4.31.1F or higher.<br>Note: `ipv6` is not supported in combination with a common MLAG peer link VLAN (ex. `mlag_l3_peer_vlan` set to 4094). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv4_pool</samp>](## "<node_type_keys.key>.defaults.mlag_peer_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 address pool used for MLAG Peer Link (control link). IP is derived from the node id.<br>Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv4_address</samp>](## "<node_type_keys.key>.defaults.mlag_peer_ipv4_address") | String |  |  | Format: ipv4 | IPv4 address without mask used for MLAG Peer Link (control link).<br>When set, it takes precedence over `mlag_peer_ipv4_pool`.<br>Note: AVD does not check for validity of the IPv4 address and does not catch duplicates. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv6_pool</samp>](## "<node_type_keys.key>.defaults.mlag_peer_ipv6_pool") | String |  |  | Format: ipv6_cidr | IPv6 address pool used for MLAG Peer Link (control link). IP is derived from the node id.<br>Required for MLAG leafs when `mlag_peer_address_family` is `ipv6`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_id</samp>](## "<node_type_keys.key>.defaults.mlag_port_channel_id") | Integer |  |  |  | If not set, the mlag port-channel id is generated based on the digits of the first interface present in 'mlag_interfaces'.<br>Valid port-channel id numbers are < 1-2000 > for EOS < 4.25.0F and < 1 - 999999 > for EOS >= 4.25.0F.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mlag_domain_id</samp>](## "<node_type_keys.key>.defaults.mlag_domain_id") | String |  |  |  | MLAG Domain ID. If not set the node group name (Set with "group" key) will be used. |
@@ -46,10 +48,12 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_vlan</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_peer_l3_vlan") | Integer |  | `4093` | Min: 0<br>Max: 4094 | Underlay L3 peering SVI interface id.<br>If set to 0 or the same vlan as mlag_peer_vlan, the mlag_peer_vlan will be used for L3 peering.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_ipv4_pool</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_peer_l3_ipv4_pool") | String |  |  | Format: ipv4_cidr | IP address pool used for MLAG underlay L3 peering. IP is derived from the node id.<br>Required when MLAG leafs present in topology and they are using a separate L3 peering VLAN.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_ipv4_address</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_peer_l3_ipv4_address") | String |  |  | Format: ipv4 | IPv4 address without mask used for MLAG underlay L3 peering.<br>When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.<br>Note: AVD does not check for validity of the IPv4 address and does not catch duplicates. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_vlan</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_peer_vlan") | Integer |  | `4094` | Min: 1<br>Max: 4094 | MLAG Peer Link (control link) SVI interface id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_link_allowed_vlans</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_peer_link_allowed_vlans") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_address_family</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_peer_address_family") | String |  | `ipv4` | Valid Values:<br>- <code>ipv4</code><br>- <code>ipv6</code> | IP address family used to establish MLAG Peer Link (control link).<br>`ipv6` requires EOS version 4.31.1F or higher.<br>Note: `ipv6` is not supported in combination with a common MLAG peer link VLAN (ex. `mlag_l3_peer_vlan` set to 4094). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv4_pool</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_peer_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 address pool used for MLAG Peer Link (control link). IP is derived from the node id.<br>Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv4_address</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_peer_ipv4_address") | String |  |  | Format: ipv4 | IPv4 address without mask used for MLAG Peer Link (control link).<br>When set, it takes precedence over `mlag_peer_ipv4_pool`.<br>Note: AVD does not check for validity of the IPv4 address and does not catch duplicates. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv6_pool</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_peer_ipv6_pool") | String |  |  | Format: ipv6_cidr | IPv6 address pool used for MLAG Peer Link (control link). IP is derived from the node id.<br>Required for MLAG leafs when `mlag_peer_address_family` is `ipv6`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_port_channel_id") | Integer |  |  |  | If not set, the mlag port-channel id is generated based on the digits of the first interface present in 'mlag_interfaces'.<br>Valid port-channel id numbers are < 1-2000 > for EOS < 4.25.0F and < 1 - 999999 > for EOS >= 4.25.0F.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].nodes.[].mlag_domain_id") | String |  |  |  | MLAG Domain ID. If not set the node group name (Set with "group" key) will be used. |
@@ -68,10 +72,12 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "<node_type_keys.key>.node_groups.[].mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_vlan</samp>](## "<node_type_keys.key>.node_groups.[].mlag_peer_l3_vlan") | Integer |  | `4093` | Min: 0<br>Max: 4094 | Underlay L3 peering SVI interface id.<br>If set to 0 or the same vlan as mlag_peer_vlan, the mlag_peer_vlan will be used for L3 peering.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_ipv4_pool</samp>](## "<node_type_keys.key>.node_groups.[].mlag_peer_l3_ipv4_pool") | String |  |  | Format: ipv4_cidr | IP address pool used for MLAG underlay L3 peering. IP is derived from the node id.<br>Required when MLAG leafs present in topology and they are using a separate L3 peering VLAN.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_ipv4_address</samp>](## "<node_type_keys.key>.node_groups.[].mlag_peer_l3_ipv4_address") | String |  |  | Format: ipv4 | IPv4 address without mask used for MLAG underlay L3 peering.<br>When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.<br>Note: AVD does not check for validity of the IPv4 address and does not catch duplicates. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_vlan</samp>](## "<node_type_keys.key>.node_groups.[].mlag_peer_vlan") | Integer |  | `4094` | Min: 1<br>Max: 4094 | MLAG Peer Link (control link) SVI interface id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_link_allowed_vlans</samp>](## "<node_type_keys.key>.node_groups.[].mlag_peer_link_allowed_vlans") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_address_family</samp>](## "<node_type_keys.key>.node_groups.[].mlag_peer_address_family") | String |  | `ipv4` | Valid Values:<br>- <code>ipv4</code><br>- <code>ipv6</code> | IP address family used to establish MLAG Peer Link (control link).<br>`ipv6` requires EOS version 4.31.1F or higher.<br>Note: `ipv6` is not supported in combination with a common MLAG peer link VLAN (ex. `mlag_l3_peer_vlan` set to 4094). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv4_pool</samp>](## "<node_type_keys.key>.node_groups.[].mlag_peer_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 address pool used for MLAG Peer Link (control link). IP is derived from the node id.<br>Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv4_address</samp>](## "<node_type_keys.key>.node_groups.[].mlag_peer_ipv4_address") | String |  |  | Format: ipv4 | IPv4 address without mask used for MLAG Peer Link (control link).<br>When set, it takes precedence over `mlag_peer_ipv4_pool`.<br>Note: AVD does not check for validity of the IPv4 address and does not catch duplicates. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv6_pool</samp>](## "<node_type_keys.key>.node_groups.[].mlag_peer_ipv6_pool") | String |  |  | Format: ipv6_cidr | IPv6 address pool used for MLAG Peer Link (control link). IP is derived from the node id.<br>Required for MLAG leafs when `mlag_peer_address_family` is `ipv6`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_id</samp>](## "<node_type_keys.key>.node_groups.[].mlag_port_channel_id") | Integer |  |  |  | If not set, the mlag port-channel id is generated based on the digits of the first interface present in 'mlag_interfaces'.<br>Valid port-channel id numbers are < 1-2000 > for EOS < 4.25.0F and < 1 - 999999 > for EOS >= 4.25.0F.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_domain_id</samp>](## "<node_type_keys.key>.node_groups.[].mlag_domain_id") | String |  |  |  | MLAG Domain ID. If not set the node group name (Set with "group" key) will be used. |
@@ -92,10 +98,12 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_interfaces_speed</samp>](## "<node_type_keys.key>.nodes.[].mlag_interfaces_speed") | String |  |  |  | Set MLAG interface speed.<br>Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto <interface_speed>`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_vlan</samp>](## "<node_type_keys.key>.nodes.[].mlag_peer_l3_vlan") | Integer |  | `4093` | Min: 0<br>Max: 4094 | Underlay L3 peering SVI interface id.<br>If set to 0 or the same vlan as mlag_peer_vlan, the mlag_peer_vlan will be used for L3 peering.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_ipv4_pool</samp>](## "<node_type_keys.key>.nodes.[].mlag_peer_l3_ipv4_pool") | String |  |  | Format: ipv4_cidr | IP address pool used for MLAG underlay L3 peering. IP is derived from the node id.<br>Required when MLAG leafs present in topology and they are using a separate L3 peering VLAN.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_l3_ipv4_address</samp>](## "<node_type_keys.key>.nodes.[].mlag_peer_l3_ipv4_address") | String |  |  | Format: ipv4 | IPv4 address without mask used for MLAG underlay L3 peering.<br>When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.<br>Note: AVD does not check for validity of the IPv4 address and does not catch duplicates. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_vlan</samp>](## "<node_type_keys.key>.nodes.[].mlag_peer_vlan") | Integer |  | `4094` | Min: 1<br>Max: 4094 | MLAG Peer Link (control link) SVI interface id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_link_allowed_vlans</samp>](## "<node_type_keys.key>.nodes.[].mlag_peer_link_allowed_vlans") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_address_family</samp>](## "<node_type_keys.key>.nodes.[].mlag_peer_address_family") | String |  | `ipv4` | Valid Values:<br>- <code>ipv4</code><br>- <code>ipv6</code> | IP address family used to establish MLAG Peer Link (control link).<br>`ipv6` requires EOS version 4.31.1F or higher.<br>Note: `ipv6` is not supported in combination with a common MLAG peer link VLAN (ex. `mlag_l3_peer_vlan` set to 4094). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv4_pool</samp>](## "<node_type_keys.key>.nodes.[].mlag_peer_ipv4_pool") | String |  |  | Format: ipv4_cidr | IPv4 address pool used for MLAG Peer Link (control link). IP is derived from the node id.<br>Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default). |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv4_address</samp>](## "<node_type_keys.key>.nodes.[].mlag_peer_ipv4_address") | String |  |  | Format: ipv4 | IPv4 address without mask used for MLAG Peer Link (control link).<br>When set, it takes precedence over `mlag_peer_ipv4_pool`.<br>Note: AVD does not check for validity of the IPv4 address and does not catch duplicates. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_peer_ipv6_pool</samp>](## "<node_type_keys.key>.nodes.[].mlag_peer_ipv6_pool") | String |  |  | Format: ipv6_cidr | IPv6 address pool used for MLAG Peer Link (control link). IP is derived from the node id.<br>Required for MLAG leafs when `mlag_peer_address_family` is `ipv6`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_port_channel_id</samp>](## "<node_type_keys.key>.nodes.[].mlag_port_channel_id") | Integer |  |  |  | If not set, the mlag port-channel id is generated based on the digits of the first interface present in 'mlag_interfaces'.<br>Valid port-channel id numbers are < 1-2000 > for EOS < 4.25.0F and < 1 - 999999 > for EOS >= 4.25.0F.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mlag_domain_id</samp>](## "<node_type_keys.key>.nodes.[].mlag_domain_id") | String |  |  |  | MLAG Domain ID. If not set the node group name (Set with "group" key) will be used. |
@@ -158,6 +166,11 @@
         # Required when MLAG leafs present in topology and they are using a separate L3 peering VLAN.
         mlag_peer_l3_ipv4_pool: <str>
 
+        # IPv4 address without mask used for MLAG underlay L3 peering.
+        # When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.
+        # Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+        mlag_peer_l3_ipv4_address: <str>
+
         # MLAG Peer Link (control link) SVI interface id.
         mlag_peer_vlan: <int; 1-4094; default=4094>
         mlag_peer_link_allowed_vlans: <str>
@@ -170,6 +183,11 @@
         # IPv4 address pool used for MLAG Peer Link (control link). IP is derived from the node id.
         # Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default).
         mlag_peer_ipv4_pool: <str>
+
+        # IPv4 address without mask used for MLAG Peer Link (control link).
+        # When set, it takes precedence over `mlag_peer_ipv4_pool`.
+        # Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+        mlag_peer_ipv4_address: <str>
 
         # IPv6 address pool used for MLAG Peer Link (control link). IP is derived from the node id.
         # Required for MLAG leafs when `mlag_peer_address_family` is `ipv6`.
@@ -250,6 +268,11 @@
               # Required when MLAG leafs present in topology and they are using a separate L3 peering VLAN.
               mlag_peer_l3_ipv4_pool: <str>
 
+              # IPv4 address without mask used for MLAG underlay L3 peering.
+              # When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.
+              # Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+              mlag_peer_l3_ipv4_address: <str>
+
               # MLAG Peer Link (control link) SVI interface id.
               mlag_peer_vlan: <int; 1-4094; default=4094>
               mlag_peer_link_allowed_vlans: <str>
@@ -262,6 +285,11 @@
               # IPv4 address pool used for MLAG Peer Link (control link). IP is derived from the node id.
               # Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default).
               mlag_peer_ipv4_pool: <str>
+
+              # IPv4 address without mask used for MLAG Peer Link (control link).
+              # When set, it takes precedence over `mlag_peer_ipv4_pool`.
+              # Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+              mlag_peer_ipv4_address: <str>
 
               # IPv6 address pool used for MLAG Peer Link (control link). IP is derived from the node id.
               # Required for MLAG leafs when `mlag_peer_address_family` is `ipv6`.
@@ -329,6 +357,11 @@
           # Required when MLAG leafs present in topology and they are using a separate L3 peering VLAN.
           mlag_peer_l3_ipv4_pool: <str>
 
+          # IPv4 address without mask used for MLAG underlay L3 peering.
+          # When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.
+          # Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+          mlag_peer_l3_ipv4_address: <str>
+
           # MLAG Peer Link (control link) SVI interface id.
           mlag_peer_vlan: <int; 1-4094; default=4094>
           mlag_peer_link_allowed_vlans: <str>
@@ -341,6 +374,11 @@
           # IPv4 address pool used for MLAG Peer Link (control link). IP is derived from the node id.
           # Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default).
           mlag_peer_ipv4_pool: <str>
+
+          # IPv4 address without mask used for MLAG Peer Link (control link).
+          # When set, it takes precedence over `mlag_peer_ipv4_pool`.
+          # Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+          mlag_peer_ipv4_address: <str>
 
           # IPv6 address pool used for MLAG Peer Link (control link). IP is derived from the node id.
           # Required for MLAG leafs when `mlag_peer_address_family` is `ipv6`.
@@ -414,6 +452,11 @@
           # Required when MLAG leafs present in topology and they are using a separate L3 peering VLAN.
           mlag_peer_l3_ipv4_pool: <str>
 
+          # IPv4 address without mask used for MLAG underlay L3 peering.
+          # When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.
+          # Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+          mlag_peer_l3_ipv4_address: <str>
+
           # MLAG Peer Link (control link) SVI interface id.
           mlag_peer_vlan: <int; 1-4094; default=4094>
           mlag_peer_link_allowed_vlans: <str>
@@ -426,6 +469,11 @@
           # IPv4 address pool used for MLAG Peer Link (control link). IP is derived from the node id.
           # Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default).
           mlag_peer_ipv4_pool: <str>
+
+          # IPv4 address without mask used for MLAG Peer Link (control link).
+          # When set, it takes precedence over `mlag_peer_ipv4_pool`.
+          # Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+          mlag_peer_ipv4_address: <str>
 
           # IPv6 address pool used for MLAG Peer Link (control link). IP is derived from the node id.
           # Required for MLAG leafs when `mlag_peer_address_family` is `ipv6`.

--- a/python-avd/pyavd/_eos_designs/ip_addressing/__init__.py
+++ b/python-avd/pyavd/_eos_designs/ip_addressing/__init__.py
@@ -85,8 +85,13 @@ class AvdIpAddressing(AvdFacts, UtilsMixin):
         """
         Return IP for MLAG Primary
 
+        If "mlag_peer_ipv4_address" is set, it is used.
         Default pool is "mlag_peer_ipv4_pool"
         """
+
+        if self._mlag_peer_ipv4_address:
+            return self._mlag_peer_ipv4_address
+
         if self.shared_utils.mlag_peer_address_family == "ipv6":
             if template_path := self.shared_utils.ip_addressing_templates.get("mlag_ip_primary"):
                 return self._template(
@@ -112,8 +117,13 @@ class AvdIpAddressing(AvdFacts, UtilsMixin):
         """
         Return IP for MLAG Secondary
 
+        If "mlag_peer_ipv4_address" is set, it is used.
         Default pool is "mlag_peer_ipv4_pool"
         """
+
+        if self._mlag_peer_ipv4_address:
+            return self._mlag_peer_ipv4_address
+
         if self.shared_utils.mlag_peer_address_family == "ipv6":
             if template_path := self.shared_utils.ip_addressing_templates.get("mlag_ip_secondary"):
                 return self._template(
@@ -139,8 +149,13 @@ class AvdIpAddressing(AvdFacts, UtilsMixin):
         """
         Return IP for L3 Peerings for MLAG Primary
 
+        If "mlag_peer_l3_ipv4_address" is set, it is used.
         Default pool is "mlag_peer_l3_ipv4_pool"
         """
+
+        if self._mlag_peer_l3_ipv4_address:
+            return self._mlag_peer_l3_ipv4_address
+
         if template_path := self.shared_utils.ip_addressing_templates.get("mlag_l3_ip_primary"):
             return self._template(
                 template_path,
@@ -155,8 +170,13 @@ class AvdIpAddressing(AvdFacts, UtilsMixin):
         """
         Return IP for L3 Peerings for MLAG Secondary
 
+        If "mlag_peer_l3_ipv4_address" is set, it is used.
         Default pool is "mlag_peer_l3_ipv4_pool"
         """
+
+        if self._mlag_peer_l3_ipv4_address:
+            return self._mlag_peer_l3_ipv4_address
+
         if template_path := self.shared_utils.ip_addressing_templates.get("mlag_l3_ip_secondary"):
             return self._template(
                 template_path,

--- a/python-avd/pyavd/_eos_designs/ip_addressing/utils.py
+++ b/python-avd/pyavd/_eos_designs/ip_addressing/utils.py
@@ -49,12 +49,21 @@ class UtilsMixin:
         return self.shared_utils.fabric_ip_addressing_p2p_uplinks_ipv4_prefix_length
 
     @cached_property
+    def _mlag_peer_ipv4_address(self: AvdIpAddressing) -> str:
+        return self.shared_utils.mlag_peer_ipv4_address
+
+    @cached_property
     def _mlag_peer_ipv4_pool(self: AvdIpAddressing) -> str:
         return self.shared_utils.mlag_peer_ipv4_pool
 
     @cached_property
     def _mlag_peer_ipv6_pool(self: AvdIpAddressing) -> str:
         return self.shared_utils.mlag_peer_ipv6_pool
+
+
+    @cached_property
+    def _mlag_peer_l3_ipv4_address(self: AvdIpAddressing) -> str:
+        return self.shared_utils.mlag_peer_l3_ipv4_address
 
     @cached_property
     def _mlag_peer_l3_ipv4_pool(self: AvdIpAddressing) -> str:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -8015,6 +8015,17 @@ $defs:
               '
             type: str
             format: ipv4_cidr
+          mlag_peer_l3_ipv4_address:
+            documentation_options:
+              table: node-type-l2-mlag-configuration
+            description: 'IPv4 address without mask used for MLAG underlay L3 peering.
+
+              When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.
+
+              Note: AVD does not check for validity of the IPv4 address and does not
+              catch duplicates.'
+            type: str
+            format: ipv4
           mlag_peer_vlan:
             documentation_options:
               table: node-type-l2-mlag-configuration
@@ -8053,6 +8064,18 @@ $defs:
               Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default).'
             type: str
             format: ipv4_cidr
+          mlag_peer_ipv4_address:
+            documentation_options:
+              table: node-type-l2-mlag-configuration
+            description: 'IPv4 address without mask used for MLAG Peer Link (control
+              link).
+
+              When set, it takes precedence over `mlag_peer_ipv4_pool`.
+
+              Note: AVD does not check for validity of the IPv4 address and does not
+              catch duplicates.'
+            type: str
+            format: ipv4
           mlag_peer_ipv6_pool:
             documentation_options:
               table: node-type-l2-mlag-configuration

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
@@ -754,6 +754,15 @@ $defs:
               Required when MLAG leafs present in topology and they are using a separate L3 peering VLAN.
             type: str
             format: ipv4_cidr
+          mlag_peer_l3_ipv4_address:
+            documentation_options:
+              table: node-type-l2-mlag-configuration
+            description: |-
+              IPv4 address without mask used for MLAG underlay L3 peering.
+              When set, it takes precedence over `mlag_peer_l3_ipv4_pool`.
+              Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+            type: str
+            format: ipv4
           mlag_peer_vlan:
             documentation_options:
               table: node-type-l2-mlag-configuration
@@ -788,6 +797,15 @@ $defs:
               Required for MLAG leafs when `mlag_peer_address_family` is `ipv4` (default).
             type: str
             format: ipv4_cidr
+          mlag_peer_ipv4_address:
+            documentation_options:
+              table: node-type-l2-mlag-configuration
+            description: |-
+              IPv4 address without mask used for MLAG Peer Link (control link).
+              When set, it takes precedence over `mlag_peer_ipv4_pool`.
+              Note: AVD does not check for validity of the IPv4 address and does not catch duplicates.
+            type: str
+            format: ipv4
           mlag_peer_ipv6_pool:
             documentation_options:
               table: node-type-l2-mlag-configuration

--- a/python-avd/pyavd/_eos_designs/shared_utils/mlag.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/mlag.py
@@ -67,12 +67,20 @@ class MlagMixin:
         return get(self.switch_data_combined, "mlag_peer_address_family", default="ipv4")
 
     @cached_property
+    def mlag_peer_ipv4_address(self: SharedUtils) -> str:
+        return get(self.switch_data_combined, "mlag_peer_ipv4_address", required=False)
+
+    @cached_property
     def mlag_peer_ipv4_pool(self: SharedUtils) -> str:
         return get(self.switch_data_combined, "mlag_peer_ipv4_pool", required=True)
 
     @cached_property
     def mlag_peer_ipv6_pool(self: SharedUtils) -> str:
         return get(self.switch_data_combined, "mlag_peer_ipv6_pool", required=True)
+
+    @cached_property
+    def mlag_peer_l3_ipv4_address(self: SharedUtils) -> str:
+        return get(self.switch_data_combined, "mlag_peer_l3_ipv4_address", required=False)
 
     @cached_property
     def mlag_peer_l3_ipv4_pool(self: SharedUtils) -> str:


### PR DESCRIPTION
This PR adds two node level keys:

mlag_peer_ipv4 and mlag_peer_l3_ipv4 to set the addresses directly without using pools.

## Related Issue(s)

Fixes #4202 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- The two keys take precedence over the _pool version
- AVD does not check if they are unique (or valid - it only knows them as string)

## How to test

added a molecule test in DC1_FABRIC.yml

## Checklist

### Repository Checklist


- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
