### PR TITLE
Fix(eos_designs)!: Add missing BGP peer description for MLAG peerings in VRFs

### DIFF
--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -772,6 +772,7 @@ router bgp 65101
       route-target export evpn 10:10
       router-id 10.255.0.3
       neighbor 10.255.1.97 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.97 description dc1-leaf1b
       redistribute connected
    !
    vrf VRF11
@@ -780,6 +781,7 @@ router bgp 65101
       route-target export evpn 11:11
       router-id 10.255.0.3
       neighbor 10.255.1.97 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.97 description dc1-leaf1b
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -772,6 +772,7 @@ router bgp 65101
       route-target export evpn 10:10
       router-id 10.255.0.4
       neighbor 10.255.1.96 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.96 description dc1-leaf1a
       redistribute connected
    !
    vrf VRF11
@@ -780,6 +781,7 @@ router bgp 65101
       route-target export evpn 11:11
       router-id 10.255.0.4
       neighbor 10.255.1.96 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.96 description dc1-leaf1a
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -830,6 +830,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 10.255.0.5
       neighbor 10.255.1.101 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.101 description dc1-leaf2b
       redistribute connected
    !
    vrf VRF11
@@ -838,6 +839,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 10.255.0.5
       neighbor 10.255.1.101 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.101 description dc1-leaf2b
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -830,6 +830,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 10.255.0.6
       neighbor 10.255.1.100 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.100 description dc1-leaf2a
       redistribute connected
    !
    vrf VRF11
@@ -838,6 +839,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 10.255.0.6
       neighbor 10.255.1.100 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.100 description dc1-leaf2a
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1a.md
@@ -772,6 +772,7 @@ router bgp 65201
       route-target export evpn 10:10
       router-id 10.255.128.13
       neighbor 10.255.129.117 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.117 description dc2-leaf1b
       redistribute connected
    !
    vrf VRF11
@@ -780,6 +781,7 @@ router bgp 65201
       route-target export evpn 11:11
       router-id 10.255.128.13
       neighbor 10.255.129.117 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.117 description dc2-leaf1b
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf1b.md
@@ -772,6 +772,7 @@ router bgp 65201
       route-target export evpn 10:10
       router-id 10.255.128.14
       neighbor 10.255.129.116 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.116 description dc2-leaf1a
       redistribute connected
    !
    vrf VRF11
@@ -780,6 +781,7 @@ router bgp 65201
       route-target export evpn 11:11
       router-id 10.255.128.14
       neighbor 10.255.129.116 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.116 description dc2-leaf1a
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2a.md
@@ -830,6 +830,7 @@ router bgp 65202
       route-target export evpn 10:10
       router-id 10.255.128.15
       neighbor 10.255.129.121 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.121 description dc2-leaf2b
       redistribute connected
    !
    vrf VRF11
@@ -838,6 +839,7 @@ router bgp 65202
       route-target export evpn 11:11
       router-id 10.255.128.15
       neighbor 10.255.129.121 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.121 description dc2-leaf2b
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/documentation/devices/dc2-leaf2b.md
@@ -830,6 +830,7 @@ router bgp 65202
       route-target export evpn 10:10
       router-id 10.255.128.16
       neighbor 10.255.129.120 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.120 description dc2-leaf2a
       redistribute connected
    !
    vrf VRF11
@@ -838,6 +839,7 @@ router bgp 65202
       route-target export evpn 11:11
       router-id 10.255.128.16
       neighbor 10.255.129.120 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.120 description dc2-leaf2a
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -327,6 +327,7 @@ router bgp 65101
       route-target export evpn 10:10
       router-id 10.255.0.3
       neighbor 10.255.1.97 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.97 description dc1-leaf1b
       redistribute connected
    !
    vrf VRF11
@@ -335,6 +336,7 @@ router bgp 65101
       route-target export evpn 11:11
       router-id 10.255.0.3
       neighbor 10.255.1.97 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.97 description dc1-leaf1b
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -327,6 +327,7 @@ router bgp 65101
       route-target export evpn 10:10
       router-id 10.255.0.4
       neighbor 10.255.1.96 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.96 description dc1-leaf1a
       redistribute connected
    !
    vrf VRF11
@@ -335,6 +336,7 @@ router bgp 65101
       route-target export evpn 11:11
       router-id 10.255.0.4
       neighbor 10.255.1.96 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.96 description dc1-leaf1a
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -362,6 +362,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 10.255.0.5
       neighbor 10.255.1.101 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.101 description dc1-leaf2b
       redistribute connected
    !
    vrf VRF11
@@ -370,6 +371,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 10.255.0.5
       neighbor 10.255.1.101 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.101 description dc1-leaf2b
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -362,6 +362,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 10.255.0.6
       neighbor 10.255.1.100 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.100 description dc1-leaf2a
       redistribute connected
    !
    vrf VRF11
@@ -370,6 +371,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 10.255.0.6
       neighbor 10.255.1.100 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.100 description dc1-leaf2a
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
@@ -327,6 +327,7 @@ router bgp 65201
       route-target export evpn 10:10
       router-id 10.255.128.13
       neighbor 10.255.129.117 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.117 description dc2-leaf1b
       redistribute connected
    !
    vrf VRF11
@@ -335,6 +336,7 @@ router bgp 65201
       route-target export evpn 11:11
       router-id 10.255.128.13
       neighbor 10.255.129.117 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.117 description dc2-leaf1b
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
@@ -327,6 +327,7 @@ router bgp 65201
       route-target export evpn 10:10
       router-id 10.255.128.14
       neighbor 10.255.129.116 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.116 description dc2-leaf1a
       redistribute connected
    !
    vrf VRF11
@@ -335,6 +336,7 @@ router bgp 65201
       route-target export evpn 11:11
       router-id 10.255.128.14
       neighbor 10.255.129.116 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.116 description dc2-leaf1a
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
@@ -362,6 +362,7 @@ router bgp 65202
       route-target export evpn 10:10
       router-id 10.255.128.15
       neighbor 10.255.129.121 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.121 description dc2-leaf2b
       redistribute connected
    !
    vrf VRF11
@@ -370,6 +371,7 @@ router bgp 65202
       route-target export evpn 11:11
       router-id 10.255.128.15
       neighbor 10.255.129.121 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.121 description dc2-leaf2b
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
@@ -362,6 +362,7 @@ router bgp 65202
       route-target export evpn 10:10
       router-id 10.255.128.16
       neighbor 10.255.129.120 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.120 description dc2-leaf2a
       redistribute connected
    !
    vrf VRF11
@@ -370,6 +371,7 @@ router bgp 65202
       route-target export evpn 11:11
       router-id 10.255.128.16
       neighbor 10.255.129.120 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.129.120 description dc2-leaf2a
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.97
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1b
   - name: VRF11
     router_id: 10.255.0.3
     rd: 10.255.0.3:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.97
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.96
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1a
   - name: VRF11
     router_id: 10.255.0.4
     rd: 10.255.0.4:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.96
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -116,6 +116,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.101
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2b
   - name: VRF11
     router_id: 10.255.0.5
     rd: 10.255.0.5:11
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.101
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -116,6 +116,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.100
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2a
   - name: VRF11
     router_id: 10.255.0.6
     rd: 10.255.0.6:11
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.100
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.117
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf1b
   - name: VRF11
     router_id: 10.255.128.13
     rd: 10.255.128.13:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.117
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf1b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.116
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf1a
   - name: VRF11
     router_id: 10.255.128.14
     rd: 10.255.128.14:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.116
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf1a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -116,6 +116,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.121
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf2b
   - name: VRF11
     router_id: 10.255.128.15
     rd: 10.255.128.15:11
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.121
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf2b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -116,6 +116,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.120
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf2a
   - name: VRF11
     router_id: 10.255.128.16
     rd: 10.255.128.16:11
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.120
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf2a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1a.md
@@ -833,6 +833,7 @@ router bgp 65101
       route-target export evpn 10:10
       router-id 10.255.0.3
       neighbor 10.255.1.97 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.97 description dc1-leaf1b
       redistribute connected
    !
    vrf VRF11
