### PR TITLE
Feat(eos_cli_config_gen): Add support for isis authentication on vlan interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -155,9 +155,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -155,8 +155,8 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 | Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -155,9 +155,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
-| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -240,9 +240,9 @@ interface Loopback2
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -240,8 +240,8 @@ interface Loopback2
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 | Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -240,9 +240,9 @@ interface Loopback2
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
-| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Vlan4093 | EVPN_UNDERLAY | - | 50 | point-to-point | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -128,6 +128,15 @@ interface Management1
 | Vlan337 |  default  |  10.0.2.2/25  |  -  |  -  |  -  |  -  |
 | Vlan338 |  default  |  -  |  -  |  -  |  -  |  -  |
 | Vlan339 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan340 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan341 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan342 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan343 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan344 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan345 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan346 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan347 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan348 |  default  |  -  |  -  |  -  |  -  |  -  |
 | Vlan501 |  default  |  10.50.26.29/27  |  -  |  -  |  -  |  -  |
 | Vlan667 |  default  |  192.0.2.2/25  |  -  |  -  |  -  |  -  |
 | Vlan1001 |  Tenant_A  |  -  |  10.1.1.1/24  |  -  |  -  |  -  |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -462,57 +462,57 @@ interface Vlan339
 !
 interface Vlan340
    description isis authentication both md5 rx
-   authentication mode md5 rx-disabled
+   isis authentication mode md5 rx-disabled
 !
 interface Vlan341
    description isis authentication both md5
-   authentication mode md5
+   isis authentication mode md5
 !
 interface Vlan342
    description isis authentication both sha rx
-   authentication mode sha key-id 2 rx-disabled
+   isis authentication mode sha key-id 2 rx-disabled
 !
 interface Vlan343
    description isis authentication both sha
-   authentication mode sha key-id 2
+   isis authentication mode sha key-id 2
 !
 interface Vlan344
    description isis authentication both shared secret rx
-   authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
+   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
 !
 interface Vlan345
    description isis authentication both shared secret
-   authentication mode shared-secret profile profile1 algorithm sha-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-1
 !
 interface Vlan346
    description isis authentication both l1 l2 md5 rx
-   authentication mode md5 rx-disabled level-1
-   authentication mode md5 rx-disabled level-2
+   isis authentication mode md5 rx-disabled level-1
+   isis authentication mode md5 rx-disabled level-2
 !
 interface Vlan347
    description isis authentication l1 l2 md5
-   authentication mode md5 level-1
-   authentication mode md5 level-2
+   isis authentication mode md5 level-1
+   isis authentication mode md5 level-2
 !
 interface Vlan348
    description isis authentication l1 l2 shared secret
-   authentication mode shared-secret profile profile1 algorithm sha-256 level-1
-   authentication mode shared-secret profile profile1 algorithm sha-256 level-2
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
 !
 interface Vlan349
    description isis authentication l1 l2 shared secret rx
-   authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
-   authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
 !
 interface Vlan350
    description isis authentication l1 l2 sha rx
-   authentication mode sha key-id 5 rx-disabled level-1
-   authentication mode sha key-id 5 rx-disabled level-2
+   isis authentication mode sha key-id 5 rx-disabled level-1
+   isis authentication mode sha key-id 5 rx-disabled level-2
 !
 interface Vlan351
    description isis authentication l1 l2 sha
-   authentication mode sha key-id 5 level-1
-   authentication mode sha key-id 5 level-2
+   isis authentication mode sha key-id 5 level-1
+   isis authentication mode sha key-id 5 level-2
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -185,8 +185,8 @@ interface Management1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
 | Vlan42 | EVPN_UNDERLAY | - | - | - | Level-1: sha |
 | Vlan83 | EVPN_UNDERLAY | - | - | - | md5 |
 | Vlan84 | EVPN_UNDERLAY | - | - | - | sha |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -187,7 +187,7 @@ interface Management1
 
 | Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
 | --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan42 | EVPN_UNDERLAY | - | - | - | sha | sha |
+| Vlan42 | EVPN_UNDERLAY | - | - | - | sha | - |
 | Vlan83 | EVPN_UNDERLAY | - | - | - | md5 | md5 |
 | Vlan84 | EVPN_UNDERLAY | - | - | - | sha | sha |
 | Vlan85 | EVPN_UNDERLAY | - | - | - | sha | sha |
@@ -259,7 +259,6 @@ interface Vlan42
    ip helper-address 10.10.96.151 source-interface Loopback0
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 level-1
-   isis authentication mode sha key-id 5 level-2
    ip address virtual 10.10.42.1/24
 !
 interface Vlan43

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -74,15 +74,18 @@ interface Management1
 | Vlan337 | v4 dhcp relay all-subnets | default | - | - |
 | Vlan338 | v6 dhcp relay all-subnets | default | - | - |
 | Vlan339 | v6 nd options | default | - | - |
-| Vlan340 | isis authentication text | default | - | - |
-| Vlan341 | isis authentication sha1 | default | - | - |
-| Vlan342 | isis authentication sha2 | default | - | - |
-| Vlan343 | isis authentication sha3 | default | - | - |
-| Vlan344 | isis authentication sha4 | default | - | - |
-| Vlan345 | isis authentication shared-secret1 | default | - | - |
-| Vlan346 | isis authentication shared-secret1 | default | - | - |
-| Vlan347 | isis authentication shared-secret2 | default | - | - |
-| Vlan348 | isis authentication shared-secret3 | default | - | - |
+| Vlan340 | isis authentication both md5 rx | default | - | - |
+| Vlan341 | isis authentication both md5 | default | - | - |
+| Vlan342 | isis authentication both sha rx | default | - | - |
+| Vlan343 | isis authentication both sha | default | - | - |
+| Vlan344 | isis authentication both shared secret rx | default | - | - |
+| Vlan345 | isis authentication both shared secret | default | - | - |
+| Vlan346 | isis authentication both l1 l2 md5 rx | default | - | - |
+| Vlan347 | isis authentication l1 l2 md5 | default | - | - |
+| Vlan348 | isis authentication l1 l2 shared secret | default | - | - |
+| Vlan349 | isis authentication l1 l2 shared secret rx | default | - | - |
+| Vlan350 | isis authentication l1 l2 sha rx | default | - | - |
+| Vlan351 | isis authentication l1 l2 sha | default | - | - |
 | Vlan501 | SVI Description | default | - | False |
 | Vlan667 | Multiple VRIDs | default | - | False |
 | Vlan1001 | SVI Description | Tenant_A | - | False |
@@ -137,6 +140,9 @@ interface Management1
 | Vlan346 |  default  |  -  |  -  |  -  |  -  |  -  |
 | Vlan347 |  default  |  -  |  -  |  -  |  -  |  -  |
 | Vlan348 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan349 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan350 |  default  |  -  |  -  |  -  |  -  |  -  |
+| Vlan351 |  default  |  -  |  -  |  -  |  -  |  -  |
 | Vlan501 |  default  |  10.50.26.29/27  |  -  |  -  |  -  |  -  |
 | Vlan667 |  default  |  192.0.2.2/25  |  -  |  -  |  -  |  -  |
 | Vlan1001 |  Tenant_A  |  -  |  10.1.1.1/24  |  -  |  -  |  -  |
@@ -455,45 +461,58 @@ interface Vlan339
    ipv6 nd other-config-flag
 !
 interface Vlan340
-   description isis authentication text
-   isis authentication mode text
-   isis authentication key 7 <removed>
+   description isis authentication both md5 rx
+   authentication mode md5 rx-disabled
 !
 interface Vlan341
-   description isis authentication sha1
-   isis authentication mode sha key-id 1000 rx-disabled
+   description isis authentication both md5
+   authentication mode md5
 !
 interface Vlan342
-   description isis authentication sha2
-   isis authentication mode sha key-id 1001
+   description isis authentication both sha rx
+   authentication mode sha key-id 2 rx-disabled
 !
 interface Vlan343
-   description isis authentication sha3
-   isis authentication mode sha key-id 1010 level-1 rx-disabled
-   isis authentication mode sha key-id 1010 level-2 rx-disabled
+   description isis authentication both sha
+   authentication mode sha key-id 2
 !
 interface Vlan344
-   description isis authentication sha4
-   isis authentication mode sha key-id 1011 level-1
-   isis authentication mode sha key-id 1011 level-2
+   description isis authentication both shared secret rx
+   authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
 !
 interface Vlan345
-   description isis authentication shared-secret1
-   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled level-1
-   isis authentication mode shared-secret profile profile1 algorithm md5 rx-disabled level-2
+   description isis authentication both shared secret
+   authentication mode shared-secret profile profile1 algorithm sha-1
 !
 interface Vlan346
-   description isis authentication shared-secret1
-   isis authentication mode shared-secret profile profile1 algorithm sha-1 level-1
-   isis authentication mode shared-secret profile profile1 algorithm md5 level-2
+   description isis authentication both l1 l2 md5 rx
+   authentication mode md5 rx-disabled level-1
+   authentication mode md5 rx-disabled level-2
 !
 interface Vlan347
-   description isis authentication shared-secret2
-   isis authentication mode shared-secret profile profile-both algorithm md5 rx-disabled
+   description isis authentication l1 l2 md5
+   authentication mode md5 level-1
+   authentication mode md5 level-2
 !
 interface Vlan348
-   description isis authentication shared-secret3
-   isis authentication mode shared-secret profile profile-both algorithm sha-256
+   description isis authentication l1 l2 shared secret
+   authentication mode shared-secret profile profile1 algorithm sha-256 level-1
+   authentication mode shared-secret profile profile1 algorithm sha-256 level-2
+!
+interface Vlan349
+   description isis authentication l1 l2 shared secret rx
+   authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
+   authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
+!
+interface Vlan350
+   description isis authentication l1 l2 sha rx
+   authentication mode sha key-id 5 rx-disabled level-1
+   authentication mode sha key-id 5 rx-disabled level-2
+!
+interface Vlan351
+   description isis authentication l1 l2 sha
+   authentication mode sha key-id 5 level-1
+   authentication mode sha key-id 5 level-2
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -450,8 +450,8 @@ interface Vlan341
 !
 interface Vlan342
    description isis authentication shared-secret
-   isis authentication mode shared-secretprofile profile1 algorithm sha-1 rx-disabled level-1
-   isis authentication mode shared-secretprofile profile1 algorithm sha-1 rx-disabled level-1 profile profile1 algorithm md5 rx-disabled level-2
+   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled level-1
+   isis authentication mode shared-secret profile profile1 algorithm md5 rx-disabled level-2
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -74,18 +74,6 @@ interface Management1
 | Vlan337 | v4 dhcp relay all-subnets | default | - | - |
 | Vlan338 | v6 dhcp relay all-subnets | default | - | - |
 | Vlan339 | v6 nd options | default | - | - |
-| Vlan340 | isis authentication both md5 rx | default | - | - |
-| Vlan341 | isis authentication both md5 | default | - | - |
-| Vlan342 | isis authentication both sha rx | default | - | - |
-| Vlan343 | isis authentication both sha | default | - | - |
-| Vlan344 | isis authentication both shared secret rx | default | - | - |
-| Vlan345 | isis authentication both shared secret | default | - | - |
-| Vlan346 | isis authentication both l1 l2 md5 rx | default | - | - |
-| Vlan347 | isis authentication l1 l2 md5 | default | - | - |
-| Vlan348 | isis authentication l1 l2 shared secret | default | - | - |
-| Vlan349 | isis authentication l1 l2 shared secret rx | default | - | - |
-| Vlan350 | isis authentication l1 l2 sha rx | default | - | - |
-| Vlan351 | isis authentication l1 l2 sha | default | - | - |
 | Vlan501 | SVI Description | default | - | False |
 | Vlan667 | Multiple VRIDs | default | - | False |
 | Vlan1001 | SVI Description | Tenant_A | - | False |
@@ -131,18 +119,6 @@ interface Management1
 | Vlan337 |  default  |  10.0.2.2/25  |  -  |  -  |  -  |  -  |
 | Vlan338 |  default  |  -  |  -  |  -  |  -  |  -  |
 | Vlan339 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan340 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan341 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan342 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan343 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan344 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan345 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan346 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan347 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan348 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan349 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan350 |  default  |  -  |  -  |  -  |  -  |  -  |
-| Vlan351 |  default  |  -  |  -  |  -  |  -  |  -  |
 | Vlan501 |  default  |  10.50.26.29/27  |  -  |  -  |  -  |  -  |
 | Vlan667 |  default  |  192.0.2.2/25  |  -  |  -  |  -  |  -  |
 | Vlan1001 |  Tenant_A  |  -  |  10.1.1.1/24  |  -  |  -  |  -  |
@@ -270,6 +246,8 @@ interface Vlan42
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   isis authentication mode sha key-id 5 level-1
+   isis authentication mode sha key-id 5 level-2
    ip address virtual 10.10.42.1/24
 !
 interface Vlan43
@@ -277,6 +255,12 @@ interface Vlan43
    no shutdown
    ipv6 dhcp relay destination a0::2 vrf TEST local-interface Loopback44 link-address a0::4
    ipv6 address a0::1/64
+   isis authentication key-id 2 algorithm sha-512 key 0 password
+   isis authentication key-id 3 algorithm sha-512 rfc-5310 key 0 password1
+   isis authentication key-id 1 algorithm sha-1 key 0 password level-1
+   isis authentication key-id 4 algorithm sha-1 rfc-5310 key 0 password level-1
+   isis authentication key-id 1 algorithm sha-1 key 0 password level-2
+   isis authentication key-id 5 algorithm sha-1 rfc-5310 key 0 password level-2
 !
 interface Vlan44
    description SVI Description
@@ -318,6 +302,8 @@ interface Vlan81
 interface Vlan83
    description SVI Description
    no shutdown
+   isis authentication mode md5
+   isis authentication key 0 password
    ip address virtual 10.10.83.1/24
    ip address virtual 10.11.83.1/24 secondary
    ip address virtual 10.11.84.1/24 secondary
@@ -327,6 +313,8 @@ interface Vlan84
    arp gratuitous accept
    arp monitor mac-address
    ip address 10.10.84.1/24
+   isis authentication mode sha key-id 2 rx-disabled
+   isis authentication key 0 password
    ip virtual-router address 10.10.84.254
    ip virtual-router address 10.11.84.254/24
 !
@@ -334,12 +322,15 @@ interface Vlan85
    description SVI Description
    arp cache dynamic capacity 50000
    ip address 10.10.84.1/24
+   isis authentication mode sha key-id 2
+   isis authentication key 0 password
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
 !
 interface Vlan86
    description SVI Description
    ip address 10.10.83.1/24
+   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
    ip attached-host route export 10
 !
 interface Vlan87
@@ -348,10 +339,15 @@ interface Vlan87
    ip address 10.10.87.1/24
    ip access-group ACL_IN in
    ip access-group ACL_OUT out
+   isis authentication mode shared-secret profile profile1 algorithm sha-1
 !
 interface Vlan88
    description SVI Description
    shutdown
+   isis authentication mode md5 rx-disabled level-1
+   isis authentication mode md5 rx-disabled level-2
+   isis authentication key 0 password level-1
+   isis authentication key 0 password level-2
    ip address virtual 10.10.87.1/23
 !
 interface Vlan89
@@ -378,11 +374,17 @@ interface Vlan89
 interface Vlan90
    description SVI Description
    ip address 10.10.83.1/24
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
    ip attached-host route export
 !
 interface Vlan91
    description PBR Description
    shutdown
+   isis authentication mode md5 level-1
+   isis authentication mode md5 level-2
+   isis authentication key 0 password level-1
+   isis authentication key 0 password level-2
    service-policy type pbr input MyServicePolicy
 !
 interface Vlan92
@@ -390,6 +392,8 @@ interface Vlan92
    ip proxy-arp
    ip directed-broadcast
    ip address 10.10.92.1/24
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
 !
 interface Vlan110
    description PVLAN Primary with vlan mapping
@@ -460,60 +464,6 @@ interface Vlan339
    ipv6 address 2001:db8:339::1/64
    ipv6 nd other-config-flag
 !
-interface Vlan340
-   description isis authentication both md5 rx
-   isis authentication mode md5 rx-disabled
-!
-interface Vlan341
-   description isis authentication both md5
-   isis authentication mode md5
-!
-interface Vlan342
-   description isis authentication both sha rx
-   isis authentication mode sha key-id 2 rx-disabled
-!
-interface Vlan343
-   description isis authentication both sha
-   isis authentication mode sha key-id 2
-!
-interface Vlan344
-   description isis authentication both shared secret rx
-   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
-!
-interface Vlan345
-   description isis authentication both shared secret
-   isis authentication mode shared-secret profile profile1 algorithm sha-1
-!
-interface Vlan346
-   description isis authentication both l1 l2 md5 rx
-   isis authentication mode md5 rx-disabled level-1
-   isis authentication mode md5 rx-disabled level-2
-!
-interface Vlan347
-   description isis authentication l1 l2 md5
-   isis authentication mode md5 level-1
-   isis authentication mode md5 level-2
-!
-interface Vlan348
-   description isis authentication l1 l2 shared secret
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
-!
-interface Vlan349
-   description isis authentication l1 l2 shared secret rx
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
-!
-interface Vlan350
-   description isis authentication l1 l2 sha rx
-   isis authentication mode sha key-id 5 rx-disabled level-1
-   isis authentication mode sha key-id 5 rx-disabled level-2
-!
-interface Vlan351
-   description isis authentication l1 l2 sha
-   isis authentication mode sha key-id 5 level-1
-   isis authentication mode sha key-id 5 level-2
-!
 interface Vlan501
    description SVI Description
    no shutdown
@@ -571,6 +521,8 @@ interface Vlan2002
    ip verify unicast source reachable-via rx
    isis enable EVPN_UNDERLAY
    isis bfd
+   isis authentication mode md5 rx-disabled
+   isis authentication key 0 password
    ip address virtual 10.2.2.1/24
 !
 interface Vlan4094
@@ -584,6 +536,8 @@ interface Vlan4094
    pim ipv4 hello count 3.5
    pim ipv4 dr-priority 200
    pim ipv4 bfd
