### PR TITLE
Feat(eos_cli_config_gen): Enhance DHCP server data model (lease time, reservations, eos_cli)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
@@ -79,6 +79,7 @@ interface Management1
 | Subnet | Name | DNS Servers | Default Gateway | Lease Time | Ranges |
 | ------ | ---- | ----------- | --------------- | ---------- | ------ |
 | 10.0.0.0/24 | TEST1 | 10.1.1.12, 10.1.1.13 | 10.0.0.1 | 0 days, 0 hours, 10 minutes | 10.0.0.10-10.0.0.100, 10.0.0.110-10.0.0.120 |
+| 2001:db8:abcd:1234:c000::/66 | - | - | - | - | - |
 
 ##### IPv4 Vendor Options
 
@@ -125,18 +126,18 @@ dhcp server vrf defaulu
 dhcp server vrf TEST
    lease time ipv4 10 days 10 hours 10 minutes
    dns domain name ipv4 testv4.com
-   lease time ipv4 12 days 12 hours 12 minutes
+   lease time ipv6 12 days 12 hours 12 minutes
    dns domain name ipv6 testv6.com
    !
    subnet 10.0.0.0/24
       reservations
+         mac-address 0001.0001.0001
+            ipv4-address 10.0.0.2
+            hostname host3
+         !
          mac-address 1a1b.1c1d.1e1f
             ipv4-address 10.0.0.1
             hostname host1
-         !
-         mac-address 2a2b.2c2d.2e2f
-            ipv6-address ff06::c3
-            hostname host2
       !
       range 10.0.0.10 10.0.0.100
       !
@@ -145,6 +146,11 @@ dhcp server vrf TEST
       dns server 10.1.1.12 10.1.1.13
       lease time 0 days 0 hours 10 minutes
       default-gateway 10.0.0.1
+   !
+   subnet 2001:db8:abcd:1234:c000::/66
+      reservations
+         mac-address 0003.0003.003
+            ipv6-address 2001:db8:abcd:1234:c000::1
    !
    vendor-option ipv4 NTP
       sub-option 1 type string data "test"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
@@ -40,14 +40,14 @@ interface Management1
 
 ### DHCP Servers Summary
 
-| DHCP Server Enabled | VRF | IPv4 DNS Domain | IPv4 DNS Servers | IPv4 Bootfile | IPv6 DNS Domain | IPv6 DNS Servers | IPv6 Bootfile |
-| ------------------- | --- | --------------- | ---------------- | ------------- | --------------- | ---------------- | ------------- |
-| True | AVRF | - | - | - | - | - | - |
-| True | defauls | - | - | - | - | - | - |
-| True | default | - | 10.0.0.1, 192.168.255.254 | https://www.arista.io/ztp/bootstrap | - | 2001:db8::1, 2001:db8::2 | https://2001:0db8:fe/ztp/bootstrap |
-| True | defaulu | - | - | - | - | - | - |
-| True | TEST | testv4.com | - | - | testv6.com | - | - |
-| False | VRF01 | - | - | - | - | - | - |
+| DHCP Server Enabled | VRF | IPv4 DNS Domain | IPv4 DNS Servers | IPv4 Bootfile | IPv4 Lease Time | IPv6 DNS Domain | IPv6 DNS Servers | IPv6 Bootfile | IPv4 Lease Time |
+| ------------------- | --- | --------------- | ---------------- | ------------- | --------------- | --------------- | ---------------- | ------------- | --------------- |
+| True | AVRF | - | - | - | - | - | - | - | - |
+| True | defauls | - | - | - | - | - | - | - | - |
+| True | default | - | 10.0.0.1, 192.168.255.254 | https://www.arista.io/ztp/bootstrap | - | - | 2001:db8::1, 2001:db8::2 | https://2001:0db8:fe/ztp/bootstrap | - |
+| True | defaulu | - | - | - | - | - | - | - | - |
+| True | TEST | testv4.com | - | - | 10 days 10 hours 10 minutes | testv6.com | - | - | 12 days 12 hours 12 minutes |
+| False | VRF01 | - | - | - | - | - | - | - | - |
 
 #### VRF AVRF DHCP Server
 
@@ -105,6 +105,8 @@ dhcp server vrf AVRF
    !
    subnet 172.16.254.0/24
       default-gateway 172.16.254.1
+   dns server ipv4 10.0.0.1 192.168.255.254
+   client class ipv4 definition Class1
 !
 dhcp server vrf defauls
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
@@ -40,7 +40,7 @@ interface Management1
 
 ### DHCP Servers Summary
 
-| DHCP Server Enabled | VRF | IPv4 DNS Domain | IPv4 DNS Servers | IPv4 Bootfile | IPv4 Lease Time | IPv6 DNS Domain | IPv6 DNS Servers | IPv6 Bootfile | IPv4 Lease Time |
+| DHCP Server Enabled | VRF | IPv4 DNS Domain | IPv4 DNS Servers | IPv4 Bootfile | IPv4 Lease Time | IPv6 DNS Domain | IPv6 DNS Servers | IPv6 Bootfile | IPv6 Lease Time |
 | ------------------- | --- | --------------- | ---------------- | ------------- | --------------- | --------------- | ---------------- | ------------- | --------------- |
 | True | AVRF | - | - | - | - | - | - | - | - |
 | True | defauls | - | - | - | - | - | - | - | - |
@@ -81,14 +81,14 @@ interface Management1
 | 10.0.0.0/24 | TEST1 | 10.1.1.12, 10.1.1.13 | 10.0.0.1 | 0 days, 0 hours, 10 minutes | 10.0.0.10-10.0.0.100, 10.0.0.110-10.0.0.120 |
 | 2001:db8:abcd:1234:c000::/66 | - | - | - | - | - |
 
-###### Reservations for subnet: 10.0.0.0/24
+###### DHCP Reservations in 10.0.0.0/24
 
 | Mac Address | IPv4 Address | IPv6 Address | Hostname |
 | ----------- | ------------ | ------------ | -------- |
 | 0001.0001.0001 | 10.0.0.2 | - |  host3 |
 | 1a1b.1c1d.1e1f | 10.0.0.1 | - |  host1 |
 
-###### Reservations for subnet: 2001:db8:abcd:1234:c000::/66
+###### DHCP Reservations in 2001:db8:abcd:1234:c000::/66
 
 | Mac Address | IPv4 Address | IPv6 Address | Hostname |
 | ----------- | ------------ | ------------ | -------- |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
@@ -81,6 +81,19 @@ interface Management1
 | 10.0.0.0/24 | TEST1 | 10.1.1.12, 10.1.1.13 | 10.0.0.1 | 0 days, 0 hours, 10 minutes | 10.0.0.10-10.0.0.100, 10.0.0.110-10.0.0.120 |
 | 2001:db8:abcd:1234:c000::/66 | - | - | - | - | - |
 
+###### Reservations for subnet: 10.0.0.0/24
+
+| Mac Address | IPv4 Address | IPv6 Address | Hostname |
+| ----------- | ------------ | ------------ | -------- |
+| 0001.0001.0001 | 10.0.0.2 | - |  host3 |
+| 1a1b.1c1d.1e1f | 10.0.0.1 | - |  host1 |
+
+###### Reservations for subnet: 2001:db8:abcd:1234:c000::/66
+
+| Mac Address | IPv4 Address | IPv6 Address | Hostname |
+| ----------- | ------------ | ------------ | -------- |
+| 0003.0003.003 | - | 2001:db8:abcd:1234:c000::1 |  - |
+
 ##### IPv4 Vendor Options
 
 | Vendor ID | Sub-option Code | Sub-option Type | Sub-option Data |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
@@ -123,10 +123,20 @@ dhcp server
 dhcp server vrf defaulu
 !
 dhcp server vrf TEST
+   lease time ipv4 10 days 10 hours 10 minutes
    dns domain name ipv4 testv4.com
+   lease time ipv4 12 days 12 hours 12 minutes
    dns domain name ipv6 testv6.com
    !
    subnet 10.0.0.0/24
