### PR TITLE
Fix(eos_cli_config_gen): Fixing the wrong CLI generated for radius-server dynamic-authorizaton

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/radius-server.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/radius-server.md
@@ -45,7 +45,7 @@ interface Management1
 
 - Dynamic Authorization is enabled on port 1700
 
-- Dynamic Authorization for TLS connections uses SSL profile - SSL_PROFILE
+- Dynamic Authorization for TLS connections uses SSL profile SSL_PROFILE
 
 #### RADIUS Server Hosts
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/radius-server.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/radius-server.md
@@ -43,7 +43,9 @@ interface Management1
 
 - Global RADIUS TLS SSL profile is GLOBAL_RADIUS_SSL_PROFILE
 
-- Dynamic Authorization is enabled on port 1700 with SSL profile SSL_PROFILE
+- Dynamic Authorization is enabled on port 1700
+
+- Dynamic Authorization for TLS connections uses SSL profile - SSL_PROFILE
 
 #### RADIUS Server Hosts
 
@@ -63,8 +65,9 @@ interface Management1
 ```eos
 !
 radius-server attribute 32 include-in-access-req hostname
+radius-server dynamic-authorization port 1700
 radius-server tls ssl-profile GLOBAL_RADIUS_SSL_PROFILE
-radius-server dynamic-authorization port 1700 tls ssl-profile SSL_PROFILE
+radius-server dynamic-authorization tls ssl-profile SSL_PROFILE
 radius-server host 10.10.11.157 vrf mgt timeout 1 retransmit 1 key 7 <removed>
 radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7 <removed>
 radius-server host 10.10.11.160 vrf mgt timeout 1 key 7 <removed>

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/radius-server.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/radius-server.cfg
@@ -5,8 +5,9 @@ transceiver qsfp default-mode 4x10G
 hostname radius-server
 !
 radius-server attribute 32 include-in-access-req hostname
+radius-server dynamic-authorization port 1700
 radius-server tls ssl-profile GLOBAL_RADIUS_SSL_PROFILE
-radius-server dynamic-authorization port 1700 tls ssl-profile SSL_PROFILE
+radius-server dynamic-authorization tls ssl-profile SSL_PROFILE
 radius-server host 10.10.11.157 vrf mgt timeout 1 retransmit 1 key 7 071B245F5A
 radius-server host 10.10.11.159 vrf mgt retransmit 1 key 7 071B245F5A
 radius-server host 10.10.11.160 vrf mgt timeout 1 key 7 071B245F5A

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/radius-server.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/radius-server.j2
@@ -27,7 +27,7 @@
 {%     endif %}
 {%     if radius_server.dynamic_authorization.tls_ssl_profile is arista.avd.defined %}
 
-- Dynamic Authorization for TLS connections uses SSL profile - {{ radius_server.dynamic_authorization.tls_ssl_profile }}
+- Dynamic Authorization for TLS connections uses SSL profile {{ radius_server.dynamic_authorization.tls_ssl_profile }}
 {%     endif %}
 
 #### RADIUS Server Hosts

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/radius-server.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/radius-server.j2
@@ -21,16 +21,13 @@
 
 - Global RADIUS TLS SSL profile is {{ radius_server.tls_ssl_profile }}
 {%     endif %}
-{%     if radius_server.dynamic_authorization is arista.avd.defined %}
-{%         set doc_line = "- Dynamic Authorization is enabled" %}
-{%         if radius_server.dynamic_authorization.port is arista.avd.defined %}
-{%             set doc_line = doc_line ~ " on port "~ radius_server.dynamic_authorization.port %}
-{%         endif %}
-{%         if radius_server.dynamic_authorization.tls_ssl_profile is arista.avd.defined %}
-{%             set doc_line = doc_line ~ " with SSL profile " ~ radius_server.dynamic_authorization.tls_ssl_profile %}
-{%         endif %}
+{%     if radius_server.dynamic_authorization.port is arista.avd.defined %}
 
-{{ doc_line }}
+- Dynamic Authorization is enabled on port {{ radius_server.dynamic_authorization.port }}
+{%     endif %}
+{%     if radius_server.dynamic_authorization.tls_ssl_profile is arista.avd.defined %}
+
+- Dynamic Authorization for TLS connections uses SSL profile - {{ radius_server.dynamic_authorization.tls_ssl_profile }}
 {%     endif %}
 
 #### RADIUS Server Hosts

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/radius-server.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/radius-server.j2
@@ -16,18 +16,14 @@
 {%         endif %}
 {{ attribute_32_include_in_access_cli }}
 {%     endif %}
+{%     if radius_server.dynamic_authorization.port is arista.avd.defined %}
+radius-server dynamic-authorization port {{ radius_server.dynamic_authorization.port }}
+{%     endif %}
 {%     if radius_server.tls_ssl_profile is arista.avd.defined %}
 radius-server tls ssl-profile {{ radius_server.tls_ssl_profile }}
 {%     endif %}
-{%     if radius_server.dynamic_authorization is arista.avd.defined %}
-{%         set dynamic_authorization_cli = "radius-server dynamic-authorization" %}
-{%         if radius_server.dynamic_authorization.port is arista.avd.defined %}
-{%             set dynamic_authorization_cli = dynamic_authorization_cli ~ " port " ~ radius_server.dynamic_authorization.port %}
-{%         endif %}
-{%         if radius_server.dynamic_authorization.tls_ssl_profile is arista.avd.defined %}
-{%             set dynamic_authorization_cli = dynamic_authorization_cli ~ " tls ssl-profile " ~ radius_server.dynamic_authorization.tls_ssl_profile %}
-{%         endif %}
-{{ dynamic_authorization_cli }}
+{%     if radius_server.dynamic_authorization.tls_ssl_profile is arista.avd.defined %}
+radius-server dynamic-authorization tls ssl-profile {{ radius_server.dynamic_authorization.tls_ssl_profile }}
 {%     endif %}
 {%     for radius_host in radius_server.hosts | arista.avd.default([]) %}
 {%         set radius_cli = "radius-server host " ~ radius_host.host %}


### PR DESCRIPTION
## Change Summary

Fixing the wrong CLI generated for radius-server dynamic-authorizaton

## Related Issue(s)

Fixes #4198 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Fixing the template to implement separate commands for -
```
radius-server dynamic-authorization port 1700
radius-server dynamic-authorization tls ssl-profile <profile_name>
```

## How to test
Test the molecule scenario and verify in EOS CLI.

## Checklist
### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