@@ -841,6 +842,7 @@ router bgp 65101
       route-target export evpn 11:11
       router-id 10.255.0.3
       neighbor 10.255.1.97 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.97 description dc1-leaf1b
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf1b.md
@@ -833,6 +833,7 @@ router bgp 65101
       route-target export evpn 10:10
       router-id 10.255.0.4
       neighbor 10.255.1.96 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.96 description dc1-leaf1a
       redistribute connected
    !
    vrf VRF11
@@ -841,6 +842,7 @@ router bgp 65101
       route-target export evpn 11:11
       router-id 10.255.0.4
       neighbor 10.255.1.96 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.96 description dc1-leaf1a
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2a.md
@@ -833,6 +833,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 10.255.0.5
       neighbor 10.255.1.101 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.101 description dc1-leaf2b
       redistribute connected
    !
    vrf VRF11
@@ -841,6 +842,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 10.255.0.5
       neighbor 10.255.1.101 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.101 description dc1-leaf2b
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/documentation/devices/dc1-leaf2b.md
@@ -833,6 +833,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 10.255.0.6
       neighbor 10.255.1.100 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.100 description dc1-leaf2a
       redistribute connected
    !
    vrf VRF11
@@ -841,6 +842,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 10.255.0.6
       neighbor 10.255.1.100 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.100 description dc1-leaf2a
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -335,6 +335,7 @@ router bgp 65101
       route-target export evpn 10:10
       router-id 10.255.0.3
       neighbor 10.255.1.97 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.97 description dc1-leaf1b
       redistribute connected
    !
    vrf VRF11
@@ -343,6 +344,7 @@ router bgp 65101
       route-target export evpn 11:11
       router-id 10.255.0.3
       neighbor 10.255.1.97 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.97 description dc1-leaf1b
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -335,6 +335,7 @@ router bgp 65101
       route-target export evpn 10:10
       router-id 10.255.0.4
       neighbor 10.255.1.96 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.96 description dc1-leaf1a
       redistribute connected
    !
    vrf VRF11
@@ -343,6 +344,7 @@ router bgp 65101
       route-target export evpn 11:11
       router-id 10.255.0.4
       neighbor 10.255.1.96 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.96 description dc1-leaf1a
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -335,6 +335,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 10.255.0.5
       neighbor 10.255.1.101 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.101 description dc1-leaf2b
       redistribute connected
    !
    vrf VRF11
@@ -343,6 +344,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 10.255.0.5
       neighbor 10.255.1.101 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.101 description dc1-leaf2b
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -335,6 +335,7 @@ router bgp 65102
       route-target export evpn 10:10
       router-id 10.255.0.6
       neighbor 10.255.1.100 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.100 description dc1-leaf2a
       redistribute connected
    !
    vrf VRF11
@@ -343,6 +344,7 @@ router bgp 65102
       route-target export evpn 11:11
       router-id 10.255.0.6
       neighbor 10.255.1.100 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.1.100 description dc1-leaf2a
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.97
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1b
   - name: VRF11
     router_id: 10.255.0.3
     rd: 10.255.0.3:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.97
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.96
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1a
   - name: VRF11
     router_id: 10.255.0.4
     rd: 10.255.0.4:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.96
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.101
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2b
   - name: VRF11
     router_id: 10.255.0.5
     rd: 10.255.0.5:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.101
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.100
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2a
   - name: VRF11
     router_id: 10.255.0.6
     rd: 10.255.0.6:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.100
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1A.md
@@ -801,6 +801,7 @@ router bgp 65104
       router-id 192.168.255.10
       update wait-install
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -810,6 +811,7 @@ router bgp 65104
       router-id 192.168.255.10
       update wait-install
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -819,6 +821,7 @@ router bgp 65104
       router-id 192.168.255.10
       update wait-install
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-BL1B.md
@@ -801,6 +801,7 @@ router bgp 65104
       router-id 192.168.255.11
       update wait-install
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -810,6 +811,7 @@ router bgp 65104
       router-id 192.168.255.11
       update wait-install
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -819,6 +821,7 @@ router bgp 65104
       router-id 192.168.255.11
       update wait-install
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2A.md
@@ -1055,6 +1055,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1064,6 +1065,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1073,6 +1075,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1082,6 +1085,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1091,6 +1095,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1100,6 +1105,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-LEAF2B.md
@@ -1055,6 +1055,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1064,6 +1065,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1073,6 +1075,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1082,6 +1085,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1091,6 +1095,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1100,6 +1105,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3A.md
@@ -1198,6 +1198,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1207,6 +1208,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1216,6 +1218,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1225,6 +1228,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1234,6 +1238,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1243,6 +1248,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1252,6 +1258,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1261,6 +1268,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1270,6 +1278,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/documentation/devices/DC1-SVC3B.md
@@ -1172,6 +1172,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1181,6 +1182,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1190,6 +1192,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1199,6 +1202,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -1208,6 +1212,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1217,6 +1222,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1226,6 +1232,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1235,6 +1242,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1244,6 +1252,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
@@ -307,6 +307,7 @@ router bgp 65104
       router-id 192.168.255.10
       update wait-install
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -316,6 +317,7 @@ router bgp 65104
       router-id 192.168.255.10
       update wait-install
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -325,6 +327,7 @@ router bgp 65104
       router-id 192.168.255.10
       update wait-install
       neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.11 description DC1-BL1B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
@@ -307,6 +307,7 @@ router bgp 65104
       router-id 192.168.255.11
       update wait-install
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -316,6 +317,7 @@ router bgp 65104
       router-id 192.168.255.11
       update wait-install
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -325,6 +327,7 @@ router bgp 65104
       router-id 192.168.255.11
       update wait-install
       neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.10 description DC1-BL1A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -499,6 +499,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -508,6 +509,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -517,6 +519,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -526,6 +529,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -535,6 +539,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -544,6 +549,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -499,6 +499,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -508,6 +509,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -517,6 +519,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -526,6 +529,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -535,6 +539,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -544,6 +549,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -600,6 +600,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -609,6 +610,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -618,6 +620,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -627,6 +630,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -636,6 +640,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -645,6 +650,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -654,6 +660,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -663,6 +670,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -672,6 +680,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -584,6 +584,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -593,6 +594,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -602,6 +604,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -611,6 +614,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WEB_Zone