+      reservations
+         mac-address 1a1b.1c1d.1e1f
+            ipv4-address 10.0.0.1
+            hostname host1
+         !
+         mac-address 2a2b.2c2d.2e2f
+            ipv6-address ff06::c3
+            hostname host2
       !
       range 10.0.0.10 10.0.0.100
       !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/dhcp-servers.md
@@ -81,14 +81,14 @@ interface Management1
 | 10.0.0.0/24 | TEST1 | 10.1.1.12, 10.1.1.13 | 10.0.0.1 | 0 days, 0 hours, 10 minutes | 10.0.0.10-10.0.0.100, 10.0.0.110-10.0.0.120 |
 | 2001:db8:abcd:1234:c000::/66 | - | - | - | - | - |
 
-###### DHCP Reservations in 10.0.0.0/24
+###### DHCP Reservations in subnet 10.0.0.0/24
 
 | Mac Address | IPv4 Address | IPv6 Address | Hostname |
 | ----------- | ------------ | ------------ | -------- |
 | 0001.0001.0001 | 10.0.0.2 | - |  host3 |
 | 1a1b.1c1d.1e1f | 10.0.0.1 | - |  host1 |
 
-###### DHCP Reservations in 2001:db8:abcd:1234:c000::/66
+###### DHCP Reservations in subnet 2001:db8:abcd:1234:c000::/66
 
 | Mac Address | IPv4 Address | IPv6 Address | Hostname |
 | ----------- | ------------ | ------------ | -------- |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-servers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-servers.cfg
@@ -23,10 +23,20 @@ dhcp server
 dhcp server vrf defaulu
 !
 dhcp server vrf TEST
+   lease time ipv4 10 days 10 hours 10 minutes
    dns domain name ipv4 testv4.com
+   lease time ipv4 12 days 12 hours 12 minutes
    dns domain name ipv6 testv6.com
    !
    subnet 10.0.0.0/24
+      reservations
+         mac-address 1a1b.1c1d.1e1f
+            ipv4-address 10.0.0.1
+            hostname host1
+         !
+         mac-address 2a2b.2c2d.2e2f
+            ipv6-address ff06::c3
+            hostname host2
       !
       range 10.0.0.10 10.0.0.100
       !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-servers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-servers.cfg
@@ -25,18 +25,18 @@ dhcp server vrf defaulu
 dhcp server vrf TEST
    lease time ipv4 10 days 10 hours 10 minutes
    dns domain name ipv4 testv4.com
-   lease time ipv4 12 days 12 hours 12 minutes
+   lease time ipv6 12 days 12 hours 12 minutes
    dns domain name ipv6 testv6.com
    !
    subnet 10.0.0.0/24
       reservations
+         mac-address 0001.0001.0001
+            ipv4-address 10.0.0.2
+            hostname host3
+         !
          mac-address 1a1b.1c1d.1e1f
             ipv4-address 10.0.0.1
             hostname host1
-         !
-         mac-address 2a2b.2c2d.2e2f
-            ipv6-address ff06::c3
-            hostname host2
       !
       range 10.0.0.10 10.0.0.100
       !
@@ -45,6 +45,11 @@ dhcp server vrf TEST
       dns server 10.1.1.12 10.1.1.13
       lease time 0 days 0 hours 10 minutes
       default-gateway 10.0.0.1
+   !
+   subnet 2001:db8:abcd:1234:c000::/66
+      reservations
+         mac-address 0003.0003.003
+            ipv6-address 2001:db8:abcd:1234:c000::1
    !
    vendor-option ipv4 NTP
       sub-option 1 type string data "test"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-servers.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/dhcp-servers.cfg
@@ -4,6 +4,8 @@ dhcp server vrf AVRF
    !
    subnet 172.16.254.0/24
       default-gateway 172.16.254.1
+   dns server ipv4 10.0.0.1 192.168.255.254
+   client class ipv4 definition Class1
 !
 dhcp server vrf defauls
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-servers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-servers.yml
@@ -12,6 +12,14 @@ dhcp_servers:
           - code: 66
             array_ipv4_address: [1.1.1.1, 2.2.2.2]
     disabled: false
+    lease_time_ipv4:
+      days: 10
+      hours: 10
+      minutes: 10
+    lease_time_ipv6:
+      days: 12
+      hours: 12
+      minutes: 12
     dns_domain_name_ipv4: testv4.com
     dns_domain_name_ipv6: testv6.com
     subnets:
@@ -30,7 +38,13 @@ dhcp_servers:
           hours: 0
           minutes: 10
         default_gateway: 10.0.0.1
-
+        reservations:
+          - mac_address: 1a1b.1c1d.1e1f
+            hostname: host1
+            ipv4_address: 10.0.0.1
+          - mac_address: 2a2b.2c2d.2e2f
+            hostname: host2
+            ipv6_address: ff06::c3
   - vrf: default
     dns_servers_ipv4:
       - 10.0.0.1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-servers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-servers.yml
@@ -42,9 +42,14 @@ dhcp_servers:
           - mac_address: 1a1b.1c1d.1e1f
             hostname: host1
             ipv4_address: 10.0.0.1
-          - mac_address: 2a2b.2c2d.2e2f
-            hostname: host2
-            ipv6_address: ff06::c3
+          - mac_address: 0001.0001.0001
+            hostname: host3
+            ipv4_address: 10.0.0.2
+      - subnet: 2001:db8:abcd:1234:c000::/66 
+        reservations:
+          - mac_address: 0003.0003.003
+            ipv6_address: 2001:db8:abcd:1234:c000::1
+
   - vrf: default
     dns_servers_ipv4:
       - 10.0.0.1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-servers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-servers.yml
@@ -45,7 +45,7 @@ dhcp_servers:
           - mac_address: 0001.0001.0001
             hostname: host3
             ipv4_address: 10.0.0.2
-      - subnet: 2001:db8:abcd:1234:c000::/66 
+      - subnet: 2001:db8:abcd:1234:c000::/66
         reservations:
           - mac_address: 0003.0003.003
             ipv6_address: 2001:db8:abcd:1234:c000::1
@@ -78,3 +78,6 @@ dhcp_servers:
     subnets:
       - subnet: 172.16.254.0/24
         default_gateway: 172.16.254.1
+    eos_cli: |-
+      dns server ipv4 10.0.0.1 192.168.255.254
+      client class ipv4 definition Class1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-servers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/dhcp-servers.yml
@@ -11,6 +11,7 @@ dhcp_servers:
             string: "test"
           - code: 66
             array_ipv4_address: [1.1.1.1, 2.2.2.2]
