### PR TITLE
Refactor(eos_cli_config_gen): Allow duplicate value of `address` in `router_pim_sparse_mode.rp_addresses`

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -213,6 +213,11 @@ By default an MLAG ID will only be configured on Port-Channel downlinks dual-hom
 + mlag_on_orphan_port_channel_downlink: true
 ```
 
+### Duplicate value of `address` is allowed in `router_pim_sparse_mode.ipv4.rp_addresses`.
+
+In AVD 4.0.0, the value of `address` key was unique in `router_pim_sparse_mode.ipv4.rp_addresses`.
+In AVD 5.0.0, duplicate value of `address` is allowed in `router_pim_sparse_mode.ipv4.rp_addresses`.
+
 ## Changes to role `arista.avd.eos_cli_config_gen`
 
 TODO: Level 3 sections for each change with details on how to migrate

--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -345,6 +345,10 @@ In AVD 4.0.0, we had "switched" as the default value for `ethernet_interfaces[].
 
 With AVD 5.0.0, the default value for `type` in `ethernet_interfaces` and `port_channel_interfaces` is no longer supported. The `type` key must now be explicitly defined in the input variables if it is needed in the configuration and documentation.
 
+### Unmark `router_pim_sparse_mode.ipv4.rp_addresses.address` as a primary_key
+
+With AVD 5.0.0, the key `router_pim_sparse_mode.ipv4.rp_addresses.address` is `not` a `primary_key`.
+
 ### Removal of deprecated data models
 
 The following data model keys have been removed from `eos_cli_config_gen` in v5.0.0.

--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -345,9 +345,9 @@ In AVD 4.0.0, we had "switched" as the default value for `ethernet_interfaces[].
 
 With AVD 5.0.0, the default value for `type` in `ethernet_interfaces` and `port_channel_interfaces` is no longer supported. The `type` key must now be explicitly defined in the input variables if it is needed in the configuration and documentation.
 
-### Unmark `router_pim_sparse_mode.ipv4.rp_addresses.address` as a primary_key
+### `router_pim_sparse_mode.ipv4.rp_addresses[].address` is unmarked as a `primary_key`
 
-With AVD 5.0.0, the key `router_pim_sparse_mode.ipv4.rp_addresses.address` is `not` a `primary_key`.
+With AVD 5.0.0, the key `router_pim_sparse_mode.ipv4.rp_addresses[].address` is `not` a `primary_key`.
 
 ### Removal of deprecated data models
 

--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -213,11 +213,6 @@ By default an MLAG ID will only be configured on Port-Channel downlinks dual-hom
 + mlag_on_orphan_port_channel_downlink: true
 ```
 
-### Duplicate value of `address` is allowed in `router_pim_sparse_mode.ipv4.rp_addresses`
-
-In AVD 4.0.0, the value of `address` key was unique in `router_pim_sparse_mode.ipv4.rp_addresses`.
-In AVD 5.0.0, duplicate value of `address` is allowed in `router_pim_sparse_mode.ipv4.rp_addresses`.
-
 ## Changes to role `arista.avd.eos_cli_config_gen`
 
 TODO: Level 3 sections for each change with details on how to migrate

--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -345,10 +345,6 @@ In AVD 4.0.0, we had "switched" as the default value for `ethernet_interfaces[].
 
 With AVD 5.0.0, the default value for `type` in `ethernet_interfaces` and `port_channel_interfaces` is no longer supported. The `type` key must now be explicitly defined in the input variables if it is needed in the configuration and documentation.
 
-### `router_pim_sparse_mode.ipv4.rp_addresses[].address` is unmarked as a `primary_key`
-
-With AVD 5.0.0, the key `router_pim_sparse_mode.ipv4.rp_addresses[].address` is `not` a `primary_key`.
-
 ### Removal of deprecated data models
 
 The following data model keys have been removed from `eos_cli_config_gen` in v5.0.0.

--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -213,7 +213,7 @@ By default an MLAG ID will only be configured on Port-Channel downlinks dual-hom
 + mlag_on_orphan_port_channel_downlink: true
 ```
 
