### PR TITLE
Bump: Minimum Python version 3.10

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -95,7 +95,6 @@ jobs:
       fail-fast: true
       matrix:
         python_version:
-          - "3.9"
           - "3.10"
           - "3.11"
           - "3.12"
@@ -482,7 +481,7 @@ jobs:
       needs.file-changes.outputs.pyavd == 'true'
     strategy:
       matrix:
-        python: ["3.9", "3.10", "3.11", "3.12"]
+        python: ["3.10", "3.11", "3.12"]
     steps:
       - name: 'Set environment variables'
         run: |

--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,5 +1,5 @@
 # Python version
-sonar.python.version=3.9, 3.10, 3.11, 3.12
+sonar.python.version=3.10, 3.11, 3.12
 # Exclude tests from source
 sonar.exclusions=python-avd/tests/**
 # Path to tests

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -21,7 +21,7 @@ AVD Documentation:
 
 The AVD collection has the following requirements:
 
-- Python 3.9 or above
+- Python 3.10 or above
 - Ansible Core 2.15.0 to 2.17.x
 - [Additional Python Dependencies](#additional-python-dependencies)
 - Modify the `ansible.cfg` file to support additional Jinja2 extensions

--- a/ansible_collections/arista/avd/docs/installation/collection-installation.md
+++ b/ansible_collections/arista/avd/docs/installation/collection-installation.md
@@ -8,7 +8,7 @@
 
 ## Installation workflow
 
-- Install [Python](https://www.python.org/downloads/) **3.9** or later
+- Install [Python](https://www.python.org/downloads/) **3.10** or later
 - Install [arista.avd](#install-collection-from-ansible-galaxy) collection including Python requirements.
 - Modify `ansible.cfg` file to support additional [jinja2 extensions](#ansible-configuration-file)
 

--- a/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
@@ -1,0 +1,51 @@
+---
+# This title is used for search results
+title: Release Notes for AVD 5.x.x
+---
+<!--
+  ~ Copyright (c) 2024 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+
+# Release Notes for AVD 5.x.x
+
+- Documentation for AVD version `5.x.x` [available here](https://avd.arista.com/devel/)
+
+## Release 5.0.0
+
+### Changes to requirements
+
+- AVD v.5.0.0 requires Python version 3.10 or newer.
+
+TODO
+
+### Data model changes from "dict-of-dicts" to "list-of-dicts"
+
+TODO: Removed type conversion
+
+### All eos_designs and eos_cli_config_gen variables are always validated by schemas
+
+In AVD 5.0.0, all `eos_designs` and `eos_cli_config_gen` keys are validated by schemas and execution will stop for any violations.
+If additional custom keys are desired, a key starting with an underscore `_`, will be ignored.
+
+### Breaking or behavioral changes in eos_cli_config_gen
+
+Breaking changes may require modifications to the inventory or playbook. See the [Porting guide for AVD 5.x.x](../porting-guides/5.x.x.md)
+for details.
+
+TODO: add level4 sections for breaking changes outlining the change and referring to porting guide for migration.
+
+### Breaking or behavioral changes in eos_designs
+
+Breaking changes may require modifications to the inventory or playbook. See the [Porting guide for AVD 5.x.x](../porting-guides/5.x.x.md)
+for details.
+
+TODO: add level4 sections for breaking changes outlining the change and referring to porting guide for migration.
+
+### Other breaking or behavioral changes
+
+Breaking changes may require modifications to the inventory or playbook. See the [Porting guide for AVD 5.x.x](../porting-guides/5.x.x.md)
+for details.
+
+TODO: add level4 sections for breaking changes outlining the change and referring to porting guide for migration.

--- a/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
@@ -18,8 +18,6 @@ title: Release Notes for AVD 5.x.x
 
 - AVD v.5.0.0 requires Python version 3.10 or newer.
 
-TODO
-
 ### Data model changes from "dict-of-dicts" to "list-of-dicts"
 
 TODO: Removed type conversion

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -26,7 +26,8 @@ except ImportError:
     HAS_PACKAGING = False
 
 # Python >= 3.9
-MIN_PYTHON_SUPPORTED_VERSION = (3, 9)
+MIN_PYTHON_SUPPORTED_VERSION = (3, 10)
+DEPRECATE_MIN_PYTHON_SUPPORTED_VERSION = False
 
 
 def _validate_python_version(info: dict, result: dict) -> bool:
@@ -54,7 +55,7 @@ def _validate_python_version(info: dict, result: dict) -> bool:
         display.error(f"Python Version running {running_version} - Minimum Version required is {min_version}", False)
         return False
     # Keeping this for next deprecation adjust the message as required
-    elif sys.version_info[:2] == MIN_PYTHON_SUPPORTED_VERSION:
+    elif DEPRECATE_MIN_PYTHON_SUPPORTED_VERSION and sys.version_info[:2] == MIN_PYTHON_SUPPORTED_VERSION:
         result.setdefault("deprecations", []).append(
             {
                 "msg": (

--- a/ansible_collections/arista/avd/plugins/action/verify_requirements.py
+++ b/ansible_collections/arista/avd/plugins/action/verify_requirements.py
@@ -25,7 +25,6 @@ try:
 except ImportError:
     HAS_PACKAGING = False
 
-# Python >= 3.9
 MIN_PYTHON_SUPPORTED_VERSION = (3, 10)
 DEPRECATE_MIN_PYTHON_SUPPORTED_VERSION = False
 

--- a/ansible_collections/arista/avd/tests/config.yml
+++ b/ansible_collections/arista/avd/tests/config.yml
@@ -1,3 +1,3 @@
 ---
 modules:
-  python_requires: ">=3.9"
+  python_requires: ">=3.10"

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -10,7 +10,6 @@ classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Intended Audience :: Developers",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -18,7 +17,7 @@ classifiers = [
     "Topic :: Software Development :: Testing",
 ]
 keywords = ["pyavd"]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "aristaproto>=0.1.1",
     "cryptography>=38.0.4",
@@ -56,7 +55,6 @@ requires = [
     "pyyaml>=6.0.0",
     "mkdocstrings[python]",
     "pydantic>=2.3.0",
-    "eval-type-backport>=0.2.0", # Only needed for 3.9
     "cryptography>=38.0.4",
     "aristaproto>=0.1.1",
 ]

--- a/python-avd/schema_tools/metaschema/meta_schema_model.py
+++ b/python-avd/schema_tools/metaschema/meta_schema_model.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from abc import ABC
 from enum import Enum
 from functools import cached_property
-from typing import Annotated, Any, ClassVar, Generator, List, Literal, Union
+from typing import Annotated, Any, ClassVar, Generator, List, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, constr
 
@@ -573,8 +573,5 @@ class AristaAvdSchema(AvdSchemaDict):
         return []
 
 
-# Workaround for tox until Python 3.9 is dropped
-# https://github.com/microsoft/pyright/issues/4615#issuecomment-1426685471
-AvdSchemaField = Union[AvdSchemaInt, AvdSchemaBool, AvdSchemaStr, AvdSchemaList, AvdSchemaDict]
-# AvdSchemaField = AvdSchemaInt | AvdSchemaBool | AvdSchemaStr | AvdSchemaList | AvdSchemaDict
+AvdSchemaField = AvdSchemaInt | AvdSchemaBool | AvdSchemaStr | AvdSchemaList | AvdSchemaDict
 """Alias for any of the AvdSchema field types"""

--- a/python-avd/tests/schema_tools/generate_docs/test_mdtabsgen.py
+++ b/python-avd/tests/schema_tools/generate_docs/test_mdtabsgen.py
@@ -2,21 +2,19 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 from pathlib import Path
-from sys import path, version_info
+from sys import path
 from unittest.mock import patch
 
 import pytest
 
-if version_info >= (3, 10):
-    # Override global path to load schema from source instead of any installed version.
-    # Avoids to load from pyavd to avoid relying on pyavd vendor things being generated.
-    path.insert(0, str(Path(__file__).parents[3]))
+# Override global path to load schema from source instead of any installed version.
+# Avoids to load from pyavd to avoid relying on pyavd vendor things being generated.
+path.insert(0, str(Path(__file__).parents[3]))
 
-    from schema_tools.generate_docs.mdtabsgen import get_md_tabs
-    from schema_tools.metaschema.meta_schema_model import AristaAvdSchema
+from schema_tools.generate_docs.mdtabsgen import get_md_tabs
+from schema_tools.metaschema.meta_schema_model import AristaAvdSchema
 
 
-@pytest.mark.skipif(version_info < (3, 10), reason="Our Pydantic models require minimum Python3.10")
 @pytest.mark.parametrize("table_name", ["network-services-multicast-settings"])
 def test_get_md_tabs(table_name: str, schema_store, artifacts_path, output_path):
     """

--- a/python-avd/tests/schema_tools/metaschema/test_meta_schema_model.py
+++ b/python-avd/tests/schema_tools/metaschema/test_meta_schema_model.py
@@ -3,20 +3,18 @@
 # that can be found in the LICENSE file.
 import json
 from pathlib import Path
-from sys import path, version_info
+from sys import path
 
-import pytest
 import yaml
 
-if version_info >= (3, 10):
-    # Override global path to load schema from source instead of any installed version.
-    # Avoids to load from pyavd to avoid relying on pyavd vendor things being generated.
-    path.insert(0, str(Path(__file__).parents[3]))
+# Override global path to load schema from source instead of any installed version.
+# Avoids to load from pyavd to avoid relying on pyavd vendor things being generated.
+path.insert(0, str(Path(__file__).parents[3]))
 
-    from schema_tools.metaschema.meta_schema_model import AristaAvdSchema
-    from schema_tools.store import create_store
+from schema_tools.metaschema.meta_schema_model import AristaAvdSchema
+from schema_tools.store import create_store
 
-    raw_schema = create_store()["eos_designs"]
+raw_schema = create_store()["eos_designs"]
 
 
 class NoAliasDumper(yaml.Dumper):
@@ -26,7 +24,6 @@ class NoAliasDumper(yaml.Dumper):
         return True
 
 
-@pytest.mark.skipif(version_info < (3, 10), reason="Our Pydantic models require minimum Python3.10")
 def test_pydantic_dump_matches_original_yaml():
     """
     Loads the schema _without_ resolving the $ref and then dumps the schema again as json.

--- a/python-avd/tox.ini
+++ b/python-avd/tox.ini
@@ -1,6 +1,5 @@
 [tox]
 env_list =
-    py39
     py310
     py311
     py312
@@ -12,7 +11,6 @@ depends =
 
 [gh-actions]
 python =
-  3.9: py39
   3.10: py310
   3.11: coverage, report
   3.12: py312


### PR DESCRIPTION
Bump: Minimum Python version 3.10 incl update of docs and removal of special 3.9 workarounds.