+          - code: 70
     disabled: false
     lease_time_ipv4:
       days: 10

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
@@ -10,6 +10,14 @@
     | [<samp>dhcp_servers</samp>](## "dhcp_servers") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;disabled</samp>](## "dhcp_servers.[].disabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "dhcp_servers.[].vrf") | String | Required, Unique |  |  | VRF in which to configure the DHCP server, use `default` to indicate default VRF. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lease_time_ipv4</samp>](## "dhcp_servers.[].lease_time_ipv4") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;days</samp>](## "dhcp_servers.[].lease_time_ipv4.days") | Integer |  |  | Min: 0<br>Max: 2000 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hours</samp>](## "dhcp_servers.[].lease_time_ipv4.hours") | Integer |  |  | Min: 0<br>Max: 23 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minutes</samp>](## "dhcp_servers.[].lease_time_ipv4.minutes") | Integer |  |  | Min: 0<br>Max: 59 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lease_time_ipv6</samp>](## "dhcp_servers.[].lease_time_ipv6") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;days</samp>](## "dhcp_servers.[].lease_time_ipv6.days") | Integer |  |  | Min: 0<br>Max: 2000 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hours</samp>](## "dhcp_servers.[].lease_time_ipv6.hours") | Integer |  |  | Min: 0<br>Max: 23 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minutes</samp>](## "dhcp_servers.[].lease_time_ipv6.minutes") | Integer |  |  | Min: 0<br>Max: 59 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dns_domain_name_ipv4</samp>](## "dhcp_servers.[].dns_domain_name_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dns_domain_name_ipv6</samp>](## "dhcp_servers.[].dns_domain_name_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dns_servers_ipv4</samp>](## "dhcp_servers.[].dns_servers_ipv4") | List, items: String |  |  | Min Length: 1 | List of DNS servers for IPv4 clients. |
@@ -28,7 +36,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;array_ipv4_address</samp>](## "dhcp_servers.[].ipv4_vendor_options.[].sub_options.[].array_ipv4_address") | List, items: String |  |  |  | Array of IPv4 addresses for suboption data.<br>Only one of `string`, `ipv4_address` and `array_ipv4_address` variables should be used for any one suboption.<br>The order of precedence if multiple of these variables are defined is `string` -> `ipv4_address` -> `array_ipv4_address`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "dhcp_servers.[].ipv4_vendor_options.[].sub_options.[].array_ipv4_address.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;subnets</samp>](## "dhcp_servers.[].subnets") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;subnet</samp>](## "dhcp_servers.[].subnets.[].subnet") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;subnet</samp>](## "dhcp_servers.[].subnets.[].subnet") | String | Required, Unique |  |  | IPv4/IPv6 subnet. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "dhcp_servers.[].subnets.[].name") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;default_gateway</samp>](## "dhcp_servers.[].subnets.[].default_gateway") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dns_servers</samp>](## "dhcp_servers.[].subnets.[].dns_servers") | List, items: String |  |  |  |  |
@@ -40,6 +48,12 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;days</samp>](## "dhcp_servers.[].subnets.[].lease_time.days") | Integer | Required |  | Min: 0<br>Max: 2000 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hours</samp>](## "dhcp_servers.[].subnets.[].lease_time.hours") | Integer | Required |  | Min: 0<br>Max: 23 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minutes</samp>](## "dhcp_servers.[].subnets.[].lease_time.minutes") | Integer | Required |  | Min: 0<br>Max: 59 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reservations</samp>](## "dhcp_servers.[].subnets.[].reservations") | List, items: Dictionary |  |  |  | DHCP client reservations. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;mac_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].mac_address") | String | Required, Unique |  |  | Ethernet address in format - H.H.H |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hostname</samp>](## "dhcp_servers.[].subnets.[].reservations.[].hostname") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv4_address") | String |  |  |  | This setting can be configured only when the subnet is ipv4. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv6_address") | String |  |  |  | This setting can be configured only when the subnet is ipv6. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "dhcp_servers.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration. |
 
 === "YAML"
 
@@ -49,6 +63,14 @@
 
         # VRF in which to configure the DHCP server, use `default` to indicate default VRF.
         vrf: <str; required; unique>
+        lease_time_ipv4:
+          days: <int; 0-2000>
+          hours: <int; 0-23>
+          minutes: <int; 0-59>
+        lease_time_ipv6:
+          days: <int; 0-2000>
+          hours: <int; 0-23>
+          minutes: <int; 0-59>
         dns_domain_name_ipv4: <str>
         dns_domain_name_ipv6: <str>
 
@@ -91,6 +113,8 @@
                 array_ipv4_address:
                   - <str>
         subnets:
+
+            # IPv4/IPv6 subnet.
           - subnet: <str; required; unique>
             name: <str>
             default_gateway: <str>
@@ -103,4 +127,20 @@
               days: <int; 0-2000; required>
               hours: <int; 0-23; required>
               minutes: <int; 0-59; required>
+
+            # DHCP client reservations.
+            reservations:
+
+                # Ethernet address in format - H.H.H
+              - mac_address: <str; required; unique>
+                hostname: <str>
+
+                # This setting can be configured only when the subnet is ipv4.
+                ipv4_address: <str>
+
+                # This setting can be configured only when the subnet is ipv6.
+                ipv6_address: <str>
+
+        # Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.
+        eos_cli: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
@@ -51,8 +51,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reservations</samp>](## "dhcp_servers.[].subnets.[].reservations") | List, items: Dictionary |  |  |  | DHCP client reservations. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;mac_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].mac_address") | String | Required, Unique |  |  | Ethernet address in format - HHHH.HHHH.HHHH |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hostname</samp>](## "dhcp_servers.[].subnets.[].reservations.[].hostname") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv4_address") | String |  |  |  | Valid IPv4 address from given subnet.<br>This setting can be configured only when the subnet is IPv4. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv6_address") | String |  |  |  | Valid IPv6 address from given subnet.<br>This setting can be configured only when the subnet is IPv6. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv4_address") | String |  |  |  | Valid IPv4 address from the given subnet.<br>This setting can only be configured when the subnet is IPv4. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv6_address") | String |  |  |  | Valid IPv6 address from the given subnet.<br>This setting can only be configured when the subnet is IPv6. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "dhcp_servers.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration. |
 
 === "YAML"
@@ -135,12 +135,12 @@
               - mac_address: <str; required; unique>
                 hostname: <str>
 
-                # Valid IPv4 address from given subnet.
-                # This setting can be configured only when the subnet is IPv4.
+                # Valid IPv4 address from the given subnet.
+                # This setting can only be configured when the subnet is IPv4.
                 ipv4_address: <str>
 
-                # Valid IPv6 address from given subnet.
-                # This setting can be configured only when the subnet is IPv6.
+                # Valid IPv6 address from the given subnet.
+                # This setting can only be configured when the subnet is IPv6.
                 ipv6_address: <str>
 
         # Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
@@ -49,10 +49,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hours</samp>](## "dhcp_servers.[].subnets.[].lease_time.hours") | Integer | Required |  | Min: 0<br>Max: 23 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minutes</samp>](## "dhcp_servers.[].subnets.[].lease_time.minutes") | Integer | Required |  | Min: 0<br>Max: 59 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reservations</samp>](## "dhcp_servers.[].subnets.[].reservations") | List, items: Dictionary |  |  |  | DHCP client reservations. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;mac_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].mac_address") | String | Required, Unique |  |  | Ethernet address in format - H.H.H |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;mac_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].mac_address") | String | Required, Unique |  |  | Ethernet address in format - HHHH.HHHH.HHHH |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hostname</samp>](## "dhcp_servers.[].subnets.[].reservations.[].hostname") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv4_address") | String |  |  |  | This setting can be configured only when the subnet is ipv4. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv6_address") | String |  |  |  | This setting can be configured only when the subnet is ipv6. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv4_address") | String |  |  |  | Valid IPv4 address from given subnet.<br>This setting can be configured only when the subnet is IPv4. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv6_address") | String |  |  |  | Valid IPv6 address from given subnet.<br>This setting can be configured only when the subnet is IPv6. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "dhcp_servers.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration. |
 
 === "YAML"
@@ -131,14 +131,16 @@
             # DHCP client reservations.
             reservations:
 
-                # Ethernet address in format - H.H.H
+                # Ethernet address in format - HHHH.HHHH.HHHH
               - mac_address: <str; required; unique>
                 hostname: <str>
 
-                # This setting can be configured only when the subnet is ipv4.
+                # Valid IPv4 address from given subnet.
+                # This setting can be configured only when the subnet is IPv4.
                 ipv4_address: <str>
 
-                # This setting can be configured only when the subnet is ipv6.
+                # Valid IPv6 address from given subnet.
+                # This setting can be configured only when the subnet is IPv6.
                 ipv6_address: <str>
 
         # Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
@@ -51,8 +51,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;reservations</samp>](## "dhcp_servers.[].subnets.[].reservations") | List, items: Dictionary |  |  |  | DHCP client reservations. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;mac_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].mac_address") | String | Required, Unique |  |  | Ethernet address in format - HHHH.HHHH.HHHH |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hostname</samp>](## "dhcp_servers.[].subnets.[].reservations.[].hostname") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv4_address") | String |  |  |  | Valid IPv4 address from the given subnet.<br>This setting can only be configured when the subnet is IPv4. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv6_address") | String |  |  |  | Valid IPv6 address from the given subnet.<br>This setting can only be configured when the subnet is IPv6. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv4_address") | String |  |  |  | Valid IPv4 address from the given subnet.<br>This should only be used within an IPv4 subnet. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "dhcp_servers.[].subnets.[].reservations.[].ipv6_address") | String |  |  |  | Valid IPv6 address from the given subnet.<br>This should only be used within an IPv6 subnet. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "dhcp_servers.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration. |
 
 === "YAML"
@@ -136,11 +136,11 @@
                 hostname: <str>
 
                 # Valid IPv4 address from the given subnet.
-                # This setting can only be configured when the subnet is IPv4.
+                # This should only be used within an IPv4 subnet.
                 ipv4_address: <str>
 
                 # Valid IPv6 address from the given subnet.
-                # This setting can only be configured when the subnet is IPv6.
+                # This should only be used within an IPv6 subnet.
                 ipv6_address: <str>
 
         # Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dhcp-servers.md
@@ -11,13 +11,13 @@
     | [<samp>&nbsp;&nbsp;-&nbsp;disabled</samp>](## "dhcp_servers.[].disabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "dhcp_servers.[].vrf") | String | Required, Unique |  |  | VRF in which to configure the DHCP server, use `default` to indicate default VRF. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lease_time_ipv4</samp>](## "dhcp_servers.[].lease_time_ipv4") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;days</samp>](## "dhcp_servers.[].lease_time_ipv4.days") | Integer |  |  | Min: 0<br>Max: 2000 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hours</samp>](## "dhcp_servers.[].lease_time_ipv4.hours") | Integer |  |  | Min: 0<br>Max: 23 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minutes</samp>](## "dhcp_servers.[].lease_time_ipv4.minutes") | Integer |  |  | Min: 0<br>Max: 59 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;days</samp>](## "dhcp_servers.[].lease_time_ipv4.days") | Integer | Required |  | Min: 0<br>Max: 2000 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hours</samp>](## "dhcp_servers.[].lease_time_ipv4.hours") | Integer | Required |  | Min: 0<br>Max: 23 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minutes</samp>](## "dhcp_servers.[].lease_time_ipv4.minutes") | Integer | Required |  | Min: 0<br>Max: 59 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;lease_time_ipv6</samp>](## "dhcp_servers.[].lease_time_ipv6") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;days</samp>](## "dhcp_servers.[].lease_time_ipv6.days") | Integer |  |  | Min: 0<br>Max: 2000 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hours</samp>](## "dhcp_servers.[].lease_time_ipv6.hours") | Integer |  |  | Min: 0<br>Max: 23 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minutes</samp>](## "dhcp_servers.[].lease_time_ipv6.minutes") | Integer |  |  | Min: 0<br>Max: 59 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;days</samp>](## "dhcp_servers.[].lease_time_ipv6.days") | Integer | Required |  | Min: 0<br>Max: 2000 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hours</samp>](## "dhcp_servers.[].lease_time_ipv6.hours") | Integer | Required |  | Min: 0<br>Max: 23 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;minutes</samp>](## "dhcp_servers.[].lease_time_ipv6.minutes") | Integer | Required |  | Min: 0<br>Max: 59 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dns_domain_name_ipv4</samp>](## "dhcp_servers.[].dns_domain_name_ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dns_domain_name_ipv6</samp>](## "dhcp_servers.[].dns_domain_name_ipv6") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dns_servers_ipv4</samp>](## "dhcp_servers.[].dns_servers_ipv4") | List, items: String |  |  | Min Length: 1 | List of DNS servers for IPv4 clients. |
@@ -64,13 +64,13 @@
         # VRF in which to configure the DHCP server, use `default` to indicate default VRF.
         vrf: <str; required; unique>
         lease_time_ipv4:
-          days: <int; 0-2000>
-          hours: <int; 0-23>
-          minutes: <int; 0-59>
+          days: <int; 0-2000; required>
+          hours: <int; 0-23; required>
+          minutes: <int; 0-59; required>
         lease_time_ipv6:
-          days: <int; 0-2000>
-          hours: <int; 0-23>
-          minutes: <int; 0-59>
+          days: <int; 0-2000; required>
+          hours: <int; 0-23; required>
+          minutes: <int; 0-59; required>
         dns_domain_name_ipv4: <str>
         dns_domain_name_ipv6: <str>
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -80,7 +80,7 @@
 {%                     for subnet in dhcp_server.subnets | arista.avd.natural_sort %}
 {%                         if subnet.reservations is arista.avd.defined %}
 
-###### DHCP Reservations in {{ subnet.subnet }}
+###### DHCP Reservations in subnet {{ subnet.subnet }}
 
 | Mac Address | IPv4 Address | IPv6 Address | Hostname |
 | ----------- | ------------ | ------------ | -------- |

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -17,7 +17,7 @@
 
 ### DHCP Servers Summary
 
-| DHCP Server Enabled | VRF | IPv4 DNS Domain | IPv4 DNS Servers | IPv4 Bootfile | IPv4 Lease Time | IPv6 DNS Domain | IPv6 DNS Servers | IPv6 Bootfile | IPv4 Lease Time |
+| DHCP Server Enabled | VRF | IPv4 DNS Domain | IPv4 DNS Servers | IPv4 Bootfile | IPv4 Lease Time | IPv6 DNS Domain | IPv6 DNS Servers | IPv6 Bootfile | IPv6 Lease Time |
 | ------------------- | --- | --------------- | ---------------- | ------------- | --------------- | --------------- | ---------------- | ------------- | --------------- |
 {%         for dhcp_server in dhcp_servers | arista.avd.natural_sort("vrf") %}
 {%             set enabled = not dhcp_server.disabled | arista.avd.default(false) %}
@@ -80,7 +80,7 @@
 {%                     for subnet in dhcp_server.subnets | arista.avd.natural_sort %}
 {%                         if subnet.reservations is arista.avd.defined %}
 
-###### Reservations for subnet: {{ subnet.subnet }}
+###### DHCP Reservations in {{ subnet.subnet }}
 
 | Mac Address | IPv4 Address | IPv6 Address | Hostname |
 | ----------- | ------------ | ------------ | -------- |

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -17,24 +17,36 @@
 
 ### DHCP Servers Summary
 
-| DHCP Server Enabled | VRF | IPv4 DNS Domain | IPv4 DNS Servers | IPv4 Bootfile | IPv6 DNS Domain | IPv6 DNS Servers | IPv6 Bootfile |
-| ------------------- | --- | --------------- | ---------------- | ------------- | --------------- | ---------------- | ------------- |
+| DHCP Server Enabled | VRF | IPv4 DNS Domain | IPv4 DNS Servers | IPv4 Bootfile | IPv4 Lease Time | IPv6 DNS Domain | IPv6 DNS Servers | IPv6 Bootfile | IPv4 Lease Time |
+| ------------------- | --- | --------------- | ---------------- | ------------- | --------------- | --------------- | ---------------- | ------------- | --------------- |
 {%         for dhcp_server in dhcp_servers | arista.avd.natural_sort("vrf") %}
 {%             set enabled = not dhcp_server.disabled | arista.avd.default(false) %}
 {%             set dns_domain_ipv4 = dhcp_server.dns_domain_name_ipv4 | arista.avd.default("-") %}
 {%             set dns_servers_ipv4 = dhcp_server.dns_servers_ipv4 | arista.avd.default(["-"]) | join(", ") %}
 {%             set tftp_server_file_ipv4 = dhcp_server.tftp_server.file_ipv4 | arista.avd.default("-") %}
+{%             if dhcp_server.lease_time_ipv4.days is arista.avd.defined
+                and dhcp_server.lease_time_ipv4.hours is arista.avd.defined
+                and dhcp_server.lease_time_ipv4.minutes is arista.avd.defined %}
+{%                 set lease_time_ipv4 = dhcp_server.lease_time_ipv4.days ~ " days " ~ dhcp_server.lease_time_ipv4.hours ~ " hours " ~ dhcp_server.lease_time_ipv4.minutes ~ " minutes" %}
+{%             endif %}
 {%             set dns_domain_ipv6 = dhcp_server.dns_domain_name_ipv6 | arista.avd.default("-") %}
 {%             set dns_servers_ipv6 = dhcp_server.dns_servers_ipv6 | arista.avd.default(["-"]) | join(", ") %}
 {%             set tftp_server_file_ipv6 = dhcp_server.tftp_server.file_ipv6 | arista.avd.default("-") %}
-| {{ enabled }} | {{ dhcp_server.vrf }} | {{ dns_domain_ipv4 }} | {{ dns_servers_ipv4 }} | {{ tftp_server_file_ipv4 }} | {{ dns_domain_ipv6 }} | {{ dns_servers_ipv6 }} | {{ tftp_server_file_ipv6 }} |
+{%             if dhcp_server.lease_time_ipv6.days is arista.avd.defined
+                and dhcp_server.lease_time_ipv6.hours is arista.avd.defined
+                and dhcp_server.lease_time_ipv6.minutes is arista.avd.defined %}
+{%                 set lease_time_ipv6 = dhcp_server.lease_time_ipv6.days ~ " days " ~ dhcp_server.lease_time_ipv6.hours ~ " hours " ~ dhcp_server.lease_time_ipv6.minutes ~ " minutes" %}
+{%             endif %}
+| {{ enabled }} | {{ dhcp_server.vrf }} | {{ dns_domain_ipv4 }} | {{ dns_servers_ipv4 }} | {{ tftp_server_file_ipv4 }} | {{ lease_time_ipv4 | arista.avd.default("-") }} | {{ dns_domain_ipv6 }} | {{ dns_servers_ipv6 }} | {{ tftp_server_file_ipv6 }} | {{ lease_time_ipv6 | arista.avd.default("-") }} |
 {%         endfor %}
 {%         for dhcp_server in dhcp_servers | arista.avd.natural_sort("vrf") %}
 {%             set dhcp_server_subnets = [] %}
 {%             set dhcp_vendor_options = [] %}
 {%             for subnet in dhcp_server.subnets | arista.avd.natural_sort %}
 {%                 set subnet_dns_servers = subnet.dns_servers | arista.avd.default(["-"]) | join(", ") %}
-{%                 if subnet.lease_time is arista.avd.defined %}
+{%                 if subnet.lease_time.days is arista.avd.defined
+                    and subnet.lease_time.hours is arista.avd.defined
+                    and subnet.lease_time.minutes is arista.avd.defined %}
 {%                     set subnet_lease_time = subnet.lease_time.days ~ " days, " ~ subnet.lease_time.hours ~ " hours, " ~ subnet.lease_time.minutes ~ " minutes" %}
 {%                 else %}
 {%                     set subnet_lease_time = "-" %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -77,6 +77,18 @@
 {%                     for subnet in dhcp_server_subnets %}
 | {{ subnet.subnet }} | {{ subnet.name | arista.avd.default("-") }} | {{ subnet.dns_servers }} | {{ subnet.default_gateway }} | {{ subnet.lease_time }} | {{ subnet.ranges }} |
 {%                     endfor %}
+{%                     for subnet in dhcp_server.subnets | arista.avd.natural_sort %}
+{%                         if subnet.reservations is arista.avd.defined %}
+
+###### Reservations for subnet: {{ subnet.subnet }}
+
+| Mac Address | IPv4 Address | IPv6 Address | Hostname |
+| ----------- | ------------ | ------------ | -------- |
+{%                             for reservation in subnet.reservations | arista.avd.natural_sort("mac_address") %}
+| {{ reservation.mac_address }} | {{ reservation.ipv4_address | arista.avd.default("-") }} | {{ reservation.ipv6_address | arista.avd.default("-") }} |  {{ reservation.hostname | arista.avd.default("-") }} |
+{%                             endfor %}
+{%                         endif %}
+{%                     endfor %}
 {%                 endif %}
 {%                 if dhcp_vendor_options | length > 0 %}
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-device-documentation.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-device-documentation.j2
@@ -28,7 +28,7 @@
 {# DHCP Relay #}
 {% include 'documentation/dhcp-relay.j2' %}
 {# DHCP Servers #}
-{% include 'documentation/dhcp-server.j2' %}
+{% include 'documentation/dhcp-servers.j2' %}
 {# System Boot Configuration #}
 {% include 'documentation/boot.j2' %}
 {# Monitoring #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dhcp-servers.j2
@@ -73,7 +73,9 @@
 {%             if subnet.dns_servers is arista.avd.defined %}
       dns server {{ subnet.dns_servers | join(" ") }}
 {%             endif %}
-{%             if subnet.lease_time is arista.avd.defined %}
+{%             if subnet.lease_time.days is arista.avd.defined
+                and subnet.lease_time.hours is arista.avd.defined
+                and subnet.lease_time.minutes is arista.avd.defined %}
       lease time {{ subnet.lease_time.days }} days {{ subnet.lease_time.hours }} hours {{ subnet.lease_time.minutes }} minutes
 {%             endif %}
 {%             if subnet.default_gateway is arista.avd.defined %}
@@ -96,5 +98,8 @@
 {%                 endif %}
 {%             endfor %}
 {%         endfor %}
+{%         if dhcp_server.eos_cli is arista.avd.defined %}
+   {{ dhcp_server.eos_cli | indent(3, false) }}
+{%         endif %}
 {%     endfor %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dhcp-servers.j2
@@ -88,15 +88,13 @@
 {%         for option in dhcp_server.ipv4_vendor_options | arista.avd.natural_sort("vendor_id") %}
    !
    vendor-option ipv4 {{ option.vendor_id }}
-{%             for sub_option in option.sub_options | arista.avd.natural_sort %}
-{%                 if sub_option.code is arista.avd.defined %}
-{%                     if sub_option.string is arista.avd.defined %}
+{%             for sub_option in option.sub_options | arista.avd.natural_sort("code") %}
+{%                 if sub_option.string is arista.avd.defined %}
       sub-option {{ sub_option.code }} type string data "{{ sub_option.string }}"
-{%                     elif sub_option.ipv4_address is arista.avd.defined %}
+{%                 elif sub_option.ipv4_address is arista.avd.defined %}
       sub-option {{ sub_option.code }} type ipv4-address data {{ sub_option.ipv4_address }}
-{%                     elif sub_option.array_ipv4_address is arista.avd.defined %}
+{%                 elif sub_option.array_ipv4_address is arista.avd.defined %}
       sub-option {{ sub_option.code }} type array ipv4-address data {{ sub_option.array_ipv4_address | join(" ") }}
-{%                     endif %}
 {%                 endif %}
 {%             endfor %}
 {%         endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dhcp-servers.j2
@@ -89,12 +89,14 @@
    !
    vendor-option ipv4 {{ option.vendor_id }}
 {%             for sub_option in option.sub_options | arista.avd.natural_sort %}
-{%                 if sub_option.string is arista.avd.defined %}
+{%                 if sub_option.code is arista.avd.defined %}
+{%                     if sub_option.string is arista.avd.defined %}
       sub-option {{ sub_option.code }} type string data "{{ sub_option.string }}"
-{%                 elif sub_option.ipv4_address is arista.avd.defined %}
+{%                     elif sub_option.ipv4_address is arista.avd.defined %}
       sub-option {{ sub_option.code }} type ipv4-address data {{ sub_option.ipv4_address }}
-{%                 elif sub_option.array_ipv4_address is arista.avd.defined %}
+{%                     elif sub_option.array_ipv4_address is arista.avd.defined %}
       sub-option {{ sub_option.code }} type array ipv4-address data {{ sub_option.array_ipv4_address | join(" ") }}
+{%                     endif %}
 {%                 endif %}
 {%             endfor %}
 {%         endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dhcp-servers.j2
@@ -12,8 +12,18 @@
 {%         endif %}
 !
 {{ server_cli }}
+{%         if dhcp_server.lease_time_ipv4.days is arista.avd.defined
+            and dhcp_server.lease_time_ipv4.hours is arista.avd.defined
+            and dhcp_server.lease_time_ipv4.minutes is arista.avd.defined %}
+   lease time ipv4 {{ dhcp_server.lease_time_ipv4.days }} days {{ dhcp_server.lease_time_ipv4.hours }} hours {{ dhcp_server.lease_time_ipv4.minutes }} minutes
+{%         endif %}
 {%         if dhcp_server.dns_domain_name_ipv4 is arista.avd.defined %}
    dns domain name ipv4 {{ dhcp_server.dns_domain_name_ipv4 }}
+{%         endif %}
+{%         if dhcp_server.lease_time_ipv6.days is arista.avd.defined
+            and dhcp_server.lease_time_ipv6.hours is arista.avd.defined
+            and dhcp_server.lease_time_ipv6.minutes is arista.avd.defined %}
+   lease time ipv6 {{ dhcp_server.lease_time_ipv6.days }} days {{ dhcp_server.lease_time_ipv6.hours }} hours {{ dhcp_server.lease_time_ipv6.minutes }} minutes
 {%         endif %}
 {%         if dhcp_server.dns_domain_name_ipv6 is arista.avd.defined %}
    dns domain name ipv6 {{ dhcp_server.dns_domain_name_ipv6 }}
@@ -33,6 +43,26 @@
 {%         for subnet in dhcp_server.subnets | arista.avd.natural_sort %}
    !
    subnet {{ subnet.subnet }}
+{%             if subnet.reservations is arista.avd.defined %}
+      reservations
+{%                 for reservation in subnet.reservations | arista.avd.natural_sort("mac_address") %}
+{%                     if reservation.mac_address is arista.avd.defined %}
+         mac-address {{ reservation.mac_address }}
+{%                         if reservation.ipv4_address is arista.avd.defined %}
+            ipv4-address {{ reservation.ipv4_address }}
+{%                         endif %}
+{%                         if reservation.ipv6_address is arista.avd.defined %}
+            ipv6-address {{ reservation.ipv6_address }}
+{%                         endif %}
+{%                         if reservation.hostname is arista.avd.defined %}
+            hostname {{ reservation.hostname }}
+{%                         endif %}
+{%                     endif %}
+{%                     if not loop.last %}
+         !
+{%                     endif %}
+{%                 endfor %}
+{%             endif %}
 {%             for range in subnet.ranges | arista.avd.natural_sort("end") | arista.avd.natural_sort("start") %}
       !
       range {{ range.start }} {{ range.end }}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -2024,6 +2024,11 @@
                 "title": "Minutes"
               }
             },
+            "required": [
+              "days",
+              "hours",
+              "minutes"
+            ],
             "additionalProperties": false,
             "patternProperties": {
               "^_.+$": {}
@@ -2052,6 +2057,11 @@
                 "title": "Minutes"
               }
             },
+            "required": [
+              "days",
+              "hours",
+              "minutes"
+            ],
             "additionalProperties": false,
             "patternProperties": {
               "^_.+$": {}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -2002,6 +2002,62 @@
             "description": "VRF in which to configure the DHCP server, use `default` to indicate default VRF.",
             "title": "VRF"
           },
+          "lease_time_ipv4": {
+            "type": "object",
+            "properties": {
+              "days": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 2000,
+                "title": "Days"
+              },
+              "hours": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 23,
+                "title": "Hours"
+              },
+              "minutes": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 59,
+                "title": "Minutes"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Lease Time IPv4"
+          },
+          "lease_time_ipv6": {
+            "type": "object",
+            "properties": {
+              "days": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 2000,
+                "title": "Days"
+              },
+              "hours": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 23,
+                "title": "Hours"
+              },
+              "minutes": {
+                "type": "integer",
+                "minimum": 0,
+                "maximum": 59,
+                "title": "Minutes"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Lease Time IPv6"
+          },
           "dns_domain_name_ipv4": {
             "type": "string",
             "title": "DNS Domain Name IPv4"
@@ -2120,6 +2176,7 @@
               "type": "object",
               "properties": {
                 "subnet": {
+                  "description": "IPv4/IPv6 subnet.",
                   "type": "string",
                   "title": "Subnet"
                 },
@@ -2195,6 +2252,42 @@
                     "^_.+$": {}
                   },
                   "title": "Lease Time"
+                },
+                "reservations": {
+                  "description": "DHCP client reservations.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "mac_address": {
+                        "type": "string",
+                        "description": "Ethernet address in format - H.H.H",
+                        "title": "MAC Address"
+                      },
+                      "hostname": {
+                        "type": "string",
+                        "title": "Hostname"
+                      },
+                      "ipv4_address": {
+                        "type": "string",
+                        "description": "This setting can be configured only when the subnet is ipv4.",
+                        "title": "IPv4 Address"
+                      },
+                      "ipv6_address": {
+                        "type": "string",
+                        "description": "This setting can be configured only when the subnet is ipv6.",
+                        "title": "IPv6 Address"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "patternProperties": {
+                      "^_.+$": {}
+                    },
+                    "required": [
+                      "mac_address"
+                    ]
+                  },
+                  "title": "Reservations"
                 }
               },
               "required": [
@@ -2206,6 +2299,11 @@
               }
             },
             "title": "Subnets"
+          },
+          "eos_cli": {
+            "type": "string",
+            "description": "Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.",
+            "title": "EOS CLI"
           }
         },
         "additionalProperties": false,

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -2280,12 +2280,12 @@
                       },
                       "ipv4_address": {
                         "type": "string",
-                        "description": "Valid IPv4 address from given subnet.\nThis setting can be configured only when the subnet is IPv4.",
+                        "description": "Valid IPv4 address from the given subnet.\nThis setting can only be configured when the subnet is IPv4.",
                         "title": "IPv4 Address"
                       },
                       "ipv6_address": {
                         "type": "string",
-                        "description": "Valid IPv6 address from given subnet.\nThis setting can be configured only when the subnet is IPv6.",
+                        "description": "Valid IPv6 address from the given subnet.\nThis setting can only be configured when the subnet is IPv6.",
                         "title": "IPv6 Address"
                       }
                     },

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -2261,7 +2261,7 @@
                     "properties": {
                       "mac_address": {
                         "type": "string",
-                        "description": "Ethernet address in format - H.H.H",
+                        "description": "Ethernet address in format - HHHH.HHHH.HHHH",
                         "title": "MAC Address"
                       },
                       "hostname": {
@@ -2270,12 +2270,12 @@
                       },
                       "ipv4_address": {
                         "type": "string",
-                        "description": "This setting can be configured only when the subnet is ipv4.",
+                        "description": "Valid IPv4 address from given subnet.\nThis setting can be configured only when the subnet is IPv4.",
                         "title": "IPv4 Address"
                       },
                       "ipv6_address": {
                         "type": "string",
-                        "description": "This setting can be configured only when the subnet is ipv6.",
+                        "description": "Valid IPv6 address from given subnet.\nThis setting can be configured only when the subnet is IPv6.",
                         "title": "IPv6 Address"
                       }
                     },

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -2280,12 +2280,12 @@
                       },
                       "ipv4_address": {
                         "type": "string",
-                        "description": "Valid IPv4 address from the given subnet.\nThis setting can only be configured when the subnet is IPv4.",
+                        "description": "Valid IPv4 address from the given subnet.\nThis should only be used within an IPv4 subnet.",
                         "title": "IPv4 Address"
                       },
                       "ipv6_address": {
                         "type": "string",
-                        "description": "Valid IPv6 address from the given subnet.\nThis setting can only be configured when the subnet is IPv6.",
+                        "description": "Valid IPv6 address from the given subnet.\nThis should only be used within an IPv6 subnet.",
                         "title": "IPv6 Address"
                       }
                     },

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1549,12 +1549,12 @@ keys:
                       type: str
                       description: 'Valid IPv4 address from the given subnet.
 
