### PR TITLE
CI(eos_designs): Remove outdated code comment in eos_designs/python_modules/network_services/ethernet_interfaces.py

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -33,7 +33,6 @@ class EthernetInterfacesMixin(UtilsMixin):
         if not (self.shared_utils.network_services_l3 or self.shared_utils.network_services_l1 or self.shared_utils.l3_interfaces):
             return None
 
-        # Using temp variables to keep the order of interfaces from Jinja
         ethernet_interfaces = []
         subif_parent_interface_names = set()
 


### PR DESCRIPTION
## Change Summary

Erroneous code comment (eos_designs/python_modules/network_services/ethernet_interfaces.py)
 # Using temp variables to keep the order of interfaces from Jinja 

## Related Issue(s)

Fixes #3694

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Remove erroneous comment in (eos_designs/python_modules/network_services/ethernet_interfaces.py).

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