-### Duplicate value of `address` is allowed in `router_pim_sparse_mode.ipv4.rp_addresses`.
+### Duplicate value of `address` is allowed in `router_pim_sparse_mode.ipv4.rp_addresses`
 
 In AVD 4.0.0, the value of `address` key was unique in `router_pim_sparse_mode.ipv4.rp_addresses`.
 In AVD 5.0.0, duplicate value of `address` is allowed in `router_pim_sparse_mode.ipv4.rp_addresses`.

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -50,6 +50,7 @@ BFD enabled: True
 | Rendezvous Point Address | Group Address | Access Lists | Priority | Hashmask | Override |
 | ------------------------ | ------------- | ------------ | -------- | -------- | -------- |
 | 10.238.1.161 | 239.12.12.12/32, 239.12.12.13/32, 239.12.12.14/32, 239.12.12.16/32, 239.12.12.20/32, 239.12.12.21/32 | RP_ACL, RP_ACL2 | 20 | - | - |
+| 10.238.1.161 | 239.12.12.12/32 | RP_ACL, RP_ACL2 | 20 | - | - |
 
 ##### IP Anycast Information
 
@@ -85,6 +86,9 @@ router pim sparse-mode
       rp address 10.238.1.161 239.12.12.16/32 priority 20
       rp address 10.238.1.161 239.12.12.20/32 priority 20
       rp address 10.238.1.161 239.12.12.21/32 priority 20
+      rp address 10.238.1.161 access-list RP_ACL priority 20
+      rp address 10.238.1.161 access-list RP_ACL2 priority 20
+      rp address 10.238.1.161 239.12.12.12/32 priority 20
       rp address 10.238.1.161 access-list RP_ACL priority 20
       rp address 10.238.1.161 access-list RP_ACL2 priority 20
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-pim-sparse-mode.md
@@ -50,7 +50,7 @@ BFD enabled: True
 | Rendezvous Point Address | Group Address | Access Lists | Priority | Hashmask | Override |
 | ------------------------ | ------------- | ------------ | -------- | -------- | -------- |
 | 10.238.1.161 | 239.12.12.12/32, 239.12.12.13/32, 239.12.12.14/32, 239.12.12.16/32, 239.12.12.20/32, 239.12.12.21/32 | RP_ACL, RP_ACL2 | 20 | - | - |
-| 10.238.1.161 | 239.12.12.12/32 | RP_ACL, RP_ACL2 | 20 | - | - |
+| 10.238.1.161 | 239.12.12.17/32 | RP_ACL3 | - | - | - |
 
 ##### IP Anycast Information
 
@@ -88,9 +88,8 @@ router pim sparse-mode
       rp address 10.238.1.161 239.12.12.21/32 priority 20
       rp address 10.238.1.161 access-list RP_ACL priority 20
       rp address 10.238.1.161 access-list RP_ACL2 priority 20
-      rp address 10.238.1.161 239.12.12.12/32 priority 20
-      rp address 10.238.1.161 access-list RP_ACL priority 20
-      rp address 10.238.1.161 access-list RP_ACL2 priority 20
+      rp address 10.238.1.161 239.12.12.17/32
+      rp address 10.238.1.161 access-list RP_ACL3
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15
       ssm range standard
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
@@ -15,6 +15,9 @@ router pim sparse-mode
       rp address 10.238.1.161 239.12.12.21/32 priority 20
       rp address 10.238.1.161 access-list RP_ACL priority 20
       rp address 10.238.1.161 access-list RP_ACL2 priority 20
+      rp address 10.238.1.161 239.12.12.12/32 priority 20
+      rp address 10.238.1.161 access-list RP_ACL priority 20
+      rp address 10.238.1.161 access-list RP_ACL2 priority 20
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15
       ssm range standard
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-pim-sparse-mode.cfg
@@ -15,9 +15,8 @@ router pim sparse-mode
       rp address 10.238.1.161 239.12.12.21/32 priority 20
       rp address 10.238.1.161 access-list RP_ACL priority 20
       rp address 10.238.1.161 access-list RP_ACL2 priority 20
-      rp address 10.238.1.161 239.12.12.12/32 priority 20
-      rp address 10.238.1.161 access-list RP_ACL priority 20
-      rp address 10.238.1.161 access-list RP_ACL2 priority 20
+      rp address 10.238.1.161 239.12.12.17/32
+      rp address 10.238.1.161 access-list RP_ACL3
       anycast-rp 10.38.1.161 10.50.64.16 register-count 15
       ssm range standard
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
@@ -18,11 +18,9 @@ router_pim_sparse_mode:
         priority: 20
       - address: 10.238.1.161
         groups:
-          - 239.12.12.12/32
+          - 239.12.12.17/32
         access_lists:
-          - RP_ACL
-          - RP_ACL2
-        priority: 20
+          - RP_ACL3
     anycast_rps:
       - address: 10.38.1.161
         other_anycast_rp_addresses:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-pim-sparse-mode.yml
@@ -16,6 +16,13 @@ router_pim_sparse_mode:
           - RP_ACL
           - RP_ACL2
         priority: 20
+      - address: 10.238.1.161
+        groups:
+          - 239.12.12.12/32
+        access_lists:
+          - RP_ACL
+          - RP_ACL2
+        priority: 20
     anycast_rps:
       - address: 10.38.1.161
         other_anycast_rp_addresses:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-pim-sparse-mode.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "router_pim_sparse_mode.ipv4.bfd") | Boolean |  |  |  | Enable/Disable BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ssm_range</samp>](## "router_pim_sparse_mode.ipv4.ssm_range") | String |  |  |  | IPv4 Prefix associated with SSM. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String | Required, Unique |  |  | RP Address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String |  |  |  | RP Address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists") | List, items: String |  |  |  |  |
@@ -53,7 +53,7 @@
         rp_addresses:
 
             # RP Address.
-          - address: <str; required; unique>
+          - address: <str>
             groups:
               - <str>
             access_lists:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-pim-sparse-mode.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-pim-sparse-mode.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "router_pim_sparse_mode.ipv4.bfd") | Boolean |  |  |  | Enable/Disable BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ssm_range</samp>](## "router_pim_sparse_mode.ipv4.ssm_range") | String |  |  |  | IPv4 Prefix associated with SSM. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;rp_addresses</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String |  |  |  | RP Address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;address</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].address") | String | Required |  |  | RP Address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].groups.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_lists</samp>](## "router_pim_sparse_mode.ipv4.rp_addresses.[].access_lists") | List, items: String |  |  |  |  |
@@ -53,7 +53,7 @@
         rp_addresses:
 
             # RP Address.
-          - address: <str>
+          - address: <str; required>
             groups:
               - <str>
             access_lists:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -15561,7 +15561,6 @@ keys:
             description: IPv4 Prefix associated with SSM.
           rp_addresses:
             type: list
-            primary_key: address
             items:
               type: dict
               keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -15561,12 +15561,13 @@ keys:
             description: IPv4 Prefix associated with SSM.
           rp_addresses:
             type: list
+            primary_key: address
+            allow_duplicate_primary_key: true
             items:
               type: dict
               keys:
                 address:
                   type: str
-                  required: true
                   description: RP Address.
                 groups:
                   type: list

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -15566,6 +15566,7 @@ keys:
               keys:
                 address:
                   type: str
+                  required: true
                   description: RP Address.
                 groups:
                   type: list

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -25,6 +25,7 @@ keys:
               keys:
                 address:
                   type: str
+                  required: true
                   description: RP Address.
                 groups:
                   type: list

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -20,12 +20,13 @@ keys:
             description: IPv4 Prefix associated with SSM.
           rp_addresses:
             type: list
+            primary_key: address
+            allow_duplicate_primary_key: true
             items:
               type: dict
               keys:
                 address:
                   type: str
-                  required: true
                   description: RP Address.
                 groups:
                   type: list

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -20,11 +20,6 @@ keys:
             description: IPv4 Prefix associated with SSM.
           rp_addresses:
             type: list
-            # This primary_key is inserted to support conversion from wildcard dicts,
-            # but it also stops the user from defining the same RP address multiple times,
-            # which should be allowed. When wildcard dict support is finally removed,
-            # this primary_key should also be removed. TODO: AVD5.0
-            primary_key: address
             items:
               type: dict
               keys:


### PR DESCRIPTION
## Change Summary

Allow duplicate value of address in router_pim_sparse_mode.rp_addresses.

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Remove primary_key mark in router_pim_sparse_mode.rp_addresses

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