-                        This setting can only be configured when the subnet is IPv4.'
+                        This should only be used within an IPv4 subnet.'
                     ipv6_address:
                       type: str
                       description: 'Valid IPv6 address from the given subnet.
 
-                        This setting can only be configured when the subnet is IPv6.'
+                        This should only be used within an IPv6 subnet.'
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the dhcp server in the

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1354,18 +1354,21 @@ keys:
               - str
               min: 0
               max: 2000
+              required: true
             hours:
               type: int
               convert_types:
               - str
               min: 0
               max: 23
+              required: true
             minutes:
               type: int
               convert_types:
               - str
               min: 0
               max: 59
+              required: true
         lease_time_ipv6:
           type: dict
           keys:
@@ -1375,18 +1378,21 @@ keys:
               - str
               min: 0
               max: 2000
+              required: true
             hours:
               type: int
               convert_types:
               - str
               min: 0
               max: 23
+              required: true
             minutes:
               type: int
               convert_types:
               - str
               min: 0
               max: 59
+              required: true
         dns_domain_name_ipv4:
           type: str
         dns_domain_name_ipv6:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1536,17 +1536,19 @@ keys:
                   keys:
                     mac_address:
                       type: str
-                      description: Ethernet address in format - H.H.H
+                      description: Ethernet address in format - HHHH.HHHH.HHHH
                     hostname:
                       type: str
                     ipv4_address:
                       type: str
