### PR TITLE
Cut(eos_cli_config_gen): Removing 'null' as valid value of esp integrity and encryption from ip-security module

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -240,6 +240,36 @@ As of AVD 5.0.0 the automatic conversion from both of the previous models has be
               route_map: static-to-bgp
     ```
 
+### The old "null" option for esp integrity and encryption has been replaced with "disabled" from the ip_security module
+
+In AVD 4.0.0 we had "null" as a valid value for esp integrity and encryption to apply the null security profile and encryption under the ip-security configuration.
+
+As of AVD 5.0.0 "null" option for esp integrity and encryption has been replaced with "disabled" to apply the null security profile and encryption under the ip-security configuration.
+
+=== "Old data models"
+
+    ```yaml
+    # Old data model
+    ip_security:
+      sa_policies:
+        name: Disabled
+        esp:
+          integrity: "null"
+          encryption: "null"
+    ```
+
+=== "New data model"
+
+    ```yaml
+    # New data model
+    ip_security:
+      sa_policies:
+        name: Disabled
+        esp:
+          integrity: disabled
+          encryption: disabled
+    ```
+
 ### Removal of deprecated data models
 
 The following data model keys have been removed from `eos_cli_config_gen` in v5.0.0.

--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -240,35 +240,22 @@ As of AVD 5.0.0 the automatic conversion from both of the previous models has be
               route_map: static-to-bgp
     ```
 
-### The old "null" option for esp integrity and encryption has been replaced with "disabled" from the ip_security module
+### `ip_security.sa_policies[].esp.integrity` and `.encryption` "null" option has been replaced with "disabled"
 
 In AVD 4.0.0 we had "null" as a valid value for esp integrity and encryption to apply the null security profile and encryption under the ip-security configuration.
 
 As of AVD 5.0.0 "null" option for esp integrity and encryption has been replaced with "disabled" to apply the null security profile and encryption under the ip-security configuration.
 
-=== "Old data models"
-
-    ```yaml
-    # Old data model
-    ip_security:
-      sa_policies:
-        name: Disabled
-        esp:
-          integrity: "null"
-          encryption: "null"
-    ```
-
-=== "New data model"
-
-    ```yaml
-    # New data model
-    ip_security:
-      sa_policies:
-        name: Disabled
-        esp:
-          integrity: disabled
-          encryption: disabled
-    ```
+```diff
+ ip_security:
+   sa_policies:
+     name: Disabled
+     esp:
+-      integrity: "null"
+-      encryption: "null"
++      integrity: disabled
++      encryption: disabled
+```
 
 ### Removal of deprecated data models
 

