### PR TITLE
Feat(eos_cli_config_gen): Add support for tunnel-interface underlay vrf

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/tunnel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/tunnel-interfaces.md
@@ -41,12 +41,12 @@ interface Management1
 
 #### Tunnel Interfaces Summary
 
-| Interface | Description | VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
-| --------- | ----------- | --- | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
-| Tunnel1 | test ipv4 only | Tunnel-VRF | 1500 | False | - | ipsec | Ethernet42 | 6.6.6.6 | True | - |
-| Tunnel2 | test ipv6 only | default | - | True | NAT-PROFILE-NO-VRF-2 | gre | Ethernet42 | dead:beef::1 | False | Profile-2 |
-| Tunnel3 | test dual stack | default | 1500 | - | - | ipsec | Ethernet42 | 1.1.1.1 | - | Profile-3 |
-| Tunnel4 | test no tcp_mss | default | 1500 | - | NAT-PROFILE-NO-VRF-1 | - | Ethernet42 | 1.1.1.1 | - | - |
+| Interface | Description | VRF | Underlay VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
+| --------- | ----------- | --- | ------------ | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
+| Tunnel1 | test ipv4 only | Tunnel-VRF | Underlay-VRF | 1500 | False | - | ipsec | Ethernet42 | 6.6.6.6 | True | - |
+| Tunnel2 | test ipv6 only | default | default | - | True | NAT-PROFILE-NO-VRF-2 | gre | Ethernet42 | dead:beef::1 | False | Profile-2 |
+| Tunnel3 | test dual stack | default | default | 1500 | - | - | ipsec | Ethernet42 | 1.1.1.1 | - | Profile-3 |
+| Tunnel4 | test no tcp_mss | default | default | 1500 | - | NAT-PROFILE-NO-VRF-1 | - | Ethernet42 | 1.1.1.1 | - | - |
 
 ##### IPv4
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/tunnel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/tunnel-interfaces.md
@@ -80,6 +80,7 @@ interface Tunnel1
    tunnel mode ipsec
    tunnel source interface Ethernet42
    tunnel destination 6.6.6.6
+   tunnel underlay vrf Underlay-VRF
    tunnel path-mtu-discovery
    comment
    Comment created from eos_cli under tunnel_interfaces.Tunnel1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/tunnel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/tunnel-interfaces.cfg
@@ -24,6 +24,7 @@ interface Tunnel1
    tunnel mode ipsec
    tunnel source interface Ethernet42
    tunnel destination 6.6.6.6
+   tunnel underlay vrf Underlay-VRF
    tunnel path-mtu-discovery
    comment
    Comment created from eos_cli under tunnel_interfaces.Tunnel1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/tunnel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/tunnel-interfaces.yml
@@ -5,6 +5,7 @@ tunnel_interfaces:
     description: test ipv4 only
     shutdown: false
     vrf: Tunnel-VRF
+    underlay_vrf: Underlay-VRF
     mtu: 1500
     ip_address: 42.42.42.42/24
     access_group_in: test-in

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -804,10 +804,10 @@ interface Loopback1
 
 #### Tunnel Interfaces Summary
 
