### PR TITLE
CI: Fix webdoc_avd to expose network to host

### DIFF
--- a/development/docker-compose.yml
+++ b/development/docker-compose.yml
@@ -8,4 +8,5 @@ services:
       - ${PWD}/:/data
     ports:
       - 127.0.0.1:8000:8000
+    network_mode: host
     entrypoint: "sh /data/development/entrypoint.sh"


### PR DESCRIPTION
## Change Summary

Expose network port in webdoc_avd docker compose. Service now starts and reachable from host:

![image](https://github.com/user-attachments/assets/2b951793-d90b-4b75-9b6b-c79c333be8b1)

