### PR TITLE
Fix: Typo in requirements.txt for PyAVD dev0 version

### DIFF
--- a/ansible_collections/arista/avd/requirements.txt
+++ b/ansible_collections/arista/avd/requirements.txt
@@ -1,3 +1,3 @@
 # PyAVD must follow the exact same version as the Ansible collection.
 # For development this should be installed as an editable install as specified in requirement-dev.txt
-pyavd[ansible-collection]==4.10.0-dev0
+pyavd[ansible-collection]==4.10.0.dev0


### PR DESCRIPTION
Typo in requirements.txt for PyAVD dev0 version

`4.10.0-dev0` should have been `4.10.0.dev0`