--- a/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
@@ -70,6 +70,10 @@ As of AVD 5.0.0 the automatic conversion from both of the previous models has be
 
 See the [porting guide](../porting-guides/5.x.x.md#no-auto-conversion-of-old-data-model-for-router_bgpredistribute_routes-and-router_bgpvrfsredistribute_routes) for details.
 
+#### The old "null" option for esp integrity and encryption has been replaced with "disabled" from the ip_security module
+
+See the [porting guide](../porting-guides/5.x.x.md#the-old-null-option-for-esp-integrity-and-encryption-has-been-replaced-with-disabled-from-the-ip_security-module) for details.
+
 #### Removal of schema in JSON format
 
 The `eos_cli_config_gen.jsonschema.json` is no longer generated. This schema was not being used and had never been complete.

--- a/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
@@ -70,9 +70,9 @@ As of AVD 5.0.0 the automatic conversion from both of the previous models has be
 
 See the [porting guide](../porting-guides/5.x.x.md#no-auto-conversion-of-old-data-model-for-router_bgpredistribute_routes-and-router_bgpvrfsredistribute_routes) for details.
 
-#### The old "null" option for esp integrity and encryption has been replaced with "disabled" from the ip_security module
+#### `ip_security.sa_policies[].esp.integrity` and `.encryption` "null" option has been replaced with "disabled"
 
-See the [porting guide](../porting-guides/5.x.x.md#the-old-null-option-for-esp-integrity-and-encryption-has-been-replaced-with-disabled-from-the-ip_security-module) for details.
+See the [porting guide](../porting-guides/5.x.x.md#ip_securitysa_policiesespintegrity-and-encryption-null-option-has-been-replaced-with-disabled) for details.
 
 #### Removal of schema in JSON format
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -59,6 +59,9 @@ interface Management1
 | SA-1 | - | aes128 | - | 14 |
 | SA-2 | - | aes128 | 42 gigabytes | 14 |
 | SA-3 | disabled | disabled | 8 hours | 17 |
+| SA-4 | md5 | 3des | - | - |
+| SA-5 | sha512 | - | - | - |
+| SA-6 | sha384 | - | - | - |
 
 ### IPSec profiles
 
@@ -108,6 +111,16 @@ ip security
       esp encryption null
       sa lifetime 8 hours
       pfs dh-group 17
+   !
+   sa policy SA-4
+      esp integrity md5
+      esp encryption 3des
+   !
+   sa policy SA-5
+      esp integrity sha512
+   !
+   sa policy SA-6
+      esp integrity sha384
    !
    profile Profile-1
       ike-policy IKE-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -38,6 +38,16 @@ ip security
       sa lifetime 8 hours
       pfs dh-group 17
    !
+   sa policy SA-4
+      esp integrity md5
+      esp encryption 3des
+   !
+   sa policy SA-5
+      esp integrity sha512
+   !
+   sa policy SA-6
+      esp integrity sha384
+   !
    profile Profile-1
       ike-policy IKE-1
       sa-policy SA-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -33,6 +33,16 @@ ip_security:
         value: 8
         # default unit is hours
       pfs_dh_group: 17
+    - name: SA-4
+      esp:
+        integrity: md5
+        encryption: 3des
+    - name: SA-5
+      esp:
+        integrity: sha512
+    - name: SA-6
+      esp:
+        integrity: sha384
   profiles:
     - name: Profile-1
       ike_policy: IKE-1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -21,8 +21,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "ip_security.sa_policies.[].sa_lifetime.value") | Integer |  |  |  | Lifetime value for this SA.<br>Valid range depends on the unit.<br><1-24>       Lifetime in hours ( default )<br><1-4000000>  Packet limit in thousands<br><1-6000>     Byte limit in GB ( 1024 MB )<br><1-6144000>  Byte limit in MB ( 1024 KB ) |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ip_security.sa_policies.[].sa_lifetime.unit") | String |  | `hours` | Valid Values:<br>- <code>gigabytes</code><br>- <code>hours</code><br>- <code>megabytes</code><br>- <code>thousand-packets</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;esp</samp>](## "ip_security.sa_policies.[].esp") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.sa_policies.[].esp.integrity") | String |  |  | Valid Values:<br>- <code>disabled</code><br>- <code>sha1</code><br>- <code>sha256</code><br>- <code>null</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.sa_policies.[].esp.encryption") | String |  |  | Valid Values:<br>- <code>disabled</code><br>- <code>aes128</code><br>- <code>aes128gcm128</code><br>- <code>aes128gcm64</code><br>- <code>aes256</code><br>- <code>aes256gcm128</code><br>- <code>null</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.sa_policies.[].esp.integrity") | String |  |  | Valid Values:<br>- <code>disabled</code><br>- <code>sha1</code><br>- <code>sha256</code><br>- <code>sha384</code><br>- <code>sha512</code><br>- <code>md5</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.sa_policies.[].esp.encryption") | String |  |  | Valid Values:<br>- <code>disabled</code><br>- <code>aes128</code><br>- <code>aes128gcm128</code><br>- <code>aes128gcm64</code><br>- <code>aes256</code><br>- <code>aes256gcm128</code><br>- <code>3des</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;pfs_dh_group</samp>](## "ip_security.sa_policies.[].pfs_dh_group") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>5</code><br>- <code>14</code><br>- <code>15</code><br>- <code>16</code><br>- <code>17</code><br>- <code>20</code><br>- <code>21</code><br>- <code>24</code> |  |
     | [<samp>&nbsp;&nbsp;profiles</samp>](## "ip_security.profiles") | List, items: Dictionary |  |  |  | IPSec profiles. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_security.profiles.[].name") | String | Required, Unique |  |  | Name of the IPsec profile. |
@@ -85,8 +85,8 @@
             value: <int>
             unit: <str; "gigabytes" | "hours" | "megabytes" | "thousand-packets"; default="hours">
           esp:
-            integrity: <str; "disabled" | "sha1" | "sha256" | "null">
-            encryption: <str; "disabled" | "aes128" | "aes128gcm128" | "aes128gcm64" | "aes256" | "aes256gcm128" | "null">
+            integrity: <str; "disabled" | "sha1" | "sha256" | "sha384" | "sha512" | "md5">
+            encryption: <str; "disabled" | "aes128" | "aes128gcm128" | "aes128gcm64" | "aes256" | "aes256gcm128" | "3des">
           pfs_dh_group: <int; 1 | 2 | 5 | 14 | 15 | 16 | 17 | 20 | 21 | 24>
 
       # IPSec profiles.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -4959,7 +4959,9 @@ keys:
                   - disabled
                   - sha1
                   - sha256
-                  - 'null'
+                  - sha384
+                  - sha512
+                  - md5
                 encryption:
                   type: str
                   valid_values:
@@ -4969,7 +4971,7 @@ keys:
                   - aes128gcm64
                   - aes256
                   - aes256gcm128
-                  - 'null'
+                  - 3des
             pfs_dh_group:
               type: int
               convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
@@ -89,7 +89,9 @@ keys:
                     - disabled
                     - sha1
                     - sha256
-                    - "null"  # TODO: AVD 5.0.0
+                    - sha384
+                    - sha512
+                    - md5
                 encryption:
                   type: str
                   valid_values:
@@ -99,7 +101,7 @@ keys:
                     - aes128gcm64
                     - aes256
                     - aes256gcm128
-                    - "null"  # TODO: AVD 5.0.0
+                    - 3des
             pfs_dh_group:
               type: int
               convert_types:


### PR DESCRIPTION
## Change Summary

 Removing 'null' as valid values of esp integrity and encryption from ip-security module.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Removed the null as valid values of both esp integrity and encryption and added more valid values.

## How to test
NA

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
