### PR TITLE
CI: Fix Check links offline for dead targets

### DIFF
--- a/.github/workflows/offline-links-check.yml
+++ b/.github/workflows/offline-links-check.yml
@@ -20,10 +20,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
-      - name: 'Start docker-compose stack'
+      - name: 'Start docker compose stack'
         run: |
-          docker-compose -f development/docker-compose.yml up -d webdoc_avd
-          docker-compose -f development/docker-compose.yml ps
+          docker compose -f development/docker-compose.yml up -d webdoc_avd
+          docker compose -f development/docker-compose.yml ps
       - name: 'Test connectivity to mkdoc server'
         run: |
           bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1:8000)" != "200" ]]; do sleep 5; done'
@@ -46,4 +46,4 @@ jobs:
             --timeout 30
       - name: 'Stop docker-compose stack'
         run: |
-          docker-compose -f development/docker-compose.yml down
+          docker compose -f development/docker-compose.yml down

--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3"
 services:
 
   webdoc_avd:


### PR DESCRIPTION
## Change Summary

CI: Fix Check links offline for dead targets, due to the updated way to run docker compose.
The attribute `version` is obsolete, it will be ignored, and it is removed to avoid potential confusion.
