### PR TITLE
Feat(eos_cli_config_gen): SyncE support

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sync-e.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sync-e.md
@@ -68,6 +68,14 @@ sync-e
 | --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet6 | P2P_LINK_TO_DC1-SPINE1_Ethernet6 | routed | - | 172.31.255.15/31 | default | 1500 | - | - | - |
 
+#### Synchronous Ethernet
+
+| Interface | Priority |
+| --------- | -------- |
+| Ethernet3 | 10 |
+| Ethernet5 | 127 |
+| Ethernet6 | disabled |
+
 #### Ethernet Interfaces Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sync-e.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sync-e.md
@@ -1,0 +1,89 @@
+# sync-e
+
+## Table of Contents
+
+- [Management](#management)
+  - [Management Interfaces](#management-interfaces)
+  - [Synchronous Ethernet (SyncE) Settings](#synchronous-ethernet-synce-settings)
+- [Interfaces](#interfaces)
+  - [Ethernet Interfaces](#ethernet-interfaces)
+
+## Management
+
+### Management Interfaces
+
+#### Management Interfaces Summary
+
+##### IPv4
+
+| Management Interface | Description | Type | VRF | IP Address | Gateway |
+| -------------------- | ----------- | ---- | --- | ---------- | ------- |
+| Management1 | oob_management | oob | MGMT | 10.73.255.122/24 | 10.73.255.2 |
+
+##### IPv6
+
+| Management Interface | Description | Type | VRF | IPv6 Address | IPv6 Gateway |
+| -------------------- | ----------- | ---- | --- | ------------ | ------------ |
+| Management1 | oob_management | oob | MGMT | - | - |
+
+#### Management Interfaces Device Configuration
+
+```eos
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+```
+
+### Synchronous Ethernet (SyncE) Settings
+
+Synchronous Ethernet Network Option: 2
+
+#### Synchronous Ethernet Device Configuration
+
+```eos
+!
+sync-e
+   network option 2
+```
+
+## Interfaces
+
+### Ethernet Interfaces
+
+#### Ethernet Interfaces Summary
+
+##### L2
+
+| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
+| --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
+| Ethernet3 |  P2P_LINK_TO_DC1-SPINE2_Ethernet5 | trunk | 2,14 | - | - | - |
+
+*Inherited from Port-Channel Interface
+
+##### IPv4
+
+| Interface | Description | Type | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
+| --------- | ----------- | -----| ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
+| Ethernet6 | P2P_LINK_TO_DC1-SPINE1_Ethernet6 | routed | - | 172.31.255.15/31 | default | 1500 | - | - | - |
+
+#### Ethernet Interfaces Device Configuration
+
+```eos
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   switchport trunk allowed vlan 2,14
+   switchport mode trunk
+   switchport
+!
+interface Ethernet5
+   description DC1-AGG01_Ethernet1
+!
+interface Ethernet6
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   mtu 1500
+   no switchport
+   ip address 172.31.255.15/31
+```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sync-e.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sync-e.md
@@ -77,13 +77,19 @@ interface Ethernet3
    switchport trunk allowed vlan 2,14
    switchport mode trunk
    switchport
+   sync-e
+      priority 10
 !
 interface Ethernet5
    description DC1-AGG01_Ethernet1
+   sync-e
+      priority 127
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
    mtu 1500
    no switchport
    ip address 172.31.255.15/31
+   sync-e
+      priority disabled
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sync-e.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/sync-e.md
@@ -91,7 +91,6 @@ interface Ethernet3
 interface Ethernet5
    description DC1-AGG01_Ethernet1
    sync-e
-      priority 127
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sync-e.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sync-e.cfg
@@ -21,7 +21,6 @@ interface Ethernet3
 interface Ethernet5
    description DC1-AGG01_Ethernet1
    sync-e
-      priority 127
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sync-e.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sync-e.cfg
@@ -15,15 +15,21 @@ interface Ethernet3
    switchport trunk allowed vlan 2,14
    switchport mode trunk
    switchport
+   sync-e
+      priority 10
 !
 interface Ethernet5
    description DC1-AGG01_Ethernet1
+   sync-e
+      priority 127
 !
 interface Ethernet6
    description P2P_LINK_TO_DC1-SPINE1_Ethernet6
    mtu 1500
    no switchport
    ip address 172.31.255.15/31
+   sync-e
+      priority disabled
 !
 interface Management1
    description oob_management

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sync-e.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/sync-e.cfg
@@ -1,0 +1,33 @@
+!RANCID-CONTENT-TYPE: arista
+!
+transceiver qsfp default-mode 4x10G
+!
+hostname sync-e
+!
+sync-e
+   network option 2
+!
+no enable password
+no aaa root
+!
+interface Ethernet3
+   description P2P_LINK_TO_DC1-SPINE2_Ethernet5
+   switchport trunk allowed vlan 2,14
+   switchport mode trunk
+   switchport
+!
+interface Ethernet5
+   description DC1-AGG01_Ethernet1
+!
+interface Ethernet6
+   description P2P_LINK_TO_DC1-SPINE1_Ethernet6
+   mtu 1500
+   no switchport
+   ip address 172.31.255.15/31
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.73.255.122/24
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sync-e.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sync-e.yml
@@ -1,0 +1,34 @@
+### sync-e
+
+sync_e:
+  network_option: 2
+
+
+### interface
+ethernet_interfaces:
+  - name: Ethernet3
+    peer: DC1-SPINE2
+    peer_interface: Ethernet5
+    peer_type: spine
+    description: P2P_LINK_TO_DC1-SPINE2_Ethernet5
+    type: switched
+    mode: trunk
+    vlans: 2,14
+
+  - name: Ethernet6
+    peer: DC1-SPINE1
+    peer_interface: Ethernet6
+    peer_type: spine
+    description: P2P_LINK_TO_DC1-SPINE1_Ethernet6
+    mtu: 1500
+    type: routed
+    ip_address: 172.31.255.15/31
+
+# port-channel interfaces
+  - name: Ethernet5
+    type: port-channel-member
+    peer: DC1-AGG01
+    peer_interface: Ethernet1
+    peer_type: l2leaf
+    description: DC1-AGG01_Ethernet1
+

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sync-e.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/sync-e.yml
@@ -14,7 +14,9 @@ ethernet_interfaces:
     type: switched
     mode: trunk
     vlans: 2,14
-
+    sync_e:
+      enable: true
+      priority: 10
   - name: Ethernet6
     peer: DC1-SPINE1
     peer_interface: Ethernet6
@@ -23,7 +25,9 @@ ethernet_interfaces:
     mtu: 1500
     type: routed
     ip_address: 172.31.255.15/31
-
+    sync_e:
+      enable: true
+      priority: disabled
 # port-channel interfaces
   - name: Ethernet5
     type: port-channel-member
@@ -31,4 +35,5 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
     description: DC1-AGG01_Ethernet1
-
+    sync_e:
+      enable: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/hosts.ini
@@ -169,6 +169,7 @@ spanning-tree-rapid-pvst
 switchport-mode
 switchport-port-security
 stun
+sync-e
 tcam-profile
 static-routes
 system

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -350,7 +350,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmodified_enable</samp>](## "ethernet_interfaces.[].sflow.egress.unmodified_enable") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sync_e</samp>](## "ethernet_interfaces.[].sync_e") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "ethernet_interfaces.[].sync_e.enable") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "ethernet_interfaces.[].sync_e.priority") | String |  |  |  | The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "ethernet_interfaces.[].sync_e.priority") | String |  |  |  | The priority is used to influence the reference clock selection. The EOS default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;port_profile</samp>](## "ethernet_interfaces.[].port_profile") | String |  |  |  | Key only used for documentation or validation purposes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uc_tx_queues</samp>](## "ethernet_interfaces.[].uc_tx_queues") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "ethernet_interfaces.[].uc_tx_queues.[].id") | Integer | Required, Unique |  |  | TX-Queue ID. |
@@ -1025,7 +1025,7 @@
         sync_e:
           enable: <bool>
 
-          # The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.
+          # The priority is used to influence the reference clock selection. The EOS default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.
           priority: <str>
 
         # Key only used for documentation or validation purposes.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -348,6 +348,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;egress</samp>](## "ethernet_interfaces.[].sflow.egress") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "ethernet_interfaces.[].sflow.egress.enable") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmodified_enable</samp>](## "ethernet_interfaces.[].sflow.egress.unmodified_enable") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sync_e</samp>](## "ethernet_interfaces.[].sync_e") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "ethernet_interfaces.[].sync_e.enable") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priority</samp>](## "ethernet_interfaces.[].sync_e.priority") | String |  |  |  | The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;port_profile</samp>](## "ethernet_interfaces.[].port_profile") | String |  |  |  | Key only used for documentation or validation purposes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;uc_tx_queues</samp>](## "ethernet_interfaces.[].uc_tx_queues") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "ethernet_interfaces.[].uc_tx_queues.[].id") | Integer | Required, Unique |  |  | TX-Queue ID. |
@@ -1019,6 +1022,11 @@
           egress:
             enable: <bool>
             unmodified_enable: <bool>
+        sync_e:
+          enable: <bool>
+
+          # The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.
+          priority: <str>
 
         # Key only used for documentation or validation purposes.
         port_profile: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/sync-e.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/sync-e.md
@@ -1,0 +1,18 @@
+<!--
+  ~ Copyright (c) 2024 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>sync_e</samp>](## "sync_e") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;network_option</samp>](## "sync_e.network_option") | Integer |  |  | Min: 1<br>Max: 2 |  |
+
+=== "YAML"
+
+    ```yaml
+    sync_e:
+      network_option: <int; 1-2>
+    ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/sync-e.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/sync-e.md
@@ -8,11 +8,11 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>sync_e</samp>](## "sync_e") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;network_option</samp>](## "sync_e.network_option") | Integer |  |  | Min: 1<br>Max: 2 |  |
+    | [<samp>&nbsp;&nbsp;network_option</samp>](## "sync_e.network_option") | Integer | Required |  | Min: 1<br>Max: 2 |  |
 
 === "YAML"
 
     ```yaml
     sync_e:
-      network_option: <int; 1-2>
+      network_option: <int; 1-2; required>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -661,6 +661,22 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{%     set sync_e_interfaces = [] %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
+{%         if ethernet_interface.sync_e is arista.avd.defined and ethernet_interface.sync_e.enable is arista.avd.defined(true) %}
+{%             do sync_e_interfaces.append(ethernet_interface) %}
+{%         endif %}
+{%     endfor %}
+{%     if sync_e_interfaces | length > 0 %}
+
+#### Synchronous Ethernet
+
+| Interface | Priority |
+| --------- | -------- |
+{%         for sync_e_interface in sync_e_interfaces %}
+| {{ sync_e_interface.name }} | {{ sync_e_interface.sync_e.priority | arista.avd.default('127') }} |
+{%         endfor %}
+{%     endif %}
 
 #### Ethernet Interfaces Device Configuration
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -663,7 +663,7 @@
 {%     endif %}
 {%     set sync_e_interfaces = [] %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
-{%         if ethernet_interface.sync_e is arista.avd.defined and ethernet_interface.sync_e.enable is arista.avd.defined(true) %}
+{%         if ethernet_interface.sync_e.enable is arista.avd.defined(true) %}
 {%             do sync_e_interfaces.append(ethernet_interface) %}
 {%         endif %}
 {%     endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/sync-e.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/sync-e.j2
@@ -4,7 +4,7 @@
  that can be found in the LICENSE file.
 #}
 {# doc - sync-e #}
-{% if sync_e is arista.avd.defined and sync_e.network_option is arista.avd.defined %}
+{% if sync_e.network_option is arista.avd.defined %}
 
 ### Synchronous Ethernet (SyncE) Settings
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/sync-e.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/sync-e.j2
@@ -1,0 +1,18 @@
+{#
+ Copyright (c) 2023-2024 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# doc - sync-e #}
+{% if sync_e is arista.avd.defined and sync_e.network_option is arista.avd.defined %}
+
+### Synchronous Ethernet (SyncE) Settings
+
+Synchronous Ethernet Network Option: {{ sync_e.network_option }}
+
+#### Synchronous Ethernet Device Configuration
+
+```eos
+{%     include 'eos/sync-e.j2' %}
+```
+{% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-device-documentation.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-device-documentation.j2
@@ -51,6 +51,8 @@
 {% include 'documentation/lacp.j2' %}
 {# Spanning Tree #}
 {% include 'documentation/spanning-tree.j2' %}
+{# Sync-E #}
+{% include 'documentation/sync-e.j2' %}
 {# Internal VLAN Allocation Policy #}
 {% include 'documentation/vlan-internal-order.j2' %}
 {# VLANs #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-intended-config.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-intended-config.j2
@@ -129,6 +129,8 @@
 {% include 'eos/hardware.j2' %}
 {# spanning-tree #}
 {% include 'eos/spanning-tree.j2' %}
+{# sync-e #}
+{% include 'eos/sync-e.j2' %}
 {# platform #}
 {% include 'eos/platform.j2' %}
 {# service unsupported-transceiver #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -864,7 +864,7 @@ interface {{ ethernet_interface.name }}
 {%             endfor %}
 {%         endfor %}
 {%     endif %}
-{%     if ethernet_interface.sync_e is arista.avd.defined and ethernet_interface.sync_e.enable is arista.avd.defined(true) %}
+{%     if ethernet_interface.sync_e.enable is arista.avd.defined(true) %}
    sync-e
       priority {{ ethernet_interface.sync_e.priority | arista.avd.default(127) }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -864,6 +864,10 @@ interface {{ ethernet_interface.name }}
 {%             endfor %}
 {%         endfor %}
 {%     endif %}
+{%     if ethernet_interface.sync_e is arista.avd.defined and ethernet_interface.sync_e.enable is arista.avd.defined(true) %}
+   sync-e
+      priority {{ ethernet_interface.sync_e.priority | arista.avd.default(127) }}
+{%     endif %}
 {%     if ethernet_interface.eos_cli is arista.avd.defined %}
    {{ ethernet_interface.eos_cli | indent(3, false) }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -866,7 +866,9 @@ interface {{ ethernet_interface.name }}
 {%     endif %}
 {%     if ethernet_interface.sync_e.enable is arista.avd.defined(true) %}
    sync-e
-      priority {{ ethernet_interface.sync_e.priority | arista.avd.default(127) }}
+{%         if ethernet_interface.sync_e.priority is arista.avd.defined %}
+      priority {{ ethernet_interface.sync_e.priority }}
+{%         endif %}
 {%     endif %}
 {%     if ethernet_interface.eos_cli is arista.avd.defined %}
    {{ ethernet_interface.eos_cli | indent(3, false) }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/sync-e.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/sync-e.j2
@@ -4,7 +4,7 @@
  that can be found in the LICENSE file.
 #}
 {# eos - sync-e #}
-{% if sync_e is arista.avd.defined and sync_e.network_option is arista.avd.defined %}
+{% if sync_e.network_option is arista.avd.defined %}
 !
 sync-e
    network option {{ sync_e.network_option }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/sync-e.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/sync-e.j2
@@ -1,0 +1,11 @@
+{#
+ Copyright (c) 2024 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# eos - sync-e #}
+{% if sync_e is arista.avd.defined and sync_e.network_option is arista.avd.defined %}
+!
+sync-e
+   network option {{ sync_e.network_option }}
+{% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -5223,6 +5223,25 @@
             },
             "title": "Sflow"
           },
+          "sync_e": {
+            "type": "object",
+            "properties": {
+              "enable": {
+                "type": "boolean",
+                "title": "Enable"
+              },
+              "priority": {
+                "type": "string",
+                "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                "title": "Priority"
+              }
+            },
+            "additionalProperties": false,
+            "patternProperties": {
+              "^_.+$": {}
+            },
+            "title": "Sync E"
+          },
           "port_profile": {
             "type": "string",
             "description": "Key only used for documentation or validation purposes.",

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -28758,6 +28758,9 @@
           "title": "Network Option"
         }
       },
+      "required": [
+        "network_option"
+      ],
       "additionalProperties": false,
       "patternProperties": {
         "^_.+$": {}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -28729,6 +28729,22 @@
       },
       "title": "Switchport Port Security"
     },
+    "sync_e": {
+      "type": "object",
+      "properties": {
+        "network_option": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 2,
+          "title": "Network Option"
+        }
+      },
+      "additionalProperties": false,
+      "patternProperties": {
+        "^_.+$": {}
+      },
+      "title": "Sync E"
+    },
     "system": {
       "type": "object",
       "properties": {

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -5232,7 +5232,7 @@
               },
               "priority": {
                 "type": "string",
-                "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                "description": "The priority is used to influence the reference clock selection. The EOS default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
                 "title": "Priority"
               }
             },

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -3138,8 +3138,8 @@ keys:
             priority:
               type: str
               description: The priority is used to influence the reference clock selection.
-                The default priority is 127. The priority can be configured to any
-                integer between 1-255, or set to `disabled`.
+                The EOS default priority is 127. The priority can be configured to
+                any integer between 1-255, or set to `disabled`.
               convert_types:
               - int
         port_profile:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -16987,6 +16987,7 @@ keys:
     type: dict
     keys:
       network_option:
+        required: true
         type: int
         min: 1
         max: 2

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -3130,6 +3130,18 @@ keys:
                   type: bool
                 unmodified_enable:
                   type: bool
+        sync_e:
+          type: dict
+          keys:
+            enable:
+              type: bool
+            priority:
+              type: str
+              description: The priority is used to influence the reference clock selection.
+                The default priority is 127. The priority can be configured to any
+                integer between 1-255, or set to `disabled`.
+              convert_types:
+              - int
         port_profile:
           type: str
           description: Key only used for documentation or validation purposes.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -16971,6 +16971,15 @@ keys:
         type: bool
       violation_protect_chip_based:
         type: bool
+  sync_e:
+    type: dict
+    keys:
+      network_option:
+        type: int
+        min: 1
+        max: 2
+        convert_types:
+        - str
   system:
     type: dict
     keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -1129,6 +1129,16 @@ keys:
                   type: bool
                 unmodified_enable:
                   type: bool
+        sync_e:
+          type: dict
+          keys:
+            enable:
+              type: bool
+            priority:
+              type: str
+              description: The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.
+              convert_types:
+                - int
         port_profile:
           type: str
           description: Key only used for documentation or validation purposes.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -1136,7 +1136,7 @@ keys:
               type: bool
             priority:
               type: str
-              description: The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.
+              description: The priority is used to influence the reference clock selection. The EOS default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.
               convert_types:
                 - int
         port_profile:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/sync_e.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/sync_e.schema.yml
@@ -10,6 +10,7 @@ keys:
     type: dict
     keys:
       network_option:
+        required: true
         type: int
         min: 1
         max: 2

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/sync_e.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/sync_e.schema.yml
@@ -1,0 +1,17 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  sync_e:
+    type: dict
+    keys:
+      network_option:
+        type: int
+        min: 1
+        max: 2
+        convert_types:
+        - str

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -46704,6 +46704,9 @@
                     "title": "Network Option"
                   }
                 },
+                "required": [
+                  "network_option"
+                ],
                 "additionalProperties": false,
                 "patternProperties": {
                   "^_.+$": {}

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -10792,7 +10792,7 @@
                   },
                   "priority": {
                     "type": "string",
-                    "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                    "description": "The priority is used to influence the reference clock selection. The EOS default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
                     "title": "Priority"
                   }
                 },
@@ -16608,7 +16608,7 @@
                   },
                   "priority": {
                     "type": "string",
-                    "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                    "description": "The priority is used to influence the reference clock selection. The EOS default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
                     "title": "Priority"
                   }
                 },
@@ -23178,7 +23178,7 @@
                         },
                         "priority": {
                           "type": "string",
-                          "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                          "description": "The priority is used to influence the reference clock selection. The EOS default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
                           "title": "Priority"
                         }
                       },
@@ -54936,7 +54936,7 @@
                   },
                   "priority": {
                     "type": "string",
-                    "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                    "description": "The priority is used to influence the reference clock selection. The EOS default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
                     "title": "Priority"
                   }
                 },

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -46637,6 +46637,22 @@
                 },
                 "title": "Switchport Port Security"
               },
+              "sync_e": {
+                "type": "object",
+                "properties": {
+                  "network_option": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "maximum": 2,
+                    "title": "Network Option"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Sync E"
+              },
               "system": {
                 "type": "object",
                 "properties": {

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -10783,6 +10783,25 @@
                 },
                 "title": "Sflow"
               },
+              "sync_e": {
+                "type": "object",
+                "properties": {
+                  "enable": {
+                    "type": "boolean",
+                    "title": "Enable"
+                  },
+                  "priority": {
+                    "type": "string",
+                    "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                    "title": "Priority"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Sync E"
+              },
               "port_profile": {
                 "type": "string",
                 "description": "Key only used for documentation or validation purposes.",
@@ -16579,6 +16598,25 @@
                   "^_.+$": {}
                 },
                 "title": "Sflow"
+              },
+              "sync_e": {
+                "type": "object",
+                "properties": {
+                  "enable": {
+                    "type": "boolean",
+                    "title": "Enable"
+                  },
+                  "priority": {
+                    "type": "string",
+                    "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                    "title": "Priority"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Sync E"
               },
               "port_profile": {
                 "type": "string",
@@ -23130,6 +23168,25 @@
                         "^_.+$": {}
                       },
                       "title": "Sflow"
+                    },
+                    "sync_e": {
+                      "type": "object",
+                      "properties": {
+                        "enable": {
+                          "type": "boolean",
+                          "title": "Enable"
+                        },
+                        "priority": {
+                          "type": "string",
+                          "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                          "title": "Priority"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "patternProperties": {
+                        "^_.+$": {}
+                      },
+                      "title": "Sync E"
                     },
                     "port_profile": {
                       "type": "string",
@@ -54866,6 +54923,25 @@
                   "^_.+$": {}
                 },
                 "title": "Sflow"
+              },
+              "sync_e": {
+                "type": "object",
+                "properties": {
+                  "enable": {
+                    "type": "boolean",
+                    "title": "Enable"
+                  },
+                  "priority": {
+                    "type": "string",
+                    "description": "The priority is used to influence the reference clock selection. The default priority is 127. The priority can be configured to any integer between 1-255, or set to `disabled`.",
+                    "title": "Priority"
+                  }
+                },
+                "additionalProperties": false,
+                "patternProperties": {
+                  "^_.+$": {}
+                },
+                "title": "Sync E"
               },
               "port_profile": {
                 "type": "string",


### PR DESCRIPTION
## Change Summary

Add configuration support for [Synchronous Ethernet](https://www.arista.com/en/support/toi/eos-4-28-1f/15846-synchronous-ethernet-synce)
## Related Issue(s)

Fixes #4231

## Component(s) name

`arista.avd.pyavd.eos_cli_config_gen`

## Proposed changes
Creation of a new `sync_e` model to enable the feature globally
```
sync_e:
   network_option: <1 | 2>
```

Modification to the existing `ethernet_interfaces` model:
```yaml
ethernet_interfaces:
   Ethernet<X>:
      sync_e:
         enabled: <true | false >
         priority: <disabled, (int)1-255>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