-                      description: This setting can be configured only when the subnet
-                        is ipv4.
+                      description: 'Valid IPv4 address from given subnet.
+
+                        This setting can be configured only when the subnet is IPv4.'
                     ipv6_address:
                       type: str
-                      description: This setting can be configured only when the subnet
-                        is ipv6.
+                      description: 'Valid IPv6 address from given subnet.
+
+                        This setting can be configured only when the subnet is IPv6.'
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the dhcp server in the

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1345,6 +1345,48 @@ keys:
             indicate default VRF.
           convert_types:
           - int
+        lease_time_ipv4:
+          type: dict
+          keys:
+            days:
+              type: int
+              convert_types:
+              - str
+              min: 0
+              max: 2000
+            hours:
+              type: int
+              convert_types:
+              - str
+              min: 0
+              max: 23
+            minutes:
+              type: int
+              convert_types:
+              - str
+              min: 0
+              max: 59
+        lease_time_ipv6:
+          type: dict
+          keys:
+            days:
+              type: int
+              convert_types:
+              - str
+              min: 0
+              max: 2000
+            hours:
+              type: int
+              convert_types:
+              - str
+              min: 0
+              max: 23
+            minutes:
+              type: int
+              convert_types:
+              - str
+              min: 0
+              max: 59
         dns_domain_name_ipv4:
           type: str
         dns_domain_name_ipv6:
@@ -1437,6 +1479,7 @@ keys:
             type: dict
             keys:
               subnet:
+                description: IPv4/IPv6 subnet.
                 type: str
                 required: true
               name:
@@ -1484,6 +1527,30 @@ keys:
                     max: 59
                     convert_types:
                     - str
+              reservations:
+                description: DHCP client reservations.
+                type: list
+                primary_key: mac_address
+                items:
+                  type: dict
+                  keys:
+                    mac_address:
+                      type: str
+                      description: Ethernet address in format - H.H.H
+                    hostname:
+                      type: str
+                    ipv4_address:
+                      type: str
+                      description: This setting can be configured only when the subnet
+                        is ipv4.
+                    ipv6_address:
+                      type: str
+                      description: This setting can be configured only when the subnet
+                        is ipv6.
+        eos_cli:
+          type: str
+          description: Multiline EOS CLI rendered directly on the dhcp server in the
+            final EOS configuration.
   dns_domain:
     type: str
     description: Domain Name.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1547,14 +1547,14 @@ keys:
                       type: str
                     ipv4_address:
                       type: str
-                      description: 'Valid IPv4 address from given subnet.
+                      description: 'Valid IPv4 address from the given subnet.
 
-                        This setting can be configured only when the subnet is IPv4.'
+                        This setting can only be configured when the subnet is IPv4.'
                     ipv6_address:
                       type: str