-| Interface | Description | VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
-| --------- | ----------- | --- | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
-| Tunnel3 | test dual stack | default | 1500 | - | - | - | Ethernet42 | 1.1.1.1 | - | - |
-| Tunnel4 | test no tcp_mss | default | 1500 | - | - | - | Ethernet42 | 1.1.1.1 | - | - |
+| Interface | Description | VRF | Underlay VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
+| --------- | ----------- | --- | ------------ | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
+| Tunnel3 | test dual stack | default | default | 1500 | - | - | - | Ethernet42 | 1.1.1.1 | - | - |
+| Tunnel4 | test no tcp_mss | default | default | 1500 | - | - | - | Ethernet42 | 1.1.1.1 | - | - |
 
 ##### IPv4
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tunnel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/tunnel-interfaces.md
@@ -13,6 +13,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "tunnel_interfaces.[].shutdown") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "tunnel_interfaces.[].mtu") | Integer |  |  | Min: 68<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "tunnel_interfaces.[].vrf") | String |  |  |  | VRF Name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;underlay_vrf</samp>](## "tunnel_interfaces.[].underlay_vrf") | String |  |  |  | Underlay VRF Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "tunnel_interfaces.[].ip_address") | String |  |  | Format: ipv4_cidr | IPv4_address/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enable</samp>](## "tunnel_interfaces.[].ipv6_enable") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "tunnel_interfaces.[].ipv6_address") | String |  |  | Format: ipv6_cidr | IPv6_address/Mask. |
@@ -45,6 +46,9 @@
 
         # VRF Name.
         vrf: <str>
+
+        # Underlay VRF Name.
+        underlay_vrf: <str>
 
         # IPv4_address/Mask.
         ip_address: <str>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/tunnel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/tunnel-interfaces.j2
@@ -12,8 +12,8 @@
 
 {%     set tunnel_interfaces_ipv4 = [] %}
 {%     set tunnel_interfaces_ipv6 = [] %}
-| Interface | Description | VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
-| --------- | ----------- | --- | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
+| Interface | Description | VRF | Underlay VRF | MTU | Shutdown | NAT Profile | Mode | Source Interface | Destination | PMTU-Discovery | IPsec Profile |
+| --------- | ----------- | --- | ------------ | --- | -------- | ----------- | ---- | ---------------- | ----------- | -------------- | ------------- |
 {%     for tunnel_interface in tunnel_interfaces | arista.avd.natural_sort('name') %}
 {%         if tunnel_interface.ipv6_address is arista.avd.defined %}
 {%             do tunnel_interfaces_ipv6.append(tunnel_interface) %}
@@ -23,6 +23,7 @@
 {%         endif %}
 {%         set description = tunnel_interface.description | arista.avd.default('-') %}
 {%         set vrf = tunnel_interface.vrf | arista.avd.default('default') %}
+{%         set underlay_vrf = tunnel_interface.underlay_vrf | arista.avd.default('default') %}
 {%         set mtu = tunnel_interface.mtu | arista.avd.default('-') %}
 {%         set shutdown = tunnel_interface.shutdown | arista.avd.default('-') %}
 {%         set nat_profile = tunnel_interface.nat_profile | arista.avd.default('-') %}
@@ -31,7 +32,7 @@
 {%         set row_destination = tunnel_interface.destination | arista.avd.default("-") %}
 {%         set row_pmtu = tunnel_interface.path_mtu_discovery | arista.avd.default("-") %}
 {%         set ipsec_profile = tunnel_interface.ipsec_profile | arista.avd.default("-") %}
-| {{ tunnel_interface.name }} | {{ description }} | {{ vrf }} | {{ mtu }} | {{ shutdown }} | {{ nat_profile }} | {{ tunnel_mode }} | {{ row_source_interface }} | {{ row_destination }} | {{ row_pmtu }} | {{ ipsec_profile }} |
+| {{ tunnel_interface.name }} | {{ description }} | {{ vrf }} | {{ underlay_vrf }} | {{ mtu }} | {{ shutdown }} | {{ nat_profile }} | {{ tunnel_mode }} | {{ row_source_interface }} | {{ row_destination }} | {{ row_pmtu }} | {{ ipsec_profile }} |
 {%     endfor %}
 {# IPv4 #}
 {%     if tunnel_interfaces_ipv4 | length > 0 %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/tunnel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/tunnel-interfaces.j2
@@ -67,6 +67,9 @@ interface {{ tunnel_interface.name }}
 {%     if tunnel_interface.destination is arista.avd.defined %}
    tunnel destination {{ tunnel_interface.destination }}
 {%     endif %}
+{%     if tunnel_interface.underlay_vrf is arista.avd.defined %}
+   tunnel underlay vrf {{ tunnel_interface.underlay_vrf }}
+{%     endif %}
 {%     if tunnel_interface.path_mtu_discovery is arista.avd.defined(true) %}
    tunnel path-mtu-discovery
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -29527,6 +29527,11 @@
             "description": "VRF Name.",
             "title": "VRF"
           },
+          "underlay_vrf": {
+            "type": "string",
+            "description": "Underlay VRF Name.",
+            "title": "Underlay VRF"
+          },
           "ip_address": {
             "type": "string",
             "description": "IPv4_address/Mask.",

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -17429,6 +17429,11 @@ keys:
           description: VRF Name.
           convert_types:
           - int
+        underlay_vrf:
+          type: str
+          description: Underlay VRF Name.
+          convert_types:
+          - int
         ip_address:
           type: str
           format: ipv4_cidr

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tunnel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tunnel_interfaces.schema.yml
@@ -32,6 +32,11 @@ keys:
           description: VRF Name.
           convert_types:
             - int
+        underlay_vrf:
+          type: str
+          description: Underlay VRF Name.
+          convert_types:
+            - int
         ip_address:
           type: str
           format: ipv4_cidr

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -47435,6 +47435,11 @@
                       "description": "VRF Name.",
                       "title": "VRF"
                     },
+                    "underlay_vrf": {
+                      "type": "string",
+                      "description": "Underlay VRF Name.",
+                      "title": "Underlay VRF"
+                    },
                     "ip_address": {
                       "type": "string",
                       "description": "IPv4_address/Mask.",


### PR DESCRIPTION
## Change Summary

Add support for setting underlay vrf for a tunnel-interface 

## Related Issue(s)

Fixes #4165

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added `underlay_vrf` as a key to the `tunnel-interfaces` model. Setting this value will generate the following CLI config:
```
interface <tunnel_name>
   tunnel underlay vrf <vrf_name>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
