### PR TITLE
Refactor(eos_cli_config_gen): Add primary key for connectivity monitor hosts

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/monitor-connectivity.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/monitor-connectivity.md
@@ -16,7 +16,7 @@
     | [<samp>&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.local_interfaces") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;address_only</samp>](## "monitor_connectivity.address_only") | Boolean |  | `True` |  | PREVIEW: This key is in preview.<br>When address-only is configured, the source IP of the packet is set to the interface<br>IP but the packet may exit the device via a different interface.<br>When set to `false`, the probe uses the interface to exit the device.<br>Not supported yet in EOS. |
     | [<samp>&nbsp;&nbsp;hosts</samp>](## "monitor_connectivity.hosts") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "monitor_connectivity.hosts.[].name") | String |  |  |  | Host Name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "monitor_connectivity.hosts.[].name") | String | Required, Unique |  |  | Host Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "monitor_connectivity.hosts.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "monitor_connectivity.hosts.[].ip") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.hosts.[].local_interfaces") | String |  |  |  |  |
@@ -31,7 +31,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.vrfs.[].local_interfaces") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_only</samp>](## "monitor_connectivity.vrfs.[].address_only") | Boolean |  | `True` |  | PREVIEW: This key is in preview.<br>When address-only is configured, the source IP of the packet is set to the interface<br>IP but the packet may exit the device via a different interface.<br>When set to `false`, the probe uses the interface to exit the device.<br>Not supported yet in EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hosts</samp>](## "monitor_connectivity.vrfs.[].hosts") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "monitor_connectivity.vrfs.[].hosts.[].name") | String |  |  |  | Host name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "monitor_connectivity.vrfs.[].hosts.[].name") | String | Required, Unique |  |  | Host name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "monitor_connectivity.vrfs.[].hosts.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip</samp>](## "monitor_connectivity.vrfs.[].hosts.[].ip") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interfaces</samp>](## "monitor_connectivity.vrfs.[].hosts.[].local_interfaces") | String |  |  |  |  |
@@ -61,7 +61,7 @@
       hosts:
 
           # Host Name.
-        - name: <str>
+        - name: <str; required; unique>
           description: <str>
           ip: <str>
           local_interfaces: <str>
@@ -92,7 +92,7 @@
           hosts:
 
               # Host name.
-            - name: <str>
+            - name: <str; required; unique>
               description: <str>
               ip: <str>
               local_interfaces: <str>

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -12430,7 +12430,10 @@
             "additionalProperties": false,
             "patternProperties": {
               "^_.+$": {}
-            }
+            },
+            "required": [
+              "name"
+            ]
           },
           "title": "Hosts"
         },
@@ -12515,7 +12518,10 @@
                   "additionalProperties": false,
                   "patternProperties": {
                     "^_.+$": {}
-                  }
+                  },
+                  "required": [
+                    "name"
+                  ]
                 },
                 "title": "Hosts"
               }

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7344,6 +7344,7 @@ keys:
         default: true
       hosts:
         type: list
+        primary_key: name
         items:
           type: dict
           keys:
@@ -7410,6 +7411,7 @@ keys:
               default: true
             hosts:
               type: list
+              primary_key: name
               items:
                 type: dict
                 keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_connectivity.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_connectivity.schema.yml
@@ -40,6 +40,7 @@ keys:
         default: true
       hosts:
         type: list
+        primary_key: name
         items:
           type: dict
           keys:
@@ -98,6 +99,7 @@ keys:
               default: true
             hosts:
               type: list
+              primary_key: name
               items:
                 type: dict
                 keys:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -30386,7 +30386,10 @@
                       "additionalProperties": false,
                       "patternProperties": {
                         "^_.+$": {}
-                      }
+                      },
+                      "required": [
+                        "name"
+                      ]
                     },
                     "title": "Hosts"
                   },
@@ -30471,7 +30474,10 @@
                             "additionalProperties": false,
                             "patternProperties": {
                               "^_.+$": {}
-                            }
+                            },
+                            "required": [
+                              "name"
+                            ]
                           },
                           "title": "Hosts"
                         }


### PR DESCRIPTION
## Change Summary

enhance model with primary key

## Related Issue(s)

Fixes #4263

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Add `primary_key: name` for hosts outside and inside VRFs for connectivity monitors

## How to test

Cannot have the same host twice (no molecule test)

Check on EOS device that same name can be reused across VRFs
```
monitor connectivity
   vrf TITI
      host BLAH
         icmp echo size 42
   !
   vrf TOTO
      host BLAH
         name-server group dddddd
         icmp echo size 42
   !
   host BLAH
      icmp echo size 42
```
## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
