### PR TITLE
Cut(eos_designs): Remove deprecated ptp data model

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -60,7 +60,7 @@ The following data model keys have been removed from `eos_designs` in v5.0.0.
 | old key 3.2(defs_node_type) | new key(TODO) |
 | <network_services_key>[].vrfs[].svis[].ipv6_address_virtual | <network_services_key>[].vrfs[].svis[].ipv6_address_virtuals |
 | svi_profiles[].ipv6_address_virtual | svi_profiles[].ipv6_address_virtuals |
-| old key 5(ptp) | new key(TODO) |
+| ptp | ptp_settings |
 
 ## Changes to role `arista.avd.eos_cli_config_gen`
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
@@ -8,19 +8,6 @@ service routing protocols model multi-agent
 !
 hostname host1
 !
-ptp clock-identity 00:1C:73:1e:00:65
-ptp priority1 30
-ptp priority2 101
-ptp domain 127
-ptp mode boundary
-ptp monitor threshold offset-from-master 250
-ptp monitor threshold mean-path-delay 1500
-ptp monitor sequence-id
-ptp monitor threshold missing-message announce 3 sequence-ids
-ptp monitor threshold missing-message delay-resp 3 sequence-ids
-ptp monitor threshold missing-message follow-up 3 sequence-ids
-ptp monitor threshold missing-message sync 3 sequence-ids
-!
 no enable password
 no aaa root
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
@@ -50,24 +50,6 @@ management_api_http:
   enable_vrfs:
   - name: MGMT
   enable_https: true
