### PR TITLE
Doc(eos_designs): Update documentation to customize WAN flow tracking.

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -309,7 +309,27 @@ wan_carriers:
 ### Flow tracking
 
 For scalabilty reasons, flow-tracking is enabled only on `Dps1` interface by default.
-It can be added on WAN and LAN interfaces using `custom_structured_configuration`.
+It can be added on WAN and LAN interfaces using the appropriate combination of `fabric_flow_tracking` and `flow_tracking_settings`, the `flow_tracking` key in various places in the schema or `custom_structured_configuration`.
+
+Example to enable flow tracking on a WAN interface:
+
+```yaml
+wan_router:
+  node_groups:
+    - group: Site511
+      cv_pathfinder_region: AVD_Land_East
+      cv_pathfinder_site: Site511
+      nodes:
+        - name: cv-pathfinder-edge
+          id: 1
+          l3_interfaces:
+            - name: Ethernet1
+              wan_carrier: ATT
+              wan_circuit_id: 666
+              ip_address: dhcp
+              flow_tracking:
+                enabled: true
+```
 
 ### WAN interfaces
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-flow-tracking-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-flow-tracking-settings.md
@@ -26,7 +26,7 @@
     | [<samp>&nbsp;&nbsp;mlag_interfaces</samp>](## "fabric_flow_tracking.mlag_interfaces") | Dictionary |  |  |  | Enable flow-tracking on all MLAG peer interfaces. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "fabric_flow_tracking.mlag_interfaces.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "fabric_flow_tracking.mlag_interfaces.name") | String |  |  |  | Flow tracker name as defined in flow_tracking_settings. |
-    | [<samp>&nbsp;&nbsp;l3_interfaces</samp>](## "fabric_flow_tracking.l3_interfaces") | Dictionary |  |  |  | Enable flow-tracking on all node.l3_interfaces. |
+    | [<samp>&nbsp;&nbsp;l3_interfaces</samp>](## "fabric_flow_tracking.l3_interfaces") | Dictionary |  |  |  | Enable flow-tracking on all node.l3_interfaces and network-services tenants.vrfs.l3_interfaces. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "fabric_flow_tracking.l3_interfaces.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "fabric_flow_tracking.l3_interfaces.name") | String |  |  |  | Flow tracker name as defined in flow_tracking_settings. |
     | [<samp>&nbsp;&nbsp;dps_interfaces</samp>](## "fabric_flow_tracking.dps_interfaces") | Dictionary |  |  |  | Enable flow-tracking on all dps_interfaces. |
@@ -117,7 +117,7 @@
         # Flow tracker name as defined in flow_tracking_settings.
         name: <str>
 
-      # Enable flow-tracking on all node.l3_interfaces.
+      # Enable flow-tracking on all node.l3_interfaces and network-services tenants.vrfs.l3_interfaces.
       l3_interfaces:
         enabled: <bool>
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -6622,7 +6622,7 @@
           "title": "MLAG Interfaces"
         },
         "l3_interfaces": {
-          "description": "Enable flow-tracking on all node.l3_interfaces.",
+          "description": "Enable flow-tracking on all node.l3_interfaces and network-services tenants.vrfs.l3_interfaces.",
           "type": "object",
           "properties": {
             "enabled": {

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -1344,7 +1344,8 @@ keys:
         type: dict
         $ref: eos_designs#/$defs/flow_tracking_link
       l3_interfaces:
-        description: Enable flow-tracking on all node.l3_interfaces.
+        description: Enable flow-tracking on all node.l3_interfaces and network-services
+          tenants.vrfs.l3_interfaces.
         type: dict
         $ref: eos_designs#/$defs/flow_tracking_link
       dps_interfaces:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_flow_tracking.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_flow_tracking.schema.yml
@@ -40,7 +40,7 @@ keys:
         type: dict
         $ref: eos_designs#/$defs/flow_tracking_link
       l3_interfaces:
-        description: Enable flow-tracking on all node.l3_interfaces.
+        description: Enable flow-tracking on all node.l3_interfaces and network-services tenants.vrfs.l3_interfaces.
         type: dict
         $ref: eos_designs#/$defs/flow_tracking_link
       dps_interfaces:


### PR DESCRIPTION
## Change Summary

The documentation is a bit outdated (though correct) as it is not mentioning the recently introduced keys

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

* Add reference to the `fabric_flow_tracking` and `flow_tracking_settings` keys
* Add an example on how to configure flow-tracking on a per WAN interface basis
* Fix a schema description not mentioning the network-services l3_interfaces

## How to test

only doc

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