@@ -620,6 +624,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -629,6 +634,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -638,6 +644,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -647,6 +654,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -656,6 +664,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -114,6 +114,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.11
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-BL1B
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.11
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-BL1B
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -152,6 +154,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.11
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-BL1B
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -114,6 +114,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.10
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-BL1A
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.10
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-BL1A
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -152,6 +154,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.10
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-BL1A
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -114,6 +114,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2B
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2B
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -152,6 +154,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2B
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -171,6 +174,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2B
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -190,6 +194,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2B
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -209,6 +214,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2B
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -114,6 +114,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2A
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2A
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -152,6 +154,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2A
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -171,6 +174,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2A
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -190,6 +194,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2A
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -209,6 +214,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2A
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -114,6 +114,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -152,6 +154,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_WAN_Zone
@@ -171,6 +174,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -190,6 +194,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -209,6 +214,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -228,6 +234,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -247,6 +254,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -266,6 +274,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -114,6 +114,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -152,6 +154,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_WAN_Zone
@@ -171,6 +174,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -190,6 +194,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -209,6 +214,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -228,6 +234,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -247,6 +254,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -266,6 +274,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server_configlets.yml
@@ -102,15 +102,18 @@ cvp_configlets:
     activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_WAN_Zone\n
     \     rd 192.168.255.10:14\n      route-target import evpn 14:14\n      route-target
     export evpn 14:14\n      router-id 192.168.255.10\n      update wait-install\n
-    \     neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n      route-target
-    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.10\n
+    \     neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor
+    10.255.251.11 description DC1-BL1B\n      redistribute connected\n   !\n   vrf
+    Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n      route-target import evpn
+    21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.10\n
     \     update wait-install\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n
-    \     route-target import evpn 31:31\n      route-target export evpn 31:31\n      router-id
-    192.168.255.10\n      update wait-install\n      neighbor 10.255.251.11 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n!\nmanagement api http-commands\n
-    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.11 description DC1-BL1B\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.10\n
+    \     update wait-install\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.11 description DC1-BL1B\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-BL1B: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -214,15 +217,18 @@ cvp_configlets:
     activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_WAN_Zone\n
     \     rd 192.168.255.11:14\n      route-target import evpn 14:14\n      route-target
     export evpn 14:14\n      router-id 192.168.255.11\n      update wait-install\n
-    \     neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n      route-target
-    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.11\n
+    \     neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor
+    10.255.251.10 description DC1-BL1A\n      redistribute connected\n   !\n   vrf
+    Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n      route-target import evpn
+    21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.11\n
     \     update wait-install\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n
-    \     route-target import evpn 31:31\n      route-target export evpn 31:31\n      router-id
-    192.168.255.11\n      update wait-install\n      neighbor 10.255.251.10 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n!\nmanagement api http-commands\n
-    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.10 description DC1-BL1A\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.11\n
+    \     update wait-install\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.10 description DC1-BL1A\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-L2LEAF1A: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -553,25 +559,29 @@ cvp_configlets:
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.6:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.6\n
     \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n
-    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
-    192.168.255.6\n      update wait-install\n      neighbor 10.255.251.3 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
-    \     rd 192.168.255.6:10\n      route-target import evpn 10:10\n      route-target
-    export evpn 10:10\n      router-id 192.168.255.6\n      update wait-install\n
-    \     neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n      route-target import
+    evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target
     import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.6\n
     \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n
-    \     route-target import evpn 20:20\n      route-target export evpn 20:20\n      router-id
-    192.168.255.6\n      update wait-install\n      neighbor 10.255.251.3 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n
-    \     rd 192.168.255.6:30\n      route-target import evpn 30:30\n      route-target
-    export evpn 30:30\n      router-id 192.168.255.6\n      update wait-install\n
-    \     neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
-    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n      route-target import
+    evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.6:30\n      route-target import
+    evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-LEAF2B: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -726,25 +736,29 @@ cvp_configlets:
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.7:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.7\n
     \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.7:13\n
-    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
-    192.168.255.7\n      update wait-install\n      neighbor 10.255.251.2 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
-    \     rd 192.168.255.7:10\n      route-target import evpn 10:10\n      route-target
-    export evpn 10:10\n      router-id 192.168.255.7\n      update wait-install\n
-    \     neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n      route-target
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.7:13\n      route-target import
+    evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.7:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n      route-target
     import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.7\n
     \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.7:20\n
-    \     route-target import evpn 20:20\n      route-target export evpn 20:20\n      router-id
-    192.168.255.7\n      update wait-install\n      neighbor 10.255.251.2 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n
-    \     rd 192.168.255.7:30\n      route-target import evpn 30:30\n      route-target
-    export evpn 30:30\n      router-id 192.168.255.7\n      update wait-install\n
-    \     neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
-    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.7:20\n      route-target import
+    evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.7:30\n      route-target import
+    evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-SPINE1: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -1208,35 +1222,41 @@ cvp_configlets:
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.8:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.8\n
     \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n
-    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
-    192.168.255.8\n      update wait-install\n      neighbor 10.255.251.7 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
-    \     rd 192.168.255.8:10\n      route-target import evpn 10:10\n      route-target
-    export evpn 10:10\n      router-id 192.168.255.8\n      update wait-install\n
-    \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n      route-target import
+    evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.8:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target
     import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.8\n
     \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n
-    \     route-target import evpn 11:11\n      route-target export evpn 11:11\n      router-id
-    192.168.255.8\n      update wait-install\n      neighbor 10.255.251.7 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n
-    \     rd 192.168.255.8:20\n      route-target import evpn 20:20\n      route-target
-    export evpn 20:20\n      router-id 192.168.255.8\n      update wait-install\n
-    \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n      route-target
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.8:20\n      route-target import
+    evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n      route-target
     import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.8\n
     \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n
-    \     route-target import evpn 30:30\n      route-target export evpn 30:30\n      router-id
-    192.168.255.8\n      update wait-install\n      neighbor 10.255.251.7 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n
-    \     rd 192.168.255.8:31\n      route-target import evpn 31:31\n      route-target
-    export evpn 31:31\n      router-id 192.168.255.8\n      update wait-install\n
-    \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
-    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n      route-target import
+    evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.8:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-SVC3B: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -1415,35 +1435,41 @@ cvp_configlets:
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.9:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.9\n
     \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n
-    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
-    192.168.255.9\n      update wait-install\n      neighbor 10.255.251.6 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
-    \     rd 192.168.255.9:10\n      route-target import evpn 10:10\n      route-target
-    export evpn 10:10\n      router-id 192.168.255.9\n      update wait-install\n
-    \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n      route-target import
+    evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.9:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target
     import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.9\n
     \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n
-    \     route-target import evpn 11:11\n      route-target export evpn 11:11\n      router-id
-    192.168.255.9\n      update wait-install\n      neighbor 10.255.251.6 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n
-    \     rd 192.168.255.9:20\n      route-target import evpn 20:20\n      route-target
-    export evpn 20:20\n      router-id 192.168.255.9\n      update wait-install\n
-    \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n      route-target
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.9:20\n      route-target import
+    evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n      route-target
     import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.9\n
     \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n
-    \     route-target import evpn 30:30\n      route-target export evpn 30:30\n      router-id
-    192.168.255.9\n      update wait-install\n      neighbor 10.255.251.6 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n
-    \     rd 192.168.255.9:31\n      route-target import evpn 31:31\n      route-target
-    export evpn 31:31\n      router-id 192.168.255.9\n      update wait-install\n
-    \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
-    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n      route-target import
+    evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.9:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
 cvp_topology:
   DC1_BL1:
     devices:

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -102,15 +102,18 @@ cvp_configlets:
     activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_WAN_Zone\n
     \     rd 192.168.255.10:14\n      route-target import evpn 14:14\n      route-target
     export evpn 14:14\n      router-id 192.168.255.10\n      update wait-install\n
-    \     neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n      route-target
-    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.10\n
+    \     neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor
+    10.255.251.11 description DC1-BL1B\n      redistribute connected\n   !\n   vrf
+    Tenant_B_WAN_Zone\n      rd 192.168.255.10:21\n      route-target import evpn
+    21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.10\n
     \     update wait-install\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n
