### PR TITLE
Refactor(pyavd): Suppress warnings for cryptography >=43.0.0

### DIFF
--- a/python-avd/pyavd/_utils/password_utils/password_utils.py
+++ b/python-avd/pyavd/_utils/password_utils/password_utils.py
@@ -12,7 +12,13 @@ It is used  in the encrypt and decrypt filters
 import base64
 
 from cryptography.hazmat.backends import default_backend
-from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+from cryptography.hazmat.primitives.ciphers import Cipher, modes
+
+# Starting cyryptography 43.0.0, TripleDES cipher has been moved to cryptography.hazmat.decrepit module
+try
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+except ImportError:
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
 
 SEED = b"\xd5\xa8\xc9\x1e\xf5\xd5\x8a\x23"
 
@@ -186,7 +192,7 @@ def cbc_encrypt(key: bytes, data: bytes) -> bytes:
     ciphertext = ENC_SIG + bytes([padding * 16 + 0xE]) + data + bytes(padding)
 
     # Accepting SonarLint issue: The insecure algorithm is ok since this simply matches the algorithm of EOS.
-    cipher = Cipher(algorithms.TripleDES(hashed_key), modes.CBC(bytes(8)), default_backend())  # NOSONAR
+    cipher = Cipher(TripleDES(hashed_key), modes.CBC(bytes(8)), default_backend())  # NOSONAR
     encryptor = cipher.encryptor()
     result = encryptor.update(ciphertext)
     encryptor.finalize()
@@ -213,7 +219,7 @@ def cbc_decrypt(key: bytes, data: bytes) -> bytes:
     hashed_key = hashkey(key)
 
     # Accepting SonarLint issue: Insecure algorithm is ok since this is simply matching the algorithm of EOS.
-    cipher = Cipher(algorithms.TripleDES(hashed_key), modes.CBC(bytes(8)), default_backend())  # NOSONAR
+    cipher = Cipher(TripleDES(hashed_key), modes.CBC(bytes(8)), default_backend())  # NOSONAR
     decryptor = cipher.decryptor()
     result = decryptor.update(data)
     decryptor.finalize()

--- a/python-avd/pyavd/_utils/password_utils/password_utils.py
+++ b/python-avd/pyavd/_utils/password_utils/password_utils.py
@@ -15,7 +15,7 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.ciphers import Cipher, modes
 
 # Starting cyryptography 43.0.0, TripleDES cipher has been moved to cryptography.hazmat.decrepit module
-try
+try:
     from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
 except ImportError:
     from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES


### PR DESCRIPTION
## Change Summary

Forward compatible import of tripleDES algo which was moved starting cryptgraphy version 43.0.0 - https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#4300---2024-07-20

## Related Issue(s)

Reported from field

## Component(s) name

`pyavd`

## Proposed changes

Import from new location and if import error use old location

## How to test

pytest passes

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