+   isis authentication mode sha key-id 5 rx-disabled level-1
+   isis authentication mode sha key-id 5 rx-disabled level-2
 ```
 
 ## BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -185,8 +185,8 @@ interface Management1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 | Vlan42 | EVPN_UNDERLAY | - | - | - | Level-1: sha |
 | Vlan83 | EVPN_UNDERLAY | - | - | - | md5 |
 | Vlan84 | EVPN_UNDERLAY | - | - | - | sha |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -76,7 +76,9 @@ interface Management1
 | Vlan339 | v6 nd options | default | - | - |
 | Vlan340 | isis authentication text | default | - | - |
 | Vlan341 | isis authentication sha | default | - | - |
-| Vlan342 | isis authentication shared-secret | default | - | - |
+| Vlan342 | isis authentication sha | default | - | - |
+| Vlan343 | isis authentication shared-secret | default | - | - |
+| Vlan344 | isis authentication shared-secret | default | - | - |
 | Vlan501 | SVI Description | default | - | False |
 | Vlan667 | Multiple VRIDs | default | - | False |
 | Vlan1001 | SVI Description | Tenant_A | - | False |
@@ -449,9 +451,18 @@ interface Vlan341
    isis authentication mode sha key-id 1000 rx-disabled
 !
 interface Vlan342
+   description isis authentication sha
+   isis authentication mode sha key-id 1010 level-1
+   isis authentication mode sha key-id 1010 level-1 key-id 1010 level-2
+!
+interface Vlan343
    description isis authentication shared-secret
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm md5 rx-disabled level-2
+!
+interface Vlan344
+   description isis authentication shared-secret
+   isis authentication mode shared-secret profile profile-both algorithm md5 rx-disabled 
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -185,20 +185,20 @@ interface Management1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan42 | EVPN_UNDERLAY | - | - | - | sha | - |
-| Vlan83 | EVPN_UNDERLAY | - | - | - | md5 | md5 |
-| Vlan84 | EVPN_UNDERLAY | - | - | - | sha | sha |
-| Vlan85 | EVPN_UNDERLAY | - | - | - | sha | sha |
-| Vlan86 | EVPN_UNDERLAY | - | - | - | shared-secret | shared-secret |
-| Vlan87 | EVPN_UNDERLAY | - | - | - | shared-secret | shared-secret |
-| Vlan88 | EVPN_UNDERLAY | - | - | - | md5 | md5 |
-| Vlan90 | EVPN_UNDERLAY | - | - | - | shared-secret | shared-secret |
-| Vlan91 | EVPN_UNDERLAY | - | - | - | md5 | md5 |
-| Vlan92 | EVPN_UNDERLAY | - | - | - | shared-secret | shared-secret |
-| Vlan2002 | EVPN_UNDERLAY | True | - | - | md5 | md5 |
-| Vlan4094 | EVPN_UNDERLAY | - | - | - | sha | sha |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Vlan42 | EVPN_UNDERLAY | - | - | - | Level-1: sha |
+| Vlan83 | EVPN_UNDERLAY | - | - | - | md5 |
+| Vlan84 | EVPN_UNDERLAY | - | - | - | sha |
+| Vlan85 | EVPN_UNDERLAY | - | - | - | sha |
+| Vlan86 | EVPN_UNDERLAY | - | - | - | shared-secret |
+| Vlan87 | EVPN_UNDERLAY | - | - | - | shared-secret |
+| Vlan88 | EVPN_UNDERLAY | - | - | - | Level-1: md5<br>Level-2: md5 |
+| Vlan90 | EVPN_UNDERLAY | - | - | - | Level-1: shared-secret<br>Level-2: shared-secret |
+| Vlan91 | EVPN_UNDERLAY | - | - | - | Level-1: md5<br>Level-2: md5 |
+| Vlan92 | EVPN_UNDERLAY | - | - | - | Level-1: shared-secret<br>Level-2: shared-secret |
+| Vlan2002 | EVPN_UNDERLAY | True | - | - | md5 |
+| Vlan4094 | EVPN_UNDERLAY | - | - | - | Level-1: sha<br>Level-2: sha |
 
 ##### Multicast Routing
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -75,10 +75,14 @@ interface Management1
 | Vlan338 | v6 dhcp relay all-subnets | default | - | - |
 | Vlan339 | v6 nd options | default | - | - |
 | Vlan340 | isis authentication text | default | - | - |
-| Vlan341 | isis authentication sha | default | - | - |
-| Vlan342 | isis authentication sha | default | - | - |
-| Vlan343 | isis authentication shared-secret | default | - | - |
-| Vlan344 | isis authentication shared-secret | default | - | - |
+| Vlan341 | isis authentication sha1 | default | - | - |
+| Vlan342 | isis authentication sha2 | default | - | - |
+| Vlan343 | isis authentication sha3 | default | - | - |
+| Vlan344 | isis authentication sha4 | default | - | - |
+| Vlan345 | isis authentication shared-secret1 | default | - | - |
+| Vlan346 | isis authentication shared-secret1 | default | - | - |
+| Vlan347 | isis authentication shared-secret2 | default | - | - |
+| Vlan348 | isis authentication shared-secret3 | default | - | - |
 | Vlan501 | SVI Description | default | - | False |
 | Vlan667 | Multiple VRIDs | default | - | False |
 | Vlan1001 | SVI Description | Tenant_A | - | False |
@@ -447,22 +451,40 @@ interface Vlan340
    isis authentication key 7 <removed>
 !
 interface Vlan341
-   description isis authentication sha
+   description isis authentication sha1
    isis authentication mode sha key-id 1000 rx-disabled
 !
 interface Vlan342
-   description isis authentication sha
-   isis authentication mode sha key-id 1010 level-1
-   isis authentication mode sha key-id 1010 level-1 key-id 1010 level-2
+   description isis authentication sha2
+   isis authentication mode sha key-id 1001
 !
 interface Vlan343
-   description isis authentication shared-secret
+   description isis authentication sha3
+   isis authentication mode sha key-id 1010 level-1 rx-disabled
+   isis authentication mode sha key-id 1010 level-2 rx-disabled
+!
+interface Vlan344
+   description isis authentication sha4
+   isis authentication mode sha key-id 1011 level-1
+   isis authentication mode sha key-id 1011 level-2
+!
+interface Vlan345
+   description isis authentication shared-secret1
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm md5 rx-disabled level-2
 !
-interface Vlan344
-   description isis authentication shared-secret
-   isis authentication mode shared-secret profile profile-both algorithm md5 rx-disabled 
+interface Vlan346
+   description isis authentication shared-secret1
+   isis authentication mode shared-secret profile profile1 algorithm sha-1 level-1
+   isis authentication mode shared-secret profile profile1 algorithm md5 level-2
+!
+interface Vlan347
+   description isis authentication shared-secret2
+   isis authentication mode shared-secret profile profile-both algorithm md5 rx-disabled
+!
+interface Vlan348
+   description isis authentication shared-secret3
+   isis authentication mode shared-secret profile profile-both algorithm sha-256
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -271,6 +271,7 @@ interface Vlan43
    isis authentication key-id 3 algorithm sha-512 rfc-5310 key 0 password1
    isis authentication key-id 1 algorithm sha-1 key 0 password level-1
    isis authentication key-id 4 algorithm sha-1 rfc-5310 key 0 password level-1
+   isis authentication key-id 5 algorithm sha-1 key 0 password3 level-1
    isis authentication key-id 1 algorithm sha-1 key 0 password level-2
    isis authentication key-id 5 algorithm sha-1 rfc-5310 key 0 password level-2
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -74,6 +74,9 @@ interface Management1
 | Vlan337 | v4 dhcp relay all-subnets | default | - | - |
 | Vlan338 | v6 dhcp relay all-subnets | default | - | - |
 | Vlan339 | v6 nd options | default | - | - |
+| Vlan340 | isis authentication text | default | - | - |
+| Vlan341 | isis authentication sha | default | - | - |
+| Vlan342 | isis authentication shared-secret | default | - | - |
 | Vlan501 | SVI Description | default | - | False |
 | Vlan667 | Multiple VRIDs | default | - | False |
 | Vlan1001 | SVI Description | Tenant_A | - | False |
@@ -435,6 +438,20 @@ interface Vlan339
    ipv6 enable
    ipv6 address 2001:db8:339::1/64
    ipv6 nd other-config-flag
+!
+interface Vlan340
+   description isis authentication text
+   isis authentication mode text
+   isis authentication key 7 <removed>
+!
+interface Vlan341
+   description isis authentication sha
+   isis authentication mode sha key-id 1000 rx-disabled
+!
+interface Vlan342
+   description isis authentication shared-secret
+   isis authentication mode shared-secretprofile profile1 algorithm sha-1 rx-disabled level-1
+   isis authentication mode shared-secretprofile profile1 algorithm sha-1 rx-disabled level-1 profile profile1 algorithm md5 rx-disabled level-2
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -185,9 +185,20 @@ interface Management1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
-| Vlan2002 | EVPN_UNDERLAY | True | - | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Vlan42 | EVPN_UNDERLAY | - | - | - | sha | sha |
+| Vlan83 | EVPN_UNDERLAY | - | - | - | md5 | md5 |
+| Vlan84 | EVPN_UNDERLAY | - | - | - | sha | sha |
+| Vlan85 | EVPN_UNDERLAY | - | - | - | sha | sha |
+| Vlan86 | EVPN_UNDERLAY | - | - | - | shared-secret | shared-secret |
+| Vlan87 | EVPN_UNDERLAY | - | - | - | shared-secret | shared-secret |
+| Vlan88 | EVPN_UNDERLAY | - | - | - | md5 | md5 |
+| Vlan90 | EVPN_UNDERLAY | - | - | - | shared-secret | shared-secret |
+| Vlan91 | EVPN_UNDERLAY | - | - | - | md5 | md5 |
+| Vlan92 | EVPN_UNDERLAY | - | - | - | shared-secret | shared-secret |
+| Vlan2002 | EVPN_UNDERLAY | True | - | - | md5 | md5 |
+| Vlan4094 | EVPN_UNDERLAY | - | - | - | sha | sha |
 
 ##### Multicast Routing
 
@@ -246,6 +257,7 @@ interface Vlan42
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 level-1
    isis authentication mode sha key-id 5 level-2
    ip address virtual 10.10.42.1/24
@@ -302,6 +314,7 @@ interface Vlan81
 interface Vlan83
    description SVI Description
    no shutdown
+   isis enable EVPN_UNDERLAY
    isis authentication mode md5
    isis authentication key 0 password
    ip address virtual 10.10.83.1/24
@@ -313,6 +326,7 @@ interface Vlan84
    arp gratuitous accept
    arp monitor mac-address
    ip address 10.10.84.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2 rx-disabled
    isis authentication key 0 password
    ip virtual-router address 10.10.84.254
@@ -322,6 +336,7 @@ interface Vlan85
    description SVI Description
    arp cache dynamic capacity 50000
    ip address 10.10.84.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
    isis authentication key 0 password
    bfd interval 500 min-rx 500 multiplier 5
@@ -330,6 +345,7 @@ interface Vlan85
 interface Vlan86
    description SVI Description
    ip address 10.10.83.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
    ip attached-host route export 10
 !
@@ -339,11 +355,13 @@ interface Vlan87
    ip address 10.10.87.1/24
    ip access-group ACL_IN in
    ip access-group ACL_OUT out
+   isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1
 !
 interface Vlan88
    description SVI Description
    shutdown
+   isis enable EVPN_UNDERLAY
    isis authentication mode md5 rx-disabled level-1
    isis authentication mode md5 rx-disabled level-2
    isis authentication key 0 password level-1
@@ -374,6 +392,7 @@ interface Vlan89
 interface Vlan90
    description SVI Description
    ip address 10.10.83.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
    ip attached-host route export
@@ -381,6 +400,7 @@ interface Vlan90
 interface Vlan91
    description PBR Description
    shutdown
+   isis enable EVPN_UNDERLAY
    isis authentication mode md5 level-1
    isis authentication mode md5 level-2
    isis authentication key 0 password level-1
@@ -392,6 +412,7 @@ interface Vlan92
    ip proxy-arp
    ip directed-broadcast
    ip address 10.10.92.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
 !
@@ -536,6 +557,7 @@ interface Vlan4094
    pim ipv4 hello count 3.5
    pim ipv4 dr-priority 200
    pim ipv4 bfd
+   isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 rx-disabled level-1
    isis authentication mode sha key-id 5 rx-disabled level-2
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -193,9 +193,9 @@ interface Management1
 | Vlan85 | EVPN_UNDERLAY | - | - | - | sha |
 | Vlan86 | EVPN_UNDERLAY | - | - | - | shared-secret |
 | Vlan87 | EVPN_UNDERLAY | - | - | - | shared-secret |
-| Vlan88 | EVPN_UNDERLAY | - | - | - | Level-1: md5<br>Level-2: md5 |
+| Vlan88 | EVPN_UNDERLAY | - | - | - | Level-1: md5<br>Level-2: text |
 | Vlan90 | EVPN_UNDERLAY | - | - | - | Level-1: shared-secret<br>Level-2: shared-secret |
-| Vlan91 | EVPN_UNDERLAY | - | - | - | Level-1: md5<br>Level-2: md5 |
+| Vlan91 | EVPN_UNDERLAY | - | - | - | Level-1: md5<br>Level-2: text |
 | Vlan92 | EVPN_UNDERLAY | - | - | - | Level-1: shared-secret<br>Level-2: shared-secret |
 | Vlan2002 | EVPN_UNDERLAY | True | - | - | md5 |
 | Vlan4094 | EVPN_UNDERLAY | - | - | - | Level-1: sha<br>Level-2: sha |
@@ -280,10 +280,6 @@ interface Vlan44
    ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
    ipv6 dhcp relay destination a0::8
    ipv6 address a0::4/64
-   isis authentication mode md5 rx-disabled level-1
-   isis authentication mode text rx-disabled level-2
-   isis authentication key 0 password level-1
-   isis authentication key 0 password level-2
 !
 interface Vlan50
    description IP NAT Testing
@@ -369,7 +365,7 @@ interface Vlan88
    shutdown
    isis enable EVPN_UNDERLAY
    isis authentication mode md5 rx-disabled level-1
-   isis authentication mode md5 rx-disabled level-2
+   isis authentication mode text rx-disabled level-2
    isis authentication key 0 password level-1
    isis authentication key 0 password level-2
    ip address virtual 10.10.87.1/23
@@ -399,7 +395,7 @@ interface Vlan90
    description SVI Description
    ip address 10.10.83.1/24
    isis enable EVPN_UNDERLAY
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
+   isis authentication mode shared-secret profile profile2 algorithm sha-1 level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
    ip attached-host route export
 !
@@ -408,7 +404,7 @@ interface Vlan91
    shutdown
    isis enable EVPN_UNDERLAY
    isis authentication mode md5 level-1
-   isis authentication mode md5 level-2
+   isis authentication mode text level-2
    isis authentication key 0 password level-1
    isis authentication key 0 password level-2
    service-policy type pbr input MyServicePolicy
@@ -419,7 +415,7 @@ interface Vlan92
    ip directed-broadcast
    ip address 10.10.92.1/24
    isis enable EVPN_UNDERLAY
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
+   isis authentication mode shared-secret profile profile2 algorithm sha-1 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
 !
 interface Vlan110
@@ -565,7 +561,7 @@ interface Vlan4094
    pim ipv4 bfd
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 rx-disabled level-1
-   isis authentication mode sha key-id 5 rx-disabled level-2
+   isis authentication mode sha key-id 10 rx-disabled level-2
 ```
 
 ## BFD

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -280,6 +280,10 @@ interface Vlan44
    ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
    ipv6 dhcp relay destination a0::8
    ipv6 address a0::4/64
+   isis authentication mode md5 rx-disabled level-1
+   isis authentication mode text rx-disabled level-2
+   isis authentication key 0 password level-1
+   isis authentication key 0 password level-2
 !
 interface Vlan50
    description IP NAT Testing
@@ -287,6 +291,8 @@ interface Vlan50
    ip nat source dynamic access-list ACL2 pool POOL2
    ip nat destination static 1.0.0.1 2.0.0.1
    ip nat destination dynamic access-list ACL1 pool POOL1
+   isis authentication mode text rx-disabled level-2
+   isis authentication key 0 password level-2
 !
 interface Vlan75
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -246,9 +246,18 @@ interface Vlan341
    isis authentication mode sha key-id 1000 rx-disabled
 !
 interface Vlan342
+   description isis authentication sha
+   isis authentication mode sha key-id 1010 level-1
+   isis authentication mode sha key-id 1010 level-1 key-id 1010 level-2
+!
+interface Vlan343
    description isis authentication shared-secret
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm md5 rx-disabled level-2
+!
+interface Vlan344
+   description isis authentication shared-secret
+   isis authentication mode shared-secret profile profile-both algorithm md5 rx-disabled 
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -236,6 +236,20 @@ interface Vlan339
    ipv6 address 2001:db8:339::1/64
    ipv6 nd other-config-flag
 !
+interface Vlan340
+   description isis authentication text
+   isis authentication mode text
+   isis authentication key 7 asfddja23452
+!
+interface Vlan341
+   description isis authentication sha
+   isis authentication mode sha key-id 1000 rx-disabled
+!
+interface Vlan342
+   description isis authentication shared-secret
+   isis authentication mode shared-secretprofile profile1 algorithm sha-1 rx-disabled level-1
+   isis authentication mode shared-secretprofile profile1 algorithm sha-1 rx-disabled level-1 profile profile1 algorithm md5 rx-disabled level-2
+!
 interface Vlan501
    description SVI Description
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -351,5 +351,3 @@ interface Vlan4094
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 rx-disabled level-1
    isis authentication mode sha key-id 10 rx-disabled level-2
-!
-end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -247,8 +247,8 @@ interface Vlan341
 !
 interface Vlan342
    description isis authentication shared-secret
-   isis authentication mode shared-secretprofile profile1 algorithm sha-1 rx-disabled level-1
-   isis authentication mode shared-secretprofile profile1 algorithm sha-1 rx-disabled level-1 profile profile1 algorithm md5 rx-disabled level-2
+   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled level-1
+   isis authentication mode shared-secret profile profile1 algorithm md5 rx-disabled level-2
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -69,6 +69,10 @@ interface Vlan44
    ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
    ipv6 dhcp relay destination a0::8
    ipv6 address a0::4/64
+   isis authentication mode md5 rx-disabled level-1
+   isis authentication mode text rx-disabled level-2
+   isis authentication key 0 password level-1
+   isis authentication key 0 password level-2
 !
 interface Vlan50
    description IP NAT Testing
@@ -76,6 +80,8 @@ interface Vlan50
    ip nat source dynamic access-list ACL2 pool POOL2
    ip nat destination static 1.0.0.1 2.0.0.1
    ip nat destination dynamic access-list ACL1 pool POOL1
+   isis authentication mode text rx-disabled level-2
+   isis authentication key 0 password level-2
 !
 interface Vlan75
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -46,6 +46,8 @@ interface Vlan42
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   isis authentication mode sha key-id 5 level-1
+   isis authentication mode sha key-id 5 level-2
    ip address virtual 10.10.42.1/24
 !
 interface Vlan43
@@ -53,6 +55,12 @@ interface Vlan43
    no shutdown
    ipv6 dhcp relay destination a0::2 vrf TEST local-interface Loopback44 link-address a0::4
    ipv6 address a0::1/64
+   isis authentication key-id 2 algorithm sha-512 key 0 password
+   isis authentication key-id 3 algorithm sha-512 rfc-5310 key 0 password1
+   isis authentication key-id 1 algorithm sha-1 key 0 password level-1
+   isis authentication key-id 4 algorithm sha-1 rfc-5310 key 0 password level-1
+   isis authentication key-id 1 algorithm sha-1 key 0 password level-2
+   isis authentication key-id 5 algorithm sha-1 rfc-5310 key 0 password level-2
 !
 interface Vlan44
    description SVI Description
@@ -94,6 +102,8 @@ interface Vlan81
 interface Vlan83
    description SVI Description
    no shutdown
+   isis authentication mode md5
+   isis authentication key 0 password
    ip address virtual 10.10.83.1/24
    ip address virtual 10.11.83.1/24 secondary
    ip address virtual 10.11.84.1/24 secondary
@@ -103,6 +113,8 @@ interface Vlan84
    arp gratuitous accept
    arp monitor mac-address
    ip address 10.10.84.1/24
+   isis authentication mode sha key-id 2 rx-disabled
+   isis authentication key 0 password
    ip virtual-router address 10.10.84.254
    ip virtual-router address 10.11.84.254/24
 !
@@ -110,12 +122,15 @@ interface Vlan85
    description SVI Description
    arp cache dynamic capacity 50000
    ip address 10.10.84.1/24
+   isis authentication mode sha key-id 2
+   isis authentication key 0 password
    bfd interval 500 min-rx 500 multiplier 5
    bfd echo
 !
 interface Vlan86
    description SVI Description
    ip address 10.10.83.1/24
+   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
    ip attached-host route export 10
 !
 interface Vlan87
@@ -124,10 +139,15 @@ interface Vlan87
    ip address 10.10.87.1/24
    ip access-group ACL_IN in
    ip access-group ACL_OUT out
+   isis authentication mode shared-secret profile profile1 algorithm sha-1
 !
 interface Vlan88
    description SVI Description
    shutdown
+   isis authentication mode md5 rx-disabled level-1
+   isis authentication mode md5 rx-disabled level-2
+   isis authentication key 0 password level-1
+   isis authentication key 0 password level-2
    ip address virtual 10.10.87.1/23
 !
 interface Vlan89
@@ -154,11 +174,17 @@ interface Vlan89
 interface Vlan90
    description SVI Description
    ip address 10.10.83.1/24
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
    ip attached-host route export
 !
 interface Vlan91
    description PBR Description
    shutdown