-                      description: 'Valid IPv6 address from given subnet.
+                      description: 'Valid IPv6 address from the given subnet.
 
-                        This setting can be configured only when the subnet is IPv6.'
+                        This setting can only be configured when the subnet is IPv6.'
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the dhcp server in the

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
@@ -25,19 +25,19 @@ keys:
             days:
               type: int
               convert_types:
-                - str
+              - str
               min: 0
               max: 2000
             hours:
               type: int
               convert_types:
-                - str
+              - str
               min: 0
               max: 23
             minutes:
               type: int
               convert_types:
-                - str
+              - str
               min: 0
               max: 59
         lease_time_ipv6:
@@ -46,19 +46,19 @@ keys:
             days:
               type: int
               convert_types:
-                - str
+              - str
               min: 0
               max: 2000
             hours:
               type: int
               convert_types:
-                - str
+              - str
               min: 0
               max: 23
             minutes:
               type: int
               convert_types:
-                - str
+              - str
               min: 0
               max: 59
         dns_domain_name_ipv4:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
@@ -28,18 +28,21 @@ keys:
               - str
               min: 0
               max: 2000
+              required: true
             hours:
               type: int
               convert_types:
               - str
               min: 0
               max: 23
+              required: true
             minutes:
               type: int
               convert_types:
               - str
               min: 0
               max: 59
+              required: true
         lease_time_ipv6:
           type: dict
           keys:
@@ -49,18 +52,21 @@ keys:
               - str
               min: 0
               max: 2000
+              required: true
             hours:
               type: int
               convert_types:
               - str
               min: 0
               max: 23
+              required: true
             minutes:
               type: int
               convert_types:
               - str
               min: 0
               max: 59
+              required: true
         dns_domain_name_ipv4:
           type: str
         dns_domain_name_ipv6:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
@@ -213,13 +213,13 @@ keys:
                     ipv4_address:
                       type: str
                       description: |-
-                        Valid IPv4 address from given subnet.
-                        This setting can be configured only when the subnet is IPv4.
+                        Valid IPv4 address from the given subnet.
+                        This setting can only be configured when the subnet is IPv4.
                     ipv6_address:
                       type: str
                       description: |-
-                        Valid IPv6 address from given subnet.
-                        This setting can be configured only when the subnet is IPv6.
+                        Valid IPv6 address from the given subnet.
+                        This setting can only be configured when the subnet is IPv6.
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
@@ -19,6 +19,48 @@ keys:
           description: VRF in which to configure the DHCP server, use `default` to indicate default VRF.
           convert_types:
           - int
+        lease_time_ipv4:
+          type: dict
+          keys:
+            days:
+              type: int
+              convert_types:
+                - str
+              min: 0
+              max: 2000
+            hours:
+              type: int
+              convert_types:
+                - str
+              min: 0
+              max: 23
+            minutes:
+              type: int
+              convert_types:
+                - str
+              min: 0
+              max: 59
+        lease_time_ipv6:
+          type: dict
+          keys:
+            days:
+              type: int
+              convert_types:
+                - str
+              min: 0
+              max: 2000
+            hours:
+              type: int
+              convert_types:
+                - str
+              min: 0
+              max: 23
+            minutes:
+              type: int
+              convert_types:
+                - str
+              min: 0
+              max: 59
         dns_domain_name_ipv4:
           type: str
         dns_domain_name_ipv6:
@@ -102,6 +144,7 @@ keys:
             type: dict
             keys:
               subnet:
+                description: IPv4/IPv6 subnet.
                 type: str
                 required: true
               name:
@@ -149,3 +192,24 @@ keys:
                     max: 59
                     convert_types:
                     - str
