### PR TITLE
Fix(eos_cli_config_gen): Sort IPsec SA, IKE policies and profiles

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -59,13 +59,10 @@ interface Management1
 | SA-1 | - | aes128 | - | 14 |
 | SA-2 | - | aes128 | 42 gigabytes | 14 |
 | SA-3 | disabled | disabled | 8 hours | 17 |
-<<<<<<< HEAD
 | SA-4 | md5 | 3des | - | - |
 | SA-5 | sha512 | - | - | - |
 | SA-6 | sha384 | - | - | - |
-=======
-| SA-4 | - | - | - | - |
->>>>>>> 4f209178e6 (Fix(eos_cli_config_gen): Sort IPsec SA, IKE policies and profiles)
+| SA-7 | - | - | - | - |
 
 ### IPSec profiles
 
@@ -118,7 +115,6 @@ ip security
       pfs dh-group 17
    !
    sa policy SA-4
-<<<<<<< HEAD
       esp integrity md5
       esp encryption 3des
    !
@@ -127,8 +123,8 @@ ip security
    !
    sa policy SA-6
       esp integrity sha384
-=======
->>>>>>> 4f209178e6 (Fix(eos_cli_config_gen): Sort IPsec SA, IKE policies and profiles)
+   !
+   sa policy SA-7
    !
    profile Profile-1
       ike-policy IKE-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -59,9 +59,13 @@ interface Management1
 | SA-1 | - | aes128 | - | 14 |
 | SA-2 | - | aes128 | 42 gigabytes | 14 |
 | SA-3 | disabled | disabled | 8 hours | 17 |
+<<<<<<< HEAD
 | SA-4 | md5 | 3des | - | - |
 | SA-5 | sha512 | - | - | - |
 | SA-6 | sha384 | - | - | - |
+=======
+| SA-4 | - | - | - | - |
+>>>>>>> 4f209178e6 (Fix(eos_cli_config_gen): Sort IPsec SA, IKE policies and profiles)
 
 ### IPSec profiles
 
@@ -70,6 +74,7 @@ interface Management1
 | Profile-1 | IKE-1 | SA-1 | start | - | - | - | transport | - |
 | Profile-2 | - | SA-2 | start | - | - | - | tunnel | False |
 | Profile-3 | - | SA-3 | start | - | - | - | tunnel | True |
+| Profile-4 | - | - | - | - | - | - | - | - |
 
 ### Key controller
 
@@ -113,6 +118,7 @@ ip security
       pfs dh-group 17
    !
    sa policy SA-4
+<<<<<<< HEAD
       esp integrity md5
       esp encryption 3des
    !
@@ -121,6 +127,8 @@ ip security
    !
    sa policy SA-6
       esp integrity sha384
+=======
+>>>>>>> 4f209178e6 (Fix(eos_cli_config_gen): Sort IPsec SA, IKE policies and profiles)
    !
    profile Profile-1
       ike-policy IKE-1
@@ -142,6 +150,8 @@ ip security
       shared-key 7 <removed>
       flow parallelization encapsulation udp
       mode tunnel
+   !
+   profile Profile-4
    !
    key controller
       profile Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -31,6 +31,7 @@ ip security
       pfs dh-group 17
    !
    sa policy SA-4
+<<<<<<< HEAD
       esp integrity md5
       esp encryption 3des
    !
@@ -39,6 +40,8 @@ ip security
    !
    sa policy SA-6
       esp integrity sha384
+=======
+>>>>>>> 4f209178e6 (Fix(eos_cli_config_gen): Sort IPsec SA, IKE policies and profiles)
    !
    profile Profile-1
       ike-policy IKE-1
@@ -60,6 +63,8 @@ ip security
       shared-key 7 1231231231321AA
       flow parallelization encapsulation udp
       mode tunnel
+   !
+   profile Profile-4
    !
    key controller
       profile Profile-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -31,7 +31,6 @@ ip security
       pfs dh-group 17
    !
    sa policy SA-4
-<<<<<<< HEAD
       esp integrity md5
       esp encryption 3des
    !
@@ -40,8 +39,8 @@ ip security
    !
    sa policy SA-6
       esp integrity sha384
-=======
->>>>>>> 4f209178e6 (Fix(eos_cli_config_gen): Sort IPsec SA, IKE policies and profiles)
+   !
+   sa policy SA-7
    !
    profile Profile-1
       ike-policy IKE-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -1,12 +1,13 @@
 ### IP Security ###
 ip_security:
   ike_policies:
+    # Testing sorting
+    - name: IKE-2
     - name: IKE-1
       local_id: 192.168.100.1
       ike_lifetime: 24
       encryption: aes256
       dh_group: 20
-    - name: IKE-2
     - name: IKE-FQDN
       local_id_fqdn: fqdn.local
     - name: IKE-UFQDN
@@ -14,6 +15,8 @@ ip_security:
       # local_id won't be rendered as local_id_fqdn takes precedence
       local_id: 192.168.42.42
   sa_policies:
+    # Testing sorting
+    - name: SA-4
     - name: SA-1
       esp:
         encryption: aes128
@@ -44,6 +47,8 @@ ip_security:
       esp:
         integrity: sha384
   profiles:
+    # testing sorting
+    - name: Profile-4
     - name: Profile-1
       ike_policy: IKE-1
       sa_policy: SA-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -16,7 +16,7 @@ ip_security:
       local_id: 192.168.42.42
   sa_policies:
     # Testing sorting
-    - name: SA-4
+    - name: SA-7
     - name: SA-1
       esp:
         encryption: aes128

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
@@ -108,26 +108,26 @@ ip security
    ike policy CP-IKE-POLICY
       local-id 192.168.142.1
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
-   !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
@@ -108,26 +108,26 @@ ip security
    ike policy CP-IKE-POLICY
       local-id 192.168.142.2
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
-   !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
@@ -108,26 +108,26 @@ ip security
    ike policy CP-IKE-POLICY
       local-id 192.168.142.3
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
-   !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -120,26 +120,26 @@ ip security
    ike policy CP-IKE-POLICY
       local-id 192.168.255.1
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
-   !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -114,26 +114,26 @@ ip security
    ike policy CP-IKE-POLICY
       local-id 192.168.255.1
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
-   !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -254,11 +254,11 @@ ip security
       encryption aes256
       dh-group 24
    !
-   sa policy DP-SA-POLICY
+   sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   sa policy CP-SA-POLICY
+   sa policy DP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
@@ -268,18 +268,18 @@ ip security
       sa lifetime 8 hours
       pfs dh-group 24
    !
-   profile DP-PROFILE
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
-   !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -259,11 +259,11 @@ ip security
       encryption aes256
       dh-group 24
    !
-   sa policy DP-SA-POLICY
+   sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   sa policy CP-SA-POLICY
+   sa policy DP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
@@ -279,18 +279,18 @@ ip security
       sa lifetime 8 hours
       pfs dh-group 24
    !
-   profile DP-PROFILE
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
-   !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -175,33 +175,33 @@ vrf instance PROD
 !
 ip security
    !
-   ike policy DP-IKE-POLICY
-      local-id 192.168.142.2
-   !
    ike policy CP-IKE-POLICY
       local-id 192.168.142.2
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
+   ike policy DP-IKE-POLICY
+      local-id 192.168.142.2
    !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      ike-policy DP-IKE-POLICY
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      ike-policy DP-IKE-POLICY
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -186,33 +186,33 @@ vrf instance PROD
 !
 ip security
    !
-   ike policy DP-IKE-POLICY
-      local-id 192.168.142.3
-   !
    ike policy CP-IKE-POLICY
       local-id 192.168.142.3
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
+   ike policy DP-IKE-POLICY
+      local-id 192.168.142.3
    !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      ike-policy DP-IKE-POLICY
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      ike-policy DP-IKE-POLICY
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3A.cfg
@@ -152,33 +152,33 @@ vrf instance PROD
 !
 ip security
    !
-   ike policy DP-IKE-POLICY
-      local-id 192.168.142.6
-   !
    ike policy CP-IKE-POLICY
       local-id 192.168.142.6
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
+   ike policy DP-IKE-POLICY
+      local-id 192.168.142.6
    !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      ike-policy DP-IKE-POLICY
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      ike-policy DP-IKE-POLICY
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3B.cfg
@@ -163,33 +163,33 @@ vrf instance PROD
 !
 ip security
    !
-   ike policy DP-IKE-POLICY
-      local-id 192.168.142.7
-   !
    ike policy CP-IKE-POLICY
       local-id 192.168.142.7
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
+   ike policy DP-IKE-POLICY
+      local-id 192.168.142.7
    !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      ike-policy DP-IKE-POLICY
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      ike-policy DP-IKE-POLICY
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -257,26 +257,26 @@ ip security
    ike policy CP-IKE-POLICY
       local-id 192.168.143.1
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
-   !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -238,26 +238,26 @@ ip security
    ike policy CP-IKE-POLICY
       local-id 192.168.143.2
    !