+   isis authentication mode md5 level-1
+   isis authentication mode md5 level-2
+   isis authentication key 0 password level-1
+   isis authentication key 0 password level-2
    service-policy type pbr input MyServicePolicy
 !
 interface Vlan92
@@ -166,6 +192,8 @@ interface Vlan92
    ip proxy-arp
    ip directed-broadcast
    ip address 10.10.92.1/24
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
 !
 interface Vlan110
    description PVLAN Primary with vlan mapping
@@ -236,60 +264,6 @@ interface Vlan339
    ipv6 address 2001:db8:339::1/64
    ipv6 nd other-config-flag
 !
-interface Vlan340
-   description isis authentication both md5 rx
-   isis authentication mode md5 rx-disabled
-!
-interface Vlan341
-   description isis authentication both md5
-   isis authentication mode md5
-!
-interface Vlan342
-   description isis authentication both sha rx
-   isis authentication mode sha key-id 2 rx-disabled
-!
-interface Vlan343
-   description isis authentication both sha
-   isis authentication mode sha key-id 2
-!
-interface Vlan344
-   description isis authentication both shared secret rx
-   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
-!
-interface Vlan345
-   description isis authentication both shared secret
-   isis authentication mode shared-secret profile profile1 algorithm sha-1
-!
-interface Vlan346
-   description isis authentication both l1 l2 md5 rx
-   isis authentication mode md5 rx-disabled level-1
-   isis authentication mode md5 rx-disabled level-2
-!
-interface Vlan347
-   description isis authentication l1 l2 md5
-   isis authentication mode md5 level-1
-   isis authentication mode md5 level-2
-!
-interface Vlan348
-   description isis authentication l1 l2 shared secret
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
-!
-interface Vlan349
-   description isis authentication l1 l2 shared secret rx
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
-!
-interface Vlan350
-   description isis authentication l1 l2 sha rx
-   isis authentication mode sha key-id 5 rx-disabled level-1
-   isis authentication mode sha key-id 5 rx-disabled level-2
-!
-interface Vlan351
-   description isis authentication l1 l2 sha
-   isis authentication mode sha key-id 5 level-1
-   isis authentication mode sha key-id 5 level-2
-!
 interface Vlan501
    description SVI Description
    no shutdown
@@ -347,6 +321,8 @@ interface Vlan2002
    ip verify unicast source reachable-via rx
    isis enable EVPN_UNDERLAY
    isis bfd
+   isis authentication mode md5 rx-disabled
+   isis authentication key 0 password
    ip address virtual 10.2.2.1/24
 !
 interface Vlan4094
@@ -360,3 +336,7 @@ interface Vlan4094
    pim ipv4 hello count 3.5
    pim ipv4 dr-priority 200
    pim ipv4 bfd
+   isis authentication mode sha key-id 5 rx-disabled level-1
+   isis authentication mode sha key-id 5 rx-disabled level-2
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -69,10 +69,6 @@ interface Vlan44
    ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
    ipv6 dhcp relay destination a0::8
    ipv6 address a0::4/64
-   isis authentication mode md5 rx-disabled level-1
-   isis authentication mode text rx-disabled level-2
-   isis authentication key 0 password level-1
-   isis authentication key 0 password level-2
 !
 interface Vlan50
    description IP NAT Testing
@@ -158,7 +154,7 @@ interface Vlan88
    shutdown
    isis enable EVPN_UNDERLAY
    isis authentication mode md5 rx-disabled level-1
-   isis authentication mode md5 rx-disabled level-2
+   isis authentication mode text rx-disabled level-2
    isis authentication key 0 password level-1
    isis authentication key 0 password level-2
    ip address virtual 10.10.87.1/23
@@ -188,7 +184,7 @@ interface Vlan90
    description SVI Description
    ip address 10.10.83.1/24
    isis enable EVPN_UNDERLAY
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
+   isis authentication mode shared-secret profile profile2 algorithm sha-1 level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
    ip attached-host route export
 !
@@ -197,7 +193,7 @@ interface Vlan91
    shutdown
    isis enable EVPN_UNDERLAY
    isis authentication mode md5 level-1
-   isis authentication mode md5 level-2
+   isis authentication mode text level-2
    isis authentication key 0 password level-1
    isis authentication key 0 password level-2
    service-policy type pbr input MyServicePolicy
@@ -208,7 +204,7 @@ interface Vlan92
    ip directed-broadcast
    ip address 10.10.92.1/24
    isis enable EVPN_UNDERLAY
-   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
+   isis authentication mode shared-secret profile profile2 algorithm sha-1 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
 !
 interface Vlan110
@@ -354,6 +350,6 @@ interface Vlan4094
    pim ipv4 bfd
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 rx-disabled level-1
-   isis authentication mode sha key-id 5 rx-disabled level-2
+   isis authentication mode sha key-id 10 rx-disabled level-2
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -242,22 +242,40 @@ interface Vlan340
    isis authentication key 7 asfddja23452
 !
 interface Vlan341
-   description isis authentication sha
+   description isis authentication sha1
    isis authentication mode sha key-id 1000 rx-disabled
 !
 interface Vlan342
-   description isis authentication sha
-   isis authentication mode sha key-id 1010 level-1
-   isis authentication mode sha key-id 1010 level-1 key-id 1010 level-2
+   description isis authentication sha2
+   isis authentication mode sha key-id 1001
 !
 interface Vlan343
-   description isis authentication shared-secret
+   description isis authentication sha3
+   isis authentication mode sha key-id 1010 level-1 rx-disabled
+   isis authentication mode sha key-id 1010 level-2 rx-disabled
+!
+interface Vlan344
+   description isis authentication sha4
+   isis authentication mode sha key-id 1011 level-1
+   isis authentication mode sha key-id 1011 level-2
+!
+interface Vlan345
+   description isis authentication shared-secret1
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm md5 rx-disabled level-2
 !
-interface Vlan344
-   description isis authentication shared-secret
-   isis authentication mode shared-secret profile profile-both algorithm md5 rx-disabled 
+interface Vlan346
+   description isis authentication shared-secret1
+   isis authentication mode shared-secret profile profile1 algorithm sha-1 level-1
+   isis authentication mode shared-secret profile profile1 algorithm md5 level-2
+!
+interface Vlan347
+   description isis authentication shared-secret2
+   isis authentication mode shared-secret profile profile-both algorithm md5 rx-disabled
+!
+interface Vlan348
+   description isis authentication shared-secret3
+   isis authentication mode shared-secret profile profile-both algorithm sha-256
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -48,7 +48,6 @@ interface Vlan42
    ip helper-address 10.10.96.151 source-interface Loopback0
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 level-1
-   isis authentication mode sha key-id 5 level-2
    ip address virtual 10.10.42.1/24
 !
 interface Vlan43

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -238,57 +238,57 @@ interface Vlan339
 !
 interface Vlan340
    description isis authentication both md5 rx
-   authentication mode md5 rx-disabled
+   isis authentication mode md5 rx-disabled
 !
 interface Vlan341
    description isis authentication both md5
-   authentication mode md5
+   isis authentication mode md5
 !
 interface Vlan342
    description isis authentication both sha rx
-   authentication mode sha key-id 2 rx-disabled
+   isis authentication mode sha key-id 2 rx-disabled
 !
 interface Vlan343
    description isis authentication both sha
-   authentication mode sha key-id 2
+   isis authentication mode sha key-id 2
 !
 interface Vlan344
    description isis authentication both shared secret rx
-   authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
+   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
 !
 interface Vlan345
    description isis authentication both shared secret
-   authentication mode shared-secret profile profile1 algorithm sha-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-1
 !
 interface Vlan346
    description isis authentication both l1 l2 md5 rx
-   authentication mode md5 rx-disabled level-1
-   authentication mode md5 rx-disabled level-2
+   isis authentication mode md5 rx-disabled level-1
+   isis authentication mode md5 rx-disabled level-2
 !
 interface Vlan347
    description isis authentication l1 l2 md5
-   authentication mode md5 level-1
-   authentication mode md5 level-2
+   isis authentication mode md5 level-1
+   isis authentication mode md5 level-2
 !
 interface Vlan348
    description isis authentication l1 l2 shared secret
-   authentication mode shared-secret profile profile1 algorithm sha-256 level-1
-   authentication mode shared-secret profile profile1 algorithm sha-256 level-2
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
 !
 interface Vlan349
    description isis authentication l1 l2 shared secret rx
-   authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
-   authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
+   isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
 !
 interface Vlan350
    description isis authentication l1 l2 sha rx
-   authentication mode sha key-id 5 rx-disabled level-1
-   authentication mode sha key-id 5 rx-disabled level-2
+   isis authentication mode sha key-id 5 rx-disabled level-1
+   isis authentication mode sha key-id 5 rx-disabled level-2
 !
 interface Vlan351
    description isis authentication l1 l2 sha
-   authentication mode sha key-id 5 level-1
-   authentication mode sha key-id 5 level-2
+   isis authentication mode sha key-id 5 level-1
+   isis authentication mode sha key-id 5 level-2
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -237,45 +237,58 @@ interface Vlan339
    ipv6 nd other-config-flag
 !
 interface Vlan340
-   description isis authentication text
-   isis authentication mode text
-   isis authentication key 7 asfddja23452
+   description isis authentication both md5 rx
+   authentication mode md5 rx-disabled
 !
 interface Vlan341
-   description isis authentication sha1
-   isis authentication mode sha key-id 1000 rx-disabled
+   description isis authentication both md5
+   authentication mode md5
 !
 interface Vlan342
-   description isis authentication sha2
-   isis authentication mode sha key-id 1001
+   description isis authentication both sha rx
+   authentication mode sha key-id 2 rx-disabled
 !
 interface Vlan343
-   description isis authentication sha3
-   isis authentication mode sha key-id 1010 level-1 rx-disabled
-   isis authentication mode sha key-id 1010 level-2 rx-disabled
+   description isis authentication both sha
+   authentication mode sha key-id 2
 !
 interface Vlan344
-   description isis authentication sha4
-   isis authentication mode sha key-id 1011 level-1
-   isis authentication mode sha key-id 1011 level-2
+   description isis authentication both shared secret rx
+   authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
 !
 interface Vlan345
-   description isis authentication shared-secret1
-   isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled level-1
-   isis authentication mode shared-secret profile profile1 algorithm md5 rx-disabled level-2
+   description isis authentication both shared secret
+   authentication mode shared-secret profile profile1 algorithm sha-1
 !
 interface Vlan346
-   description isis authentication shared-secret1
-   isis authentication mode shared-secret profile profile1 algorithm sha-1 level-1
-   isis authentication mode shared-secret profile profile1 algorithm md5 level-2
+   description isis authentication both l1 l2 md5 rx
+   authentication mode md5 rx-disabled level-1
+   authentication mode md5 rx-disabled level-2
 !
 interface Vlan347
-   description isis authentication shared-secret2
-   isis authentication mode shared-secret profile profile-both algorithm md5 rx-disabled
+   description isis authentication l1 l2 md5
+   authentication mode md5 level-1
+   authentication mode md5 level-2
 !
 interface Vlan348
-   description isis authentication shared-secret3
-   isis authentication mode shared-secret profile profile-both algorithm sha-256
+   description isis authentication l1 l2 shared secret
+   authentication mode shared-secret profile profile1 algorithm sha-256 level-1
+   authentication mode shared-secret profile profile1 algorithm sha-256 level-2
+!
+interface Vlan349
+   description isis authentication l1 l2 shared secret rx
+   authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
+   authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
+!
+interface Vlan350
+   description isis authentication l1 l2 sha rx
+   authentication mode sha key-id 5 rx-disabled level-1
+   authentication mode sha key-id 5 rx-disabled level-2
+!
+interface Vlan351
+   description isis authentication l1 l2 sha
+   authentication mode sha key-id 5 level-1
+   authentication mode sha key-id 5 level-2
 !
 interface Vlan501
    description SVI Description

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -60,6 +60,7 @@ interface Vlan43
    isis authentication key-id 3 algorithm sha-512 rfc-5310 key 0 password1
    isis authentication key-id 1 algorithm sha-1 key 0 password level-1
    isis authentication key-id 4 algorithm sha-1 rfc-5310 key 0 password level-1
+   isis authentication key-id 5 algorithm sha-1 key 0 password3 level-1
    isis authentication key-id 1 algorithm sha-1 key 0 password level-2
    isis authentication key-id 5 algorithm sha-1 rfc-5310 key 0 password level-2
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -46,6 +46,7 @@ interface Vlan42
    ip helper-address 10.10.64.150 source-interface Loopback0
    ip helper-address 10.10.96.150 source-interface Loopback0
    ip helper-address 10.10.96.151 source-interface Loopback0
+   isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 level-1
    isis authentication mode sha key-id 5 level-2
    ip address virtual 10.10.42.1/24
@@ -102,6 +103,7 @@ interface Vlan81
 interface Vlan83
    description SVI Description
    no shutdown
+   isis enable EVPN_UNDERLAY
    isis authentication mode md5
    isis authentication key 0 password
    ip address virtual 10.10.83.1/24
@@ -113,6 +115,7 @@ interface Vlan84
    arp gratuitous accept
    arp monitor mac-address
    ip address 10.10.84.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2 rx-disabled
    isis authentication key 0 password
    ip virtual-router address 10.10.84.254
@@ -122,6 +125,7 @@ interface Vlan85
    description SVI Description
    arp cache dynamic capacity 50000
    ip address 10.10.84.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
    isis authentication key 0 password
    bfd interval 500 min-rx 500 multiplier 5
@@ -130,6 +134,7 @@ interface Vlan85
 interface Vlan86
    description SVI Description
    ip address 10.10.83.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
    ip attached-host route export 10
 !
@@ -139,11 +144,13 @@ interface Vlan87
    ip address 10.10.87.1/24
    ip access-group ACL_IN in
    ip access-group ACL_OUT out
+   isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1
 !
 interface Vlan88
    description SVI Description
    shutdown
+   isis enable EVPN_UNDERLAY
    isis authentication mode md5 rx-disabled level-1
    isis authentication mode md5 rx-disabled level-2
    isis authentication key 0 password level-1
@@ -174,6 +181,7 @@ interface Vlan89
 interface Vlan90
    description SVI Description
    ip address 10.10.83.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-256 level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
    ip attached-host route export
@@ -181,6 +189,7 @@ interface Vlan90
 interface Vlan91
    description PBR Description
    shutdown
+   isis enable EVPN_UNDERLAY
    isis authentication mode md5 level-1
    isis authentication mode md5 level-2
    isis authentication key 0 password level-1
@@ -192,6 +201,7 @@ interface Vlan92
    ip proxy-arp
    ip directed-broadcast
    ip address 10.10.92.1/24
+   isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
 !
@@ -336,6 +346,7 @@ interface Vlan4094
    pim ipv4 hello count 3.5
    pim ipv4 dr-priority 200
    pim ipv4 bfd
+   isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 rx-disabled level-1
    isis authentication mode sha key-id 5 rx-disabled level-2
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -137,7 +137,7 @@ vlan_interfaces:
     description: SVI Description
     shutdown: true
     ip_address_virtual: 10.10.87.1/23
-    # Test isis auth both l1l2 md5 rx
+    # Test isis auth both l1l2 md5 text rx
     isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       level_1:
@@ -148,7 +148,7 @@ vlan_interfaces:
       level_2:
         key_type: 0
         key: password
-        mode: md5
+        mode: text
         rx_disabled: true
 
   - name: Vlan91
@@ -157,7 +157,7 @@ vlan_interfaces:
     service_policy:
       pbr:
         input: MyServicePolicy
-    # Test isis auth l1l2 md5
+    # Test isis auth l1l2 md5 text
     isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       level_1:
@@ -167,7 +167,7 @@ vlan_interfaces:
       level_2:
         key_type: 0
         key: password
-        mode: md5
+        mode: text
 
   - name: Vlan90
     description: SVI Description
@@ -180,8 +180,8 @@ vlan_interfaces:
       level_1:
         mode: shared-secret
         shared_secret:
-          profile: profile1
-          algorithm: sha-256
+          profile: profile2
+          algorithm: sha-1
       level_2:
         mode: shared-secret
         shared_secret:
@@ -199,8 +199,8 @@ vlan_interfaces:
       level_1:
         mode: shared-secret
         shared_secret:
-          profile: profile1
-          algorithm: sha-256
+          profile: profile2
+          algorithm: sha-1
         rx_disabled: true
       level_2:
         mode: shared-secret
@@ -236,7 +236,7 @@ vlan_interfaces:
       level_2:
         mode: sha
         sha:
-          key_id: 5
+          key_id: 10
         rx_disabled: true
 
 # Helpers on SVI
@@ -363,17 +363,7 @@ vlan_interfaces:
         source_address: a0::6
         link_address: a0::7
       - address: a0::8
-    isis_authentication:
-      level_1:
-        key_type: 0
-        key: password
-        mode: md5
-        rx_disabled: true
-      level_2:
-        key_type: 0
-        key: password
-        mode: text
-        rx_disabled: true
+
   - name: Vlan50
     description: IP NAT Testing
     ip_nat:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -21,6 +21,23 @@ vlan_interfaces:
     isis_enable: "EVPN_UNDERLAY"
     isis_bfd: true
     ip_verify_unicast_source_reachable_via: rx
+    # Test isis authentication both md5 rx
+    isis_authentication:
+      both:
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
+      level_1:
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
+      level_2:
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
 
   - name: Vlan81
     description: IPv6 Virtual Address
@@ -39,6 +56,12 @@ vlan_interfaces:
     ip_address_virtual_secondaries:
       - 10.11.83.1/24
       - 10.11.84.1/24
+    # Test isis auth both md5
+    isis_authentication:
+      both:
+        key_type: 0
+        key: password
+        mode: md5
 
   - name: Vlan84
     description: SVI Description
@@ -48,6 +71,15 @@ vlan_interfaces:
       - 10.11.84.254/24
     arp_gratuitous_accept: true
     arp_monitor_mac_address: true
+    # Test isis auth both sha rx
+    isis_authentication:
+      both:
+        key_type: 0
+        key: password
+        mode: sha
+        sha:
+          key_id: 2
+        rx_disabled: true
 
   - name: Vlan85
     description: SVI Description
@@ -58,6 +90,14 @@ vlan_interfaces:
       interval: 500
       min_rx: 500
       multiplier: 5
+    # Test isis auth both sha
+    isis_authentication:
+      both:
+        key_type: 0
+        key: password
+        mode: sha
+        sha:
+          key_id: 2
 
   - name: Vlan86
     description: SVI Description
@@ -65,6 +105,14 @@ vlan_interfaces:
     ip_attached_host_route_export:
       enabled: true
       distance: 10
+    # Test isis auth both shared secret rx
+    isis_authentication:
+      both:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-1
+        rx_disabled: true
 
   - name: Vlan87
     description: SVI Description
@@ -72,11 +120,30 @@ vlan_interfaces:
     ip_address: 10.10.87.1/24
     access_group_in: ACL_IN
     access_group_out: ACL_OUT
+    # Test isis auth both shared secret
+    isis_authentication:
+      both:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-1
 
   - name: Vlan88
     description: SVI Description
     shutdown: true
     ip_address_virtual: 10.10.87.1/23
+    # Test isis auth both l1l2 md5 rx
+    isis_authentication:
+      level_1:
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
+      level_2:
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
 
   - name: Vlan91
     description: PBR Description
@@ -84,18 +151,54 @@ vlan_interfaces:
     service_policy:
       pbr:
         input: MyServicePolicy
+    # Test isis auth l1l2 md5
+    isis_authentication:
+      level_1:
+        key_type: 0
+        key: password
+        mode: md5
+      level_2:
+        key_type: 0
+        key: password
+        mode: md5
 
   - name: Vlan90
     description: SVI Description
     ip_address: 10.10.83.1/24
     ip_attached_host_route_export:
       enabled: true
