### PR TITLE
Doc(eos_designs): Remove lookup plugin reference for Zscaler IE

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -576,10 +576,12 @@ interface Ethernet3
 An internet-exit policy of type `zscaler` leverages the following AVD data model to generate the target configuration.
 
 AVD supports up to three tunnels (primary, secondary, tertiary).
+AVD `eos_designs` will fetch Zscaler integration information from Cloudvision.
 
 ```yaml
+# Variables used by eos_designs to connect to Cloudvision
 cv_server: <cloudvision_ip>
-cv_token: <cloudvision_token>
+cv_token: <service account token as defined on CloudVision. This value should be using Ansible Vault>
 ```
 
 For each `zscaler` type Internet-policies, AVD uses the `cv_pathinfder_internet_exit_policies[name=<POLICY-NAME>].zscaler` dictionary and the `zscaler_endpoints` in combination with the `l3_interfaces.cv_pathfinder_internet_exit.policies[name=<POLICY-NAME>].tunnel_interface_numbers` to generate the internet-exit configuration.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -580,7 +580,7 @@ AVD `eos_designs` will fetch Zscaler integration information from Cloudvision.
 
 ```yaml
 # Variables used by eos_designs to connect to Cloudvision
-cv_server: <cloudvision_ip>
+cv_server:  <hostname or IP address of CloudVision host. Ex. "www.arista.io" for CVaaS>
 cv_token: <service account token as defined on CloudVision. This value should be using Ansible Vault>
 ```
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -581,6 +581,7 @@ AVD supports up to three tunnels (primary, secondary, tertiary).
 cv_server: <cloudvision_ip>
 cv_token: <cloudvision_token>
 ```
+
 For each `zscaler` type Internet-policies, AVD uses the `cv_pathinfder_internet_exit_policies[name=<POLICY-NAME>].zscaler` dictionary and the `zscaler_endpoints` in combination with the `l3_interfaces.cv_pathfinder_internet_exit.policies[name=<POLICY-NAME>].tunnel_interface_numbers` to generate the internet-exit configuration.
 
 The `cv_pathinfder_internet_exit_policies[name=<POLICY-NAME>].zscaler` dictionary has additonnal options to configure the policy parameters shared with Zscaler through Cloudvision.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -577,17 +577,10 @@ An internet-exit policy of type `zscaler` leverages the following AVD data model
 
 AVD supports up to three tunnels (primary, secondary, tertiary).
 
-The target is for this data to be retrieved from Cloudvision through a lookup plugin for each device to determine what are the best tunnel(s) to use for a given location.
-
 ```yaml
-# Variables used by the lookup plugin to connect to Cloudvision
 cv_server: <cloudvision_ip>
 cv_token: <cloudvision_token>
-
-# Lookup plugin usage
-zscaler_endpoints: "{{ lookup('arista.avd.cv_zscaler_endpoints') }}"
 ```
-
 For each `zscaler` type Internet-policies, AVD uses the `cv_pathinfder_internet_exit_policies[name=<POLICY-NAME>].zscaler` dictionary and the `zscaler_endpoints` in combination with the `l3_interfaces.cv_pathfinder_internet_exit.policies[name=<POLICY-NAME>].tunnel_interface_numbers` to generate the internet-exit configuration.
 
 The `cv_pathinfder_internet_exit_policies[name=<POLICY-NAME>].zscaler` dictionary has additonnal options to configure the policy parameters shared with Zscaler through Cloudvision.


### PR DESCRIPTION
## Change Summary

Doc has not been updated properly for Zcsaler IE Policy - the data is not retrieved using a lookup plugin anymore but fetched during eos_designs run from CVaaS

## Related Issue(s)

Reported by systest

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Remove legacy doc

## How to test

No test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