-    \     route-target import evpn 31:31\n      route-target export evpn 31:31\n      router-id
-    192.168.255.10\n      update wait-install\n      neighbor 10.255.251.11 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n!\nmanagement api http-commands\n
-    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.11 description DC1-BL1B\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.10:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.10\n
+    \     update wait-install\n      neighbor 10.255.251.11 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.11 description DC1-BL1B\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-BL1B: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -214,15 +217,18 @@ cvp_configlets:
     activate\n      neighbor MLAG-IPv4-UNDERLAY-PEER activate\n   !\n   vrf Tenant_A_WAN_Zone\n
     \     rd 192.168.255.11:14\n      route-target import evpn 14:14\n      route-target
     export evpn 14:14\n      router-id 192.168.255.11\n      update wait-install\n
-    \     neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n      route-target
-    import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.11\n
+    \     neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n      neighbor
+    10.255.251.10 description DC1-BL1A\n      redistribute connected\n   !\n   vrf
+    Tenant_B_WAN_Zone\n      rd 192.168.255.11:21\n      route-target import evpn
+    21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.11\n
     \     update wait-install\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n
-    \     route-target import evpn 31:31\n      route-target export evpn 31:31\n      router-id
-    192.168.255.11\n      update wait-install\n      neighbor 10.255.251.10 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n!\nmanagement api http-commands\n
-    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.10 description DC1-BL1A\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.11:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.11\n
+    \     update wait-install\n      neighbor 10.255.251.10 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.10 description DC1-BL1A\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-L2LEAF1A: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -553,25 +559,29 @@ cvp_configlets:
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.6:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.6\n
     \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n
-    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
-    192.168.255.6\n      update wait-install\n      neighbor 10.255.251.3 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
-    \     rd 192.168.255.6:10\n      route-target import evpn 10:10\n      route-target
-    export evpn 10:10\n      router-id 192.168.255.6\n      update wait-install\n
-    \     neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.6:13\n      route-target import
+    evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.6:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.6:11\n      route-target
     import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.6\n
     \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n
-    \     route-target import evpn 20:20\n      route-target export evpn 20:20\n      router-id
-    192.168.255.6\n      update wait-install\n      neighbor 10.255.251.3 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n
-    \     rd 192.168.255.6:30\n      route-target import evpn 30:30\n      route-target
-    export evpn 30:30\n      router-id 192.168.255.6\n      update wait-install\n
-    \     neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
-    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.6:20\n      route-target import
+    evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.6:30\n      route-target import
+    evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.6\n
+    \     update wait-install\n      neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.3 description DC1-LEAF2B\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-LEAF2B: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -726,25 +736,29 @@ cvp_configlets:
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.7:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.7\n
     \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.7:13\n
-    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
-    192.168.255.7\n      update wait-install\n      neighbor 10.255.251.2 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
-    \     rd 192.168.255.7:10\n      route-target import evpn 10:10\n      route-target
-    export evpn 10:10\n      router-id 192.168.255.7\n      update wait-install\n
-    \     neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n      route-target
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.7:13\n      route-target import
+    evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.7:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.7:11\n      route-target
     import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.7\n
     \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.7:20\n
-    \     route-target import evpn 20:20\n      route-target export evpn 20:20\n      router-id
-    192.168.255.7\n      update wait-install\n      neighbor 10.255.251.2 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n
-    \     rd 192.168.255.7:30\n      route-target import evpn 30:30\n      route-target
-    export evpn 30:30\n      router-id 192.168.255.7\n      update wait-install\n
-    \     neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
-    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.7:20\n      route-target import
+    evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.7:30\n      route-target import
+    evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.7\n
+    \     update wait-install\n      neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.2 description DC1-LEAF2A\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-SPINE1: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -1208,35 +1222,41 @@ cvp_configlets:
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.8:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.8\n
     \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n
-    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
-    192.168.255.8\n      update wait-install\n      neighbor 10.255.251.7 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
-    \     rd 192.168.255.8:10\n      route-target import evpn 10:10\n      route-target
-    export evpn 10:10\n      router-id 192.168.255.8\n      update wait-install\n
-    \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.8:13\n      route-target import
+    evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.8:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.8:14\n      route-target
     import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.8\n
     \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n
-    \     route-target import evpn 11:11\n      route-target export evpn 11:11\n      router-id
-    192.168.255.8\n      update wait-install\n      neighbor 10.255.251.7 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n
-    \     rd 192.168.255.8:20\n      route-target import evpn 20:20\n      route-target
-    export evpn 20:20\n      router-id 192.168.255.8\n      update wait-install\n
-    \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n      route-target
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.8:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.8:20\n      route-target import
+    evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.8:21\n      route-target
     import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.8\n
     \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n
-    \     route-target import evpn 30:30\n      route-target export evpn 30:30\n      router-id
-    192.168.255.8\n      update wait-install\n      neighbor 10.255.251.7 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n
-    \     rd 192.168.255.8:31\n      route-target import evpn 31:31\n      route-target
-    export evpn 31:31\n      router-id 192.168.255.8\n      update wait-install\n
-    \     neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
-    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.8:30\n      route-target import
+    evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.8:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.8\n
+    \     update wait-install\n      neighbor 10.255.251.7 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.7 description DC1-SVC3B\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
   AVD_DC1-SVC3B: "!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
     -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
     -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
@@ -1415,35 +1435,41 @@ cvp_configlets:
     activate\n   !\n   vrf Tenant_A_APP_Zone\n      rd 192.168.255.9:12\n      route-target
     import evpn 12:12\n      route-target export evpn 12:12\n      router-id 192.168.255.9\n
     \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n
-    \     route-target import evpn 13:13\n      route-target export evpn 13:13\n      router-id
-    192.168.255.9\n      update wait-install\n      neighbor 10.255.251.6 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_A_OP_Zone\n
-    \     rd 192.168.255.9:10\n      route-target import evpn 10:10\n      route-target
-    export evpn 10:10\n      router-id 192.168.255.9\n      update wait-install\n
-    \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_DB_Zone\n      rd 192.168.255.9:13\n      route-target import
+    evpn 13:13\n      route-target export evpn 13:13\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_OP_Zone\n      rd 192.168.255.9:10\n      route-target import
+    evpn 10:10\n      route-target export evpn 10:10\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WAN_Zone\n      rd 192.168.255.9:14\n      route-target
     import evpn 14:14\n      route-target export evpn 14:14\n      router-id 192.168.255.9\n
     \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n
-    \     route-target import evpn 11:11\n      route-target export evpn 11:11\n      router-id
-    192.168.255.9\n      update wait-install\n      neighbor 10.255.251.6 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_B_OP_Zone\n
-    \     rd 192.168.255.9:20\n      route-target import evpn 20:20\n      route-target
-    export evpn 20:20\n      router-id 192.168.255.9\n      update wait-install\n
-    \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n   !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n      route-target
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_A_WEB_Zone\n      rd 192.168.255.9:11\n      route-target
+    import evpn 11:11\n      route-target export evpn 11:11\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_OP_Zone\n      rd 192.168.255.9:20\n      route-target import
+    evpn 20:20\n      route-target export evpn 20:20\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_B_WAN_Zone\n      rd 192.168.255.9:21\n      route-target
     import evpn 21:21\n      route-target export evpn 21:21\n      router-id 192.168.255.9\n
     \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
