### PR TITLE
Test(eos_cli_config_gen): Added test in molecule for unsafe prompt to improve the coverage

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prompt-2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prompt-2.md
@@ -38,5 +38,5 @@ interface Management1
 
 ```eos
 !
-prompt unsafe
+prompt Test
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prompt-2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/prompt-2.md
@@ -1,0 +1,42 @@
+# prompt-2
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+- [Prompt Device Configuration](#prompt-device-configuration)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | Description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+## Prompt Device Configuration
+
+```eos
+!
+prompt unsafe
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/prompt-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/prompt-2.cfg
@@ -1,0 +1,17 @@
+!RANCID-CONTENT-TYPE: arista
+!
+prompt unsafe
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname prompt-2
+!
+no enable password
+no aaa root
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/prompt-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/prompt-2.cfg
@@ -1,6 +1,6 @@
 !RANCID-CONTENT-TYPE: arista
 !
-prompt unsafe
+prompt Test
 !
 transceiver qsfp default-mode 4x10G
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/prompt-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/prompt-2.yml
@@ -1,0 +1,2 @@
+### Prompt without unsafe for pyavd coverage report
+prompt: unsafe

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/prompt-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/prompt-2.yml
@@ -1,2 +1,2 @@
 ### Prompt without unsafe for pyavd coverage report
-prompt: unsafe
+prompt: Test

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -111,6 +111,7 @@ policy-maps-pbr
 port-channel-interfaces
 prefix-lists
 prompt
+prompt-2
 ptp
 qos
 queue-monitor-length


### PR DESCRIPTION
## Change Summary

Added test in molecule for unsafe prompt to improve the coverage

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added test in molecule for unsafe prompt to improve the pyavd coverage

## How to test
Run molecule and tox

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
