### PR TITLE
Fix(eos_validate_state): Sanitize markdown output on markdown validation report 

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/md_report.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/md_report.py
@@ -129,7 +129,7 @@ class MDReportBase(ABC):
         heading_name = self.generate_heading_name()
         heading = "#" * heading_level + " " + heading_name
         self.mdfile.write(f"{heading}\n\n")
-    
+
     def safe_markdown(self, text: str | None) -> str:
         """Escape markdown characters in the text to prevent markdown rendering issues.
 

--- a/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/md_report.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/eos_validate_state_utils/md_report.py
@@ -129,6 +129,27 @@ class MDReportBase(ABC):
         heading_name = self.generate_heading_name()
         heading = "#" * heading_level + " " + heading_name
         self.mdfile.write(f"{heading}\n\n")
+    
+    def safe_markdown(self, text: str | None) -> str:
+        """Escape markdown characters in the text to prevent markdown rendering issues.
+
+        Args:
+        ----------
+            text (str): The text to escape markdown characters from.
+
+        Returns
+        -------
+            str: The text with escaped markdown characters.
+        """
+        # Custom field from a TestResult object can be None
+        if text is None:
+            return ""
+
+        # Replace newlines with spaces to keep content on one line
+        text = text.replace("\n", " ")
+
+        # Replace backticks with single quotes
+        return text.replace("`", "'")
 
 
 class ValidateStateReport(MDReportBase):
@@ -231,7 +252,7 @@ class FailedTestResultsSummary(MDReportBase):
     def generate_rows(self) -> Generator[str, None, None]:
         """Generate the rows of the failed test results table."""
         for result in self.results.failed_tests:
-            messages = ", ".join(result["messages"])
+            messages = self.safe_markdown(", ".join(result["messages"]))
             categories = ", ".join(result["categories"])
             yield (
                 f"| {result['id'] or '-'} | {result['dut'] or '-'} | {categories or '-'} | {result['test'] or '-'} |"
@@ -258,7 +279,7 @@ class AllTestResults(MDReportBase):
     def generate_rows(self) -> Generator[str, None, None]:
         """Generate the rows of the all test results table."""
         for result in self.results.all_tests:
-            messages = ", ".join(result["messages"])
+            messages = self.safe_markdown(", ".join(result["messages"]))
             categories = ", ".join(result["categories"])
             yield (
                 f"| {result['id'] or '-'} | {result['dut'] or '-'} | {categories or '-'} | {result['test'] or '-'} |"


### PR DESCRIPTION
## Change Summary

Borrowed the `safe_markdown` method from the ANTA project to fix a bug where some tests (LLDP Neighbors) inserted newlines in the message field which would break markdown formatting. 

## Related Issue(s)

aristanetworks/anta#752

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes

Implemented `safe_markdown` as part of `MDReportBase` and added it to sanitize the message output in the markdown table of failed tests and all tests. `safe_markdown` replaces backticks with single quotes and replaces newlines with a single space. 

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
