### PR TITLE
Refactor(eos_designs): Optimize handling of WAN internet exits

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -8,7 +8,7 @@ from functools import cached_property
 from typing import TYPE_CHECKING, Literal
 
 from pyavd._errors import AristaAvdError, AristaAvdMissingVariableError
-from pyavd._utils import default, get, get_ip_from_ip_prefix, get_item
+from pyavd._utils import default, get, get_all, get_ip_from_ip_prefix, get_item
 from pyavd._utils.password_utils.password import simple_7_encrypt
 from pyavd.j2filters import natural_sort, range_expand
 
@@ -810,16 +810,22 @@ class UtilsMixin(UtilsZscalerMixin):
         internet_exit_policies = []
 
         for internet_exit_policy in candidate_internet_exit_policies:
-            internet_exit_policy["connections"] = self.get_internet_exit_connections(internet_exit_policy)
-            if not internet_exit_policy["connections"]:
+            local_interfaces = [
+                wan_interface
+                for wan_interface in self.shared_utils.wan_interfaces
+                if internet_exit_policy["name"] in get_all(wan_interface, "cv_pathfinder_internet_exit.policies.name")
+            ]
+            if not local_interfaces:
                 # No local interface for this policy
                 # TODO: Decide if we should raise here instead
                 continue
+
+            internet_exit_policy["connections"] = self.get_internet_exit_connections(internet_exit_policy, local_interfaces)
             internet_exit_policies.append(internet_exit_policy)
 
         return internet_exit_policies
 
-    def get_internet_exit_connections(self: AvdStructuredConfigNetworkServices, internet_exit_policy: dict) -> list:
+    def get_internet_exit_connections(self: AvdStructuredConfigNetworkServices, internet_exit_policy: dict, local_interfaces: list[dict]) -> list:
         """
         Return a list of connections (dicts) for the given internet_exit_policy.
 
@@ -829,23 +835,23 @@ class UtilsMixin(UtilsZscalerMixin):
         policy_type = internet_exit_policy["type"]
 
         if policy_type == "direct":
-            return self.get_direct_internet_exit_connections(internet_exit_policy)
+            return self.get_direct_internet_exit_connections(internet_exit_policy, local_interfaces)
 
         if policy_type == "zscaler":
-            return self.get_zscaler_internet_exit_connections(internet_exit_policy)
+            return self.get_zscaler_internet_exit_connections(internet_exit_policy, local_interfaces)
 
         msg = f"Unsupported type '{policy_type}' found in cv_pathfinder_internet_exit[name={policy_name}]."
         raise AristaAvdError(msg)
 
-    def get_direct_internet_exit_connections(self: AvdStructuredConfigNetworkServices, internet_exit_policy: dict) -> list:
+    def get_direct_internet_exit_connections(self: AvdStructuredConfigNetworkServices, internet_exit_policy: dict, local_interfaces: list[dict]) -> list:
         """Return a list of connections (dicts) for the given internet_exit_policy of type direct."""
         if get(internet_exit_policy, "type") != "direct":
             return []
 
         connections = []
 
-        # Check if the policy has any local interface
-        for wan_interface in self.shared_utils.wan_interfaces:
+        # Build internet exit connection for each local interface (wan_interface)
+        for wan_interface in local_interfaces:
             wan_interface_internet_exit_policies = get(wan_interface, "cv_pathfinder_internet_exit.policies", default=[])
             if get_item(wan_interface_internet_exit_policies, "name", internet_exit_policy["name"]) is None:
                 continue
@@ -886,7 +892,7 @@ class UtilsMixin(UtilsZscalerMixin):
 
         return connections
 
-    def get_zscaler_internet_exit_connections(self: AvdStructuredConfigNetworkServices, internet_exit_policy: dict) -> list:
+    def get_zscaler_internet_exit_connections(self: AvdStructuredConfigNetworkServices, internet_exit_policy: dict, local_interfaces: list[dict]) -> list:
         """Return a list of connections (dicts) for the given internet_exit_policy of type zscaler."""
         if get(internet_exit_policy, "type") != "zscaler":
             return []
@@ -896,8 +902,8 @@ class UtilsMixin(UtilsZscalerMixin):
         cloud_name = get(self._zscaler_endpoints, "cloud_name", required=True)
         connections = []
 
-        # Check if the policy has any local interface
-        for wan_interface in self.shared_utils.wan_interfaces:
+        # Build internet exit connection for each local interface (wan_interface)
+        for wan_interface in local_interfaces:
             wan_interface_internet_exit_policies = get(wan_interface, "cv_pathfinder_internet_exit.policies", default=[])
             if (interface_policy_config := get_item(wan_interface_internet_exit_policies, "name", internet_exit_policy["name"])) is None:
                 continue


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Optimize handling of WAN internet exits


## Related Issue(s)

Issue with errors from zscaler API calls for devices that do not use zscaler internet exit.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Avoid fetching zscaler endpoint information unless there are local interfaces for the Zscaler IE policy.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Already covered. Only performance / API usage impact.

Tested manually by Vinay and confirmed that with some auth issue all devices failed before and with the fix only the zscaler enabled devices failed.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
