### PR TITLE
Fix(eos_cli_config_gen): Fix unexpected behavior of "validation_mode" setting (#4256)

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py
@@ -97,7 +97,8 @@ class ActionModule(ActionBase):
         if validation_result.failed:
             validation_mode = validated_args.get("validation_mode", "warning")
             self._log_validation_errors(validation_result, validation_mode)
-            return result
+            if validation_mode == "error":
+                return result
 
         has_custom_templates = bool(task_vars.get("custom_templates"))
         try:


### PR DESCRIPTION

## Change Summary

Added a check if  "validation_mode" is "error". Only then return direly after the validation stage.

## Related Issue(s)

Fixes #4256 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

In ansible_collections/arista/avd/plugins/action/eos_cli_config_gen.py

```python
        if validation_result.failed:
            validation_mode = validated_args.get("validation_mode", "warning")
            self._log_validation_errors(validation_result, validation_mode)
            if validation_mode == "error":
                return result
```

Check the "validation_mode"

## How to test

- Add an unexpected value to the structured config
- If "validation_mode" is set to error: no config is generated
- Otherwise: a configuration is generated

## Checklist


### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
