### PR TITLE
Fix(eos_designs): Provide the proper kwarg to Ansible Display.warning() in schema tools

### DIFF
--- a/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschematools.py
+++ b/ansible_collections/arista/avd/plugins/plugin_utils/schema/avdschematools.py
@@ -217,7 +217,7 @@ class AvdSchemaTools:
                 self.ansible_display.v(message)
             else:
                 # when mode == "warning"
-                self.ansible_display.warning(message, wrap_text=False)
+                self.ansible_display.warning(message, formatted=False)
         return counter
 
     def validate_schema(self) -> int:


### PR DESCRIPTION
## Change Summary

Ansible Display.warning() takes `formatted` kwarg and not `text_wrap` like his friend Display.error():
`def warning(self, msg: str, formatted: bool = False) -> None:`

Updated the caller in avdschematools accordingly. This is the only placed where Display.warning() is being used in the repo.

## Related Issue(s)

Fixes #4344 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
