### PR TITLE
Test(eos_cli_config_gen): Added test in molecule for ip-virtual-router-mac-address to improve the coverage

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-virtual-router-mac-address.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-virtual-router-mac-address.md
@@ -1,0 +1,51 @@
+# ip-virtual-router-mac-address
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Routing](#routing)
+  - [Virtual Router MAC Address](#virtual-router-mac-address)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | Description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## Routing
+
+### Virtual Router MAC Address
+
+#### Virtual Router MAC Address Summary
+
+Virtual Router MAC Address: 00:1c:73:00:dc:01
+
+#### Virtual Router MAC Address Device Configuration
+
+```eos
+!
+ip virtual-router mac-address 00:1c:73:00:dc:01
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-virtual-router-mac-address.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-virtual-router-mac-address.cfg
@@ -1,0 +1,17 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname ip-virtual-router-mac-address
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+ip virtual-router mac-address 00:1c:73:00:dc:01
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-virtual-router-mac-address.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-virtual-router-mac-address.yml
@@ -1,0 +1,2 @@
+### IP Virtual Router MAC Address ###
+ip_virtual_router_mac_address: 00:1c:73:00:dc:01

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -56,6 +56,7 @@ ip-routing-fib
 ip-radius-source-interface
 ip-tacacs-source-interface
 ip-client-source-interfaces
+ip-virtual-router-mac-address
 ipv6-access-lists
 ipv6-dhcp-relay
 ipv6-neighbors


### PR DESCRIPTION
## Change Summary

Added test in molecule for ip-virtual-router-mac-address to improve the coverage

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
There was no test for ip-virtual-router-mac-address option in molecule so added which caused to improved the coverage.

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
