### PR TITLE
Feat(eos_designs): Enhance custom IP addressing and descriptions for p2p-vrfs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_interface_descriptions_with_data.py
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_interface_descriptions_with_data.py
@@ -27,10 +27,12 @@ class CustomAvdInterfaceDescriptions(AvdInterfaceDescriptions):
             - mpls_lsr
             - overlay_routing_protocol
             - type
+            - vrf
         """
         link_peer = str(data.peer).upper()
         if data.link_type == "underlay_p2p":
-            return f"{self._custom_description_prefix}_P2P_LINK_TO_{link_peer}_{data.peer_interface}"
+            vrf_desc = f" VRF {data.vrf}" if data.vrf else ""
+            return f"{self._custom_description_prefix}_P2P_LINK_TO_{link_peer}_{data.peer_interface}{vrf_desc}"
 
         if data.link_type == "underlay_l2":
             return f"{self._custom_description_prefix}_{link_peer}_{data.peer_interface}"

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_ip_addressing.py
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_modules/custom_ip_addressing.py
@@ -106,6 +106,25 @@ class CustomAvdIpAddressing(AvdIpAddressing):
         offset = ((self._id - 1) * self._max_uplink_switches * self._max_parallel_uplinks) + uplink_switch_index + self._custom_ip_offset_20_subnets
         return self._ip(self._uplink_ipv4_pool, 31, offset, 0)
 
+    def p2p_vrfs_uplinks_ip(self, uplink_switch_index: int, vrf: str) -> str:
+        """
+        Implementation of custom code to override IP addressing on VRF uplinks.
+        We read the uplink pool from a custom dict `custom_ip_pools_for_vrfs.<vrf>` - Note no error handling in this example.
+        """
+        offset = ((self._id - 1) * self._max_uplink_switches * self._max_parallel_uplinks) + uplink_switch_index + self._custom_ip_offset_20_subnets
+
+        vrf_pool = self._hostvars["custom_ip_pools_for_vrfs"][vrf]
+        return self._ip(vrf_pool, 31, offset, 1)
+
+    def p2p_vrfs_uplinks_peer_ip(self, uplink_switch_index: int, vrf: str) -> str:
+        """
+        Implementation of custom code to override IP addressing on VRF downlinks
+        We read the uplink pool from a custom dict `custom_ip_pools_for_vrfs.<vrf>` - Note no error handling in this example.
+        """
+        offset = ((self._id - 1) * self._max_uplink_switches * self._max_parallel_uplinks) + uplink_switch_index + self._custom_ip_offset_20_subnets
+        vrf_pool = self._hostvars["custom_ip_pools_for_vrfs"][vrf]
+        return self._ip(vrf_pool, 31, offset, 0)
+
     def router_id(self) -> str:
         """
         Implementation of custom code similar to jinja:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
@@ -48,9 +48,20 @@ interface Ethernet1
    ip address 172.31.255.21/31
 !
 interface Ethernet3
-   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet3
+   description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1
    no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.31.255.24/31
    channel-group 3 mode active
+!
+interface Ethernet3.1
+   description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1.1 VRF TEST_VRF
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1
+   vrf TEST_VRF
+   ip address 172.16.0.24/31
 !
 interface Ethernet4
    description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet4
@@ -163,6 +174,9 @@ router bgp 65101
    neighbor 172.31.255.20 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.31.255.20 remote-as 65001
    neighbor 172.31.255.20 description CUSTOM-PYTHON_MODULES-SPINE1_Ethernet1