-    \     redistribute connected\n   !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n
-    \     route-target import evpn 30:30\n      route-target export evpn 30:30\n      router-id
-    192.168.255.9\n      update wait-install\n      neighbor 10.255.251.6 peer group
-    MLAG-IPv4-UNDERLAY-PEER\n      redistribute connected\n   !\n   vrf Tenant_C_WAN_Zone\n
-    \     rd 192.168.255.9:31\n      route-target import evpn 31:31\n      route-target
-    export evpn 31:31\n      router-id 192.168.255.9\n      update wait-install\n
-    \     neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n      redistribute
-    connected\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
-    \  !\n   vrf MGMT\n      no shutdown\n!\nend\n"
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_OP_Zone\n      rd 192.168.255.9:30\n      route-target import
+    evpn 30:30\n      route-target export evpn 30:30\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n
+    \  !\n   vrf Tenant_C_WAN_Zone\n      rd 192.168.255.9:31\n      route-target
+    import evpn 31:31\n      route-target export evpn 31:31\n      router-id 192.168.255.9\n
+    \     update wait-install\n      neighbor 10.255.251.6 peer group MLAG-IPv4-UNDERLAY-PEER\n
+    \     neighbor 10.255.251.6 description DC1-SVC3A\n      redistribute connected\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\nend\n"
 cvp_topology:
   DC1_BL1:
     devices:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
@@ -201,6 +201,7 @@ router bgp 65101
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.240.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.240.11 description CUSTOM-PYTHON_MODULES-L3LEAF1B
       neighbor 172.16.0.25 remote-as 65103
       neighbor 172.16.0.25 peer group IPv4-UNDERLAY-PEERS
       neighbor 172.16.0.25 description CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1.1_vrf_TEST_VRF

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
@@ -187,6 +187,7 @@ router bgp 65101
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.240.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.240.10 description CUSTOM-PYTHON_MODULES-L3LEAF1A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
@@ -193,6 +193,7 @@ router bgp 65101
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.240.11 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.240.11 description CUSTOM-TEMPLATES-L3LEAF1B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
@@ -203,6 +203,7 @@ router bgp 65101
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.240.10 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.240.10 description CUSTOM-TEMPLATES-L3LEAF1A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -1037,6 +1037,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_DB_Zone
@@ -1046,6 +1047,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_OP_Zone
@@ -1055,6 +1057,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1066,6 +1069,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_WEB_Zone
@@ -1075,6 +1079,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 172.31.11.7 peer group MLAG-PEERS
+      neighbor 172.31.11.7 description DC1-SVC3B
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_B_OP_Zone
@@ -1084,6 +1089,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1093,6 +1099,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1102,6 +1109,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1111,6 +1119,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.251.7 peer group MLAG-PEERS
+      neighbor 10.255.251.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -1002,6 +1002,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_DB_Zone
@@ -1011,6 +1012,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_OP_Zone
@@ -1020,6 +1022,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1031,6 +1034,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_WEB_Zone
@@ -1040,6 +1044,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 172.31.11.6 peer group MLAG-PEERS
+      neighbor 172.31.11.6 description DC1-SVC3A
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_B_OP_Zone
@@ -1049,6 +1054,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1058,6 +1064,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1067,6 +1074,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1076,6 +1084,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.251.6 peer group MLAG-PEERS
+      neighbor 10.255.251.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -652,6 +652,7 @@ router bgp 65110
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 10.255.251.25 description DC1_UNDEPLOYED_LEAF1B
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_DB_Zone
@@ -661,6 +662,7 @@ router bgp 65110
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 10.255.251.25 description DC1_UNDEPLOYED_LEAF1B
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_OP_Zone
@@ -670,6 +672,7 @@ router bgp 65110
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 10.255.251.25 description DC1_UNDEPLOYED_LEAF1B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -681,6 +684,7 @@ router bgp 65110
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 10.255.251.25 description DC1_UNDEPLOYED_LEAF1B
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_WEB_Zone
@@ -690,6 +694,7 @@ router bgp 65110
       router-id 192.168.255.21
       update wait-install
       neighbor 172.31.11.25 peer group MLAG-PEERS
+      neighbor 172.31.11.25 description DC1_UNDEPLOYED_LEAF1B
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_B_OP_Zone
@@ -699,6 +704,7 @@ router bgp 65110
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 10.255.251.25 description DC1_UNDEPLOYED_LEAF1B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -708,6 +714,7 @@ router bgp 65110
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 10.255.251.25 description DC1_UNDEPLOYED_LEAF1B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -717,6 +724,7 @@ router bgp 65110
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 10.255.251.25 description DC1_UNDEPLOYED_LEAF1B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -726,6 +734,7 @@ router bgp 65110
       router-id 192.168.255.21
       update wait-install
       neighbor 10.255.251.25 peer group MLAG-PEERS
+      neighbor 10.255.251.25 description DC1_UNDEPLOYED_LEAF1B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -652,6 +652,7 @@ router bgp 65111
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 10.255.251.24 description DC1_UNDEPLOYED_LEAF1A
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_DB_Zone
@@ -661,6 +662,7 @@ router bgp 65111
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 10.255.251.24 description DC1_UNDEPLOYED_LEAF1A
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_OP_Zone
@@ -670,6 +672,7 @@ router bgp 65111
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 10.255.251.24 description DC1_UNDEPLOYED_LEAF1A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -681,6 +684,7 @@ router bgp 65111
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 10.255.251.24 description DC1_UNDEPLOYED_LEAF1A
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_A_WEB_Zone
@@ -690,6 +694,7 @@ router bgp 65111
       router-id 192.168.255.22
       update wait-install
       neighbor 172.31.11.24 peer group MLAG-PEERS
+      neighbor 172.31.11.24 description DC1_UNDEPLOYED_LEAF1A
       redistribute connected route-map RM-CONN-2-BGP-VRFS
    !
    vrf Tenant_B_OP_Zone
@@ -699,6 +704,7 @@ router bgp 65111
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 10.255.251.24 description DC1_UNDEPLOYED_LEAF1A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -708,6 +714,7 @@ router bgp 65111
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 10.255.251.24 description DC1_UNDEPLOYED_LEAF1A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -717,6 +724,7 @@ router bgp 65111
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 10.255.251.24 description DC1_UNDEPLOYED_LEAF1A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -726,6 +734,7 @@ router bgp 65111
       router-id 192.168.255.22
       update wait-install
       neighbor 10.255.251.24 peer group MLAG-PEERS
+      neighbor 10.255.251.24 description DC1_UNDEPLOYED_LEAF1A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
@@ -1025,6 +1025,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf MULTICAST_DISABLED_310_311
@@ -1034,6 +1035,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf MULTICAST_ENABLED_1_2
@@ -1043,6 +1045,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf MULTICAST_ENABLED_3_DISABLED_4
@@ -1052,6 +1055,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf MULTICAST_ENABLED_110_111
@@ -1061,6 +1065,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf MULTICAST_ENABLED_210_DISABLED_211
@@ -1070,6 +1075,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf TEN_C_L3_MULTICAST_DISABLED_330_331
@@ -1079,6 +1085,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf TEN_C_L3_MULTICAST_ENABLED_130_131
@@ -1089,6 +1096,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
@@ -1099,6 +1107,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf TEN_D_L3_MULTICAST_DISABLED_240_241
@@ -1108,6 +1117,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
@@ -1118,6 +1128,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
@@ -1128,6 +1139,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
@@ -1140,6 +1152,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf TEN_E_L3_MULTICAST_TRANSIT
@@ -1152,6 +1165,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
    !
    vrf TEN_E_PEG_L3_MULTICAST_ENABLED