+    # Test isis auth l1l2 shared secret
+    isis_authentication:
+      level_1:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-256
+      level_2:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-256
 
   - name: Vlan92
     description: SVI Description
     ip_address: 10.10.92.1/24
     ip_proxy_arp: true
     ip_directed_broadcast: true
+    # Test isis auth l1l2 shared secret rx
+    isis_authentication:
+      level_1:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-256
+        rx_disabled: true
+      level_2:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-256
+        rx_disabled: true
 
 # MCAST Configuration
 
@@ -113,6 +216,18 @@ vlan_interfaces:
         hello:
           count: 3.5
           interval: 10
+    # Test isis auth l1l2 sha rx
+    isis_authentication:
+      level_1:
+        mode: sha
+        sha:
+          key_id: 5
+        rx_disabled: true
+      level_2:
+        mode: sha
+        sha:
+          key_id: 5
+        rx_disabled: true
 
 # Helpers on SVI
 
@@ -161,6 +276,16 @@ vlan_interfaces:
         source_interface: Loopback0
       - ip_helper: 10.10.64.150
         source_interface: Loopback0
+    # Test isis auth l1l2 sha
+    isis_authentication:
+      level_1:
+        mode: sha
+        sha:
+          key_id: 5
+      level_2:
+        mode: sha
+        sha:
+          key_id: 5
 
   - name: Vlan43
     description: SVI Description
@@ -171,6 +296,51 @@ vlan_interfaces:
         vrf: TEST
         local_interface: Loopback44
         link_address: a0::4
+    isis_authentication:
+      both:
+        key_ids:
+          - id: 2
+            algorithm: sha-512
+            key_type: 0
+            key: password
+            rfc_5310: false
+          - id: 3
+            algorithm: sha-512
+            key_type: 0
+            key: password1
+            rfc_5310: true
+      level_1:
+        key_ids:
+          - id: 1
+            algorithm: sha-1
+            key_type: 0
+            key: password
+            rfc_5310: false
+          - id: 4
+            algorithm: sha-1
+            key_type: 0
+            key: password
+            rfc_5310: true
+          - id: 3
+            algorithm: sha-1
+            key_type: 0
+            key: password3
+      level_2:
+        key_ids:
+          - id: 1
+            algorithm: sha-1
+            key_type: 0
+            key: password
+            rfc_5310: false
+          - id: 5
+            algorithm: sha-1
+            key_type: 0
+            key: password
+            rfc_5310: true
+          - id: 3
+            algorithm: sha-1
+            key_type: 0
+            key: password2
 
   - name: Vlan44
     description: SVI Description
@@ -460,152 +630,3 @@ vlan_interfaces:
       dynamic_capacity: 900
       expire: 250
       refresh_always: true
-
-  - name: Vlan340
-    description: isis authentication both md5 rx
-    isis_authentication:
-      both:
-        key_type: 0
-        key: password
-        mode: md5
-        rx_disabled: true
-      level_1:
-        key_type: 0
-        key: password
-        mode: md5
-        rx_disabled: true
-      level_2:
-        key_type: 0
-        key: password
-        mode: md5
-        rx_disabled: true
-
-  - name: Vlan341
-    description: isis authentication both md5
-    isis_authentication:
-      both:
-        key_type: 0
-        key: password
-        mode: md5
-
-  - name: Vlan342
-    description: isis authentication both sha rx
-    isis_authentication:
-      both:
-        key_type: 0
-        key: password
-        mode: sha
-        sha:
-          key_id: 2
-        rx_disabled: true
-
-  - name: Vlan343
-    description: isis authentication both sha
-    isis_authentication:
-      both:
-        key_type: 0
-        key: password
-        mode: sha
-        sha:
-          key_id: 2
-
-  - name: Vlan344
-    description: isis authentication both shared secret rx
-    isis_authentication:
-      both:
-        mode: shared-secret
-        shared_secret:
-          profile: profile1
-          algorithm: sha-1
-        rx_disabled: true
-
-  - name: Vlan345
-    description: isis authentication both shared secret
-    isis_authentication:
-      both:
-        mode: shared-secret
-        shared_secret:
-          profile: profile1
-          algorithm: sha-1
-
-  - name: Vlan346
-    description: isis authentication both l1 l2 md5 rx
-    isis_authentication:
-      level_1:
-        key_type: 0
-        key: password
-        mode: md5
-        rx_disabled: true
-      level_2:
-        key_type: 0
-        key: password
-        mode: md5
-        rx_disabled: true
-
-  - name: Vlan347
-    description: isis authentication l1 l2 md5
-    isis_authentication:
-      level_1:
-        key_type: 0
-        key: password
-        mode: md5
-      level_2:
-        key_type: 0
-        key: password
-        mode: md5
-
-  - name: Vlan348
-    description: isis authentication l1 l2 shared secret
-    isis_authentication:
-      level_1:
-        mode: shared-secret
-        shared_secret:
-          profile: profile1
-          algorithm: sha-256
-      level_2:
-        mode: shared-secret
-        shared_secret:
-          profile: profile1
-          algorithm: sha-256
-
-  - name: Vlan349
-    description: isis authentication l1 l2 shared secret rx
-    isis_authentication:
-      level_1:
-        mode: shared-secret
-        shared_secret:
-          profile: profile1
-          algorithm: sha-256
-        rx_disabled: true
-      level_2:
-        mode: shared-secret
-        shared_secret:
-          profile: profile1
-          algorithm: sha-256
-        rx_disabled: true
-
-  - name: Vlan350
-    description: isis authentication l1 l2 sha rx
-    isis_authentication:
-      level_1:
-        mode: sha
-        sha:
-          key_id: 5
-        rx_disabled: true
-      level_2:
-        mode: sha
-        sha:
-          key_id: 5
-        rx_disabled: true
-
-  - name: Vlan351
-    description: isis authentication l1 l2 sha
-    isis_authentication:
-      level_1:
-        mode: sha
-        sha:
-          key_id: 5
-      level_2:
-        mode: sha
-        sha:
-          key_id: 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -460,3 +460,31 @@ vlan_interfaces:
       dynamic_capacity: 900
       expire: 250
       refresh_always: true
+
+  - name: Vlan340
+    description: isis authentication text
+    isis_authentication_mode: text
+    isis_authentication_key: "asfddja23452"
+
+  - name: Vlan341
+    description: isis authentication sha
+    isis_authentication_mode: sha
+    isis_authentication_mode_sha:
+      both:
+        key_id: 1000
+        rx_disabled: true
+      level_1:
+        key_id: 1010
+
+  - name: Vlan342
+    description: isis authentication shared-secret
+    isis_authentication_mode: shared-secret
+    isis_authentication_mode_shared_secret:
+      level_1:
+        profile: profile1
+        algorithm: sha-1
+        rx_disabled: true
+      level_2:
+        profile: profile1
+        algorithm: md5
+        rx_disabled: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -57,6 +57,7 @@ vlan_interfaces:
       - 10.11.83.1/24
       - 10.11.84.1/24
     # Test isis auth both md5
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       both:
         key_type: 0
@@ -71,6 +72,7 @@ vlan_interfaces:
       - 10.11.84.254/24
     arp_gratuitous_accept: true
     arp_monitor_mac_address: true
+    isis_enable: "EVPN_UNDERLAY"
     # Test isis auth both sha rx
     isis_authentication:
       both:
@@ -91,6 +93,7 @@ vlan_interfaces:
       min_rx: 500
       multiplier: 5
     # Test isis auth both sha
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       both:
         key_type: 0
@@ -106,6 +109,7 @@ vlan_interfaces:
       enabled: true
       distance: 10
     # Test isis auth both shared secret rx
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       both:
         mode: shared-secret
@@ -121,6 +125,7 @@ vlan_interfaces:
     access_group_in: ACL_IN
     access_group_out: ACL_OUT
     # Test isis auth both shared secret
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       both:
         mode: shared-secret
@@ -133,6 +138,7 @@ vlan_interfaces:
     shutdown: true
     ip_address_virtual: 10.10.87.1/23
     # Test isis auth both l1l2 md5 rx
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       level_1:
         key_type: 0
@@ -152,6 +158,7 @@ vlan_interfaces:
       pbr:
         input: MyServicePolicy
     # Test isis auth l1l2 md5
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       level_1:
         key_type: 0
@@ -168,6 +175,7 @@ vlan_interfaces:
     ip_attached_host_route_export:
       enabled: true
     # Test isis auth l1l2 shared secret
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       level_1:
         mode: shared-secret
@@ -186,6 +194,7 @@ vlan_interfaces:
     ip_proxy_arp: true
     ip_directed_broadcast: true
     # Test isis auth l1l2 shared secret rx
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       level_1:
         mode: shared-secret
@@ -217,6 +226,7 @@ vlan_interfaces:
           count: 3.5
           interval: 10
     # Test isis auth l1l2 sha rx
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       level_1:
         mode: sha
@@ -277,6 +287,7 @@ vlan_interfaces:
       - ip_helper: 10.10.64.150
         source_interface: Loopback0
     # Test isis auth l1l2 sha
+    isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       level_1:
         mode: sha

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -462,100 +462,150 @@ vlan_interfaces:
       refresh_always: true
 
   - name: Vlan340
-    description: isis authentication text
-    isis_authentication_mode: text
-    isis_authentication_key: "asfddja23452"
+    description: isis authentication both md5 rx
+    isis_authentication:
+      both:
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
+      level_1:
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
+      level_2:
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
 
   - name: Vlan341
-    description: isis authentication sha1
-    isis_authentication_mode: sha
-    isis_authentication_mode_sha:
+    description: isis authentication both md5
+    isis_authentication:
       both:
-        key_id: 1000
-        rx_disabled: true
-      level_1:
-        key_id: 1010
-      level_2:
-        key_id: 1010
+        key_type: 0
+        key: password
+        mode: md5
 
   - name: Vlan342
-    description: isis authentication sha2
-    isis_authentication_mode: sha
-    isis_authentication_mode_sha:
+    description: isis authentication both sha rx
+    isis_authentication:
       both:
-        key_id: 1001
-        rx_disabled: false
+        key_type: 0
+        key: password
+        mode: sha
+        sha:
+          key_id: 2
+        rx_disabled: true
 
   - name: Vlan343
-    description: isis authentication sha3
-    isis_authentication_mode: sha
-    isis_authentication_mode_sha:
-      level_1:
-        key_id: 1010
-        rx_disabled: true
-      level_2:
-        key_id: 1010
-        rx_disabled: true
+    description: isis authentication both sha
+    isis_authentication:
+      both:
+        key_type: 0
+        key: password
+        mode: sha
+        sha:
+          key_id: 2
 
   - name: Vlan344
-    description: isis authentication sha4
-    isis_authentication_mode: sha
-    isis_authentication_mode_sha:
-      level_1:
-        key_id: 1011
-        rx_disabled: false
-      level_2:
-        key_id: 1011
-        rx_disabled: false
+    description: isis authentication both shared secret rx
+    isis_authentication:
+      both:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-1
+        rx_disabled: true
 
   - name: Vlan345
-    description: isis authentication shared-secret1
-    isis_authentication_mode: shared-secret
-    isis_authentication_mode_shared_secret:
-      level_1:
-        profile: profile1
-        algorithm: sha-1
-        rx_disabled: true
-      level_2:
-        profile: profile1
-        algorithm: md5
-        rx_disabled: true
+    description: isis authentication both shared secret
+    isis_authentication:
+      both:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-1
 
   - name: Vlan346
-    description: isis authentication shared-secret1
-    isis_authentication_mode: shared-secret
-    isis_authentication_mode_shared_secret:
+    description: isis authentication both l1 l2 md5 rx
+    isis_authentication:
       level_1:
-        profile: profile1
-        algorithm: sha-1
-        rx_disabled: false
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
       level_2:
-        profile: profile1
-        algorithm: md5
-        rx_disabled: false
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
 
   - name: Vlan347
-    description: isis authentication shared-secret2
-    isis_authentication_mode: shared-secret
-    isis_authentication_mode_shared_secret:
-      both:
-        profile: profile-both
-        algorithm: md5
-        rx_disabled: true
+    description: isis authentication l1 l2 md5
+    isis_authentication:
       level_1:
-        profile: profile1
-        algorithm: sha-1
-        rx_disabled: true
+        key_type: 0
+        key: password
+        mode: md5
       level_2:
-        profile: profile1
-        algorithm: md5
-        rx_disabled: true
+        key_type: 0
+        key: password
+        mode: md5
 
   - name: Vlan348
-    description: isis authentication shared-secret3
-    isis_authentication_mode: shared-secret
-    isis_authentication_mode_shared_secret:
-      both:
-        profile: profile-both
-        algorithm: sha-256
-        rx_disabled: false
+    description: isis authentication l1 l2 shared secret
+    isis_authentication:
+      level_1:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-256
+      level_2:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-256
+
+  - name: Vlan349
+    description: isis authentication l1 l2 shared secret rx
+    isis_authentication:
+      level_1:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-256
+        rx_disabled: true
+      level_2:
+        mode: shared-secret
+        shared_secret:
+          profile: profile1
+          algorithm: sha-256
+        rx_disabled: true
+
+  - name: Vlan350
+    description: isis authentication l1 l2 sha rx
+    isis_authentication:
+      level_1:
+        mode: sha
+        sha:
+          key_id: 5
+        rx_disabled: true
+      level_2:
+        mode: sha
+        sha:
+          key_id: 5
+        rx_disabled: true
+
+  - name: Vlan351
+    description: isis authentication l1 l2 sha
+    isis_authentication:
+      level_1:
+        mode: sha
+        sha:
+          key_id: 5
+      level_2:
+        mode: sha
+        sha:
+          key_id: 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -475,11 +475,39 @@ vlan_interfaces:
         rx_disabled: true
       level_1:
         key_id: 1010
+      level_2:
+        key_id: 1010
 
   - name: Vlan342
+    description: isis authentication sha
+    isis_authentication_mode: sha
+    isis_authentication_mode_sha:
+      level_1:
+        key_id: 1010
+      level_2:
+        key_id: 1010
+
+  - name: Vlan343
     description: isis authentication shared-secret
     isis_authentication_mode: shared-secret
     isis_authentication_mode_shared_secret:
+      level_1:
+        profile: profile1
+        algorithm: sha-1
+        rx_disabled: true
+      level_2:
+        profile: profile1
+        algorithm: md5
+        rx_disabled: true
+
+  - name: Vlan344
+    description: isis authentication shared-secret
+    isis_authentication_mode: shared-secret
+    isis_authentication_mode_shared_secret:
+      both:
+        profile: profile-both
+        algorithm: md5
+        rx_disabled: true
       level_1:
         profile: profile1
         algorithm: sha-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -363,7 +363,17 @@ vlan_interfaces:
         source_address: a0::6
         link_address: a0::7
       - address: a0::8
-
+    isis_authentication:
+      level_1:
+        key_type: 0
+        key: password
+        mode: md5
+        rx_disabled: true
+      level_2:
+        key_type: 0
+        key: password
+        mode: text
+        rx_disabled: true
   - name: Vlan50
     description: IP NAT Testing
     ip_nat:
@@ -382,6 +392,12 @@ vlan_interfaces:
         static:
           - original_ip: 3.0.0.1
             translated_ip: 4.0.0.1
+    isis_authentication:
+      level_2:
+        key_type: 0
+        key: password
+        mode: text
+        rx_disabled: true
 
 # IPv6 SVI configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -36,7 +36,7 @@ vlan_interfaces:
       level_2:
         key_type: 0
         key: password
-        mode: md5
+        mode: text
         rx_disabled: true
 
   - name: Vlan81
@@ -290,10 +290,6 @@ vlan_interfaces:
     isis_enable: "EVPN_UNDERLAY"
     isis_authentication:
       level_1:
-        mode: sha
-        sha:
-          key_id: 5
-      level_2:
         mode: sha
         sha:
           key_id: 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -467,7 +467,7 @@ vlan_interfaces:
     isis_authentication_key: "asfddja23452"
 
   - name: Vlan341
-    description: isis authentication sha
+    description: isis authentication sha1
     isis_authentication_mode: sha
     isis_authentication_mode_sha:
       both:
@@ -479,16 +479,37 @@ vlan_interfaces:
         key_id: 1010
 
   - name: Vlan342
-    description: isis authentication sha
+    description: isis authentication sha2
+    isis_authentication_mode: sha
+    isis_authentication_mode_sha:
+      both:
+        key_id: 1001
+        rx_disabled: false
+
+  - name: Vlan343
+    description: isis authentication sha3
     isis_authentication_mode: sha
     isis_authentication_mode_sha:
       level_1:
         key_id: 1010
+        rx_disabled: true
       level_2:
         key_id: 1010
+        rx_disabled: true
 
-  - name: Vlan343
-    description: isis authentication shared-secret
+  - name: Vlan344
+    description: isis authentication sha4
+    isis_authentication_mode: sha
+    isis_authentication_mode_sha:
+      level_1:
+        key_id: 1011
+        rx_disabled: false
+      level_2:
+        key_id: 1011
+        rx_disabled: false
+
+  - name: Vlan345
+    description: isis authentication shared-secret1
     isis_authentication_mode: shared-secret
     isis_authentication_mode_shared_secret:
       level_1:
@@ -500,8 +521,21 @@ vlan_interfaces:
         algorithm: md5
         rx_disabled: true
 
-  - name: Vlan344
-    description: isis authentication shared-secret
+  - name: Vlan346
+    description: isis authentication shared-secret1
+    isis_authentication_mode: shared-secret
+    isis_authentication_mode_shared_secret:
+      level_1:
+        profile: profile1
+        algorithm: sha-1
+        rx_disabled: false
+      level_2:
+        profile: profile1
+        algorithm: md5
+        rx_disabled: false
+
+  - name: Vlan347
+    description: isis authentication shared-secret2
     isis_authentication_mode: shared-secret
     isis_authentication_mode_shared_secret:
       both:
@@ -516,3 +550,12 @@ vlan_interfaces:
         profile: profile1
         algorithm: md5
         rx_disabled: true
+
+  - name: Vlan348
+    description: isis authentication shared-secret3
+    isis_authentication_mode: shared-secret
+    isis_authentication_mode_shared_secret:
+      both:
+        profile: profile-both
+        algorithm: sha-256
+        rx_disabled: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -336,6 +336,10 @@ vlan_interfaces:
             algorithm: sha-1
             key_type: 0
             key: password3
+          - id: 5
+            algorithm: sha-1
+            key_type: 0
+            key: password3
       level_2:
         key_ids:
           - id: 1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -467,9 +467,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -467,8 +467,8 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 | Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -467,9 +467,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -452,8 +452,8 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 | Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -452,9 +452,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -452,9 +452,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -467,9 +467,9 @@ interface Loopback10
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -467,9 +467,9 @@ interface Loopback10
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -467,8 +467,8 @@ interface Loopback10
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 | Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -467,9 +467,9 @@ interface Loopback10
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -467,9 +467,9 @@ interface Loopback10
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -467,8 +467,8 @@ interface Loopback10
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 | Vlan4093 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -466,9 +466,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -466,8 +466,8 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 | Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -466,9 +466,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
-| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -466,9 +466,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
-| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -466,8 +466,8 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 | Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - |
 
 #### VLAN Interfaces Device Configuration

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -466,9 +466,9 @@ interface Loopback1
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
-| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Vlan4094 | EVPN_UNDERLAY | True | 50 | point-to-point | - | - |
 
 #### VLAN Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -41,7 +41,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "router_isis.authentication.both.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "router_isis.authentication.both.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.both.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication check on the receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "router_isis.authentication.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_1.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