+   neighbor 172.31.255.25 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.25 remote-as 65103
+   neighbor 172.31.255.25 description CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description CUSTOM-PYTHON_MODULES-SPINE1
@@ -188,6 +202,9 @@ router bgp 65101
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.240.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 172.16.0.25 remote-as 65103
+      neighbor 172.16.0.25 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.16.0.25 description CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1.1_vrf_TEST_VRF
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF2.cfg
@@ -1,0 +1,125 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname CUSTOM-PYTHON_MODULES-L3LEAF2
+!
+no enable password
+no aaa root
+!
+vlan 110
+   name Tenant_A_OP_Zone_1
+!
+vrf instance MGMT
+!
+vrf instance TEST_VRF
+!
+interface Ethernet1
+   description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3
+   no shutdown
+   mtu 9214
+   no switchport
+   ip address 172.31.255.25/31
+!
+interface Ethernet1.1
+   description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3.1 VRF TEST_VRF
+   no shutdown
+   mtu 9214
+   encapsulation dot1q vlan 1
+   vrf TEST_VRF
+   ip address 172.16.0.25/31
+!
+interface Loopback0
+   description TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_L3LEAF
+   no shutdown
+   ip address 192.168.255.23/32
+!
+interface Loopback1
+   description TEST_CUSTOM_PREFIX_VTEP_VXLAN_Tunnel_Source_L3LEAF
+   no shutdown
+   ip address 192.168.254.23/32
+!
+interface Vlan110
+   description Tenant_A_OP_Zone_1
+   no shutdown
+   vrf TEST_VRF
+   ip address virtual 10.1.10.1/24
+!
+interface Vxlan1
+   description CUSTOM-PYTHON_MODULES-L3LEAF2_VTEP
+   vxlan source-interface Loopback1
+   vxlan udp-port 4789
+   vxlan vlan 110 vni 11110
+   vxlan vrf TEST_VRF vni 1
+!
+ip virtual-router mac-address 00:dc:00:00:00:0a
+!
+ip routing
+no ip routing vrf MGMT
+ip routing vrf TEST_VRF
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+   seq 20 permit 192.168.254.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65103
+   router-id 192.168.255.23
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 172.31.255.24 peer group IPv4-UNDERLAY-PEERS
+   neighbor 172.31.255.24 remote-as 65101
+   neighbor 172.31.255.24 description CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   vlan 110
+      rd 192.168.255.23:11110
+      route-target both 11110:11110
+      redistribute learned
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+   !
+   vrf TEST_VRF
+      rd 192.168.255.23:1
+      route-target import evpn 1:1
+      route-target export evpn 1:1
+      router-id 192.168.255.23
+      neighbor 172.16.0.24 remote-as 65101
+      neighbor 172.16.0.24 peer group IPv4-UNDERLAY-PEERS
+      neighbor 172.16.0.24 description CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3.1_vrf_TEST_VRF
+      redistribute connected
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -49,6 +49,11 @@ router_bgp:
     remote_as: '65001'
     peer: CUSTOM-PYTHON_MODULES-SPINE1
     description: CUSTOM-PYTHON_MODULES-SPINE1_Ethernet1
+  - ip_address: 172.31.255.25
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65103'
+    peer: CUSTOM-PYTHON_MODULES-L3LEAF2
+    description: CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1
   - ip_address: 192.168.255.1
     peer_group: EVPN-OVERLAY-PEERS
     peer: CUSTOM-PYTHON_MODULES-SPINE1
@@ -57,13 +62,16 @@ router_bgp:
   redistribute_routes:
   - source_protocol: connected
     route_map: RM-CONN-2-BGP
-  address_family_evpn:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: true
   vrfs:
   - name: TEST_VRF
     router_id: 192.168.255.21
+    neighbors:
+    - ip_address: 172.16.0.25
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65103'
+      description: CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1.1_vrf_TEST_VRF
+    - ip_address: 10.255.240.11
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
     rd: 192.168.255.21:1
     route_targets:
       import:
@@ -76,11 +84,12 @@ router_bgp:
         - '1:1'
     redistribute_routes:
     - source_protocol: connected
-    neighbors:
-    - ip_address: 10.255.240.11
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
     updates:
       wait_install: true
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
   vlans:
   - id: 110
     tenant: CUSTOM_PYTHON_MODULES_TENANT