-   sa policy DP-SA-POLICY
-      esp encryption aes256gcm128
-      pfs dh-group 14
-   !
    sa policy CP-SA-POLICY
       esp encryption aes256gcm128
       pfs dh-group 14
    !
-   profile DP-PROFILE
-      sa-policy DP-SA-POLICY
-      connection start
-      shared-key 7 ABCDEF1234567890666
-      dpd 10 50 clear
-      mode transport
+   sa policy DP-SA-POLICY
+      esp encryption aes256gcm128
+      pfs dh-group 14
    !
    profile CP-PROFILE
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
       shared-key 7 ABCDEF1234567890
+      dpd 10 50 clear
+      mode transport
+   !
+   profile DP-PROFILE
+      sa-policy DP-SA-POLICY
+      connection start
+      shared-key 7 ABCDEF1234567890666
       dpd 10 50 clear
       mode transport
    !

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-security.j2
@@ -17,7 +17,7 @@
 
 | Policy name | IKE lifetime | Encryption | DH group | Local ID |
 | ----------- | ------------ | ---------- | -------- | -------- |
-{%         for ike_policy in ip_security.ike_policies | arista.avd.default([]) %}
+{%         for ike_policy in ip_security.ike_policies | arista.avd.natural_sort('name') %}
 | {{ ike_policy.name }} | {{ ike_policy.ike_lifetime | arista.avd.default("-") }} | {{ ike_policy.encryption | arista.avd.default("-") }} | {{ ike_policy.dh_group | arista.avd.default("-") }} | {{ ike_policy.local_id_fqdn | arista.avd.default(ike_policy.local_id, "-") }} |
 {%         endfor %}
 {%     endif %}
@@ -27,7 +27,7 @@
 
 | Policy name | ESP Integrity | ESP Encryption | Lifetime | PFS DH Group |
 | ----------- | ------------- | -------------- | -------- | ------------ |
-{%         for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
+{%         for sa_policy in ip_security.sa_policies | arista.avd.natural_sort('name') %}
 {%             if sa_policy.sa_lifetime.value is arista.avd.defined %}
 {%                 set lifetime = sa_policy.sa_lifetime.value ~ " " ~ sa_policy.sa_lifetime.unit | arista.avd.default("hours") %}
 {%             endif %}
@@ -40,7 +40,7 @@
 
 | Profile name | IKE policy | SA policy | Connection | DPD Interval | DPD Time | DPD action | Mode | Flow Parallelization |
 | ------------ | ---------- | ----------| ---------- | ------------ | -------- | ---------- | ---- | -------------------- |
-{%         for profile in ip_security.profiles | arista.avd.default([]) %}
+{%         for profile in ip_security.profiles | arista.avd.natural_sort('name') %}
 {%             set ike_policy = profile.ike_policy | arista.avd.default("-") %}
 {%             set sa_policy = profile.sa_policy | arista.avd.default("-") %}
 {%             set connection = profile.connection | arista.avd.default("-") %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-security.j2
@@ -7,7 +7,7 @@
 {% if ip_security is arista.avd.defined %}
 !
 ip security
-{%     for ike_policy in ip_security.ike_policies | arista.avd.default([]) %}
+{%     for ike_policy in ip_security.ike_policies | arista.avd.natural_sort('name') %}
    !
    ike policy {{ ike_policy.name }}
 {%         if ike_policy.local_id_fqdn is arista.avd.defined %}
@@ -25,7 +25,7 @@ ip security
       dh-group {{ ike_policy.dh_group }}
 {%         endif %}
 {%     endfor %}
-{%     for sa_policy in ip_security.sa_policies | arista.avd.default([]) %}
+{%     for sa_policy in ip_security.sa_policies | arista.avd.natural_sort('name') %}
    !
    sa policy {{ sa_policy.name }}
 {%         if sa_policy.esp.integrity is arista.avd.defined %}
@@ -49,7 +49,7 @@ ip security
       pfs dh-group {{ sa_policy.pfs_dh_group }}
 {%         endif %}
 {%     endfor %}
-{%     for profile in ip_security.profiles | arista.avd.default([]) %}
+{%     for profile in ip_security.profiles | arista.avd.natural_sort('name') %}
    !
    profile {{ profile.name }}
 {%         if profile.ike_policy is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Today these objects are not sorted and so not matching the EOS cli output

## Related Issue(s)

Found in field 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Adding sort for doc and eos template

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