+              reservations:
+                description: DHCP client reservations.
+                type: list
+                primary_key: mac_address
+                items:
+                  type: dict
+                  keys:
+                    mac_address:
+                      type: str
+                      description: Ethernet address in format - H.H.H
+                    hostname:
+                      type: str
+                    ipv4_address:
+                      type: str
+                      description: This setting can be configured only when the subnet is ipv4.
+                    ipv6_address:
+                      type: str
+                      description: This setting can be configured only when the subnet is ipv6.
+        eos_cli:
+          type: str
+          description: Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
@@ -214,12 +214,12 @@ keys:
                       type: str
                       description: |-
                         Valid IPv4 address from the given subnet.
-                        This setting can only be configured when the subnet is IPv4.
+                        This should only be used within an IPv4 subnet.
                     ipv6_address:
                       type: str
                       description: |-
                         Valid IPv6 address from the given subnet.
-                        This setting can only be configured when the subnet is IPv6.
+                        This should only be used within an IPv6 subnet.
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
@@ -201,15 +201,19 @@ keys:
                   keys:
                     mac_address:
                       type: str
-                      description: Ethernet address in format - H.H.H
+                      description: Ethernet address in format - HHHH.HHHH.HHHH
                     hostname:
                       type: str
                     ipv4_address:
                       type: str
-                      description: This setting can be configured only when the subnet is ipv4.
+                      description: |-
+                        Valid IPv4 address from given subnet.
+                        This setting can be configured only when the subnet is IPv4.
                     ipv6_address:
                       type: str
-                      description: This setting can be configured only when the subnet is ipv6.
+                      description: |-
+                        Valid IPv6 address from given subnet.
+                        This setting can be configured only when the subnet is IPv6.
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -20042,6 +20042,62 @@
                       "description": "VRF in which to configure the DHCP server, use `default` to indicate default VRF.",
                       "title": "VRF"
                     },
+                    "lease_time_ipv4": {
+                      "type": "object",
+                      "properties": {
+                        "days": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 2000,
+                          "title": "Days"
+                        },
+                        "hours": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 23,
+                          "title": "Hours"
+                        },
+                        "minutes": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 59,
+                          "title": "Minutes"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Lease Time IPv4"
+                    },
+                    "lease_time_ipv6": {
+                      "type": "object",
+                      "properties": {
+                        "days": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 2000,
+                          "title": "Days"
+                        },
+                        "hours": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 23,
+                          "title": "Hours"
+                        },
+                        "minutes": {
+                          "type": "integer",
+                          "minimum": 0,
+                          "maximum": 59,
+                          "title": "Minutes"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Lease Time IPv6"
+                    },
                     "dns_domain_name_ipv4": {
                       "type": "string",
                       "title": "DNS Domain Name IPv4"
@@ -20160,6 +20216,7 @@
                         "type": "object",
                         "properties": {
                           "subnet": {
+                            "description": "IPv4/IPv6 subnet.",
                             "type": "string",
                             "title": "Subnet"
                           },
@@ -20235,6 +20292,42 @@
                               "^_.+$": {}
                             },
                             "title": "Lease Time"
+                          },
+                          "reservations": {
+                            "description": "DHCP client reservations.",
+                            "type": "array",
+                            "items": {
+                              "type": "object",
+                              "properties": {
+                                "mac_address": {
+                                  "type": "string",
+                                  "description": "Ethernet address in format - H.H.H",
+                                  "title": "MAC Address"
+                                },
+                                "hostname": {
+                                  "type": "string",
+                                  "title": "Hostname"
+                                },
+                                "ipv4_address": {
+                                  "type": "string",
+                                  "description": "This setting can be configured only when the subnet is ipv4.",
+                                  "title": "IPv4 Address"
+                                },
+                                "ipv6_address": {
+                                  "type": "string",
+                                  "description": "This setting can be configured only when the subnet is ipv6.",
+                                  "title": "IPv6 Address"
+                                }
+                              },
+                              "additionalProperties": false,
+                              "patternProperties": {
+                                "^_.+$": {}
+                              },
+                              "required": [
+                                "mac_address"
+                              ]
+                            },
+                            "title": "Reservations"
                           }
                         },
                         "required": [
@@ -20246,6 +20339,11 @@
                         }
                       },
                       "title": "Subnets"
+                    },
+                    "eos_cli": {
+                      "type": "string",
+                      "description": "Multiline EOS CLI rendered directly on the dhcp server in the final EOS configuration.",
+                      "title": "EOS CLI"
                     }
                   },
                   "additionalProperties": false,

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -20320,12 +20320,12 @@
                                 },
                                 "ipv4_address": {
                                   "type": "string",
-                                  "description": "Valid IPv4 address from given subnet.\nThis setting can be configured only when the subnet is IPv4.",
+                                  "description": "Valid IPv4 address from the given subnet.\nThis setting can only be configured when the subnet is IPv4.",
                                   "title": "IPv4 Address"
                                 },
                                 "ipv6_address": {
                                   "type": "string",
-                                  "description": "Valid IPv6 address from given subnet.\nThis setting can be configured only when the subnet is IPv6.",
+                                  "description": "Valid IPv6 address from the given subnet.\nThis setting can only be configured when the subnet is IPv6.",
                                   "title": "IPv6 Address"
                                 }
                               },

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -20301,7 +20301,7 @@
                               "properties": {
                                 "mac_address": {
                                   "type": "string",
-                                  "description": "Ethernet address in format - H.H.H",
+                                  "description": "Ethernet address in format - HHHH.HHHH.HHHH",
                                   "title": "MAC Address"
                                 },
                                 "hostname": {
@@ -20310,12 +20310,12 @@
                                 },
                                 "ipv4_address": {
                                   "type": "string",
-                                  "description": "This setting can be configured only when the subnet is ipv4.",
+                                  "description": "Valid IPv4 address from given subnet.\nThis setting can be configured only when the subnet is IPv4.",
                                   "title": "IPv4 Address"
                                 },
                                 "ipv6_address": {
                                   "type": "string",
-                                  "description": "This setting can be configured only when the subnet is ipv6.",
+                                  "description": "Valid IPv6 address from given subnet.\nThis setting can be configured only when the subnet is IPv6.",
                                   "title": "IPv6 Address"
                                 }
                               },

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -20064,6 +20064,11 @@
                           "title": "Minutes"
                         }
                       },
+                      "required": [
+                        "days",
+                        "hours",
+                        "minutes"
+                      ],
                       "additionalProperties": false,
                       "patternProperties": {
                         "^_.+$": {}
@@ -20092,6 +20097,11 @@
                           "title": "Minutes"
                         }
                       },
+                      "required": [
+                        "days",
+                        "hours",
+                        "minutes"
+                      ],
                       "additionalProperties": false,
                       "patternProperties": {
                         "^_.+$": {}

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -20320,12 +20320,12 @@
                                 },
                                 "ipv4_address": {
                                   "type": "string",
-                                  "description": "Valid IPv4 address from the given subnet.\nThis setting can only be configured when the subnet is IPv4.",
+                                  "description": "Valid IPv4 address from the given subnet.\nThis should only be used within an IPv4 subnet.",
                                   "title": "IPv4 Address"
                                 },
                                 "ipv6_address": {
                                   "type": "string",
-                                  "description": "Valid IPv6 address from the given subnet.\nThis setting can only be configured when the subnet is IPv6.",
+                                  "description": "Valid IPv6 address from the given subnet.\nThis should only be used within an IPv6 subnet.",
                                   "title": "IPv6 Address"
                                 }
                               },


### PR DESCRIPTION
## Change Summary

Enhance DHCP server data model (lease time, reservations, eos_cli).

## Related Issue(s)

Fixes #4216 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Enhancing the `dhcp_servers` data-model with keys - `lease_time_ipv4`, `lease_time_ipv6`, `subnets.reservations`

## How to test
Added molecule tests and check the EOS CLI.

## Test Coverage

Coverage is 99%, there is a warning for always true case.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