-ptp:
-  mode: boundary
-  clock_identity: 00:1C:73:1e:00:65
-  priority1: 30
-  priority2: 101
-  domain: 127
-  monitor:
-    enabled: true
-    threshold:
-      offset_from_master: 250
-      mean_path_delay: 1500
-    missing_message:
-      sequence_ids:
-        enabled: true
-        announce: 3
-        delay_resp: 3
-        follow_up: 3
-        sync: 3
 loopback_interfaces:
 - name: Loopback0
   description: EVPN_Overlay_Peering

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/ptp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/ptp.yml
@@ -1,4 +1,0 @@
----
-ptp_settings:
-  enabled: true
-  auto_clock_identity: true

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/ptp_settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/ptp_settings.md
@@ -7,11 +7,7 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>ptp</samp>](## "ptp") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version v5.0.0. Use <samp>ptp_settings</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;enabled</samp>](## "ptp.enabled") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;profile</samp>](## "ptp.profile") | String |  | `aes67-r16-2016` | Valid Values:<br>- <code>aes67</code><br>- <code>smpte2059-2</code><br>- <code>aes67-r16-2016</code> |  |
-    | [<samp>&nbsp;&nbsp;domain</samp>](## "ptp.domain") | Integer |  |  | Min: 0<br>Max: 255 |  |
-    | [<samp>&nbsp;&nbsp;auto_clock_identity</samp>](## "ptp.auto_clock_identity") | Boolean |  | `True` |  |  |
+    | [<samp>ptp</samp>](## "ptp") <span style="color:red">removed</span> | Dictionary |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version v5.0.0. Use <samp>ptp_settings</samp> instead.</span> |
     | [<samp>ptp_profiles</samp>](## "ptp_profiles") | List, items: Dictionary |  | See (+) on YAML tab |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;profile</samp>](## "ptp_profiles.[].profile") | String |  |  |  | PTP profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;announce</samp>](## "ptp_profiles.[].announce") | Dictionary |  |  |  | PTP announce interval. |
@@ -21,7 +17,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sync_message</samp>](## "ptp_profiles.[].sync_message") | Dictionary |  |  |  | PTP sync message interval. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ptp_profiles.[].sync_message.interval") | Integer |  |  | Min: -7<br>Max: 3 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "ptp_profiles.[].transport") | String |  |  | Valid Values:<br>- <code>ipv4</code> |  |
-    | [<samp>ptp_settings</samp>](## "ptp_settings") | Dictionary |  |  |  | Common PTP settings.<br>`ptp_settings` replaces the old `ptp` key. `ptp_settings` takes precedence. |
+    | [<samp>ptp_settings</samp>](## "ptp_settings") | Dictionary |  |  |  | Common PTP settings. |
     | [<samp>&nbsp;&nbsp;enabled</samp>](## "ptp_settings.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;profile</samp>](## "ptp_settings.profile") | String |  | `aes67-r16-2016` | Valid Values:<br>- <code>aes67</code><br>- <code>smpte2059-2</code><br>- <code>aes67-r16-2016</code> |  |
     | [<samp>&nbsp;&nbsp;domain</samp>](## "ptp_settings.domain") | Integer |  |  | Min: 0<br>Max: 255 |  |
@@ -30,14 +26,6 @@
 === "YAML"
 
     ```yaml
-    # This key is deprecated.
-    # Support will be removed in AVD version v5.0.0.
-    # Use <samp>ptp_settings</samp> instead.
-    ptp:
-      enabled: <bool>
-      profile: <str; "aes67" | "smpte2059-2" | "aes67-r16-2016"; default="aes67-r16-2016">
-      domain: <int; 0-255>
-      auto_clock_identity: <bool; default=True>
     ptp_profiles: # (1)!
 
         # PTP profile.
@@ -55,7 +43,6 @@
         transport: <str; "ipv4">
 
     # Common PTP settings.
-    # `ptp_settings` replaces the old `ptp` key. `ptp_settings` takes precedence.
     ptp_settings:
       enabled: <bool>
       profile: <str; "aes67" | "smpte2059-2" | "aes67-r16-2016"; default="aes67-r16-2016">

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -3169,27 +3169,12 @@ keys:
   ptp:
     deprecation:
       warning: true
+      removed: true
       new_key: ptp_settings
       remove_in_version: v5.0.0
     documentation_options:
       table: ptp_settings
     type: dict
-    keys:
-      enabled:
-        type: bool
-      profile:
-        type: str
-        valid_values:
-        - aes67
-        - smpte2059-2
-        - aes67-r16-2016
-        default: aes67-r16-2016
-      domain:
-        type: int
-        $ref: eos_cli_config_gen#/keys/ptp/keys/domain
-      auto_clock_identity:
-        type: bool
-        default: true
   ptp_profiles:
     documentation_options:
       table: ptp_settings
@@ -3265,9 +3250,7 @@ keys:
     documentation_options:
       table: ptp_settings
     type: dict
-    description: 'Common PTP settings.
-
-      `ptp_settings` replaces the old `ptp` key. `ptp_settings` takes precedence.'
+    description: Common PTP settings.
     keys:
       enabled:
         type: bool

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ptp.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ptp.schema.yml
@@ -9,24 +9,9 @@ keys:
   ptp:
     deprecation:
       warning: true
+      removed: true
       new_key: 'ptp_settings'
       remove_in_version: v5.0.0
     documentation_options:
       table: ptp_settings
     type: dict
-    keys:
-      enabled:
-        type: bool
-      profile:
-        type: str
-        valid_values:
-          - "aes67"
-          - "smpte2059-2"
-          - "aes67-r16-2016"
-        default: "aes67-r16-2016"
-      domain:
-        type: int
-        $ref: "eos_cli_config_gen#/keys/ptp/keys/domain"
-      auto_clock_identity:
-        type: bool
-        default: true

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ptp_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ptp_settings.schema.yml
@@ -10,10 +10,7 @@ keys:
     documentation_options:
       table: ptp_settings
     type: dict
-    # TODO AVD5.0: Update description to not mention ptp key.
-    description: |-
-      Common PTP settings.
-      `ptp_settings` replaces the old `ptp` key. `ptp_settings` takes precedence.
+    description: Common PTP settings.
     keys:
       enabled:
         type: bool

--- a/python-avd/pyavd/_eos_designs/shared_utils/ptp.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/ptp.py
@@ -64,7 +64,7 @@ class PtpMixin:
 
     @cached_property
     def ptp_profile_name(self: SharedUtils) -> str:
-        default_ptp_profile = default(get(self.hostvars, "ptp_settings.profile"), "aes67-r16-2016")
+        default_ptp_profile = get(self.hostvars, "ptp_settings.profile", default="aes67-r16-2016")
         return get(self.switch_data_combined, "ptp.profile", default_ptp_profile)
 
     @cached_property

--- a/python-avd/pyavd/_eos_designs/shared_utils/ptp.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/ptp.py
@@ -55,7 +55,7 @@ class PtpMixin:
 
     @cached_property
     def ptp_enabled(self: SharedUtils) -> bool:
-        default_ptp_enabled = default(get(self.hostvars, "ptp_settings.enabled"))
+        default_ptp_enabled = get(self.hostvars, "ptp_settings.enabled")
         return get(self.switch_data_combined, "ptp.enabled", default=default_ptp_enabled) is True
 
     @cached_property

--- a/python-avd/pyavd/_eos_designs/shared_utils/ptp.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/ptp.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from pyavd._utils import default, get, get_item
+from pyavd._utils import get, get_item
 
 if TYPE_CHECKING:
     from . import SharedUtils

--- a/python-avd/pyavd/_eos_designs/shared_utils/ptp.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/ptp.py
@@ -55,7 +55,7 @@ class PtpMixin:
 
     @cached_property
     def ptp_enabled(self: SharedUtils) -> bool:
-        default_ptp_enabled = default(get(self.hostvars, "ptp_settings.enabled"), get(self.hostvars, "ptp.enabled"))
+        default_ptp_enabled = default(get(self.hostvars, "ptp_settings.enabled"))
         return get(self.switch_data_combined, "ptp.enabled", default=default_ptp_enabled) is True
 
     @cached_property
@@ -64,7 +64,7 @@ class PtpMixin:
 
     @cached_property
     def ptp_profile_name(self: SharedUtils) -> str:
-        default_ptp_profile = default(get(self.hostvars, "ptp_settings.profile"), get(self.hostvars, "ptp.profile"), "aes67-r16-2016")
+        default_ptp_profile = default(get(self.hostvars, "ptp_settings.profile"), "aes67-r16-2016")
         return get(self.switch_data_combined, "ptp.profile", default_ptp_profile)
 
     @cached_property

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -607,10 +607,7 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
                 raise AristaAvdMissingVariableError(msg)
 
             priority2 = self.shared_utils.id % 256
-        default_auto_clock_identity = default(
-            get(self._hostvars, "ptp_settings.auto_clock_identity"),
-            True,  # noqa: FBT003
-        )
+        default_auto_clock_identity = get(self._hostvars, "ptp_settings.auto_clock_identity", default=True)
         if get(self.shared_utils.switch_data_combined, "ptp.auto_clock_identity", default=default_auto_clock_identity) is True:
             clock_identity_prefix = get(self.shared_utils.switch_data_combined, "ptp.clock_identity_prefix", default="00:1C:73")
             default_clock_identity = f"{clock_identity_prefix}:{priority1:02x}:00:{priority2:02x}"

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -594,13 +594,8 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
             default_priority2 = self.id % 256.
         """
         if not self.shared_utils.ptp_enabled:
-            # Since we have overlapping data model "ptp" between eos_designs and eos_cli_config_gen,
-            # we need to overwrite the input dict if set but not enabled.
-            # TODO: AVD5.0.0 Remove this handling since the `ptp` key is removed from eos_designs.
-            if get(self._hostvars, "ptp") is not None:
-                return {}
             return None
-        default_ptp_domain = default(get(self._hostvars, "ptp_settings.domain"), get(self._hostvars, "ptp.domain"), 127)
+        default_ptp_domain = default(get(self._hostvars, "ptp_settings.domain"), 127)
         default_ptp_priority1 = get(self.shared_utils.node_type_key_data, "default_ptp_priority1", default=127)
         default_clock_identity = None
 
@@ -614,7 +609,6 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
             priority2 = self.shared_utils.id % 256
         default_auto_clock_identity = default(
             get(self._hostvars, "ptp_settings.auto_clock_identity"),
-            get(self._hostvars, "ptp.auto_clock_identity"),
             True,  # noqa: FBT003
         )
         if get(self.shared_utils.switch_data_combined, "ptp.auto_clock_identity", default=default_auto_clock_identity) is True:

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -7,7 +7,7 @@ from functools import cached_property
 
 from pyavd._eos_designs.avdfacts import AvdFacts
 from pyavd._errors import AristaAvdMissingVariableError
-from pyavd._utils import default, get, strip_null_from_data
+from pyavd._utils import get, strip_null_from_data
 from pyavd.j2filters import convert_dicts, natural_sort
 
 from .ntp import NtpMixin

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -595,7 +595,7 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
         """
         if not self.shared_utils.ptp_enabled:
             return None
-        default_ptp_domain = default(get(self._hostvars, "ptp_settings.domain"), 127)
+        default_ptp_domain = get(self._hostvars, "ptp_settings.domain", default=127)
         default_ptp_priority1 = get(self.shared_utils.node_type_key_data, "default_ptp_priority1", default=127)
         default_clock_identity = None
 


### PR DESCRIPTION
## Change Summary

Remove deprecated ptp data model

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Remove deprecated ptp data model.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
