### PR TITLE
Cut(eos_cli_config_gen): Remove deprecated key cvcompression from daemon_terminattr data model

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -61,7 +61,7 @@ The following data model keys have been removed from `eos_cli_config_gen` in v5.
 
 | Removed key | New key |
 | ----------- | ------- |
-| old key 1(daemon_terminattr) | new key(TODO) |
+| cvcompression | - |
 | event_handlers.action | event_handlers.actions.bash_command |
 | event_handlers.action_type | event_handlers.actions |
 | event_handlers.regex | event_handlers.trigger_on_logging.regex |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/daemon-terminattr.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/daemon-terminattr.yml
@@ -17,5 +17,3 @@ daemon_terminattr:
         method: "token"
         token_file: "/tmp/tokenDC2"
       cvvrf: mgt
-  # deprecated in 4.4.0. To be removed in 5.0.0
-  cvcompression: gzip

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/daemon-terminattr.md
@@ -51,7 +51,7 @@
     | [<samp>&nbsp;&nbsp;sflow</samp>](## "daemon_terminattr.sflow") | Boolean |  |  |  | Enable sFlow provider (TerminAttr default is true).<br> |
     | [<samp>&nbsp;&nbsp;sflowaddr</samp>](## "daemon_terminattr.sflowaddr") | String |  |  |  | ECO sFlow Collector address to listen on to receive sFlow packets (TerminAttr default "127.0.0.1:6343").<br> |
     | [<samp>&nbsp;&nbsp;cvconfig</samp>](## "daemon_terminattr.cvconfig") | Boolean |  |  |  | Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).<br> |
-    | [<samp>&nbsp;&nbsp;cvcompression</samp>](## "daemon_terminattr.cvcompression") <span style="color:red">deprecated</span> | String |  |  |  | The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.<br>There is no need to change the compression scheme.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version v5.0.0.</span> |
+    | [<samp>&nbsp;&nbsp;cvcompression</samp>](## "daemon_terminattr.cvcompression") <span style="color:red">removed</span> | String |  |  |  | The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.<br>There is no need to change the compression scheme.<br><span style="color:red">This key was removed. Support was removed in AVD version v5.0.0.</span> |
 
 === "YAML"
 
@@ -206,10 +206,4 @@
 
       # Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
       cvconfig: <bool>
-
-      # The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.
-      # There is no need to change the compression scheme.
-      # This key is deprecated.
-      # Support will be removed in AVD version v5.0.0.
-      cvcompression: <str>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.jsonschema.json
@@ -1915,12 +1915,6 @@
           "type": "boolean",
           "description": "Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).\n",
           "title": "Cvconfig"
-        },
-        "cvcompression": {
-          "type": "string",
-          "description": "The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.\nThere is no need to change the compression scheme.\n\nThis key is deprecated. Support will be removed in AVD version v5.0.0.",
-          "deprecated": true,
-          "title": "Cvcompression"
         }
       },
       "additionalProperties": false,

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1287,6 +1287,7 @@ keys:
           '
       cvcompression:
         deprecation:
+          removed: true
           warning: true
           remove_in_version: v5.0.0
         type: str

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
@@ -215,6 +215,7 @@ keys:
           Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).
       cvcompression:
         deprecation:
+          removed: true
           warning: true
           remove_in_version: v5.0.0
         type: str

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.jsonschema.json
@@ -19934,12 +19934,6 @@
                     "type": "boolean",
                     "description": "Subscribe to dynamic device configuration from CloudVision (TerminAttr default is false).\n",
                     "title": "Cvconfig"
-                  },
-                  "cvcompression": {
-                    "type": "string",
-                    "description": "The default compression scheme when streaming to CloudVision is gzip since TerminAttr 1.6.1 and CVP 2019.1.0.\nThere is no need to change the compression scheme.\n\nThis key is deprecated. Support will be removed in AVD version v5.0.0.",
-                    "deprecated": true,
-                    "title": "Cvcompression"
                   }
                 },
                 "additionalProperties": false,


### PR DESCRIPTION
## Change Summary

Removing deprecated keys cvcompression from daemon_terminattr data model

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Removing deprecated keys cvcompression from daemon_terminattr data model

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
