### PR TITLE
Cut(eos_cli_config_gen): Remove deprecated key entropy_source from management_security data model

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -68,7 +68,7 @@ The following data model keys have been removed from `eos_cli_config_gen` in v5.
 | old key 3(flow_trackings) | new key(TODO) |
 | old key 4.1(management_api_gnmi) | new key(TODO) |
 | old key 4.2(management_api_gnmi) | new key(TODO) |
-| old key 5(management_security) | new key(TODO) |
+| management_security.entropy_source | management_security.entropy_sources |
 | old key 6(name_server) | new key(TODO) |
 | old key 7.1(port_channel_interfaces) | new key(TODO) |
 | old key 7.2(port_channel_interfaces) | new key(TODO) |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/documentation/devices/host1.md
@@ -12,9 +12,6 @@
 - [Authentication](#authentication)
   - [Local Users](#local-users)
   - [RADIUS Server](#radius-server)
-- [Management Security](#management-security)
-  - [Management Security Summary](#management-security-summary)
-  - [Management Security Device Configuration](#management-security-device-configuration)
 - [Monitoring](#monitoring)
   - [TerminAttr Daemon](#terminattr-daemon)
   - [Custom daemons](#custom-daemons)
@@ -270,22 +267,6 @@ username admin privilege 15 role network-admin nopassword
 radius-server host 10.10.10.157 vrf mgt key 7 <removed>
 radius-server host 10.10.10.249 key 7 <removed>
 radius-server host 10.10.10.158 key 7 <removed>
-```
-
-## Management Security
-
-### Management Security Summary
-
-| Settings | Value |
-| -------- | ----- |
-| Entropy source | hardware |
-
-### Management Security Device Configuration
-
-```eos
-!
-management security
-   entropy source hardware
 ```
 
 ## Monitoring

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
@@ -615,9 +615,6 @@ management api gnmi
       vrf MONITORING
    provider eos-native
 !
-management security
-   entropy source hardware
-!
 stun
    server
       local-interface Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/management-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/management-security.yml
@@ -1,6 +1,0 @@
-### Management Security
-
-management_security:
-  # Testing entropy source as string
-  # String type is deprecated. To be removed in 5.0.0
-  entropy_source: hardware

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -8,7 +8,6 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>management_security</samp>](## "management_security") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") <span style="color:red">removed</span> | String |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version v5.0.0. Use <samp>entropy_sources</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;entropy_sources</samp>](## "management_security.entropy_sources") | Dictionary |  |  |  | Source of entropy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware</samp>](## "management_security.entropy_sources.hardware") | Boolean |  |  |  | Use a hardware based source. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;haveged</samp>](## "management_security.entropy_sources.haveged") | Boolean |  |  |  | Use the HAVEGE algorithm. |
@@ -67,6 +66,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;start_date_time</samp>](## "management_security.shared_secret_profiles.[].secrets.[].transmit_lifetime.start_date_time") | String |  |  |  | Start date and time of lifetime of the secret. End date should be greater than start date.<br>Formats supported:<br>1. mm/dd/yyyy hh:mm:ss<br>2. yyyy-mm-dd hh:mm:ss<br>e.g 2024-12-20 10:00:00 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;end_date_time</samp>](## "management_security.shared_secret_profiles.[].secrets.[].transmit_lifetime.end_date_time") | String |  |  |  | End date and time of lifetime of the secret. End date should be greater than start date.<br>Formats supported:<br>1. mm/dd/yyyy hh:mm:ss<br>2. yyyy-mm-dd hh:mm:ss<br>e.g 2024-12-20 10:00:00 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_time</samp>](## "management_security.shared_secret_profiles.[].secrets.[].local_time") | Boolean |  |  |  | Configuring secret using the local timezone from system clock. Default is UTC. |
+    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") <span style="color:red">removed</span> | String |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version v5.0.0. Use <samp>entropy_sources</samp> instead.</span> |
 
 === "YAML"
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-security.md
@@ -8,7 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>management_security</samp>](## "management_security") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") <span style="color:red">deprecated</span> | String |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version v5.0.0. Use <samp>entropy_sources</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;entropy_source</samp>](## "management_security.entropy_source") <span style="color:red">removed</span> | String |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version v5.0.0. Use <samp>entropy_sources</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;entropy_sources</samp>](## "management_security.entropy_sources") | Dictionary |  |  |  | Source of entropy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware</samp>](## "management_security.entropy_sources.hardware") | Boolean |  |  |  | Use a hardware based source. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;haveged</samp>](## "management_security.entropy_sources.haveged") | Boolean |  |  |  | Use the HAVEGE algorithm. |
@@ -72,10 +72,6 @@
 
     ```yaml
     management_security:
-      # This key is deprecated.
-      # Support will be removed in AVD version v5.0.0.
-      # Use <samp>entropy_sources</samp> instead.
-      entropy_source: <str>
 
       # Source of entropy.
       entropy_sources:

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-security.j2
@@ -12,9 +12,6 @@
 
 | Settings | Value |
 | -------- | ----- |
-{%     if management_security.entropy_source is arista.avd.defined %}
-| Entropy source | {{ management_security.entropy_source }} |
-{%     endif %}
 {%     if management_security.entropy_sources is arista.avd.defined %}
 {%         set entropy_sources = [] %}
 {%         for source in ['hardware', 'haveged', 'cpu_jitter', 'hardware_exclusive'] %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-security.j2
@@ -7,9 +7,6 @@
 {% if management_security is arista.avd.defined %}
 !
 management security
-{%     if management_security.entropy_source is arista.avd.defined %}
-   entropy source {{ management_security.entropy_source }}
-{%     endif %}
 {%     if management_security.entropy_sources is arista.avd.defined %}
 {%         set entropy_sources = [] %}
 {%         for source in ['hardware', 'haveged', 'cpu_jitter'] %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -11027,10 +11027,6 @@
     "management_security": {
       "type": "object",
       "properties": {
-        "entropy_source": {
-          "type": "string",
-          "title": "Entropy Source"
-        },
         "entropy_sources": {
           "type": "object",
           "description": "Source of entropy.",

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -6590,13 +6590,6 @@ keys:
   management_security:
     type: dict
     keys:
-      entropy_source:
-        type: str
-        deprecation:
-          warning: true
-          removed: true
-          remove_in_version: v5.0.0
-          new_key: entropy_sources
       entropy_sources:
         type: dict
         description: Source of entropy.
@@ -6854,6 +6847,13 @@ keys:
                     type: bool
                     description: Configuring secret using the local timezone from
                       system clock. Default is UTC.
+      entropy_source:
+        type: str
+        deprecation:
+          warning: true
+          removed: true
+          remove_in_version: v5.0.0
+          new_key: entropy_sources
   management_ssh:
     type: dict
     keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -6594,6 +6594,7 @@ keys:
         type: str
         deprecation:
           warning: true
+          removed: true
           remove_in_version: v5.0.0
           new_key: entropy_sources
       entropy_sources:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_security.schema.yml
@@ -9,13 +9,6 @@ keys:
   management_security:
     type: dict
     keys:
-      entropy_source:
-        type: str
-        deprecation:
-          warning: true
-          removed: true
-          remove_in_version: v5.0.0
-          new_key: entropy_sources
       entropy_sources:
         type: dict
         description: Source of entropy.
@@ -254,3 +247,10 @@ keys:
                   local_time:
                     type: bool
                     description: Configuring secret using the local timezone from system clock. Default is UTC.
+      entropy_source:
+        type: str
+        deprecation:
+          warning: true
+          removed: true
+          remove_in_version: v5.0.0
+          new_key: entropy_sources

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_security.schema.yml
@@ -13,6 +13,7 @@ keys:
         type: str
         deprecation:
           warning: true
+          removed: true
           remove_in_version: v5.0.0
           new_key: entropy_sources
       entropy_sources:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -29046,10 +29046,6 @@
               "management_security": {
                 "type": "object",
                 "properties": {
-                  "entropy_source": {
-                    "type": "string",
-                    "title": "Entropy Source"
-                  },
                   "entropy_sources": {
                     "type": "object",
                     "description": "Source of entropy.",


### PR DESCRIPTION
## Change Summary

 Remove deprecated var for management_security.entropy_source from templates.

## Related Issue(s)



## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
 Remove deprecated var for management_security.entropy_source from templates.

## How to test

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