@@ -1162,6 +1176,7 @@ router bgp 65101
       router-id 192.168.255.3
       update wait-install
       neighbor 10.255.251.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.1 description EVPN-MULTICAST-L3LEAF1B
       redistribute connected
 !
 router multicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
@@ -1025,6 +1025,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf MULTICAST_DISABLED_310_311
@@ -1034,6 +1035,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf MULTICAST_ENABLED_1_2
@@ -1043,6 +1045,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf MULTICAST_ENABLED_3_DISABLED_4
@@ -1052,6 +1055,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf MULTICAST_ENABLED_110_111
@@ -1061,6 +1065,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf MULTICAST_ENABLED_210_DISABLED_211
@@ -1070,6 +1075,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf TEN_C_L3_MULTICAST_DISABLED_330_331
@@ -1079,6 +1085,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf TEN_C_L3_MULTICAST_ENABLED_130_131
@@ -1089,6 +1096,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
@@ -1099,6 +1107,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf TEN_D_L3_MULTICAST_DISABLED_240_241
@@ -1108,6 +1117,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
@@ -1118,6 +1128,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
@@ -1128,6 +1139,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
@@ -1140,6 +1152,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf TEN_E_L3_MULTICAST_TRANSIT
@@ -1152,6 +1165,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
    !
    vrf TEN_E_PEG_L3_MULTICAST_ENABLED
@@ -1162,6 +1176,7 @@ router bgp 65101
       router-id 192.168.255.4
       update wait-install
       neighbor 10.255.251.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.0 description EVPN-MULTICAST-L3LEAF1A
       redistribute connected
 !
 router multicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1A.cfg
@@ -172,6 +172,7 @@ router bgp 923
       router-id 192.168.255.32
       update wait-install
       neighbor 10.10.224.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.10.224.2 description MLAG_SAME_SUBNET_L3LEAF1B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1B.cfg
@@ -172,6 +172,7 @@ router bgp 923
       router-id 192.168.255.33
       update wait-install
       neighbor 10.10.224.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.10.224.1 description MLAG_SAME_SUBNET_L3LEAF1A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2A.cfg
@@ -172,6 +172,7 @@ router bgp 923
       router-id 192.168.255.34
       update wait-install
       neighbor 10.10.224.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.10.224.2 description MLAG_SAME_SUBNET_L3LEAF2B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2B.cfg
@@ -172,6 +172,7 @@ router bgp 923
       router-id 192.168.255.35
       update wait-install
       neighbor 10.10.224.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.10.224.1 description MLAG_SAME_SUBNET_L3LEAF2A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf3.cfg
@@ -304,6 +304,7 @@ router bgp 65105
       route-target export evpn 1:1
       router-id 10.254.1.5
       neighbor 10.254.1.105 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.254.1.105 description flow-tracking-tests-leaf4
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf4.cfg
@@ -304,6 +304,7 @@ router bgp 65105
       route-target export evpn 1:1
       router-id 10.254.1.6
       neighbor 10.254.1.104 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.254.1.104 description flow-tracking-tests-leaf3
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack1.cfg
@@ -268,6 +268,7 @@ router bgp 65002
       router-id 10.0.255.3
       update wait-install
       neighbor 100.64.1.5 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 100.64.1.5 description inband-mgmt-parent-dualstack2
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack2.cfg
@@ -268,6 +268,7 @@ router bgp 65002
       router-id 10.0.255.4
       update wait-install
       neighbor 100.64.1.4 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 100.64.1.4 description inband-mgmt-parent-dualstack1
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
@@ -333,6 +333,7 @@ router bgp 65101
       route-target export evpn 1:1
       router-id 10.254.1.1
       neighbor 10.254.1.97 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.254.1.97 description ptp-tests-leaf2
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
@@ -313,6 +313,7 @@ router bgp 65102
       route-target export evpn 1:1
       router-id 10.254.1.2
       neighbor 10.254.1.96 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.254.1.96 description ptp-tests-leaf1
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf3.cfg
@@ -282,6 +282,7 @@ router bgp 65105
       route-target export evpn 1:1
       router-id 10.254.1.5
       neighbor 10.254.1.105 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.254.1.105 description sflow-tests-leaf4
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf4.cfg
@@ -282,6 +282,7 @@ router bgp 65105
       route-target export evpn 1:1
       router-id 10.254.1.6
       neighbor 10.254.1.104 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.254.1.104 description sflow-tests-leaf3
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
@@ -392,6 +392,7 @@ router bgp 65001
       router-id 192.168.250.9
       update wait-install
       neighbor 10.255.247.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.247.1 description trunk-group-tests-l3leaf1b
       redistribute connected
    !
    vrf TG_200
@@ -401,6 +402,7 @@ router bgp 65001
       router-id 192.168.250.9
       update wait-install
       neighbor 10.255.247.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.247.1 description trunk-group-tests-l3leaf1b
       redistribute connected
    !
    vrf TG_300
@@ -410,6 +412,7 @@ router bgp 65001
       router-id 192.168.250.9
       update wait-install
       neighbor 10.255.247.1 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.247.1 description trunk-group-tests-l3leaf1b
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
@@ -372,6 +372,7 @@ router bgp 65001
       router-id 192.168.250.10
       update wait-install
       neighbor 10.255.247.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.247.0 description trunk-group-tests-l3leaf1a
       redistribute connected
    !
    vrf TG_200
@@ -381,6 +382,7 @@ router bgp 65001
       router-id 192.168.250.10
       update wait-install
       neighbor 10.255.247.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.247.0 description trunk-group-tests-l3leaf1a
       redistribute connected
    !
    vrf TG_300
@@ -390,6 +392,7 @@ router bgp 65001
       router-id 192.168.250.10
       update wait-install
       neighbor 10.255.247.0 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.247.0 description trunk-group-tests-l3leaf1a
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
@@ -198,6 +198,7 @@ router bgp 65002
       router-id 192.168.250.11
       update wait-install
       neighbor 10.255.247.5 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.247.5 description trunk-group-tests-l3leaf2b
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
@@ -193,6 +193,7 @@ router bgp 65002
       router-id 192.168.250.12
       update wait-install
       neighbor 10.255.247.4 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.247.4 description trunk-group-tests-l3leaf2a
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -72,6 +72,7 @@ router_bgp:
       description: CUSTOM-PYTHON_MODULES-L3LEAF2_Ethernet1.1_vrf_TEST_VRF
     - ip_address: 10.255.240.11
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: CUSTOM-PYTHON_MODULES-L3LEAF1B
     rd: 192.168.255.21:1
     route_targets:
       import:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -79,6 +79,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.240.10
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: CUSTOM-PYTHON_MODULES-L3LEAF1A
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -79,6 +79,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.240.11
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: CUSTOM-TEMPLATES-L3LEAF1B
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -79,6 +79,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.240.10
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: CUSTOM-TEMPLATES-L3LEAF1A
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -120,6 +120,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -140,6 +141,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -159,6 +161,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_WAN_Zone
@@ -181,6 +184,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -201,6 +205,7 @@ router_bgp:
     neighbors:
     - ip_address: 172.31.11.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -220,6 +225,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -239,6 +245,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -258,6 +265,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -277,6 +285,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -120,6 +120,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -140,6 +141,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -159,6 +161,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_WAN_Zone