@@ -179,15 +188,17 @@ port_channel_interfaces:
   - MLAG
 ethernet_interfaces:
 - name: Ethernet3
-  peer: CUSTOM-PYTHON_MODULES-L3LEAF1B
-  peer_interface: Ethernet3
-  peer_type: mlag_peer
-  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Ethernet3
-  type: port-channel-member
+  peer: CUSTOM-PYTHON_MODULES-L3LEAF2
+  peer_interface: Ethernet1
+  peer_type: l3leaf
+  description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1
+  type: routed
   shutdown: false
   channel_group:
     id: 3
     mode: active
+  mtu: 9214
+  ip_address: 172.31.255.24/31
 - name: Ethernet4
   peer: CUSTOM-PYTHON_MODULES-L3LEAF1B
   peer_interface: Ethernet4
@@ -207,6 +218,17 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.31.255.21/31
+- name: Ethernet3.1
+  peer: CUSTOM-PYTHON_MODULES-L3LEAF2
+  peer_interface: Ethernet1.1
+  peer_type: l3leaf
+  vrf: TEST_VRF
+  description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1.1 VRF TEST_VRF
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 1
+  mtu: 9214
+  ip_address: 172.16.0.24/31
 mlag_configuration:
   domain_id: CUSTOM_PYTHON_MODULES_L3LEAF1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF2.yml
@@ -1,0 +1,173 @@
+hostname: CUSTOM-PYTHON_MODULES-L3LEAF2
+is_deployed: true
+router_bgp:
+  as: '65103'
+  router_id: 192.168.255.23
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  updates:
+    wait_install: true
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+  redistribute_routes:
+  - source_protocol: connected
+    route_map: RM-CONN-2-BGP
+  neighbors:
+  - ip_address: 172.31.255.24
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
+    description: CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3
+  vrfs:
+  - name: TEST_VRF
+    router_id: 192.168.255.23
+    neighbors:
+    - ip_address: 172.16.0.24
+      peer_group: IPv4-UNDERLAY-PEERS
+      remote_as: '65101'
+      description: CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3.1_vrf_TEST_VRF
+    rd: 192.168.255.23:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+    redistribute_routes:
+    - source_protocol: connected
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
+  vlans:
+  - id: 110
+    tenant: CUSTOM_PYTHON_MODULES_TENANT
+    rd: 192.168.255.23:11110
+    route_targets:
+      both:
+      - 11110:11110
+    redistribute_routes:
+    - learned
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+- name: TEST_VRF
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+  ip_routing: true
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ethernet_interfaces:
+- name: Ethernet1
+  peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
+  peer_interface: Ethernet3
+  peer_type: l3leaf
+  description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3
+  shutdown: false
+  mtu: 9214
+  type: routed
+  ip_address: 172.31.255.25/31
+- name: Ethernet1.1
+  peer: CUSTOM-PYTHON_MODULES-L3LEAF1A
+  peer_interface: Ethernet3.1
+  peer_type: l3leaf
+  vrf: TEST_VRF
+  description: TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3.1 VRF TEST_VRF
+  shutdown: false
+  type: l3dot1q
+  encapsulation_dot1q_vlan: 1
+  mtu: 9214
+  ip_address: 172.16.0.25/31
+loopback_interfaces:
+- name: Loopback0
+  description: TEST_CUSTOM_PREFIX_EVPN_Overlay_Peering_L3LEAF
+  shutdown: false
+  ip_address: 192.168.255.23/32
+- name: Loopback1
+  description: TEST_CUSTOM_PREFIX_VTEP_VXLAN_Tunnel_Source_L3LEAF
+  shutdown: false
+  ip_address: 192.168.254.23/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+  - sequence: 20
+    action: permit 192.168.254.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+vlans:
+- id: 110
+  name: Tenant_A_OP_Zone_1
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+ip_igmp_snooping:
+  globally_enabled: true
+ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+vlan_interfaces:
+- name: Vlan110
+  tenant: CUSTOM_PYTHON_MODULES_TENANT
+  tags:
+  - opzone
+  description: Tenant_A_OP_Zone_1
+  shutdown: false
+  ip_address_virtual: 10.1.10.1/24
+  vrf: TEST_VRF
+vxlan_interface:
+  Vxlan1:
+    description: CUSTOM-PYTHON_MODULES-L3LEAF2_VTEP
+    vxlan:
+      udp_port: 4789
+      source_interface: Loopback1
+      vlans:
+      - id: 110
+        vni: 11110
+      vrfs:
+      - name: TEST_VRF
+        vni: 1
+metadata:
+  platform: vEOS-LAB

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_L3LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_L3LEAFS.yml
@@ -27,6 +27,14 @@ l3leaf:
           id: 2
           mgmt_ip: 192.168.200.102/24
           uplink_switch_interfaces: [Ethernet2]
