### PR TITLE
Fix(eos_designs): Do not render vrf default under router ospf

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -131,6 +131,9 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vlan 1234
+   name VRF_DEFAULT_SVI_WITH_OSPF
+!
 vrf instance 12345678
 !
 vrf instance MGMT
@@ -368,6 +371,11 @@ interface Vlan452
    ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
 !
+interface Vlan1234
+   description VRF_DEFAULT_SVI_WITH_OSPF
+   shutdown
+   ip ospf area 0.0.0.0
+!
 interface Vxlan1
    description evpn_services_l2_only_false_VTEP
    vxlan source-interface Loopback1
@@ -404,7 +412,9 @@ interface Vxlan1
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
+   vxlan vlan 1234 vni 41234
    vxlan vrf 12345678 vni 41
+   vxlan vrf default vni 123
    vxlan vrf Tenant_A_APP_Zone vni 12
    vxlan vrf Tenant_A_DB_Zone vni 13
    vxlan vrf Tenant_A_OP_Zone vni 10
@@ -480,6 +490,12 @@ router bgp 101
       route-target both 41:41
       redistribute learned
       vlan 450-452
+   !
+   vlan-aware-bundle default
+      rd 192.168.255.109:123
+      route-target both 123:123
+      redistribute learned
+      vlan 1234
    !
    vlan-aware-bundle l2vlan_with_no_tags
       rd 192.168.255.109:20162
@@ -580,6 +596,12 @@ router bgp 101
       router-id 192.168.255.109
       redistribute connected
    !
+   vrf default
+      rd 192.168.255.109:123
+      route-target import evpn 123:123
+      route-target export evpn 123:123
+      redistribute ospf
+   !
    vrf Tenant_A_APP_Zone
       rd 192.168.255.109:12
       route-target import evpn 12:12
@@ -651,6 +673,12 @@ router bgp 101
       route-target export evpn 40:40
       router-id 192.168.255.109
       redistribute connected
+!
+router ospf 123
+   router-id 192.168.255.109
+   passive-interface default
+   no passive-interface Vlan1234
+   redistribute bgp
 !
 management api http-commands
    protocol https

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -131,6 +131,9 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vlan 1234
+   name VRF_DEFAULT_SVI_WITH_OSPF
+!
 vrf instance MGMT
 !
 interface Loopback0
@@ -185,6 +188,7 @@ interface Vxlan1
    vxlan vlan 450 vni 40450
    vxlan vlan 451 vni 40451
    vxlan vlan 452 vni 40452
+   vxlan vlan 1234 vni 41234
 !
 ip routing
 no ip routing vrf MGMT
@@ -224,6 +228,12 @@ router bgp 101
       route-target both 41:41
       redistribute learned
       vlan 450-452
+   !
+   vlan-aware-bundle default
+      rd 192.168.255.109:123
+      route-target both 123:123
+      redistribute learned
+      vlan 1234
    !
    vlan-aware-bundle l2vlan_with_no_tags
       rd 192.168.255.109:20162

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -131,6 +131,9 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vlan 1234
+   name VRF_DEFAULT_SVI_WITH_OSPF
+!
 vrf instance MGMT
 !
 interface Management1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -131,6 +131,9 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vlan 1234
+   name VRF_DEFAULT_SVI_WITH_OSPF
+!
 vrf instance MGMT
 !
 interface MY_INTERFACE_FABRIC

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -133,6 +133,9 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vlan 1234
+   name VRF_DEFAULT_SVI_WITH_OSPF
+!
 vrf instance MGMT
 !
 interface MY_INTERFACE_HOST

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -133,6 +133,9 @@ vlan 451
 vlan 452
    name Tenant_D_v6_WAN_Zone_3
 !
+vlan 1234
+   name VRF_DEFAULT_SVI_WITH_OSPF
+!
 vrf instance MGMT
 !
 interface Management0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -186,6 +186,19 @@ router_bgp:
         - '41:41'
     redistribute_routes:
     - source_protocol: connected
+  - name: default
+    rd: 192.168.255.109:123
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 123:123
+      export:
+      - address_family: evpn
+        route_targets:
+        - 123:123
+    redistribute_routes:
+    - source_protocol: ospf
   - name: Tenant_D_OP_Zone
     router_id: 192.168.255.109
     rd: 192.168.255.109:40
@@ -317,6 +330,14 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 450-452
+  - name: default
+    rd: 192.168.255.109:123
+    route_targets:
+      both:
+      - 123:123
+    redistribute_routes:
+    - learned
+    vlan: '1234'
   - name: Tenant_D_OP_Zone
     rd: 192.168.255.109:40
     route_targets:
@@ -555,6 +576,9 @@ vlans:
   tenant: Tenant_D
 - id: 452
   name: Tenant_D_v6_WAN_Zone_3
+  tenant: Tenant_D
+- id: 1234
+  name: VRF_DEFAULT_SVI_WITH_OSPF
   tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
@@ -807,6 +831,12 @@ vlan_interfaces:
   ipv6_address_virtuals:
   - 2001:db8:412::1/64
   vrf: '12345678'
+- name: Vlan1234
+  tenant: Tenant_D
+  description: VRF_DEFAULT_SVI_WITH_OSPF
+  shutdown: true
+  ospf_area: 0.0.0.0
+  ospf_network_point_to_point: false
 - name: Vlan410
   tenant: Tenant_D
   tags:
@@ -863,6 +893,15 @@ vlan_interfaces:
   - ip_helper: 1.1.1.2
     source_interface: lo102
     vrf: TEST
+router_ospf:
+  process_ids:
+  - id: 123
+    passive_interface_default: true
+    router_id: 192.168.255.109
+    no_passive_interfaces:
+    - Vlan1234
+    redistribute:
+      bgp: {}
 vxlan_interface:
   Vxlan1:
     description: evpn_services_l2_only_false_VTEP
@@ -926,6 +965,8 @@ vxlan_interface:
         vni: 40451
       - id: 452
         vni: 40452
+      - id: 1234
+        vni: 41234
       - id: 410
         vni: 40410
       - id: 411
@@ -955,6 +996,8 @@ vxlan_interface:
         vni: 31
       - name: '12345678'
         vni: 41
+      - name: default
+        vni: 123
       - name: Tenant_D_OP_Zone
         vni: 40
 virtual_source_nat_vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -160,6 +160,14 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 450-452
+  - name: default
+    rd: 192.168.255.109:123
+    route_targets:
+      both:
+      - 123:123
+    redistribute_routes:
+    - learned
+    vlan: '1234'
   - name: Tenant_D_OP_Zone
     rd: 192.168.255.109:40
     route_targets:
@@ -354,6 +362,9 @@ vlans:
 - id: 452
   name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
+- id: 1234
+  name: VRF_DEFAULT_SVI_WITH_OSPF
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D
@@ -434,6 +445,8 @@ vxlan_interface:
         vni: 40451
       - id: 452
         vni: 40452
+      - id: 1234
+        vni: 41234
       - id: 410
         vni: 40410
       - id: 411

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -157,6 +157,9 @@ vlans:
 - id: 452
   name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
+- id: 1234
+  name: VRF_DEFAULT_SVI_WITH_OSPF
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -157,6 +157,9 @@ vlans:
 - id: 452
   name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
+- id: 1234
+  name: VRF_DEFAULT_SVI_WITH_OSPF
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -163,6 +163,9 @@ vlans:
 - id: 452
   name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
+- id: 1234
+  name: VRF_DEFAULT_SVI_WITH_OSPF
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -163,6 +163,9 @@ vlans:
 - id: 452
   name: Tenant_D_v6_WAN_Zone_3
   tenant: Tenant_D
+- id: 1234
+  name: VRF_DEFAULT_SVI_WITH_OSPF
+  tenant: Tenant_D
 - id: 410
   name: Tenant_D_v6_OP_Zone_1
   tenant: Tenant_D

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
@@ -110,3 +110,14 @@ tenant_d:
             tags: ['v6wan']
             enabled: True
             profile: GENERIC_DUAL_STACK
+      - name: default
+        vrf_id: 123
+        ospf:
+          enabled: true
+          process_id: 123
+        svis:
+          - id: 1234
+            name: VRF_DEFAULT_SVI_WITH_OSPF
+            ospf:
+              area: 0.0.0.0
+              enabled: true

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/router_ospf.py
@@ -63,7 +63,7 @@ class RouterOspfMixin(UtilsMixin):
 
                 process = {
                     "id": process_id,
-                    "vrf": vrf["name"],
+                    "vrf": vrf["name"] if vrf["name"] != "default" else None,
                     "passive_interface_default": True,
                     "router_id": default(get(vrf, "ospf.router_id"), self.shared_utils.router_id),
                     "no_passive_interfaces": ospf_interfaces,


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Do not render vrf default under router ospf

## Related Issue(s)

Replaces #3976 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

When enabling OSPF under VRF default in network services we no longer render `vrf: default` in structured config. In turn `eos_cli_config_gen` will not render `router ospf <> vrf default` but just `router ospf <>`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added molecule test coverage.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