@@ -181,6 +184,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -201,6 +205,7 @@ router_bgp:
     neighbors:
     - ip_address: 172.31.11.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -220,6 +225,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -239,6 +245,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -258,6 +265,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -277,6 +285,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -120,6 +120,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.25
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1B
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -140,6 +141,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.25
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1B
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -159,6 +161,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.25
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1B
     updates:
       wait_install: true
   - name: Tenant_A_WAN_Zone
@@ -181,6 +184,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.25
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1B
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -201,6 +205,7 @@ router_bgp:
     neighbors:
     - ip_address: 172.31.11.25
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1B
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -220,6 +225,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.25
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1B
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -239,6 +245,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.25
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1B
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -258,6 +265,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.25
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1B
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -277,6 +285,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.25
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1B
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -120,6 +120,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.24
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1A
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -140,6 +141,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.24
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1A
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -159,6 +161,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.24
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1A
     updates:
       wait_install: true
   - name: Tenant_A_WAN_Zone
@@ -181,6 +184,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.24
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1A
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -201,6 +205,7 @@ router_bgp:
     neighbors:
     - ip_address: 172.31.11.24
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1A
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -220,6 +225,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.24
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1A
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -239,6 +245,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.24
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1A
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -258,6 +265,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.24
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1A
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -277,6 +285,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.24
       peer_group: MLAG-PEERS
+      description: DC1_UNDEPLOYED_LEAF1A
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -79,6 +79,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: MULTICAST_ENABLED_110_111
@@ -98,6 +99,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: MULTICAST_ENABLED_210_DISABLED_211
@@ -117,6 +119,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: MULTICAST_DISABLED_5_6
@@ -136,6 +139,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: MULTICAST_ENABLED_1_2
@@ -155,6 +159,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: MULTICAST_ENABLED_3_DISABLED_4
@@ -174,6 +179,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: TEN_C_L3_MULTICAST_DISABLED_330_331
@@ -194,6 +200,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: TEN_C_L3_MULTICAST_ENABLED_130_131
@@ -214,6 +221,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
@@ -234,6 +242,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: TEN_D_L3_MULTICAST_DISABLED_240_241
@@ -254,6 +263,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
@@ -274,6 +284,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
@@ -294,6 +305,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
@@ -317,6 +329,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: TEN_E_L3_MULTICAST_TRANSIT
@@ -340,6 +353,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   - name: TEN_E_PEG_L3_MULTICAST_ENABLED
@@ -360,6 +374,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1B
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -79,6 +79,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: MULTICAST_ENABLED_110_111
@@ -98,6 +99,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: MULTICAST_ENABLED_210_DISABLED_211
@@ -117,6 +119,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: MULTICAST_DISABLED_5_6
@@ -136,6 +139,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: MULTICAST_ENABLED_1_2
@@ -155,6 +159,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: MULTICAST_ENABLED_3_DISABLED_4
@@ -174,6 +179,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: TEN_C_L3_MULTICAST_DISABLED_330_331
@@ -194,6 +200,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: TEN_C_L3_MULTICAST_ENABLED_130_131
@@ -214,6 +221,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: TEN_C_L3_MULTICAST_ENABLED_230_DISABLED_231
@@ -234,6 +242,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: TEN_D_L3_MULTICAST_DISABLED_240_241
@@ -254,6 +263,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: TEN_D_L3_MULTICAST_ENABLED_140_DISABLED_141
@@ -274,6 +284,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: TEN_E_L3_MULTICAST_ENABLED_PEG_OVERRIDE
@@ -294,6 +305,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: TEN_E_L3_MULTICAST_EVPN_PEG_RP_NODES
@@ -317,6 +329,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: TEN_E_L3_MULTICAST_TRANSIT
@@ -340,6 +353,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   - name: TEN_E_PEG_L3_MULTICAST_ENABLED
@@ -360,6 +374,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: EVPN-MULTICAST-L3LEAF1A
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF1A.yml
@@ -69,6 +69,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.10.224.2
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: MLAG_SAME_SUBNET_L3LEAF1B
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF1B.yml
@@ -69,6 +69,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.10.224.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: MLAG_SAME_SUBNET_L3LEAF1A
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF2A.yml
@@ -69,6 +69,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.10.224.2
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: MLAG_SAME_SUBNET_L3LEAF2B
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG_SAME_SUBNET_L3LEAF2B.yml
@@ -69,6 +69,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.10.224.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: MLAG_SAME_SUBNET_L3LEAF2A
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf3.yml
@@ -88,6 +88,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.254.1.105
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: flow-tracking-tests-leaf4
   vlans:
   - id: 11
     tenant: FLOW_TRACKING

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf4.yml
@@ -88,6 +88,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.254.1.104
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: flow-tracking-tests-leaf3
   vlans:
   - id: 11
     tenant: FLOW_TRACKING

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-dualstack1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-dualstack1.yml
@@ -70,6 +70,7 @@ router_bgp:
     neighbors:
     - ip_address: 100.64.1.5
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: inband-mgmt-parent-dualstack2
     updates:
       wait_install: true
 service_routing_protocols_model: multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-dualstack2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-dualstack2.yml
@@ -70,6 +70,7 @@ router_bgp:
     neighbors:
     - ip_address: 100.64.1.4
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: inband-mgmt-parent-dualstack1
     updates:
       wait_install: true
 service_routing_protocols_model: multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -82,6 +82,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.254.1.97
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: ptp-tests-leaf2
   vlans:
   - id: 11
     tenant: PTP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -82,6 +82,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.254.1.96
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: ptp-tests-leaf1
   vlans:
   - id: 11
     tenant: PTP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf3.yml
@@ -83,6 +83,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.254.1.105
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: sflow-tests-leaf4
   vlans:
   - id: 11
     tenant: SFLOW

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf4.yml
@@ -83,6 +83,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.254.1.104
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: sflow-tests-leaf3
   vlans:
   - id: 11
     tenant: SFLOW

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -69,6 +69,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.247.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: trunk-group-tests-l3leaf1b
     updates:
       wait_install: true
   - name: TG_200
@@ -88,6 +89,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.247.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: trunk-group-tests-l3leaf1b
     updates:
       wait_install: true
   - name: TG_300
@@ -107,6 +109,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.247.1
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: trunk-group-tests-l3leaf1b
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -69,6 +69,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.247.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: trunk-group-tests-l3leaf1a
     updates:
       wait_install: true
   - name: TG_200
@@ -88,6 +89,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.247.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: trunk-group-tests-l3leaf1a
     updates:
       wait_install: true
   - name: TG_300
@@ -107,6 +109,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.247.0
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: trunk-group-tests-l3leaf1a
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -69,6 +69,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.247.5
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: trunk-group-tests-l3leaf2b
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -69,6 +69,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.247.4
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: trunk-group-tests-l3leaf2a
     updates:
       wait_install: true
   vlans:

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1a.yml
@@ -104,6 +104,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.97
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1b
   - name: VRF11
     router_id: 10.255.0.3
     rd: 10.255.0.3:11
@@ -121,6 +122,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.97
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1b.yml
@@ -101,6 +101,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.96
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1a
   - name: VRF11
     router_id: 10.255.0.4
     rd: 10.255.0.4:11
@@ -118,6 +119,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.96
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf1a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2a.yml
@@ -117,6 +117,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.101
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2b
   - name: VRF11
     router_id: 10.255.0.5
     rd: 10.255.0.5:11
@@ -134,6 +135,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.101
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2b.yml
@@ -117,6 +117,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.100
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2a
   - name: VRF11
     router_id: 10.255.0.6
     rd: 10.255.0.6:11
