### PR TITLE
CI: Autogenerated comment with steps to test PR - move ansible collections to the venv

### DIFF
--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -31,7 +31,7 @@ jobs:
             source test-avd-pr-${{ github.event.pull_request.number }}/bin/activate
             # Install all requirements including PyAVD
             pip install "pyavd[ansible] @ git+${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.ref }}#subdirectory=python-avd" --force
-            # Point Ansible collection path to the Python virtual environment
+            # Point Ansible collections path to the Python virtual environment
             export ANSIBLE_COLLECTIONS_PATH=$VIRTUAL_ENV/ansible_collections
             # Install Ansible collection
             ansible-galaxy collection install git+${{ github.event.pull_request.head.repo.clone_url }}#/ansible_collections/arista/avd/,${{ github.event.pull_request.head.ref }} --force

--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -31,6 +31,8 @@ jobs:
             source test-avd-pr-${{ github.event.pull_request.number }}/bin/activate
             # Install all requirements including PyAVD
             pip install "pyavd[ansible] @ git+${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.ref }}#subdirectory=python-avd" --force
+            # Point Ansible collection path to the python virtual environment
+            export ANSIBLE_COLLECTIONS_PATH=$VIRTUAL_ENV/ansible_collections
             # Install Ansible collection
             ansible-galaxy collection install git+${{ github.event.pull_request.head.repo.clone_url }}#/ansible_collections/arista/avd/,${{ github.event.pull_request.head.ref }} --force
             # Optional: Install AVD examples

--- a/.github/workflows/pull-request-comment.yml
+++ b/.github/workflows/pull-request-comment.yml
@@ -31,7 +31,7 @@ jobs:
             source test-avd-pr-${{ github.event.pull_request.number }}/bin/activate
             # Install all requirements including PyAVD
             pip install "pyavd[ansible] @ git+${{ github.event.pull_request.head.repo.clone_url }}@${{ github.event.pull_request.head.ref }}#subdirectory=python-avd" --force
-            # Point Ansible collection path to the python virtual environment
+            # Point Ansible collection path to the Python virtual environment
             export ANSIBLE_COLLECTIONS_PATH=$VIRTUAL_ENV/ansible_collections
             # Install Ansible collection
             ansible-galaxy collection install git+${{ github.event.pull_request.head.repo.clone_url }}#/ansible_collections/arista/avd/,${{ github.event.pull_request.head.ref }} --force


### PR DESCRIPTION
## Change Summary

<!-- Added a step to move the ansible collections to within the venv -->

## Related Issue(s)

Fixes #4245 

## Component(s) name

`github actions`

## Proposed changes
<!--- Added a step to set an environment variable to make ansible install collections inside of the venv -->

## How to test
<!--- I ran the steps for PR 4168, but including the lines on this PR. -->
<!--- Tested via WSL1 running Ubuntu -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
