### PR TITLE
Test(eos_cli_config_gen): Added the test for domain-list in molecule to improve the coverage

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/domain-list.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/domain-list.md
@@ -38,13 +38,13 @@ interface Management1
 
 #### Domains List
 
-- Domain1
-- Domain2
+- domain1.local
+- domain2.local
 
 #### IP Domain-list Device Configuration
 
 ```eos
-ip domain-list Domain1
-ip domain-list Domain2
+ip domain-list domain1.local
+ip domain-list domain2.local
 !
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/domain-list.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/domain-list.md
@@ -1,0 +1,50 @@
+# domain-list
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [IP Domain-list](#ip-domain-list)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | Description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+### IP Domain-list
+
+#### Domains List
+
+- Domain1
+- Domain2
+
+#### IP Domain-list Device Configuration
+
+```eos
+ip domain-list Domain1
+ip domain-list Domain2
+!
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/domain-list.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/domain-list.cfg
@@ -1,0 +1,17 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname domain-list
+ip domain-list Domain1
+ip domain-list Domain2
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/domain-list.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/domain-list.cfg
@@ -3,8 +3,8 @@
 transceiver qsfp default-mode 4x10G
 !
 hostname domain-list
-ip domain-list Domain1
-ip domain-list Domain2
+ip domain-list domain1.local
+ip domain-list domain2.local
 !
 no enable password
 no aaa root

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/domain-list.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/domain-list.yml
@@ -1,0 +1,4 @@
+### Domain List ###
+domain_list:
+  - Domain1
+  - Domain2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/domain-list.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/domain-list.yml
@@ -1,4 +1,4 @@
 ### Domain List ###
 domain_list:
-  - Domain1
-  - Domain2
+  - domain1.local
+  - domain2.local

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -21,6 +21,7 @@ daemon_terminattr
 daemons
 dps-interfaces
 dns-ntp
+domain-list
 dhcp-relay
 dhcp-servers
 dot1x


### PR DESCRIPTION
## Change Summary

Added the test for domain-list in molecule to improve the coverage

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Test were not added for domain list in eos_cli_config_gen moledule which were caused the low coverage for that module. Hence just added a test of domain list in molecule

## How to test
Run the molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