@@ -134,6 +135,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.1.100
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc1-leaf2a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1a.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.117
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf1b
   - name: VRF11
     router_id: 10.255.128.13
     rd: 10.255.128.13:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.117
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf1b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1b.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.116
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf1a
   - name: VRF11
     router_id: 10.255.128.14
     rd: 10.255.128.14:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.116
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf1a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2a.yml
@@ -116,6 +116,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.121
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf2b
   - name: VRF11
     router_id: 10.255.128.15
     rd: 10.255.128.15:11
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.121
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf2b
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2b.yml
@@ -116,6 +116,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.120
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf2a
   - name: VRF11
     router_id: 10.255.128.16
     rd: 10.255.128.16:11
@@ -133,6 +134,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.120
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf2a
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf3a.arista.com.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf3a.arista.com.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.125
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf3b.arista.com
   - name: VRF11
     router_id: 10.255.128.17
     rd: 10.255.128.17:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.125
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf3b.arista.com
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf3b.arista.com.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf3b.arista.com.yml
@@ -90,6 +90,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.124
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf3a.arista.com
   - name: VRF11
     router_id: 10.255.128.18
     rd: 10.255.128.18:11
@@ -107,6 +108,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.129.124
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: dc2-leaf3a.arista.com
   vlans:
   - id: 11
     tenant: TENANT1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -1501,6 +1501,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1510,6 +1511,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1519,6 +1521,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1530,6 +1533,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
       redistribute static
    !
@@ -1540,6 +1544,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1549,6 +1554,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1558,6 +1564,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1567,6 +1574,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1576,6 +1584,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -1501,6 +1501,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -1510,6 +1511,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -1519,6 +1521,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -1530,6 +1533,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
       redistribute static
    !
@@ -1540,6 +1544,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -1549,6 +1554,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -1558,6 +1564,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -1567,6 +1574,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -1576,6 +1584,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -849,6 +849,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -858,6 +859,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -867,6 +869,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -878,6 +881,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
       redistribute static
    !
@@ -888,6 +892,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -897,6 +902,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -906,6 +912,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -915,6 +922,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -924,6 +932,7 @@ router bgp 65103
       router-id 192.168.255.12
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-PEERS
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -849,6 +849,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_DB_Zone
@@ -858,6 +859,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_OP_Zone
@@ -867,6 +869,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_A_WAN_Zone
@@ -878,6 +881,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
       redistribute static
    !
@@ -888,6 +892,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_OP_Zone
@@ -897,6 +902,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_B_WAN_Zone
@@ -906,6 +912,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_OP_Zone
@@ -915,6 +922,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
    !
    vrf Tenant_C_WAN_Zone
@@ -924,6 +932,7 @@ router bgp 65103
       router-id 192.168.255.13
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-PEERS
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -118,6 +118,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -137,6 +138,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -156,6 +158,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_WAN_Zone
@@ -178,6 +181,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -197,6 +201,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -216,6 +221,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -235,6 +241,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -254,6 +261,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -273,6 +281,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-PEERS
+      description: DC1-SVC3B
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -118,6 +118,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_DB_Zone
@@ -137,6 +138,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_OP_Zone
@@ -156,6 +158,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_WAN_Zone
@@ -178,6 +181,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_A_WEB_Zone
@@ -197,6 +201,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_B_OP_Zone
@@ -216,6 +221,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_B_WAN_Zone
@@ -235,6 +241,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_C_OP_Zone
@@ -254,6 +261,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   - name: Tenant_C_WAN_Zone
@@ -273,6 +281,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-PEERS
+      description: DC1-SVC3A
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -762,6 +762,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -762,6 +762,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3A.md
@@ -755,6 +755,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/documentation/devices/DC1-SVC3B.md
@@ -755,6 +755,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -252,6 +252,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
 !
 router ospf 101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -252,6 +252,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
 !
 router ospf 101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -247,6 +247,7 @@ router bgp 65103
       router-id 192.168.255.8
       update wait-install
       neighbor 10.255.252.7 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.252.7 description DC1-SVC3B
       redistribute connected
 !
 router ospf 101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -247,6 +247,7 @@ router bgp 65103
       router-id 192.168.255.9
       update wait-install
       neighbor 10.255.252.6 peer group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 10.255.252.6 description DC1-SVC3A
       redistribute connected
 !
 router ospf 101

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -84,6 +84,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2B
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -84,6 +84,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-LEAF2A
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -84,6 +84,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.7
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3B
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -84,6 +84,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.252.6
       peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: DC1-SVC3A
     updates:
       wait_install: true
   vlan_aware_bundles:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2A.md
@@ -1139,6 +1139,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -1151,6 +1152,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -1163,6 +1165,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -1175,6 +1178,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -1187,6 +1191,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -1199,6 +1204,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/documentation/devices/DC1-LEAF2B.md
@@ -1139,6 +1139,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -1151,6 +1152,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -1163,6 +1165,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -1175,6 +1178,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -1187,6 +1191,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -1199,6 +1204,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -545,6 +545,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -557,6 +558,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -569,6 +571,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -581,6 +584,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -593,6 +597,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4
@@ -605,6 +610,7 @@ router bgp 65102
       router-id 192.168.255.6
       update wait-install
       neighbor 10.255.251.3 peer group MLAG_PEER
+      neighbor 10.255.251.3 description DC1-LEAF2B
       redistribute connected
       !
       address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -545,6 +545,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -557,6 +558,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -569,6 +571,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -581,6 +584,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -593,6 +597,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4
@@ -605,6 +610,7 @@ router bgp 65102
       router-id 192.168.255.7
       update wait-install
       neighbor 10.255.251.2 peer group MLAG_PEER
+      neighbor 10.255.251.2 description DC1-LEAF2A
       redistribute connected
       !
       address-family ipv4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -128,6 +128,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+      description: DC1-LEAF2B
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.3
@@ -153,6 +154,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+      description: DC1-LEAF2B
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.3
@@ -178,6 +180,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+      description: DC1-LEAF2B
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.3
@@ -203,6 +206,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+      description: DC1-LEAF2B
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.3
@@ -228,6 +232,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+      description: DC1-LEAF2B
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.3
@@ -253,6 +258,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.3
       peer_group: MLAG_PEER
+      description: DC1-LEAF2B
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -128,6 +128,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+      description: DC1-LEAF2A
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.2
@@ -153,6 +154,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+      description: DC1-LEAF2A
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.2
@@ -178,6 +180,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+      description: DC1-LEAF2A
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.2
@@ -203,6 +206,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+      description: DC1-LEAF2A
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.2
@@ -228,6 +232,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+      description: DC1-LEAF2A
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.2
@@ -253,6 +258,7 @@ router_bgp:
     neighbors:
     - ip_address: 10.255.251.2
       peer_group: MLAG_PEER
+      description: DC1-LEAF2A
     address_family_ipv4:
       neighbors:
       - ip_address: 10.255.251.2

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/router_bgp.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/router_bgp.py
@@ -322,6 +322,7 @@ class RouterBgpMixin(UtilsMixin):
                 {
                     "ip_address": ip_address,
                     "peer_group": self.shared_utils.bgp_peer_groups["mlag_ipv4_underlay_peer"]["name"],
+                    "description": self.shared_utils.mlag_peer,
                 },
             )
             if self.shared_utils.underlay_rfc5549:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add missing BGP peer description for MLAG peerings in VRFs

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

Add missing BGP peer description for all MLAG peerings in VRFs.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing molecule artifacts got updated.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