@@ -57,7 +57,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "router_isis.authentication.level_1.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "router_isis.authentication.level_1.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.level_1.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication check on the receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "router_isis.authentication.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_2.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
@@ -73,7 +73,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "router_isis.authentication.level_2.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "router_isis.authentication.level_2.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.level_2.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_2.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_2.rx_disabled") | Boolean |  |  |  | Disable authentication check on the receive side. |
     | [<samp>&nbsp;&nbsp;advertise</samp>](## "router_isis.advertise") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;passive_only</samp>](## "router_isis.advertise.passive_only") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;redistribute_routes</samp>](## "router_isis.redistribute_routes") | List, items: Dictionary |  |  |  |  |
@@ -195,7 +195,7 @@
             profile: <str; required>
             algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
-          # Disable authentication on receive side.
+          # Disable authentication check on the receive side.
           rx_disabled: <bool>
 
         # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
@@ -233,7 +233,7 @@
             profile: <str; required>
             algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
-          # Disable authentication on receive side.
+          # Disable authentication check on the receive side.
           rx_disabled: <bool>
 
         # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
@@ -271,7 +271,7 @@
             profile: <str; required>
             algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
-          # Disable authentication on receive side.
+          # Disable authentication check on the receive side.
           rx_disabled: <bool>
       advertise:
         passive_only: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -27,7 +27,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "router_isis.set_overload_bit.on_startup.wait_for_bgp.timeout") | Integer |  |  |  | Number of seconds. |
     | [<samp>&nbsp;&nbsp;authentication</samp>](## "router_isis.authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "router_isis.authentication.both") | Dictionary |  |  |  | Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.both.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "router_isis.authentication.both.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "router_isis.authentication.both.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -43,7 +43,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.both.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "router_isis.authentication.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_1.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "router_isis.authentication.level_1.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "router_isis.authentication.level_1.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -59,7 +59,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.level_1.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "router_isis.authentication.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_2.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "router_isis.authentication.level_2.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "router_isis.authentication.level_2.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -163,7 +163,7 @@
         # Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
         both:
 
-          # Configure authentication key type. EOS default `key_type` is 0.
+          # Configure authentication key type. EOS default `key_type` is 7.
           key_type: <str; "0" | "7" | "8a">
 
           # Password string. `key_type` is required for this setting.
@@ -201,7 +201,7 @@
         # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
         level_1:
 
-          # Configure authentication key type. EOS default `key_type` is 0.
+          # Configure authentication key type. EOS default `key_type` is 7.
           key_type: <str; "0" | "7" | "8a">
 
           # Password string. `key_type` is required for this setting.
@@ -239,7 +239,7 @@
         # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
         level_2:
 
-          # Configure authentication key type. EOS default `key_type` is 0.
+          # Configure authentication key type. EOS default `key_type` is 7.
           key_type: <str; "0" | "7" | "8a">
 
           # Password string. `key_type` is required for this setting.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -27,8 +27,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "router_isis.set_overload_bit.on_startup.wait_for_bgp.timeout") | Integer |  |  |  | Number of seconds. |
     | [<samp>&nbsp;&nbsp;authentication</samp>](## "router_isis.authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "router_isis.authentication.both") | Dictionary |  |  |  | Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. Default key_id is 0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.both.key") | String |  |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.both.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "router_isis.authentication.both.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "router_isis.authentication.both.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.both.key_ids.[].algorithm") | String | Required |  | Valid Values:<br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
@@ -41,10 +41,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "router_isis.authentication.both.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "router_isis.authentication.both.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.both.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.both.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "router_isis.authentication.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. Default key_id is 0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_1.key") | String |  |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_1.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "router_isis.authentication.level_1.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "router_isis.authentication.level_1.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.level_1.key_ids.[].algorithm") | String | Required |  | Valid Values:<br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
@@ -57,10 +57,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "router_isis.authentication.level_1.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "router_isis.authentication.level_1.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.level_1.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_1.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "router_isis.authentication.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. Default key_id is 0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_2.key") | String |  |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_2.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "router_isis.authentication.level_2.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "router_isis.authentication.level_2.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.level_2.key_ids.[].algorithm") | String | Required |  | Valid Values:<br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
@@ -73,7 +73,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "router_isis.authentication.level_2.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "router_isis.authentication.level_2.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.level_2.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_2.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_2.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;advertise</samp>](## "router_isis.advertise") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;passive_only</samp>](## "router_isis.advertise.passive_only") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;redistribute_routes</samp>](## "router_isis.redistribute_routes") | List, items: Dictionary |  |  |  |  |
@@ -163,10 +163,10 @@
         # Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
         both:
 
-          # Configure authentication key type. Default key_id is 0.
+          # Configure authentication key type. EOS default `key_type` is 0.
           key_type: <str; "0" | "7" | "8a">
 
-          # Password string.
+          # Password string. `key_type` is required for this setting.
           key: <str>
           key_ids:
 
@@ -194,15 +194,17 @@
           shared_secret:
             profile: <str; required>
             algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+          # Disable authentication on receive side.
           rx_disabled: <bool>
 
         # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
         level_1:
 
-          # Configure authentication key type. Default key_id is 0.
+          # Configure authentication key type. EOS default `key_type` is 0.
           key_type: <str; "0" | "7" | "8a">
 
-          # Password string.
+          # Password string. `key_type` is required for this setting.
           key: <str>
           key_ids:
 
@@ -230,15 +232,17 @@
           shared_secret:
             profile: <str; required>
             algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+          # Disable authentication on receive side.
           rx_disabled: <bool>
 
         # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
         level_2:
 
-          # Configure authentication key type. Default key_id is 0.
+          # Configure authentication key type. EOS default `key_type` is 0.
           key_type: <str; "0" | "7" | "8a">
 
-          # Password string.
+          # Password string. `key_type` is required for this setting.
           key: <str>
           key_ids:
 
@@ -266,6 +270,8 @@
           shared_secret:
             profile: <str; required>
             algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+          # Disable authentication on receive side.
           rx_disabled: <bool>
       advertise:
         passive_only: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -27,7 +27,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timeout</samp>](## "router_isis.set_overload_bit.on_startup.wait_for_bgp.timeout") | Integer |  |  |  | Number of seconds. |
     | [<samp>&nbsp;&nbsp;authentication</samp>](## "router_isis.authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "router_isis.authentication.both") | Dictionary |  |  |  | Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.both.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "router_isis.authentication.both.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "router_isis.authentication.both.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -43,7 +43,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.both.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "router_isis.authentication.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_1.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "router_isis.authentication.level_1.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "router_isis.authentication.level_1.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -59,7 +59,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "router_isis.authentication.level_1.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "router_isis.authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "router_isis.authentication.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "router_isis.authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "router_isis.authentication.level_2.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "router_isis.authentication.level_2.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "router_isis.authentication.level_2.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -163,7 +163,7 @@
         # Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
         both:
 
-          # Configure authentication key type. EOS default `key_type` is 7.
+          # Configure authentication key type.
           key_type: <str; "0" | "7" | "8a">
 
           # Password string. `key_type` is required for this setting.
@@ -201,7 +201,7 @@
         # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
         level_1:
 
-          # Configure authentication key type. EOS default `key_type` is 7.
+          # Configure authentication key type.
           key_type: <str; "0" | "7" | "8a">
 
           # Password string. `key_type` is required for this setting.
@@ -239,7 +239,7 @@
         # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
         level_2:
 
-          # Configure authentication key type. EOS default `key_type` is 7.
+          # Configure authentication key type.
           key_type: <str; "0" | "7" | "8a">
 
           # Password string. `key_type` is required for this setting.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -158,8 +158,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_network_point_to_point</samp>](## "vlan_interfaces.[].isis_network_point_to_point") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication</samp>](## "vlan_interfaces.[].isis_authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "vlan_interfaces.[].isis_authentication.both") | Dictionary |  |  |  | Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. Default key_id is 0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.both.key") | String |  |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.both.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids.[].algorithm") | String | Required |  | Valid Values:<br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
@@ -172,10 +172,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.both.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "vlan_interfaces.[].isis_authentication.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. Default key_id is 0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key") | String |  |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids.[].algorithm") | String | Required |  | Valid Values:<br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
@@ -188,10 +188,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_1.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "vlan_interfaces.[].isis_authentication.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. Default key_id is 0. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key") | String |  |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids.[].algorithm") | String | Required |  | Valid Values:<br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
@@ -204,7 +204,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "vlan_interfaces.[].isis_authentication.level_2.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication.level_2.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_2.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_2.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_2.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "vlan_interfaces.[].mtu") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;no_autostate</samp>](## "vlan_interfaces.[].no_autostate") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrrp_ids</samp>](## "vlan_interfaces.[].vrrp_ids") | List, items: Dictionary |  |  |  | Improved "vrrp" data model to support multiple VRRP IDs. |
@@ -554,10 +554,10 @@
           # Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
           both:
 
-            # Configure authentication key type. Default key_id is 0.
+            # Configure authentication key type. EOS default `key_type` is 0.
             key_type: <str; "0" | "7" | "8a">
 
-            # Password string.
+            # Password string. `key_type` is required for this setting.
             key: <str>
             key_ids:
 
@@ -585,15 +585,17 @@
             shared_secret:
               profile: <str; required>
               algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+            # Disable authentication on receive side.
             rx_disabled: <bool>
 
           # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
           level_1:
 
-            # Configure authentication key type. Default key_id is 0.
+            # Configure authentication key type. EOS default `key_type` is 0.
             key_type: <str; "0" | "7" | "8a">
 
-            # Password string.
+            # Password string. `key_type` is required for this setting.
             key: <str>
             key_ids:
 
@@ -621,15 +623,17 @@
             shared_secret:
               profile: <str; required>
               algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+            # Disable authentication on receive side.
             rx_disabled: <bool>
 
           # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
           level_2:
 
-            # Configure authentication key type. Default key_id is 0.
+            # Configure authentication key type. EOS default `key_type` is 0.
             key_type: <str; "0" | "7" | "8a">
 
-            # Password string.
+            # Password string. `key_type` is required for this setting.
             key: <str>
             key_ids:
 
@@ -657,6 +661,8 @@
             shared_secret:
               profile: <str; required>
               algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+            # Disable authentication on receive side.
             rx_disabled: <bool>
         mtu: <int>
         no_autostate: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -172,7 +172,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication check on the receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "vlan_interfaces.[].isis_authentication.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
@@ -188,7 +188,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication check on the receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "vlan_interfaces.[].isis_authentication.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
@@ -204,7 +204,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "vlan_interfaces.[].isis_authentication.level_2.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication.level_2.shared_secret.profile") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_2.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_2.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_2.rx_disabled") | Boolean |  |  |  | Disable authentication check on the receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "vlan_interfaces.[].mtu") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;no_autostate</samp>](## "vlan_interfaces.[].no_autostate") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrrp_ids</samp>](## "vlan_interfaces.[].vrrp_ids") | List, items: Dictionary |  |  |  | Improved "vrrp" data model to support multiple VRRP IDs. |
@@ -586,7 +586,7 @@
               profile: <str; required>
               algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
-            # Disable authentication on receive side.
+            # Disable authentication check on the receive side.
             rx_disabled: <bool>
 
           # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
@@ -624,7 +624,7 @@
               profile: <str; required>
               algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
-            # Disable authentication on receive side.
+            # Disable authentication check on the receive side.
             rx_disabled: <bool>
 
           # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
@@ -662,7 +662,7 @@
               profile: <str; required>
               algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
