### PR TITLE
Doc(eos_designs): Add warning about WAN BGP peer groups password

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -124,6 +124,14 @@ Additionally, following keys must be set for the WAN route servers for the conne
 
 - `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes`: To set the ranges of IP address from which to expect BGP peerings for the WAN. Include the VTEP ranges for all routers connecting to this patfinder.
 
+!!! warning
+
+    When configuring a password on the `wan_overlay_peers` BGP peer group, and
+    in the case where there are multiple pathinders in full-mesh with peering IP
+    addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
+    it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
+    peer group or the peerings will not come up.
+
 #### WAN mode
 
 AVD supports two design types for WAN:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/how-to/wan.md
@@ -126,11 +126,10 @@ Additionally, following keys must be set for the WAN route servers for the conne
 
 !!! warning
 
-    When configuring a password on the `wan_overlay_peers` BGP peer group, and
-    in the case where there are multiple pathinders in full-mesh with peering IP
-    addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
-    it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
-    peer group or the peerings will not come up.
+    When configuring a password on the `wan_overlay_peers` BGP peer group,
+    it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.
+    This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.
+    If the password is not set, the static BGP peerings between Pathfinders may not come up.
 
 #### WAN mode
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
@@ -56,7 +56,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;wan_overlay_peers</samp>](## "bgp_peer_groups.wan_overlay_peers") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.wan_overlay_peers.name") | String |  | `WAN-OVERLAY-PEERS` |  | Name of peer group. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_overlay_peers.password") | String |  |  |  | Type 7 encrypted password.<br>When configuring a password on the `wan_overlay_peers` BGP peer group, and<br>in the case where there are multiple pathinders in full-mesh with peering IP<br>addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,<br>it is necessary to also add a password on the `wan_rr_overlay_peers` BGP<br>peer group or the peerings will not come up. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_overlay_peers.password") | String |  |  |  | Type 7 encrypted password.<br>When configuring a password on the `wan_overlay_peers` BGP peer group,<br>it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.<br>This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.wan_overlay_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_timers</samp>](## "bgp_peer_groups.wan_overlay_peers.bfd_timers") | Dictionary |  |  |  | Specify the BFD timers to override the default values.<br>It is recommended to keep BFD total timeout longer than the DPS timeout.<br>The Default BFD timeout is 10 x 1 seconds and the default DPS timeout is 5 x 1 seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "bgp_peer_groups.wan_overlay_peers.bfd_timers.interval") | Integer | Required | `1000` | Min: 50<br>Max: 60000 | Interval in milliseconds. |
@@ -68,7 +68,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.wan_overlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;wan_rr_overlay_peers</samp>](## "bgp_peer_groups.wan_rr_overlay_peers") | Dictionary |  |  |  | Configuration options for the peer-group created to peer between AutoVPN RRs or CV Pathfinders. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.name") | String |  | `WAN-RR-OVERLAY-PEERS` |  | Name of peer group. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.password") | String |  |  |  | Type 7 encrypted password.<br>When configuring a password on the `wan_overlay_peers` BGP peer group, and<br>in the case where there are multiple pathinders in full-mesh with peering IP<br>addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,<br>it is necessary to also add a password on the `wan_rr_overlay_peers` BGP<br>peer group or the peerings will not come up. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.password") | String |  |  |  | Type 7 encrypted password.<br>When configuring a password on the `wan_overlay_peers` BGP peer group,<br>it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.<br>This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.<br>If the password is not set, the static BGP peerings between Pathfinders may not come up. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_timers</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.bfd_timers") | Dictionary |  |  |  | Specify the BFD timers to override the default values.<br>It is recommended to keep BFD total timeout longer than the DPS timeout.<br>The Default BFD timeout is 10 x 1 seconds and the default DPS timeout is 5 x 1 seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.bfd_timers.interval") | Integer | Required | `1000` | Min: 50<br>Max: 60000 | Interval in milliseconds. |
@@ -201,11 +201,9 @@
         name: <str; default="WAN-OVERLAY-PEERS">
 
         # Type 7 encrypted password.
-        # When configuring a password on the `wan_overlay_peers` BGP peer group, and
-        # in the case where there are multiple pathinders in full-mesh with peering IP
-        # addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
-        # it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
-        # peer group or the peerings will not come up.
+        # When configuring a password on the `wan_overlay_peers` BGP peer group,
+        # it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.
+        # This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.
         password: <str>
         bfd: <bool; default=True>
 
@@ -239,11 +237,10 @@
         name: <str; default="WAN-RR-OVERLAY-PEERS">
 
         # Type 7 encrypted password.
-        # When configuring a password on the `wan_overlay_peers` BGP peer group, and
-        # in the case where there are multiple pathinders in full-mesh with peering IP
-        # addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
-        # it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
-        # peer group or the peerings will not come up.
+        # When configuring a password on the `wan_overlay_peers` BGP peer group,
+        # it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.
+        # This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.
+        # If the password is not set, the static BGP peerings between Pathfinders may not come up.
         password: <str>
         bfd: <bool; default=True>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
@@ -56,7 +56,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;wan_overlay_peers</samp>](## "bgp_peer_groups.wan_overlay_peers") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.wan_overlay_peers.name") | String |  | `WAN-OVERLAY-PEERS` |  | Name of peer group. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_overlay_peers.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_overlay_peers.password") | String |  |  |  | Type 7 encrypted password.<br>When configuring a password on the `wan_overlay_peers` BGP peer group, and<br>in the case where there are multiple pathinders in full-mesh with peering IP<br>addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,<br>it is necessary to also add a password on the `wan_rr_overlay_peers` BGP<br>peer group or the peerings will not come up. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.wan_overlay_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_timers</samp>](## "bgp_peer_groups.wan_overlay_peers.bfd_timers") | Dictionary |  |  |  | Specify the BFD timers to override the default values.<br>It is recommended to keep BFD total timeout longer than the DPS timeout.<br>The Default BFD timeout is 10 x 1 seconds and the default DPS timeout is 5 x 1 seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "bgp_peer_groups.wan_overlay_peers.bfd_timers.interval") | Integer | Required | `1000` | Min: 50<br>Max: 60000 | Interval in milliseconds. |
@@ -68,7 +68,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.wan_overlay_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;wan_rr_overlay_peers</samp>](## "bgp_peer_groups.wan_rr_overlay_peers") | Dictionary |  |  |  | Configuration options for the peer-group created to peer between AutoVPN RRs or CV Pathfinders. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.name") | String |  | `WAN-RR-OVERLAY-PEERS` |  | Name of peer group. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.password") | String |  |  |  | Type 7 encrypted password. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.password") | String |  |  |  | Type 7 encrypted password.<br>When configuring a password on the `wan_overlay_peers` BGP peer group, and<br>in the case where there are multiple pathinders in full-mesh with peering IP<br>addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,<br>it is necessary to also add a password on the `wan_rr_overlay_peers` BGP<br>peer group or the peerings will not come up. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_timers</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.bfd_timers") | Dictionary |  |  |  | Specify the BFD timers to override the default values.<br>It is recommended to keep BFD total timeout longer than the DPS timeout.<br>The Default BFD timeout is 10 x 1 seconds and the default DPS timeout is 5 x 1 seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "bgp_peer_groups.wan_rr_overlay_peers.bfd_timers.interval") | Integer | Required | `1000` | Min: 50<br>Max: 60000 | Interval in milliseconds. |
@@ -201,6 +201,11 @@
         name: <str; default="WAN-OVERLAY-PEERS">
 
         # Type 7 encrypted password.
+        # When configuring a password on the `wan_overlay_peers` BGP peer group, and
+        # in the case where there are multiple pathinders in full-mesh with peering IP
+        # addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
+        # it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
+        # peer group or the peerings will not come up.
         password: <str>
         bfd: <bool; default=True>
 
@@ -234,6 +239,11 @@
         name: <str; default="WAN-RR-OVERLAY-PEERS">
 
         # Type 7 encrypted password.
+        # When configuring a password on the `wan_overlay_peers` BGP peer group, and
+        # in the case where there are multiple pathinders in full-mesh with peering IP
+        # addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
+        # it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
+        # peer group or the peerings will not come up.
         password: <str>
         bfd: <bool; default=True>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/bgp-settings.md
@@ -56,7 +56,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "bgp_peer_groups.ipvpn_gateway_peers.structured_config") | Dictionary |  |  |  | Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;wan_overlay_peers</samp>](## "bgp_peer_groups.wan_overlay_peers") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "bgp_peer_groups.wan_overlay_peers.name") | String |  | `WAN-OVERLAY-PEERS` |  | Name of peer group. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_overlay_peers.password") | String |  |  |  | Type 7 encrypted password.<br>When configuring a password on the `wan_overlay_peers` BGP peer group,<br>it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.<br>This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;password</samp>](## "bgp_peer_groups.wan_overlay_peers.password") | String |  |  |  | Type 7 encrypted password.<br>When configuring a password on the `wan_overlay_peers` BGP peer group,<br>it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.<br>This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.<br>If the password is not set, the static BGP peerings between Pathfinders may not come up. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "bgp_peer_groups.wan_overlay_peers.bfd") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd_timers</samp>](## "bgp_peer_groups.wan_overlay_peers.bfd_timers") | Dictionary |  |  |  | Specify the BFD timers to override the default values.<br>It is recommended to keep BFD total timeout longer than the DPS timeout.<br>The Default BFD timeout is 10 x 1 seconds and the default DPS timeout is 5 x 1 seconds. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "bgp_peer_groups.wan_overlay_peers.bfd_timers.interval") | Integer | Required | `1000` | Min: 50<br>Max: 60000 | Interval in milliseconds. |
@@ -204,6 +204,7 @@
         # When configuring a password on the `wan_overlay_peers` BGP peer group,
         # it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.
         # This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.
+        # If the password is not set, the static BGP peerings between Pathfinders may not come up.
         password: <str>
         bfd: <bool; default=True>
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -3832,7 +3832,7 @@
             },
             "password": {
               "type": "string",
-              "description": "Type 7 encrypted password.",
+              "description": "Type 7 encrypted password.\nWhen configuring a password on the `wan_overlay_peers` BGP peer group, and\nin the case where there are multiple pathinders in full-mesh with peering IP\naddresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,\nit is necessary to also add a password on the `wan_rr_overlay_peers` BGP\npeer group or the peerings will not come up.",
               "title": "Password"
             },
             "bfd": {
@@ -4350,7 +4350,7 @@
             },
             "password": {
               "type": "string",
-              "description": "Type 7 encrypted password.",
+              "description": "Type 7 encrypted password.\nWhen configuring a password on the `wan_overlay_peers` BGP peer group, and\nin the case where there are multiple pathinders in full-mesh with peering IP\naddresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,\nit is necessary to also add a password on the `wan_rr_overlay_peers` BGP\npeer group or the peerings will not come up.",
               "title": "Password"
             },
             "bfd": {

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -3832,7 +3832,7 @@
             },
             "password": {
               "type": "string",
-              "description": "Type 7 encrypted password.\nWhen configuring a password on the `wan_overlay_peers` BGP peer group, and\nin the case where there are multiple pathinders in full-mesh with peering IP\naddresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,\nit is necessary to also add a password on the `wan_rr_overlay_peers` BGP\npeer group or the peerings will not come up.",
+              "description": "Type 7 encrypted password.\nWhen configuring a password on the `wan_overlay_peers` BGP peer group,\nit may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.\nThis is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.",
               "title": "Password"
             },
             "bfd": {
@@ -4350,7 +4350,7 @@
             },
             "password": {
               "type": "string",
-              "description": "Type 7 encrypted password.\nWhen configuring a password on the `wan_overlay_peers` BGP peer group, and\nin the case where there are multiple pathinders in full-mesh with peering IP\naddresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,\nit is necessary to also add a password on the `wan_rr_overlay_peers` BGP\npeer group or the peerings will not come up.",
+              "description": "Type 7 encrypted password.\nWhen configuring a password on the `wan_overlay_peers` BGP peer group,\nit may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.\nThis is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.\nIf the password is not set, the static BGP peerings between Pathfinders may not come up.",
               "title": "Password"
             },
             "bfd": {

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -3832,7 +3832,7 @@
             },
             "password": {
               "type": "string",
-              "description": "Type 7 encrypted password.\nWhen configuring a password on the `wan_overlay_peers` BGP peer group,\nit may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.\nThis is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.",
+              "description": "Type 7 encrypted password.\nWhen configuring a password on the `wan_overlay_peers` BGP peer group,\nit may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.\nThis is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.\nIf the password is not set, the static BGP peerings between Pathfinders may not come up.",
               "title": "Password"
             },
             "bfd": {

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -357,18 +357,12 @@ keys:
             description: 'Type 7 encrypted password.
 
               When configuring a password on the `wan_overlay_peers` BGP peer group,
-              and
 
-              in the case where there are multiple pathinders in full-mesh with peering
-              IP
+              it may also be required to set a password for the `wan_rr_overlay_peers`
+              BGP peer group.
 
-              addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes`
-              prefixes,
-
-              it is necessary to also add a password on the `wan_rr_overlay_peers`
-              BGP
-
-              peer group or the peerings will not come up.'
+              This is required in the case where one or more pathfinders use the same
+              VTEP IP range as the edge routers.'
           bfd:
             type: bool
             default: true
@@ -427,18 +421,15 @@ keys:
             description: 'Type 7 encrypted password.
 
               When configuring a password on the `wan_overlay_peers` BGP peer group,
-              and
 
-              in the case where there are multiple pathinders in full-mesh with peering
-              IP
+              it may also be required to set a password for the `wan_rr_overlay_peers`
+              BGP peer group.
 
-              addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes`
-              prefixes,
+              This is required in the case where one or more pathfinders use the same
+              VTEP IP range as the edge routers.
 
-              it is necessary to also add a password on the `wan_rr_overlay_peers`
-              BGP
-
-              peer group or the peerings will not come up.'
+              If the password is not set, the static BGP peerings between Pathfinders
+              may not come up.'
           bfd:
             type: bool
             default: true

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -354,7 +354,21 @@ keys:
             description: Name of peer group.
           password:
             type: str
-            description: Type 7 encrypted password.
+            description: 'Type 7 encrypted password.
+
+              When configuring a password on the `wan_overlay_peers` BGP peer group,
+              and
+
+              in the case where there are multiple pathinders in full-mesh with peering
+              IP
+
+              addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes`
+              prefixes,
+
+              it is necessary to also add a password on the `wan_rr_overlay_peers`
+              BGP
+
+              peer group or the peerings will not come up.'
           bfd:
             type: bool
             default: true
@@ -410,7 +424,21 @@ keys:
             description: Name of peer group.
           password:
             type: str
-            description: Type 7 encrypted password.
+            description: 'Type 7 encrypted password.
+
+              When configuring a password on the `wan_overlay_peers` BGP peer group,
+              and
+
+              in the case where there are multiple pathinders in full-mesh with peering
+              IP
+
+              addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes`
+              prefixes,
+
+              it is necessary to also add a password on the `wan_rr_overlay_peers`
+              BGP
+
+              peer group or the peerings will not come up.'
           bfd:
             type: bool
             default: true

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -362,7 +362,10 @@ keys:
               BGP peer group.
 
               This is required in the case where one or more pathfinders use the same
-              VTEP IP range as the edge routers.'
+              VTEP IP range as the edge routers.
+
+              If the password is not set, the static BGP peerings between Pathfinders
+              may not come up.'
           bfd:
             type: bool
             default: true

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_peer_groups.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_peer_groups.schema.yml
@@ -158,11 +158,9 @@ keys:
             type: str
             description: |-
               Type 7 encrypted password.
-              When configuring a password on the `wan_overlay_peers` BGP peer group, and
-              in the case where there are multiple pathinders in full-mesh with peering IP
-              addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
-              it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
-              peer group or the peerings will not come up.
+              When configuring a password on the `wan_overlay_peers` BGP peer group,
+              it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.
+              This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.
           bfd:
             type: bool
             default: True
@@ -214,11 +212,10 @@ keys:
             type: str
             description: |-
               Type 7 encrypted password.
-              When configuring a password on the `wan_overlay_peers` BGP peer group, and
-              in the case where there are multiple pathinders in full-mesh with peering IP
-              addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
-              it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
-              peer group or the peerings will not come up.
+              When configuring a password on the `wan_overlay_peers` BGP peer group,
+              it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.
+              This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.
+              If the password is not set, the static BGP peerings between Pathfinders may not come up.
           bfd:
             type: bool
             default: True

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_peer_groups.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_peer_groups.schema.yml
@@ -161,6 +161,7 @@ keys:
               When configuring a password on the `wan_overlay_peers` BGP peer group,
               it may also be required to set a password for the `wan_rr_overlay_peers` BGP peer group.
               This is required in the case where one or more pathfinders use the same VTEP IP range as the edge routers.
+              If the password is not set, the static BGP peerings between Pathfinders may not come up.
           bfd:
             type: bool
             default: True

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_peer_groups.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_peer_groups.schema.yml
@@ -156,7 +156,13 @@ keys:
             description: Name of peer group.
           password:
             type: str
-            description: Type 7 encrypted password.
+            description: |-
+              Type 7 encrypted password.
+              When configuring a password on the `wan_overlay_peers` BGP peer group, and
+              in the case where there are multiple pathinders in full-mesh with peering IP
+              addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
+              it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
+              peer group or the peerings will not come up.
           bfd:
             type: bool
             default: True
@@ -206,7 +212,13 @@ keys:
             description: Name of peer group.
           password:
             type: str
-            description: Type 7 encrypted password.
+            description: |-
+              Type 7 encrypted password.
+              When configuring a password on the `wan_overlay_peers` BGP peer group, and
+              in the case where there are multiple pathinders in full-mesh with peering IP
+              addresses overlaping with the `bgp_peer_groups.wan_overlay_peers.listen_range_prefixes` prefixes,
+              it is necessary to also add a password on the `wan_rr_overlay_peers` BGP
+              peer group or the peerings will not come up.
           bfd:
             type: bool
             default: True


### PR DESCRIPTION
## Change Summary

Document some known issue for BGP peer group passwords

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

text about WAN BGP peer group passwords

## How to test

no test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
