### PR TITLE
Cut(eos_designs): Remove deprecated key cvp_instance_ip

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -52,7 +52,7 @@ The following data model keys have been removed from `eos_designs` in v5.0.0.
 
 | Removed key | New key |
 | ----------- | ------- |
-| old key 1(cvp_instance_ip) | new key(TODO) |
+| cvp_instance_ip | cvp_instance_ips |
 | old key 2(defs_adapter_config) | new key(TODO) |
 | old key 3.1(defs_node_type) | new key(TODO) |
 | old key 3.2(defs_node_type) | new key(TODO) |

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
@@ -1,9 +1,5 @@
 !RANCID-CONTENT-TYPE: arista
 !
-daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=192.168.200.12:9910,192.168.200.13:9910,192.168.200.11:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
-   no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
@@ -38,18 +38,6 @@ router_bgp:
       activate: true
 service_routing_protocols_model: multi-agent
 ip_routing: true
-daemon_terminattr:
-  cvaddrs:
-  - 192.168.200.12:9910
-  - 192.168.200.13:9910
-  - 192.168.200.11:9910
-  cvauth:
-    method: token
-    token_file: /tmp/token
-  cvvrf: MGMT
-  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
-  ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
-  disable_aaa: false
 vlan_internal_order:
   allocation: ascending
   range:

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/cvp_instance_ip.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/cvp_instance_ip.yml
@@ -1,8 +1,0 @@
-type: l2leaf
-l2leaf: {}
-
-cvp_instance_ips:
-  - 192.168.200.12
-  - 192.168.200.13
-
-cvp_instance_ip: 192.168.200.11

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/cloudvision-settings.md
@@ -8,7 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>cvp_ingestauth_key</samp>](## "cvp_ingestauth_key") | String |  |  |  | On-premise CVP ingest auth key. If set, TerminAttr will be configured with key-based authentication for on-premise CVP.<br>If not set, TerminAttr will be configured with certificate based authentication:<br>- On-premise using token onboarding. Default token path is '/tmp/token'.<br>- CVaaS using token-secure onboarding. Default token path is '/tmp/cv-onboarding-token'.<br>Token must be copied to the device first. |
-    | [<samp>cvp_instance_ip</samp>](## "cvp_instance_ip") <span style="color:red">deprecated</span> | String |  |  |  | IPv4 address or DNS name for CloudVision.<br>This variable only supports an on-premise single-node cluster or the DNS name of a CloudVision as a Service instance.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 5.0.0. Use <samp>cvp_instance_ips</samp> instead.</span> |
+    | [<samp>cvp_instance_ip</samp>](## "cvp_instance_ip") <span style="color:red">removed</span> | String |  |  |  | IPv4 address or DNS name for CloudVision.<br>This variable only supports an on-premise single-node cluster or the DNS name of a CloudVision as a Service instance.<br><span style="color:red">This key was removed. Support was removed in AVD version 5.0.0. Use <samp>cvp_instance_ips</samp> instead.</span> |
     | [<samp>cvp_instance_ips</samp>](## "cvp_instance_ips") | List, items: String |  |  |  | List of IPv4 addresses or DNS names for CloudVision.<br>For on-premise CloudVision enter all the nodes of the cluster.<br>For CloudVision as a Service enter the DNS name of the instance.<br>`eos_designs` only supports one CloudVision cluster.<br> |
     | [<samp>&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "cvp_instance_ips.[]") | String |  |  |  | IPv4 address or DNS name for CloudVision. |
     | [<samp>cvp_token_file</samp>](## "cvp_token_file") | String |  |  |  | cvp_token_file is the path to the token file on the switch.<br>If not set the default locations for on-premise or CVaaS will be used.<br>See cvp_ingestauth_key for details. |
@@ -26,13 +26,6 @@
     # - CVaaS using token-secure onboarding. Default token path is '/tmp/cv-onboarding-token'.
     # Token must be copied to the device first.
     cvp_ingestauth_key: <str>
-
-    # IPv4 address or DNS name for CloudVision.
-    # This variable only supports an on-premise single-node cluster or the DNS name of a CloudVision as a Service instance.
-    # This key is deprecated.
-    # Support will be removed in AVD version 5.0.0.
-    # Use <samp>cvp_instance_ips</samp> instead.
-    cvp_instance_ip: <str>
 
     # List of IPv4 addresses or DNS names for CloudVision.
     # For on-premise CloudVision enter all the nodes of the cluster.

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -852,6 +852,7 @@ keys:
       warning: true
       new_key: cvp_instance_ips
       remove_in_version: 5.0.0
+      removed: true
     type: str
     description: 'IPv4 address or DNS name for CloudVision.
 

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cvp_instance_ip.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cvp_instance_ip.schema.yml
@@ -13,6 +13,7 @@ keys:
       warning: true
       new_key: cvp_instance_ips
       remove_in_version: "5.0.0"
+      removed: true
     type: str
     description: |
       IPv4 address or DNS name for CloudVision.

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -234,20 +234,16 @@ class AvdStructuredConfigBase(AvdFacts, NtpMixin, SnmpServerMixin):
     @cached_property
     def daemon_terminattr(self) -> dict | None:
         """
-        daemon_terminattr set based on cvp_instance_ip and cvp_instance_ips variables.
+        daemon_terminattr set based on cvp_instance_ips.
 
         Updating cvaddrs and cvauth considering conditions for cvaas and cvp_on_prem IPs
 
-            if 'arista.io' in cvp_instance_ip:
+            if 'arista.io' in cvp_instance_ips:
                  <updating as cvaas_ip>
             else:
                  <updating as cvp_on_prem ip>
         """
-        # cvp_instance_ip will be removed in AVD5.0
-        cvp_instance_ip = get(self._hostvars, "cvp_instance_ip")
         cvp_instance_ip_list = get(self._hostvars, "cvp_instance_ips", [])
-        if cvp_instance_ip is not None:
-            cvp_instance_ip_list.append(cvp_instance_ip)
         if not cvp_instance_ip_list:
             return None
 


### PR DESCRIPTION
## Change Summary

Remove deprecated key cvp_instace_ip

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Remove deprecated key cvp_instace_ip

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