-            # Disable authentication on receive side.
+            # Disable authentication check on the receive side.
             rx_disabled: <bool>
         mtu: <int>
         no_autostate: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -158,7 +158,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_network_point_to_point</samp>](## "vlan_interfaces.[].isis_network_point_to_point") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication</samp>](## "vlan_interfaces.[].isis_authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "vlan_interfaces.[].isis_authentication.both") | Dictionary |  |  |  | Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.both.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -174,7 +174,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "vlan_interfaces.[].isis_authentication.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -190,7 +190,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "vlan_interfaces.[].isis_authentication.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -554,7 +554,7 @@
           # Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
           both:
 
-            # Configure authentication key type. EOS default `key_type` is 7.
+            # Configure authentication key type.
             key_type: <str; "0" | "7" | "8a">
 
             # Password string. `key_type` is required for this setting.
@@ -592,7 +592,7 @@
           # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
           level_1:
 
-            # Configure authentication key type. EOS default `key_type` is 7.
+            # Configure authentication key type.
             key_type: <str; "0" | "7" | "8a">
 
             # Password string. `key_type` is required for this setting.
@@ -630,7 +630,7 @@
           # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
           level_2:
 
-            # Configure authentication key type. EOS default `key_type` is 7.
+            # Configure authentication key type.
             key_type: <str; "0" | "7" | "8a">
 
             # Password string. `key_type` is required for this setting.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -156,31 +156,55 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_passive</samp>](## "vlan_interfaces.[].isis_passive") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_metric</samp>](## "vlan_interfaces.[].isis_metric") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_network_point_to_point</samp>](## "vlan_interfaces.[].isis_network_point_to_point") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_mode</samp>](## "vlan_interfaces.[].isis_authentication_mode") | String |  |  | Valid Values:<br>- <code>text</code><br>- <code>md5</code><br>- <code>sha</code><br>- <code>shared-secret</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_key</samp>](## "vlan_interfaces.[].isis_authentication_key") | String |  |  |  | Type-7 encrypted password. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_mode_shared_secret</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret") | Dictionary |  |  |  | Required for authentication mode `shared-secret`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.both") | Dictionary |  |  |  | When set `both` takes precedence over `level_1` and `level_2`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.both.rx_disabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.both.profile") | String | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.both.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_1.rx_disabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_1.profile") | String | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_1.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_2.rx_disabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_2.profile") | String | Required |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_2.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_mode_sha</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha") | Dictionary |  |  |  | Required for authentication mode `sha`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.both") | Dictionary |  |  |  | When set `both` takes precedence over `level_1` and `level_2`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.both.rx_disabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_id</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.both.key_id") | Integer | Required |  | Min: 1<br>Max: 65535 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_1.rx_disabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_id</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_1.key_id") | Integer | Required |  | Min: 1<br>Max: 65535 |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_2.rx_disabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_id</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_2.key_id") | Integer | Required |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication</samp>](## "vlan_interfaces.[].isis_authentication") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "vlan_interfaces.[].isis_authentication.both") | Dictionary |  |  |  | Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. Default key_id is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.both.key") | String |  |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids.[].algorithm") | String | Required |  | Valid Values:<br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids.[].key_type") | String | Required |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids.[].key") | String | Required |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rfc_5310</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids.[].rfc_5310") | Boolean |  |  |  | SHA digest computation according to rfc5310. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "vlan_interfaces.[].isis_authentication.both.mode") | String |  |  | Valid Values:<br>- <code>md5</code><br>- <code>sha</code><br>- <code>text</code><br>- <code>shared-secret</code> | Authentication mode. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sha</samp>](## "vlan_interfaces.[].isis_authentication.both.sha") | Dictionary |  |  |  | Required settings for authentication mode 'sha'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_id</samp>](## "vlan_interfaces.[].isis_authentication.both.sha.key_id") | Integer | Required |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret.profile") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.both.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "vlan_interfaces.[].isis_authentication.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. Default key_id is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key") | String |  |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids.[].algorithm") | String | Required |  | Valid Values:<br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids.[].key_type") | String | Required |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids.[].key") | String | Required |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rfc_5310</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids.[].rfc_5310") | Boolean |  |  |  | SHA digest computation according to rfc5310. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "vlan_interfaces.[].isis_authentication.level_1.mode") | String |  |  | Valid Values:<br>- <code>md5</code><br>- <code>sha</code><br>- <code>text</code><br>- <code>shared-secret</code> | Authentication mode. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sha</samp>](## "vlan_interfaces.[].isis_authentication.level_1.sha") | Dictionary |  |  |  | Required settings for authentication mode 'sha'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_id</samp>](## "vlan_interfaces.[].isis_authentication.level_1.sha.key_id") | Integer | Required |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret.profile") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_1.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "vlan_interfaces.[].isis_authentication.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. Default key_id is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key") | String |  |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids.[].algorithm") | String | Required |  | Valid Values:<br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids.[].key_type") | String | Required |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids.[].key") | String | Required |  |  | Password string. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rfc_5310</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids.[].rfc_5310") | Boolean |  |  |  | SHA digest computation according to rfc5310. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "vlan_interfaces.[].isis_authentication.level_2.mode") | String |  |  | Valid Values:<br>- <code>md5</code><br>- <code>sha</code><br>- <code>text</code><br>- <code>shared-secret</code> | Authentication mode. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sha</samp>](## "vlan_interfaces.[].isis_authentication.level_2.sha") | Dictionary |  |  |  | Required settings for authentication mode 'sha'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_id</samp>](## "vlan_interfaces.[].isis_authentication.level_2.sha.key_id") | Integer | Required |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shared_secret</samp>](## "vlan_interfaces.[].isis_authentication.level_2.shared_secret") | Dictionary |  |  |  | Required settings for authentication mode 'shared_secret'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication.level_2.shared_secret.profile") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_2.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_2.rx_disabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "vlan_interfaces.[].mtu") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;no_autostate</samp>](## "vlan_interfaces.[].no_autostate") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrrp_ids</samp>](## "vlan_interfaces.[].vrrp_ids") | List, items: Dictionary |  |  |  | Improved "vrrp" data model to support multiple VRRP IDs. |
@@ -525,49 +549,115 @@
         isis_passive: <bool>
         isis_metric: <int>
         isis_network_point_to_point: <bool>
-        isis_authentication_mode: <str; "text" | "md5" | "sha" | "shared-secret">
+        isis_authentication:
 
-        # Type-7 encrypted password.
-        isis_authentication_key: <str>
-
-        # Required for authentication mode `shared-secret`.
-        isis_authentication_mode_shared_secret:
-
-          # When set `both` takes precedence over `level_1` and `level_2`.
+          # Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
           both:
+
+            # Configure authentication key type. Default key_id is 0.
+            key_type: <str; "0" | "7" | "8a">
+
+            # Password string.
+            key: <str>
+            key_ids:
+
+                # Configure authentication key-id.
+              - id: <int; 1-65535; required; unique>
+                algorithm: <str; "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+                # Configure authentication key type.
+                key_type: <str; "0" | "7" | "8a"; required>
+
+                # Password string.
+                key: <str; required>
+
+                # SHA digest computation according to rfc5310.
+                rfc_5310: <bool>
+
+            # Authentication mode.
+            mode: <str; "md5" | "sha" | "text" | "shared-secret">
+
+            # Required settings for authentication mode 'sha'.
+            sha:
+              key_id: <int; 1-65535; required>
+
+            # Required settings for authentication mode 'shared_secret'.
+            shared_secret:
+              profile: <str; required>
+              algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
             rx_disabled: <bool>
-            profile: <str; required>
-            algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
           # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
           level_1:
+
+            # Configure authentication key type. Default key_id is 0.
+            key_type: <str; "0" | "7" | "8a">
+
+            # Password string.
+            key: <str>
+            key_ids:
+
+                # Configure authentication key-id.
+              - id: <int; 1-65535; required; unique>
+                algorithm: <str; "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+                # Configure authentication key type.
+                key_type: <str; "0" | "7" | "8a"; required>
+
+                # Password string.
+                key: <str; required>
+
+                # SHA digest computation according to rfc5310.
+                rfc_5310: <bool>
+
+            # Authentication mode.
+            mode: <str; "md5" | "sha" | "text" | "shared-secret">
+
+            # Required settings for authentication mode 'sha'.
+            sha:
+              key_id: <int; 1-65535; required>
+
+            # Required settings for authentication mode 'shared_secret'.
+            shared_secret:
+              profile: <str; required>
+              algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
             rx_disabled: <bool>
-            profile: <str; required>
-            algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
           # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
           level_2:
-            rx_disabled: <bool>
-            profile: <str; required>
-            algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
-        # Required for authentication mode `sha`.
-        isis_authentication_mode_sha:
+            # Configure authentication key type. Default key_id is 0.
+            key_type: <str; "0" | "7" | "8a">
 
-          # When set `both` takes precedence over `level_1` and `level_2`.
-          both:
-            rx_disabled: <bool>
-            key_id: <int; 1-65535; required>
+            # Password string.
+            key: <str>
+            key_ids:
 
-          # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
-          level_1:
-            rx_disabled: <bool>
-            key_id: <int; 1-65535; required>
+                # Configure authentication key-id.
+              - id: <int; 1-65535; required; unique>
+                algorithm: <str; "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
 
-          # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
-          level_2:
+                # Configure authentication key type.
+                key_type: <str; "0" | "7" | "8a"; required>
+
+                # Password string.
+                key: <str; required>
+
+                # SHA digest computation according to rfc5310.
+                rfc_5310: <bool>
+
+            # Authentication mode.
+            mode: <str; "md5" | "sha" | "text" | "shared-secret">
+
+            # Required settings for authentication mode 'sha'.
+            sha:
+              key_id: <int; 1-65535; required>
+
+            # Required settings for authentication mode 'shared_secret'.
+            shared_secret:
+              profile: <str; required>
+              algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
             rx_disabled: <bool>
-            key_id: <int; 1-65535; required>
         mtu: <int>
         no_autostate: <bool>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -158,7 +158,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_network_point_to_point</samp>](## "vlan_interfaces.[].isis_network_point_to_point") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication</samp>](## "vlan_interfaces.[].isis_authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "vlan_interfaces.[].isis_authentication.both") | Dictionary |  |  |  | Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.both.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.both.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.both.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -174,7 +174,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.both.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.both.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "vlan_interfaces.[].isis_authentication.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.level_1.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -190,7 +190,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication.level_1.shared_secret.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication.level_1.rx_disabled") | Boolean |  |  |  | Disable authentication on receive side. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "vlan_interfaces.[].isis_authentication.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> | Configure authentication key type. EOS default `key_type` is 7. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key") | String |  |  |  | Password string. `key_type` is required for this setting. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_ids</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "vlan_interfaces.[].isis_authentication.level_2.key_ids.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65535 | Configure authentication key-id. |
@@ -554,7 +554,7 @@
           # Authentication settings for level-1 and level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
           both:
 
-            # Configure authentication key type. EOS default `key_type` is 0.
+            # Configure authentication key type. EOS default `key_type` is 7.
             key_type: <str; "0" | "7" | "8a">
 
             # Password string. `key_type` is required for this setting.
@@ -592,7 +592,7 @@
           # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
           level_1:
 
-            # Configure authentication key type. EOS default `key_type` is 0.
+            # Configure authentication key type. EOS default `key_type` is 7.
             key_type: <str; "0" | "7" | "8a">
 
             # Password string. `key_type` is required for this setting.
@@ -630,7 +630,7 @@
           # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
           level_2:
 
-            # Configure authentication key type. EOS default `key_type` is 0.
+            # Configure authentication key type. EOS default `key_type` is 7.
             key_type: <str; "0" | "7" | "8a">
 
             # Password string. `key_type` is required for this setting.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -156,6 +156,31 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_passive</samp>](## "vlan_interfaces.[].isis_passive") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_metric</samp>](## "vlan_interfaces.[].isis_metric") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_network_point_to_point</samp>](## "vlan_interfaces.[].isis_network_point_to_point") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_mode</samp>](## "vlan_interfaces.[].isis_authentication_mode") | String |  |  | Valid Values:<br>- <code>text</code><br>- <code>md5</code><br>- <code>sha</code><br>- <code>shared-secret</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_key</samp>](## "vlan_interfaces.[].isis_authentication_key") | String |  |  |  | Type-7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_mode_shared_secret</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret") | Dictionary |  |  |  | Required for authentication mode `shared-secret`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.both") | Dictionary |  |  |  | When set `both` takes precedence over `level_1` and `level_2`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.both.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.both.profile") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.both.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_1.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_1.profile") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_1.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_2.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_2.profile") | String | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;algorithm</samp>](## "vlan_interfaces.[].isis_authentication_mode_shared_secret.level_2.algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha-1</code><br>- <code>sha-224</code><br>- <code>sha-256</code><br>- <code>sha-384</code><br>- <code>sha-512</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;isis_authentication_mode_sha</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha") | Dictionary |  |  |  | Required for authentication mode `sha`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;both</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.both") | Dictionary |  |  |  | When set `both` takes precedence over `level_1` and `level_2`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.both.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_id</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.both.key_id") | Integer | Required |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_1</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_1") | Dictionary |  |  |  | Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_1.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_id</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_1.key_id") | Integer | Required |  | Min: 1<br>Max: 65535 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;level_2</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_2") | Dictionary |  |  |  | Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_disabled</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_2.rx_disabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_id</samp>](## "vlan_interfaces.[].isis_authentication_mode_sha.level_2.key_id") | Integer | Required |  | Min: 1<br>Max: 65535 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "vlan_interfaces.[].mtu") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;no_autostate</samp>](## "vlan_interfaces.[].no_autostate") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrrp_ids</samp>](## "vlan_interfaces.[].vrrp_ids") | List, items: Dictionary |  |  |  | Improved "vrrp" data model to support multiple VRRP IDs. |
@@ -500,6 +525,49 @@
         isis_passive: <bool>
         isis_metric: <int>
         isis_network_point_to_point: <bool>
+        isis_authentication_mode: <str; "text" | "md5" | "sha" | "shared-secret">
+
+        # Type-7 encrypted password.
+        isis_authentication_key: <str>
+
+        # Required for authentication mode `shared-secret`.
+        isis_authentication_mode_shared_secret:
+
+          # When set `both` takes precedence over `level_1` and `level_2`.
+          both:
+            rx_disabled: <bool>
+            profile: <str; required>
+            algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+          # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
+          level_1:
+            rx_disabled: <bool>
+            profile: <str; required>
+            algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+          # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
+          level_2:
+            rx_disabled: <bool>
+            profile: <str; required>
+            algorithm: <str; "md5" | "sha-1" | "sha-224" | "sha-256" | "sha-384" | "sha-512"; required>
+
+        # Required for authentication mode `sha`.
+        isis_authentication_mode_sha:
+
+          # When set `both` takes precedence over `level_1` and `level_2`.
+          both:
+            rx_disabled: <bool>
+            key_id: <int; 1-65535; required>
+
+          # Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
+          level_1:
+            rx_disabled: <bool>
+            key_id: <int; 1-65535; required>
+
+          # Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
+          level_2:
+            rx_disabled: <bool>
+            key_id: <int; 1-65535; required>
         mtu: <int>
         no_autostate: <bool>
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -139,8 +139,8 @@
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
-| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ |
 {%         for vlan_interface in vlan_interfaces | arista.avd.natural_sort('name') %}
 {%             if vlan_interface.isis_authentication.both.mode is arista.avd.defined %}
 {%                 set isis_authentication_mode = vlan_interface.isis_authentication.both.mode %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -160,7 +160,7 @@
 {%                 else %}
 {%                     set mode = "-" %}
 {%                 endif %}
-| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} | {{ isis_authentication_mode }} |
+| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} | {{ isis_authentication_mode | arista.avd.default("-") }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -162,7 +162,7 @@
 {%                 else %}
 {%                     set mode = "-" %}
 {%                 endif %}
-| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} | {{ isis_authentication_mode | arista.avd.default("-") }} |
+| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} | {{ isis_authentication_mode }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -139,11 +139,20 @@
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
-| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | ISIS Authentication Mode | 
+| --------- | ------------- | -------- | ----------- | ---- | ------------------------ | 
 {%         for vlan_interface in vlan_interfaces | arista.avd.natural_sort('name') %}
-{%             set isis_level2_authentication_mode = vlan_interface.isis_authentication.both.mode | arista.avd.default(vlan_interface.isis_authentication.level_2.mode, "-") %}
-{%             set isis_level1_authentication_mode = vlan_interface.isis_authentication.both.mode | arista.avd.default(vlan_interface.isis_authentication.level_1.mode, "-") %}
+{%             if vlan_interface.isis_authentication.both.mode is arista.avd.defined %}
+{%                 set isis_authentication_mode = vlan_interface.isis_authentication.both.mode %}
+{%             elif vlan_interface.isis_authentication.level_1.mode is arista.avd.defined and vlan_interface.isis_authentication.level_2.mode is arista.avd.defined %}
+{%                 set isis_authentication_mode = "Level-1: " ~ vlan_interface.isis_authentication.level_1.mode ~ "<br>" ~ "Level-2: " ~ vlan_interface.isis_authentication.level_2.mode %}
+{%             elif vlan_interface.isis_authentication.level_1.mode is arista.avd.defined %}
+{%                 set isis_authentication_mode = "Level-1: " ~ vlan_interface.isis_authentication.level_1.mode %}
+{%             elif vlan_interface.isis_authentication.level_2.mode is arista.avd.defined %}
+{%                 set isis_authentication_mode = "Level-2: " ~ vlan_interface.isis_authentication.level_2.mode %}
+{%             else %}
+{%                 set isis_authentication_mode = "-" %}
+{%             endif %}
 {%             if vlan_interface.isis_enable is arista.avd.defined %}
 {%                 set isis_metric = vlan_interface.isis_metric | arista.avd.default('-') %}
 {%                 if vlan_interface.isis_network_point_to_point is arista.avd.defined %}
@@ -153,7 +162,7 @@
 {%                 else %}
 {%                     set mode = "-" %}
 {%                 endif %}
-| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} | {{ isis_level1_authentication_mode }} | {{ isis_level2_authentication_mode }} |
+| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} | {{ isis_authentication_mode | arista.avd.default("-") }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -150,8 +150,6 @@
 {%                 set isis_authentication_mode = "Level-1: " ~ vlan_interface.isis_authentication.level_1.mode %}
 {%             elif vlan_interface.isis_authentication.level_2.mode is arista.avd.defined %}
 {%                 set isis_authentication_mode = "Level-2: " ~ vlan_interface.isis_authentication.level_2.mode %}
-{%             else %}
-{%                 set isis_authentication_mode = "-" %}
 {%             endif %}
 {%             if vlan_interface.isis_enable is arista.avd.defined %}
 {%                 set isis_metric = vlan_interface.isis_metric | arista.avd.default('-') %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -142,8 +142,8 @@
 | Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
 | --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
 {%         for vlan_interface in vlan_interfaces | arista.avd.natural_sort('name') %}
-{%             set isis_level2_authentication_mode = vlan_interface.isis_authentication.level_2.mode | arista.avd.default(vlan_interface.isis_authentication.both.mode, "-") %}
-{%             set isis_level1_authentication_mode = vlan_interface.isis_authentication.level_1.mode | arista.avd.default(vlan_interface.isis_authentication.both.mode, "-") %}
+{%             set isis_level2_authentication_mode = vlan_interface.isis_authentication.both.mode | arista.avd.default(vlan_interface.isis_authentication.level_2.mode, "-") %}
+{%             set isis_level1_authentication_mode = vlan_interface.isis_authentication.both.mode | arista.avd.default(vlan_interface.isis_authentication.level_1.mode, "-") %}
 {%             if vlan_interface.isis_enable is arista.avd.defined %}
 {%                 set isis_metric = vlan_interface.isis_metric | arista.avd.default('-') %}
 {%                 if vlan_interface.isis_network_point_to_point is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlan-interfaces.j2
@@ -139,9 +139,11 @@
 
 ##### ISIS
 
-| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode |
-| --------- | ------------- | -------- | ----------- | ---- |
+| Interface | ISIS Instance | ISIS BFD | ISIS Metric | Mode | Level-1 Authentication Mode | Level-2 Authentication Mode |
+| --------- | ------------- | -------- | ----------- | ---- | --------------------------- | --------------------------- |
 {%         for vlan_interface in vlan_interfaces | arista.avd.natural_sort('name') %}
+{%             set isis_level2_authentication_mode = vlan_interface.isis_authentication.level_2.mode | arista.avd.default(vlan_interface.isis_authentication.both.mode, "-") %}
+{%             set isis_level1_authentication_mode = vlan_interface.isis_authentication.level_1.mode | arista.avd.default(vlan_interface.isis_authentication.both.mode, "-") %}
 {%             if vlan_interface.isis_enable is arista.avd.defined %}
 {%                 set isis_metric = vlan_interface.isis_metric | arista.avd.default('-') %}
 {%                 if vlan_interface.isis_network_point_to_point is arista.avd.defined %}
@@ -151,7 +153,7 @@
 {%                 else %}
 {%                     set mode = "-" %}
 {%                 endif %}
-| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} |
+| {{ vlan_interface.name }} | {{ vlan_interface.isis_enable }} | {{ vlan_interface.isis_bfd | arista.avd.default("-") }} | {{ isis_metric }} | {{ mode }} | {{ isis_level1_authentication_mode }} | {{ isis_level2_authentication_mode }} |
 {%             endif %}
 {%         endfor %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -312,7 +312,7 @@ interface {{ vlan_interface.name }}
                or (vlan_interface.isis_authentication.both.mode == "shared-secret"
                    and vlan_interface.isis_authentication.both.shared_secret.profile is arista.avd.defined
                    and vlan_interface.isis_authentication.both.shared_secret.algorithm is arista.avd.defined)) %}
-{%         set isis_auth_cli = "authentication mode " ~ vlan_interface.isis_authentication.both.mode %}
+{%         set isis_auth_cli = "isis authentication mode " ~ vlan_interface.isis_authentication.both.mode %}
 {%         if vlan_interface.isis_authentication.both.mode == "sha" %}
 {%             set isis_auth_cli = isis_auth_cli ~ " key-id " ~ vlan_interface.isis_authentication.both.sha.key_id %}
 {%         elif vlan_interface.isis_authentication.both.mode == "shared-secret" %}
@@ -330,7 +330,7 @@ interface {{ vlan_interface.name }}
                or (vlan_interface.isis_authentication.level_1.mode == "shared-secret"
                    and vlan_interface.isis_authentication.level_1.shared_secret.profile is arista.avd.defined
                    and vlan_interface.isis_authentication.level_1.shared_secret.algorithm is arista.avd.defined)) %}
-{%             set isis_auth_cli = "authentication mode " ~ vlan_interface.isis_authentication.level_1.mode %}
+{%             set isis_auth_cli = "isis authentication mode " ~ vlan_interface.isis_authentication.level_1.mode %}
 {%             if vlan_interface.isis_authentication.level_1.mode == "sha" %}
 {%                 set isis_auth_cli = isis_auth_cli ~ " key-id " ~ vlan_interface.isis_authentication.level_1.sha.key_id %}
 {%             elif vlan_interface.isis_authentication.level_1.mode == "shared-secret" %}
@@ -348,7 +348,7 @@ interface {{ vlan_interface.name }}
                or (vlan_interface.isis_authentication.level_2.mode == "shared-secret"
                    and vlan_interface.isis_authentication.level_2.shared_secret.profile is arista.avd.defined
                    and vlan_interface.isis_authentication.level_2.shared_secret.algorithm is arista.avd.defined)) %}
