### PR TITLE
CI: Add step to run make dep when installing pyavd in editable mode

### DIFF
--- a/python-avd/scripts/custom_build_backend.py
+++ b/python-avd/scripts/custom_build_backend.py
@@ -66,9 +66,18 @@ def get_requires_for_build_wheel(config_settings=None):
     print("Fetch version from ansible.avd ansible collection and insert into __init__.py")
     _insert_version()
 
-    print("Running 'make dep' to vendor various scripts and templates from arista.avd ansible collection")
+    print("Running 'make dep' to generate compiled Jinja2 templates and schemas pickle files.")
     with Popen("make dep", shell=True) as make_process:
         if make_process.wait() != 0:
             raise RuntimeError("Something went wrong during 'make dep'")
 
     return _orig.get_requires_for_build_wheel(config_settings)
+
+
+def get_requires_for_build_editable(config_settings=None):
+    print("Running 'make dep' to generate compiled Jinja2 templates and schemas pickle files.")
+    with Popen("make dep", shell=True) as make_process:
+        if make_process.wait() != 0:
+            raise RuntimeError("Something went wrong during 'make dep'")
+
+    return _orig.get_requires_for_build_editable(config_settings)


### PR DESCRIPTION
## Change Summary

When running editable install of pyavd, pickle files may not exist and so running AVD will fail

## Related Issue(s)

Reported in the field when running dev containers. When devcontainer is started without a specified branch, the following is done: https://github.com/aristanetworks/avd/blob/d8dcef092c789354ba16a1d0683a6c3100cb09fd/containers/dev/.devcontainer/entrypoint.sh#L19

running AVD fails because pickle files are missing. It is possible to fix this by running manually `make dep` or `pre-commit`

## Component(s) name

`pyavd`

## Proposed changes

Added a step in the custom build backend we use to run `make dep` on editable install as well

## How to test

1. Check issue does not appear in container anymore
2. run editable install and verifies pickle files and compiled templates are generated

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