+  nodes:
+    - name: CUSTOM-PYTHON_MODULES-L3LEAF2
+      id: 3
+      bgp_as: 65103
+      uplink_type: p2p-vrfs
+      uplink_switches: [CUSTOM-PYTHON_MODULES-L3LEAF1A]
+      uplink_switch_interfaces: [Ethernet3]
+
 
 tenants:
   - name: CUSTOM_PYTHON_MODULES_TENANT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_PYTHON_MODULES_TESTS.yml
@@ -34,3 +34,6 @@ ip_offset_10: 10
 ip_offset_20: 20
 
 description_prefix: "TEST_CUSTOM_PREFIX"
+
+custom_ip_pools_for_vrfs:
+  TEST_VRF: 172.16.0.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -194,6 +194,7 @@ all:
               hosts:
                 CUSTOM-PYTHON_MODULES-L3LEAF1A:
                 CUSTOM-PYTHON_MODULES-L3LEAF1B:
+                CUSTOM-PYTHON_MODULES-L3LEAF2:
         AUTO_BGP_ASN:
           hosts:
             AUTO_BGP_ASN_LEAF1A:

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/uplinks.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/uplinks.py
@@ -344,8 +344,8 @@ class UplinksMixin:
                     subinterface["ipv6_enable"] = True
                 else:
                     subinterface["prefix_length"] = self.shared_utils.fabric_ip_addressing_p2p_uplinks_ipv4_prefix_length
-                    subinterface["ip_address"] = self.shared_utils.ip_addressing.p2p_uplinks_ip(uplink_index)
-                    subinterface["peer_ip_address"] = self.shared_utils.ip_addressing.p2p_uplinks_peer_ip(uplink_index)
+                    subinterface["ip_address"] = self.shared_utils.ip_addressing.p2p_vrfs_uplinks_ip(uplink_index, vrf["name"])
+                    subinterface["peer_ip_address"] = self.shared_utils.ip_addressing.p2p_vrfs_uplinks_peer_ip(uplink_index, vrf["name"])
 
                 if self.shared_utils.uplink_structured_config is not None:
                     subinterface["structured_config"] = self.shared_utils.uplink_structured_config

--- a/python-avd/pyavd/_eos_designs/interface_descriptions/__init__.py
+++ b/python-avd/pyavd/_eos_designs/interface_descriptions/__init__.py
@@ -1,6 +1,8 @@
 # Copyright (c) 2023-2024 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
+from __future__ import annotations
+
 from collections import ChainMap
 
 from ..avdfacts import AvdFacts

--- a/python-avd/pyavd/_eos_designs/interface_descriptions/__init__.py
+++ b/python-avd/pyavd/_eos_designs/interface_descriptions/__init__.py
@@ -94,7 +94,7 @@ class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
             link_peer=data.peer, link_peer_channel_group_id=data.peer_channel_group_id, link_channel_description=data.port_channel_description
         )
 