-{%             set isis_auth_cli = "authentication mode " ~ vlan_interface.isis_authentication.level_2.mode %}
+{%             set isis_auth_cli = "isis authentication mode " ~ vlan_interface.isis_authentication.level_2.mode %}
 {%             if vlan_interface.isis_authentication.level_2.mode == "sha" %}
 {%                 set isis_auth_cli = isis_auth_cli ~ " key-id " ~ vlan_interface.isis_authentication.level_2.sha.key_id %}
 {%             elif vlan_interface.isis_authentication.level_2.mode == "shared-secret" %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -341,20 +341,20 @@ interface {{ vlan_interface.name }}
    {{ auth_cli }}
 {%             else %}
 {%                 if vlan_interface.isis_authentication_mode_shared_secret.level_1.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.level_1.algorithm is arista.avd.defined %}
-{%                     set auth_cli = auth_cli ~  "profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.algorithm %}
+{%                     set auth_cli_level1 = auth_cli ~  " profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.algorithm %}
 {%                     if vlan_interface.isis_authentication_mode_shared_secret.level_1.rx_disabled is arista.avd.defined %}
-{%                         set auth_cli = auth_cli ~ " rx-disabled" %}
+{%                         set auth_cli_level1 = auth_cli_level1 ~ " rx-disabled" %}
 {%                     endif %}
-{%                     set auth_cli = auth_cli ~ " level-1" %}
-   {{ auth_cli }}
+{%                     set auth_cli_level1 = auth_cli_level1 ~ " level-1" %}
+   {{ auth_cli_level1 }}
 {%                 endif %}
 {%                 if vlan_interface.isis_authentication_mode_shared_secret.level_2.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.level_2.algorithm is arista.avd.defined %}
-{%                     set auth_cli = auth_cli ~ " profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.algorithm %}
+{%                     set auth_cli_level2 = auth_cli ~ " profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.algorithm %}
 {%                     if vlan_interface.isis_authentication_mode_shared_secret.level_2.rx_disabled is arista.avd.defined %}
-{%                         set auth_cli = auth_cli ~ " rx-disabled" %}
+{%                         set auth_cli_level2 = auth_cli_level2 ~ " rx-disabled" %}
 {%                     endif %}
-{%                     set auth_cli = auth_cli ~ " level-2" %}
-   {{ auth_cli }}
+{%                     set auth_cli_level2 = auth_cli_level2 ~ " level-2" %}
+   {{ auth_cli_level2 }}
 {%                 endif %}
 {%             endif %}
 {%         endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -316,8 +316,7 @@ interface {{ vlan_interface.name }}
 {%         if vlan_interface.isis_authentication.both.mode == "sha" %}
 {%             set isis_auth_cli = isis_auth_cli ~ " key-id " ~ vlan_interface.isis_authentication.both.sha.key_id %}
 {%         elif vlan_interface.isis_authentication.both.mode == "shared-secret" %}
-{%             set isis_auth_cli = isis_auth_cli ~ " profile " ~ vlan_interface.isis_authentication.both.shared_secret.profile %}
-{%             set isis_auth_cli = isis_auth_cli ~ " algorithm " ~ vlan_interface.isis_authentication.both.shared_secret.algorithm %}
+{%             set isis_auth_cli = isis_auth_cli ~ " profile " ~ vlan_interface.isis_authentication.both.shared_secret.profile ~ " algorithm " ~ vlan_interface.isis_authentication.both.shared_secret.algorithm %}
 {%         endif %}
 {%         if vlan_interface.isis_authentication.both.rx_disabled is arista.avd.defined(true) %}
 {%             set isis_auth_cli = isis_auth_cli ~ " rx-disabled" %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -306,6 +306,84 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%     endif %}
+{%     if vlan_interface.isis_authentication_mode is arista.avd.defined %}
+{%         set auth_cli = "isis authentication mode" ~ " " ~ vlan_interface.isis_authentication_mode %}
+{%         if vlan_interface.isis_authentication_mode == "sha" and vlan_interface.isis_authentication_mode_sha is arista.avd.defined %}
+{%             if vlan_interface.isis_authentication_mode_sha.both.key_id is arista.avd.defined %}
+{%                 set auth_cli = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.both.key_id %}
+{%                 if vlan_interface.isis_authentication_mode_sha.both.rx_disabled is arista.avd.defined %}
+{%                     set auth_cli = auth_cli ~ " rx-disabled" %}
+{%                 endif %}
+   {{ auth_cli }}
+{%             else %}
+{%                 if vlan_interface.isis_authentication_mode_sha.level_1.key_id is arista.avd.defined %}
+{%                     if vlan_interface.isis_authentication_mode_sha.level_1.rx_disabled is arista.avd.defined %}
+{%                         set auth_cli = auth_cli ~ " rx-disabled" %}
+{%                     endif %}
+{%                     set auth_cli = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.level_1.key_id ~ " level-1" %}
+   {{ auth_cli }}
+{%                 endif %}
+{%                 if vlan_interface.isis_authentication_mode_sha.level_2.key_id is arista.avd.defined %}
+{%                     if vlan_interface.isis_authentication_mode_sha.level_2.rx_disabled is arista.avd.defined %}
+{%                         set auth_cli = auth_cli ~ " rx-disabled" %}
+{%                     endif %}
+{%                     set auth_cli = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.level_2.key_id ~ " level-2" %}
+   {{ auth_cli }}
+{%                 endif %}
+{%             endif %}
+{%         endif %}
+{%         if vlan_interface.isis_authentication_mode == "shared-secret" and vlan_interface.isis_authentication_mode_shared_secret is arista.avd.defined %}
+{%             if vlan_interface.isis_authentication_mode_shared_secret.both.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.both.algorithm is arista.avd.defined %}
+{%                 set auth_cli = auth_cli ~ " profile " ~  vlan_interface.isis_authentication_mode_shared_secret.both.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.both.algorithm %}
+{%                 if vlan_interface.isis_authentication_mode_shared_secret.both.rx_disabled is arista.avd.defined %}
+{%                     set auth_cli = auth_cli ~ " rx-disabled " %}
+{%                 endif %}
+   {{ auth_cli }}
+{%             else %}
+{%                 if vlan_interface.isis_authentication_mode_shared_secret.level_1.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.level_1.algorithm is arista.avd.defined %}
+{%                     set auth_cli = auth_cli ~  "profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.algorithm %}
+{%                     if vlan_interface.isis_authentication_mode_shared_secret.level_1.rx_disabled is arista.avd.defined %}
+{%                         set auth_cli = auth_cli ~ " rx-disabled" %}
+{%                     endif %}
+{%                     set auth_cli = auth_cli ~ " level-1" %}
+   {{ auth_cli }}
+{%                 endif %}
+{%                 if vlan_interface.isis_authentication_mode_shared_secret.level_2.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.level_2.algorithm is arista.avd.defined %}
+{%                     set auth_cli = auth_cli ~ " profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.algorithm %}
+{%                     if vlan_interface.isis_authentication_mode_shared_secret.level_2.rx_disabled is arista.avd.defined %}
+{%                         set auth_cli = auth_cli ~ " rx-disabled" %}
+{%                     endif %}
+{%                     set auth_cli = auth_cli ~ " level-2" %}
+   {{ auth_cli }}
+{%                 endif %}
+{%             endif %}
+{%         endif %}
+{%         if vlan_interface.isis_authentication_mode is in [ "text", "md5" ] %}
+   {{ auth_cli }}
+{%         endif %}
+{%     endif %}
+{%     if vlan_interface.isis_authentication_key is arista.avd.defined %}
+   isis authentication key 7 {{ vlan_interface.isis_authentication_key | arista.avd.hide_passwords(hide_passwords) }}
+{%     endif %}
+{# The below "vrrp" keys will be deprecated in AVD v4.0 - These should not be mixed with the new "vrrp_ids" key above to avoid conflicts. #}
+{%     if vlan_interface.vrrp.virtual_router is arista.avd.defined %}
+{%         if vlan_interface.vrrp.priority is arista.avd.defined %}
+   vrrp {{ vlan_interface.vrrp.virtual_router }} priority-level {{ vlan_interface.vrrp.priority }}
+{%         endif %}
+{%         if vlan_interface.vrrp.advertisement_interval is arista.avd.defined %}
+   vrrp {{ vlan_interface.vrrp.virtual_router }} advertisement interval {{ vlan_interface.vrrp.advertisement_interval }}
+{%         endif %}
+{%         if vlan_interface.vrrp.preempt_delay_minimum is arista.avd.defined %}
+   vrrp {{ vlan_interface.vrrp.virtual_router }} preempt delay minimum {{ vlan_interface.vrrp.preempt_delay_minimum }}
+{%         endif %}
+{%         if vlan_interface.vrrp.ipv4 is arista.avd.defined %}
+   vrrp {{ vlan_interface.vrrp.virtual_router }} ipv4 {{ vlan_interface.vrrp.ipv4 }}
+{%         endif %}
+{%         if vlan_interface.vrrp.ipv6 is arista.avd.defined %}
+   vrrp {{ vlan_interface.vrrp.virtual_router }} ipv6 {{ vlan_interface.vrrp.ipv6 }}
+{%         endif %}
+{%     endif %}
+{# New improved "vrrp" data model to support multiple IDs #}
 {%     if vlan_interface.vrrp_ids is arista.avd.defined %}
 {%         for vrid in vlan_interface.vrrp_ids | arista.avd.natural_sort('id') if vrid.id is arista.avd.defined %}
 {%             if vrid.priority_level is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -334,8 +334,7 @@ interface {{ vlan_interface.name }}
 {%             if vlan_interface.isis_authentication.level_1.mode == "sha" %}
 {%                 set isis_auth_cli = isis_auth_cli ~ " key-id " ~ vlan_interface.isis_authentication.level_1.sha.key_id %}
 {%             elif vlan_interface.isis_authentication.level_1.mode == "shared-secret" %}
-{%                 set isis_auth_cli = isis_auth_cli ~ " profile " ~ vlan_interface.isis_authentication.level_1.shared_secret.profile %}
-{%                 set isis_auth_cli = isis_auth_cli ~ " algorithm " ~ vlan_interface.isis_authentication.level_1.shared_secret.algorithm %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " profile " ~ vlan_interface.isis_authentication.level_1.shared_secret.profile ~ " algorithm " ~ vlan_interface.isis_authentication.level_1.shared_secret.algorithm %}
 {%             endif %}
 {%             if vlan_interface.isis_authentication.level_1.rx_disabled is arista.avd.defined(true) %}
 {%                 set isis_auth_cli = isis_auth_cli ~ " rx-disabled" %}
@@ -352,13 +351,70 @@ interface {{ vlan_interface.name }}
 {%             if vlan_interface.isis_authentication.level_2.mode == "sha" %}
 {%                 set isis_auth_cli = isis_auth_cli ~ " key-id " ~ vlan_interface.isis_authentication.level_2.sha.key_id %}
 {%             elif vlan_interface.isis_authentication.level_2.mode == "shared-secret" %}
-{%                 set isis_auth_cli = isis_auth_cli ~ " profile " ~ vlan_interface.isis_authentication.level_2.shared_secret.profile %}
-{%                 set isis_auth_cli = isis_auth_cli ~ " algorithm " ~ vlan_interface.isis_authentication.level_2.shared_secret.algorithm %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " profile " ~ vlan_interface.isis_authentication.level_2.shared_secret.profile ~ " algorithm " ~ vlan_interface.isis_authentication.level_2.shared_secret.algorithm %}
 {%             endif %}
 {%             if vlan_interface.isis_authentication.level_2.rx_disabled is arista.avd.defined(true) %}
 {%                 set isis_auth_cli = isis_auth_cli ~ " rx-disabled" %}
 {%             endif %}
    {{ isis_auth_cli }} level-2
+{%         endif %}
+{%     endif %}
+{%     if vlan_interface.isis_authentication is arista.avd.defined %}
+{%         set both_key_ids = [] %}
+{%         if vlan_interface.isis_authentication.both.key_ids is arista.avd.defined %}
+{%             for auth_key in vlan_interface.isis_authentication.both.key_ids | arista.avd.natural_sort("id") %}
+{%                 if auth_key.id is arista.avd.defined
+                       and auth_key.algorithm is arista.avd.defined
+                       and auth_key.key_type is arista.avd.defined
+                       and auth_key.key is arista.avd.defined %}
+{%                     do both_key_ids.append(auth_key.id) %}
+{%                     if auth_key.rfc_5310 is arista.avd.defined(true) %}
+   isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} rfc-5310 key {{ auth_key.key_type }} {{ auth_key.key }}
+{%                     else %}
+   isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} key {{ auth_key.key_type }} {{ auth_key.key }}
+{%                     endif %}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if vlan_interface.isis_authentication.level_1.key_ids is arista.avd.defined %}
+{%             for auth_key in vlan_interface.isis_authentication.level_1.key_ids %}
+{%                 if auth_key.id is arista.avd.defined
+                       and auth_key.id not in both_key_ids
+                       and auth_key.algorithm is arista.avd.defined
+                       and auth_key.key_type is arista.avd.defined
+                       and auth_key.key is arista.avd.defined %}
+{%                     if auth_key.rfc_5310 is arista.avd.defined(true) %}
+   isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} rfc-5310 key {{ auth_key.key_type }} {{ auth_key.key }} level-1
+{%                     else %}
+   isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} key {{ auth_key.key_type }} {{ auth_key.key }} level-1
+{%                     endif %}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if vlan_interface.isis_authentication.level_2.key_ids is arista.avd.defined %}
+{%             for auth_key in vlan_interface.isis_authentication.level_2.key_ids %}
+{%                 if auth_key.id is arista.avd.defined
+                       and auth_key.id not in both_key_ids
+                       and auth_key.algorithm is arista.avd.defined
+                       and auth_key.key_type is arista.avd.defined
+                       and auth_key.key is arista.avd.defined %}
+{%                     if auth_key.rfc_5310 is arista.avd.defined(true) %}
+   isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} rfc-5310 key {{ auth_key.key_type }} {{ auth_key.key }} level-2
+{%                     else %}
+   isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} key {{ auth_key.key_type }} {{ auth_key.key }} level-2
+{%                     endif %}
+{%                 endif %}
+{%             endfor %}
+{%         endif %}
+{%         if vlan_interface.isis_authentication.both.key_type is arista.avd.defined and vlan_interface.isis_authentication.both.key is arista.avd.defined %}
+   isis authentication key {{ vlan_interface.isis_authentication.both.key_type }} {{ vlan_interface.isis_authentication.both.key }}
+{%         else %}
+{%             if vlan_interface.isis_authentication.level_1.key_type is arista.avd.defined and vlan_interface.isis_authentication.level_1.key is arista.avd.defined %}
+   isis authentication key {{ vlan_interface.isis_authentication.level_1.key_type }} {{ vlan_interface.isis_authentication.level_1.key }} level-1
+{%             endif %}
+{%             if vlan_interface.isis_authentication.level_2.key_type is arista.avd.defined and vlan_interface.isis_authentication.level_2.key is arista.avd.defined %}
+   isis authentication key {{ vlan_interface.isis_authentication.level_2.key_type }} {{ vlan_interface.isis_authentication.level_2.key }} level-2
+{%             endif %}
 {%         endif %}
 {%     endif %}
 {%     if vlan_interface.vrrp_ids is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -376,36 +376,32 @@ interface {{ vlan_interface.name }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}
-{%         if vlan_interface.isis_authentication.level_1.key_ids is arista.avd.defined %}
-{%             for auth_key in vlan_interface.isis_authentication.level_1.key_ids %}
-{%                 if auth_key.id is arista.avd.defined
-                       and auth_key.id not in both_key_ids
-                       and auth_key.algorithm is arista.avd.defined
-                       and auth_key.key_type is arista.avd.defined
-                       and auth_key.key is arista.avd.defined %}
-{%                     if auth_key.rfc_5310 is arista.avd.defined(true) %}
+{%         for auth_key in vlan_interface.isis_authentication.level_1.key_ids | arista.avd.natural_sort("id") %}
+{%             if auth_key.id is arista.avd.defined
+                  and auth_key.id not in both_key_ids
+                  and auth_key.algorithm is arista.avd.defined
+                  and auth_key.key_type is arista.avd.defined
+                  and auth_key.key is arista.avd.defined %}
+{%                 if auth_key.rfc_5310 is arista.avd.defined(true) %}
    isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} rfc-5310 key {{ auth_key.key_type }} {{ auth_key.key }} level-1
-{%                     else %}
+{%                 else %}
    isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} key {{ auth_key.key_type }} {{ auth_key.key }} level-1
-{%                     endif %}
 {%                 endif %}
-{%             endfor %}
-{%         endif %}
-{%         if vlan_interface.isis_authentication.level_2.key_ids is arista.avd.defined %}
-{%             for auth_key in vlan_interface.isis_authentication.level_2.key_ids %}
-{%                 if auth_key.id is arista.avd.defined
-                       and auth_key.id not in both_key_ids
-                       and auth_key.algorithm is arista.avd.defined
-                       and auth_key.key_type is arista.avd.defined
-                       and auth_key.key is arista.avd.defined %}
-{%                     if auth_key.rfc_5310 is arista.avd.defined(true) %}
+{%             endif %}
+{%         endfor %}
+{%         for auth_key in vlan_interface.isis_authentication.level_2.key_ids | arista.avd.natural_sort("id") %}
+{%             if auth_key.id is arista.avd.defined
+                  and auth_key.id not in both_key_ids
+                  and auth_key.algorithm is arista.avd.defined
+                  and auth_key.key_type is arista.avd.defined
+                  and auth_key.key is arista.avd.defined %}
+{%                 if auth_key.rfc_5310 is arista.avd.defined(true) %}
    isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} rfc-5310 key {{ auth_key.key_type }} {{ auth_key.key }} level-2
-{%                     else %}
+{%                 else %}
    isis authentication key-id {{ auth_key.id }} algorithm {{ auth_key.algorithm }} key {{ auth_key.key_type }} {{ auth_key.key }} level-2
-{%                     endif %}
 {%                 endif %}
-{%             endfor %}
-{%         endif %}
+{%             endif %}
+{%         endfor %}
 {%         if vlan_interface.isis_authentication.both.key_type is arista.avd.defined and vlan_interface.isis_authentication.both.key is arista.avd.defined %}
    isis authentication key {{ vlan_interface.isis_authentication.both.key_type }} {{ vlan_interface.isis_authentication.both.key }}
 {%         else %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -361,7 +361,6 @@ interface {{ vlan_interface.name }}
    {{ isis_auth_cli }} level-2
 {%         endif %}
 {%     endif %}
-{# New improved "vrrp" data model to support multiple IDs #}
 {%     if vlan_interface.vrrp_ids is arista.avd.defined %}
 {%         for vrid in vlan_interface.vrrp_ids | arista.avd.natural_sort('id') if vrid.id is arista.avd.defined %}
 {%             if vrid.priority_level is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -306,81 +306,59 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
 {%     endif %}
-{%     if vlan_interface.isis_authentication_mode is arista.avd.defined %}
-{%         set auth_cli = "isis authentication mode" ~ " " ~ vlan_interface.isis_authentication_mode %}
-{%         if vlan_interface.isis_authentication_mode == "sha" and vlan_interface.isis_authentication_mode_sha is arista.avd.defined %}
-{%             if vlan_interface.isis_authentication_mode_sha.both.key_id is arista.avd.defined %}
-{%                 set auth_cli = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.both.key_id %}
-{%                 if vlan_interface.isis_authentication_mode_sha.both.rx_disabled is arista.avd.defined(true) %}
-{%                     set auth_cli = auth_cli ~ " rx-disabled" %}
-{%                 endif %}
-   {{ auth_cli }}
-{%             else %}
-{%                 if vlan_interface.isis_authentication_mode_sha.level_1.key_id is arista.avd.defined %}
-{%                     set auth_cli_level1 = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.level_1.key_id ~ " level-1" %}
-{%                     if vlan_interface.isis_authentication_mode_sha.level_1.rx_disabled is arista.avd.defined(true) %}
-{%                         set auth_cli_level1 = auth_cli_level1 ~ " rx-disabled" %}
-{%                     endif %}
-   {{ auth_cli_level1 }}
-{%                 endif %}
-{%                 if vlan_interface.isis_authentication_mode_sha.level_2.key_id is arista.avd.defined %}
-{%                     set auth_cli_level2 = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.level_2.key_id ~ " level-2" %}
-{%                     if vlan_interface.isis_authentication_mode_sha.level_2.rx_disabled is arista.avd.defined(true) %}
-{%                         set auth_cli_level2 = auth_cli_level2 ~ " rx-disabled" %}
-{%                     endif %}
-   {{ auth_cli_level2 }}
-{%                 endif %}
+{%     if vlan_interface.isis_authentication.both.mode is arista.avd.defined
+          and (vlan_interface.isis_authentication.both.mode in ["md5", "text"]
+               or (vlan_interface.isis_authentication.both.mode == "sha" and vlan_interface.isis_authentication.both.sha.key_id is arista.avd.defined)
+               or (vlan_interface.isis_authentication.both.mode == "shared-secret"
+                   and vlan_interface.isis_authentication.both.shared_secret.profile is arista.avd.defined
+                   and vlan_interface.isis_authentication.both.shared_secret.algorithm is arista.avd.defined)) %}
+{%         set isis_auth_cli = "authentication mode " ~ vlan_interface.isis_authentication.both.mode %}
+{%         if vlan_interface.isis_authentication.both.mode == "sha" %}
+{%             set isis_auth_cli = isis_auth_cli ~ " key-id " ~ vlan_interface.isis_authentication.both.sha.key_id %}
+{%         elif vlan_interface.isis_authentication.both.mode == "shared-secret" %}
+{%             set isis_auth_cli = isis_auth_cli ~ " profile " ~ vlan_interface.isis_authentication.both.shared_secret.profile %}
+{%             set isis_auth_cli = isis_auth_cli ~ " algorithm " ~ vlan_interface.isis_authentication.both.shared_secret.algorithm %}
+{%         endif %}
+{%         if vlan_interface.isis_authentication.both.rx_disabled is arista.avd.defined(true) %}
+{%             set isis_auth_cli = isis_auth_cli ~ " rx-disabled" %}
+{%         endif %}
+   {{ isis_auth_cli }}
+{%     else %}
+{%         if vlan_interface.isis_authentication.level_1.mode is arista.avd.defined
+               and (vlan_interface.isis_authentication.level_1.mode in ["md5", "text"]
+               or (vlan_interface.isis_authentication.level_1.mode == "sha" and vlan_interface.isis_authentication.level_1.sha.key_id is arista.avd.defined)
+               or (vlan_interface.isis_authentication.level_1.mode == "shared-secret"
+                   and vlan_interface.isis_authentication.level_1.shared_secret.profile is arista.avd.defined
+                   and vlan_interface.isis_authentication.level_1.shared_secret.algorithm is arista.avd.defined)) %}
+{%             set isis_auth_cli = "authentication mode " ~ vlan_interface.isis_authentication.level_1.mode %}
+{%             if vlan_interface.isis_authentication.level_1.mode == "sha" %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " key-id " ~ vlan_interface.isis_authentication.level_1.sha.key_id %}
+{%             elif vlan_interface.isis_authentication.level_1.mode == "shared-secret" %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " profile " ~ vlan_interface.isis_authentication.level_1.shared_secret.profile %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " algorithm " ~ vlan_interface.isis_authentication.level_1.shared_secret.algorithm %}
 {%             endif %}
-{%         endif %}
-{%         if vlan_interface.isis_authentication_mode == "shared-secret" and vlan_interface.isis_authentication_mode_shared_secret is arista.avd.defined %}
-{%             if vlan_interface.isis_authentication_mode_shared_secret.both.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.both.algorithm is arista.avd.defined %}
-{%                 set auth_cli = auth_cli ~ " profile " ~  vlan_interface.isis_authentication_mode_shared_secret.both.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.both.algorithm %}
-{%                 if vlan_interface.isis_authentication_mode_shared_secret.both.rx_disabled is arista.avd.defined(true) %}
-{%                     set auth_cli = auth_cli ~ " rx-disabled" %}
-{%                 endif %}
-   {{ auth_cli }}
-{%             else %}
-{%                 if vlan_interface.isis_authentication_mode_shared_secret.level_1.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.level_1.algorithm is arista.avd.defined %}
-{%                     set auth_cli_level1 = auth_cli ~  " profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.algorithm %}
-{%                     if vlan_interface.isis_authentication_mode_shared_secret.level_1.rx_disabled is arista.avd.defined(true) %}
-{%                         set auth_cli_level1 = auth_cli_level1 ~ " rx-disabled" %}
-{%                     endif %}
-{%                     set auth_cli_level1 = auth_cli_level1 ~ " level-1" %}
-   {{ auth_cli_level1 }}
-{%                 endif %}
-{%                 if vlan_interface.isis_authentication_mode_shared_secret.level_2.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.level_2.algorithm is arista.avd.defined %}
-{%                     set auth_cli_level2 = auth_cli ~ " profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.algorithm %}
-{%                     if vlan_interface.isis_authentication_mode_shared_secret.level_2.rx_disabled is arista.avd.defined(true) %}
-{%                         set auth_cli_level2 = auth_cli_level2 ~ " rx-disabled" %}
-{%                     endif %}
-{%                     set auth_cli_level2 = auth_cli_level2 ~ " level-2" %}
-   {{ auth_cli_level2 }}
-{%                 endif %}
+{%             if vlan_interface.isis_authentication.level_1.rx_disabled is arista.avd.defined(true) %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " rx-disabled" %}
 {%             endif %}
+   {{ isis_auth_cli }} level-1
 {%         endif %}
-{%         if vlan_interface.isis_authentication_mode is in [ "text", "md5" ] %}
-   {{ auth_cli }}
-{%         endif %}
-{%     endif %}
-{%     if vlan_interface.isis_authentication_key is arista.avd.defined %}
-   isis authentication key 7 {{ vlan_interface.isis_authentication_key | arista.avd.hide_passwords(hide_passwords) }}
-{%     endif %}
-{# The below "vrrp" keys will be deprecated in AVD v4.0 - These should not be mixed with the new "vrrp_ids" key above to avoid conflicts. #}
-{%     if vlan_interface.vrrp.virtual_router is arista.avd.defined %}
-{%         if vlan_interface.vrrp.priority is arista.avd.defined %}
-   vrrp {{ vlan_interface.vrrp.virtual_router }} priority-level {{ vlan_interface.vrrp.priority }}
-{%         endif %}
-{%         if vlan_interface.vrrp.advertisement_interval is arista.avd.defined %}
-   vrrp {{ vlan_interface.vrrp.virtual_router }} advertisement interval {{ vlan_interface.vrrp.advertisement_interval }}
-{%         endif %}
-{%         if vlan_interface.vrrp.preempt_delay_minimum is arista.avd.defined %}
-   vrrp {{ vlan_interface.vrrp.virtual_router }} preempt delay minimum {{ vlan_interface.vrrp.preempt_delay_minimum }}
-{%         endif %}
-{%         if vlan_interface.vrrp.ipv4 is arista.avd.defined %}
-   vrrp {{ vlan_interface.vrrp.virtual_router }} ipv4 {{ vlan_interface.vrrp.ipv4 }}
-{%         endif %}
-{%         if vlan_interface.vrrp.ipv6 is arista.avd.defined %}
-   vrrp {{ vlan_interface.vrrp.virtual_router }} ipv6 {{ vlan_interface.vrrp.ipv6 }}
+{%         if vlan_interface.isis_authentication.level_2.mode is arista.avd.defined
+               and (vlan_interface.isis_authentication.level_2.mode in ["md5", "text"]
+               or (vlan_interface.isis_authentication.level_2.mode == "sha" and vlan_interface.isis_authentication.level_2.sha.key_id is arista.avd.defined)
+               or (vlan_interface.isis_authentication.level_2.mode == "shared-secret"
+                   and vlan_interface.isis_authentication.level_2.shared_secret.profile is arista.avd.defined
+                   and vlan_interface.isis_authentication.level_2.shared_secret.algorithm is arista.avd.defined)) %}
+{%             set isis_auth_cli = "authentication mode " ~ vlan_interface.isis_authentication.level_2.mode %}
+{%             if vlan_interface.isis_authentication.level_2.mode == "sha" %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " key-id " ~ vlan_interface.isis_authentication.level_2.sha.key_id %}
+{%             elif vlan_interface.isis_authentication.level_2.mode == "shared-secret" %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " profile " ~ vlan_interface.isis_authentication.level_2.shared_secret.profile %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " algorithm " ~ vlan_interface.isis_authentication.level_2.shared_secret.algorithm %}
+{%             endif %}
+{%             if vlan_interface.isis_authentication.level_2.rx_disabled is arista.avd.defined(true) %}
+{%                 set isis_auth_cli = isis_auth_cli ~ " rx-disabled" %}
+{%             endif %}
+   {{ isis_auth_cli }} level-2
 {%         endif %}
 {%     endif %}
 {# New improved "vrrp" data model to support multiple IDs #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -311,38 +311,38 @@ interface {{ vlan_interface.name }}
 {%         if vlan_interface.isis_authentication_mode == "sha" and vlan_interface.isis_authentication_mode_sha is arista.avd.defined %}
 {%             if vlan_interface.isis_authentication_mode_sha.both.key_id is arista.avd.defined %}
 {%                 set auth_cli = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.both.key_id %}
-{%                 if vlan_interface.isis_authentication_mode_sha.both.rx_disabled is arista.avd.defined %}
+{%                 if vlan_interface.isis_authentication_mode_sha.both.rx_disabled is arista.avd.defined(true) %}
 {%                     set auth_cli = auth_cli ~ " rx-disabled" %}
 {%                 endif %}
    {{ auth_cli }}
 {%             else %}
 {%                 if vlan_interface.isis_authentication_mode_sha.level_1.key_id is arista.avd.defined %}
-{%                     if vlan_interface.isis_authentication_mode_sha.level_1.rx_disabled is arista.avd.defined %}
-{%                         set auth_cli = auth_cli ~ " rx-disabled" %}
+{%                     set auth_cli_level1 = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.level_1.key_id ~ " level-1" %}
+{%                     if vlan_interface.isis_authentication_mode_sha.level_1.rx_disabled is arista.avd.defined(true) %}
+{%                         set auth_cli_level1 = auth_cli_level1 ~ " rx-disabled" %}
 {%                     endif %}
-{%                     set auth_cli = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.level_1.key_id ~ " level-1" %}
-   {{ auth_cli }}
+   {{ auth_cli_level1 }}
 {%                 endif %}
 {%                 if vlan_interface.isis_authentication_mode_sha.level_2.key_id is arista.avd.defined %}
-{%                     if vlan_interface.isis_authentication_mode_sha.level_2.rx_disabled is arista.avd.defined %}
-{%                         set auth_cli = auth_cli ~ " rx-disabled" %}
+{%                     set auth_cli_level2 = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.level_2.key_id ~ " level-2" %}
+{%                     if vlan_interface.isis_authentication_mode_sha.level_2.rx_disabled is arista.avd.defined(true) %}
+{%                         set auth_cli_level2 = auth_cli_level2 ~ " rx-disabled" %}
 {%                     endif %}
-{%                     set auth_cli = auth_cli ~ " key-id " ~ vlan_interface.isis_authentication_mode_sha.level_2.key_id ~ " level-2" %}
-   {{ auth_cli }}
+   {{ auth_cli_level2 }}
 {%                 endif %}
 {%             endif %}
 {%         endif %}
 {%         if vlan_interface.isis_authentication_mode == "shared-secret" and vlan_interface.isis_authentication_mode_shared_secret is arista.avd.defined %}
 {%             if vlan_interface.isis_authentication_mode_shared_secret.both.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.both.algorithm is arista.avd.defined %}
 {%                 set auth_cli = auth_cli ~ " profile " ~  vlan_interface.isis_authentication_mode_shared_secret.both.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.both.algorithm %}
-{%                 if vlan_interface.isis_authentication_mode_shared_secret.both.rx_disabled is arista.avd.defined %}
-{%                     set auth_cli = auth_cli ~ " rx-disabled " %}
+{%                 if vlan_interface.isis_authentication_mode_shared_secret.both.rx_disabled is arista.avd.defined(true) %}
+{%                     set auth_cli = auth_cli ~ " rx-disabled" %}
 {%                 endif %}
    {{ auth_cli }}
 {%             else %}
 {%                 if vlan_interface.isis_authentication_mode_shared_secret.level_1.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.level_1.algorithm is arista.avd.defined %}
 {%                     set auth_cli_level1 = auth_cli ~  " profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_1.algorithm %}
-{%                     if vlan_interface.isis_authentication_mode_shared_secret.level_1.rx_disabled is arista.avd.defined %}
+{%                     if vlan_interface.isis_authentication_mode_shared_secret.level_1.rx_disabled is arista.avd.defined(true) %}
 {%                         set auth_cli_level1 = auth_cli_level1 ~ " rx-disabled" %}
 {%                     endif %}
 {%                     set auth_cli_level1 = auth_cli_level1 ~ " level-1" %}
@@ -350,7 +350,7 @@ interface {{ vlan_interface.name }}
 {%                 endif %}
 {%                 if vlan_interface.isis_authentication_mode_shared_secret.level_2.profile is arista.avd.defined and vlan_interface.isis_authentication_mode_shared_secret.level_2.algorithm is arista.avd.defined %}
 {%                     set auth_cli_level2 = auth_cli ~ " profile " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.profile ~ " algorithm " ~ vlan_interface.isis_authentication_mode_shared_secret.level_2.algorithm %}
-{%                     if vlan_interface.isis_authentication_mode_shared_secret.level_2.rx_disabled is arista.avd.defined %}
+{%                     if vlan_interface.isis_authentication_mode_shared_secret.level_2.rx_disabled is arista.avd.defined(true) %}
 {%                         set auth_cli_level2 = auth_cli_level2 ~ " rx-disabled" %}
 {%                     endif %}
 {%                     set auth_cli_level2 = auth_cli_level2 ~ " level-2" %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -14418,7 +14418,7 @@ keys:
                     - sha-512
               rx_disabled:
                 type: bool
-                description: Disable authentication on receive side.
+                description: Disable authentication check on the receive side.
           level_1:
             type: dict
             description: Authentication settings for level-1. 'both' takes precedence

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -17700,58 +17700,9 @@ keys:
           - str
         isis_network_point_to_point:
           type: bool
-        isis_authentication_mode:
-          type: str
-          valid_values:
-          - text
-          - md5
-          - sha
-          - shared-secret
-        isis_authentication_key:
-          type: str
-          description: Type-7 encrypted password.
-        isis_authentication_mode_shared_secret:
+        isis_authentication:
           type: dict
-          description: Required for authentication mode `shared-secret`.
-          keys:
-            both:
-              type: dict
-              description: When set `both` takes precedence over `level_1` and `level_2`.
-              $ref: eos_cli_config_gen#/keys/router_isis/keys/authentication/keys/both/keys/shared_secret
-              keys:
-                rx_disabled:
-                  type: bool
-            level_1:
-              type: dict
-              description: Authentication settings for level-1. 'both' takes precedence
-                over 'level_1' and 'level_2' settings.
-              $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both
-            level_2:
-              type: dict
-              description: Authentication settings for level-2. 'both' takes precedence
-                over 'level_1' and 'level_2' settings.
-              $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both
-        isis_authentication_mode_sha:
-          type: dict
-          description: Required for authentication mode `sha`.
-          keys:
-            both:
-              type: dict
-              description: When set `both` takes precedence over `level_1` and `level_2`.
-              $ref: eos_cli_config_gen#/keys/router_isis/keys/authentication/keys/both/keys/sha
-              keys:
-                rx_disabled:
-                  type: bool
-            level_1:
-              type: dict
-              description: Authentication settings for level-1. 'both' takes precedence
-                over 'level_1' and 'level_2' settings.
-              $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both
-            level_2:
-              type: dict
-              description: Authentication settings for level-2. 'both' takes precedence
-                over 'level_1' and 'level_2' settings.
-              $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both
+          $ref: eos_cli_config_gen#/keys/router_isis/keys/authentication
         mtu:
           type: int
           convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -14337,7 +14337,7 @@ keys:
                 - '7'
                 - 8a
                 description: Configure authentication key type. EOS default `key_type`
-                  is 0.
+                  is 7.
               key:
                 type: str
                 description: Password string. `key_type` is required for this setting.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -17728,7 +17728,7 @@ keys:
               $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both
             level_2:
               type: dict
-              description: Authentication settings for level-1. 'both' takes precedence
+              description: Authentication settings for level-2. 'both' takes precedence
                 over 'level_1' and 'level_2' settings.
               $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both
         isis_authentication_mode_sha:
@@ -17749,7 +17749,7 @@ keys:
               $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both
             level_2:
               type: dict
-              description: Authentication settings for level-1. 'both' takes precedence
+              description: Authentication settings for level-2. 'both' takes precedence
                 over 'level_1' and 'level_2' settings.
               $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both
         mtu:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -14336,8 +14336,7 @@ keys:
                 - '0'
                 - '7'
                 - 8a
-                description: Configure authentication key type. EOS default `key_type`
-                  is 7.
+                description: Configure authentication key type.
               key:
                 type: str
                 description: Password string. `key_type` is required for this setting.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -14336,11 +14336,11 @@ keys:
                 - '0'
                 - '7'
                 - 8a
-                description: Configure authentication key type. Default key_id is
-                  0.
+                description: Configure authentication key type. EOS default `key_type`
+                  is 0.
               key:
                 type: str
-                description: Password string.
+                description: Password string. `key_type` is required for this setting.
               key_ids:
                 type: list
                 primary_key: id
@@ -14419,6 +14419,7 @@ keys:
                     - sha-512
               rx_disabled:
                 type: bool
+                description: Disable authentication on receive side.
           level_1:
             type: dict
             description: Authentication settings for level-1. 'both' takes precedence

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -17700,6 +17700,58 @@ keys:
           - str
         isis_network_point_to_point:
           type: bool
+        isis_authentication_mode:
+          type: str
+          valid_values:
+          - text
+          - md5
+          - sha
+          - shared-secret
+        isis_authentication_key:
+          type: str
+          description: Type-7 encrypted password.
+        isis_authentication_mode_shared_secret:
+          type: dict
+          description: Required for authentication mode `shared-secret`.
+          keys:
+            both:
+              type: dict
+              description: When set `both` takes precedence over `level_1` and `level_2`.
+              $ref: eos_cli_config_gen#/keys/router_isis/keys/authentication/keys/both/keys/shared_secret
+              keys:
+                rx_disabled:
+                  type: bool
+            level_1:
+              type: dict
+              description: Authentication settings for level-1. 'both' takes precedence
+                over 'level_1' and 'level_2' settings.
+              $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both
+            level_2:
+              type: dict
+              description: Authentication settings for level-1. 'both' takes precedence
+                over 'level_1' and 'level_2' settings.
+              $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both
+        isis_authentication_mode_sha:
+          type: dict
+          description: Required for authentication mode `sha`.
+          keys:
+            both:
+              type: dict
+              description: When set `both` takes precedence over `level_1` and `level_2`.
+              $ref: eos_cli_config_gen#/keys/router_isis/keys/authentication/keys/both/keys/sha
+              keys:
+                rx_disabled:
+                  type: bool
+            level_1:
+              type: dict
+              description: Authentication settings for level-1. 'both' takes precedence
+                over 'level_1' and 'level_2' settings.
+              $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both
+            level_2:
+              type: dict
+              description: Authentication settings for level-1. 'both' takes precedence
+                over 'level_1' and 'level_2' settings.
+              $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both
         mtu:
           type: int
           convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
@@ -164,7 +164,7 @@ keys:
                       - sha-512
               rx_disabled:
                 type: bool
-                description: Disable authentication on receive side.
+                description: Disable authentication check on the receive side.
           level_1:
             type: dict
             description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
@@ -82,7 +82,7 @@ keys:
                   - '0'
                   - '7'
                   - '8a'
-                description: Configure authentication key type. EOS default `key_type` is 0.
+                description: Configure authentication key type. EOS default `key_type` is 7.
               key:
                 type: str
                 description: Password string. `key_type` is required for this setting.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
@@ -82,10 +82,10 @@ keys:
                   - '0'
                   - '7'
                   - '8a'
-                description: Configure authentication key type. Default key_id is 0.
+                description: Configure authentication key type. EOS default `key_type` is 0.
               key:
                 type: str
-                description: Password string.
+                description: Password string. `key_type` is required for this setting.
               key_ids:
                 type: list
                 primary_key: id
@@ -164,6 +164,7 @@ keys:
                       - sha-512
               rx_disabled:
                 type: bool
+                description: Disable authentication on receive side.
           level_1:
             type: dict
             description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
@@ -82,7 +82,7 @@ keys:
                   - '0'
                   - '7'
                   - '8a'
-                description: Configure authentication key type. EOS default `key_type` is 7.
+                description: Configure authentication key type.
               key:
                 type: str
                 description: Password string. `key_type` is required for this setting.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -455,7 +455,7 @@ keys:
               $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both"
             level_2:
               type: dict
-              description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
+              description: Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
               $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both"
         isis_authentication_mode_sha:
           type: dict
@@ -474,7 +474,7 @@ keys:
               $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both"
             level_2:
               type: dict
-              description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
+              description: Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
               $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both"
         mtu:
           type: int

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -432,50 +432,9 @@ keys:
             - str
         isis_network_point_to_point:
           type: bool
-        isis_authentication_mode:
-          type: str
-          valid_values: ["text", "md5", "sha", "shared-secret"]
-        isis_authentication_key:
-          type: str
-          description: Type-7 encrypted password.
-        isis_authentication_mode_shared_secret:
+        isis_authentication:
           type: dict
-          description: Required for authentication mode `shared-secret`.
-          keys:
-            both:
-              type: dict
-              description: When set `both` takes precedence over `level_1` and `level_2`.
-              $ref: "eos_cli_config_gen#/keys/router_isis/keys/authentication/keys/both/keys/shared_secret"
-              keys:
-                rx_disabled:
-                  type: bool
-            level_1:
-              type: dict
-              description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
-              $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both"
-            level_2:
-              type: dict
-              description: Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
-              $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both"
-        isis_authentication_mode_sha:
-          type: dict
-          description: Required for authentication mode `sha`.
-          keys:
-            both:
-              type: dict
-              description: When set `both` takes precedence over `level_1` and `level_2`.
-              $ref: "eos_cli_config_gen#/keys/router_isis/keys/authentication/keys/both/keys/sha"
-              keys:
-                rx_disabled:
-                  type: bool
-            level_1:
-              type: dict
-              description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
-              $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both"
-            level_2:
-              type: dict
-              description: Authentication settings for level-2. 'both' takes precedence over 'level_1' and 'level_2' settings.
-              $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both"
+          $ref: "eos_cli_config_gen#/keys/router_isis/keys/authentication"
         mtu:
           type: int
           convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -432,6 +432,50 @@ keys:
             - str
         isis_network_point_to_point:
           type: bool
+        isis_authentication_mode:
+          type: str
+          valid_values: ["text", "md5", "sha", "shared-secret"]
+        isis_authentication_key:
+          type: str
+          description: Type-7 encrypted password.
+        isis_authentication_mode_shared_secret:
+          type: dict
+          description: Required for authentication mode `shared-secret`.
+          keys:
+            both:
+              type: dict
+              description: When set `both` takes precedence over `level_1` and `level_2`.
+              $ref: "eos_cli_config_gen#/keys/router_isis/keys/authentication/keys/both/keys/shared_secret"
+              keys:
+                rx_disabled:
+                  type: bool
+            level_1:
+              type: dict
+              description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
+              $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both"
+            level_2:
+              type: dict
+              description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
+              $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_shared_secret/keys/both"
+        isis_authentication_mode_sha:
+          type: dict
+          description: Required for authentication mode `sha`.
+          keys:
+            both:
+              type: dict
+              description: When set `both` takes precedence over `level_1` and `level_2`.
+              $ref: "eos_cli_config_gen#/keys/router_isis/keys/authentication/keys/both/keys/sha"
+              keys:
+                rx_disabled:
+                  type: bool
+            level_1:
+              type: dict
+              description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
+              $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both"
+            level_2:
+              type: dict
+              description: Authentication settings for level-1. 'both' takes precedence over 'level_1' and 'level_2' settings.
+              $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/isis_authentication_mode_sha/keys/both"
         mtu:
           type: int
           convert_types:


### PR DESCRIPTION
## Change Summary

 Add support for isis authentication on vlan interfaces. This needs to be merged before PR #4102.

## Related Issue(s)



## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Add support for  isis authentication on vlan interfaces.

## How to test


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