-    def underlay_port_channel_interfaces(self, link_peer: str, link_peer_channel_group_id: int, link_channel_description: str) -> str:
+    def underlay_port_channel_interfaces(self, link_peer: str, link_peer_channel_group_id: int, link_channel_description: str | None) -> str:
         """TODO: AVD5.0.0 move this to the new function."""
         if template_path := self.shared_utils.interface_descriptions_templates.get("underlay_port_channel_interfaces"):
             return self._template(
@@ -133,7 +133,7 @@ class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
 
     def mlag_port_channel_interface(
         self,
-        data: InterfaceDescriptionData,  # pylint: disable=unused-argument
+        data: InterfaceDescriptionData,  # pylint: disable=unused-argument # NOSONAR
     ) -> str:
         """
         Available data:
@@ -228,7 +228,7 @@ class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
         """
         return self.overlay_loopback_interface(overlay_loopback_description=data.description)
 
-    def overlay_loopback_interface(self, overlay_loopback_description: str = None) -> str:
+    def overlay_loopback_interface(self, overlay_loopback_description: str | None = None) -> str:
         """TODO: AVD5.0.0 move this to the new function."""
         if template_path := self.shared_utils.interface_descriptions_templates.get("overlay_loopback_interface"):
             return self._template(template_path, overlay_loopback_description=overlay_loopback_description)

--- a/python-avd/pyavd/_eos_designs/ip_addressing/__init__.py
+++ b/python-avd/pyavd/_eos_designs/ip_addressing/__init__.py
@@ -201,6 +201,30 @@ class AvdIpAddressing(AvdFacts, UtilsMixin):
 
         return get_ip_from_pool(p2p_ipv4_pool, prefixlen, offset, 0)
 
+    def p2p_vrfs_uplinks_ip(
+        self,
+        uplink_switch_index: int,
+        vrf: str,  # pylint: disable=unused-argument # NOSONAR
+    ) -> str:
+        """
+        Return Child IP for P2P-VRFs Uplinks
+
+        Unless overridden in a custom IP addressing module, this will just reuse the regular ip addressing logic.
+        """
+        return self.p2p_uplinks_ip(uplink_switch_index)
+
+    def p2p_vrfs_uplinks_peer_ip(
+        self,
+        uplink_switch_index: int,
+        vrf: str,  # pylint: disable=unused-argument # NOSONAR
+    ) -> str:
+        """
+        Return Parent IP for P2P-VRFs Uplinks
+
+        Unless overridden in a custom IP addressing module, this will just reuse the regular ip addressing logic.
+        """
+        return self.p2p_uplinks_peer_ip(uplink_switch_index)
+
     def router_id(self) -> str:
         """
         Return IP address for Router ID

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/ethernet_interfaces.py
@@ -194,7 +194,7 @@ class EthernetInterfacesMixin(UtilsMixin):
                         "mtu": self.shared_utils.p2p_uplinks_mtu,
                     }
                     if subinterface.get("ip_address") is not None:
-                        ethernet_subinterface.update({"ip_address": f"{subinterface['ip_address']}/{subinterface['prefix_length']}"}),
+                        ethernet_subinterface.update({"ip_address": f"{subinterface['ip_address']}/{subinterface['prefix_length']}"})
 
                     ethernet_subinterface = {key: value for key, value in ethernet_subinterface.items() if value is not None}
                     append_if_not_duplicate(


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Enhance custom IP addressing and descriptions for p2p-vrfs.

Allow custom IP and description logic to take VRF name into account.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add new methods for `p2p-vrfs` subinterfaces in ip_addressing module and update pointers. Built-in logic will just relay to the original methods.
- Add `vrf` attribute on `InterfaceDescriptionData` class and populate for `p2p-vrfs` subinterfaces.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added molecule example for both description and ip addressing.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
