### PR TITLE
Fix(eos_cli_config_gen): Use the correct VRF name for ip nat profile

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
@@ -195,7 +195,7 @@ ip nat profile NAT-PROFILE-NO-VRF-2
    ip nat destination dynamic access-list ACL5 pool POOL5 priority 4294967295 comment Priority high end
    ip nat destination dynamic access-list ACL6 pool POOL6 comment Priority default
 !
-ip nat profile NAT-PROFILE-TEST-VRF vrf NAT-PROFILE-TEST-VRF
+ip nat profile NAT-PROFILE-TEST-VRF vrf TEST
 !
 ip nat pool prefix_16 prefix-length 16
    range 10.0.0.1 10.0.255.254

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
@@ -46,7 +46,7 @@ ip nat profile NAT-PROFILE-NO-VRF-2
    ip nat destination dynamic access-list ACL5 pool POOL5 priority 4294967295 comment Priority high end
    ip nat destination dynamic access-list ACL6 pool POOL6 comment Priority default
 !
-ip nat profile NAT-PROFILE-TEST-VRF vrf NAT-PROFILE-TEST-VRF
+ip nat profile NAT-PROFILE-TEST-VRF vrf TEST
 !
 interface Management1
    description oob_management

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-nat-part1.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-nat-part1.j2
@@ -37,7 +37,7 @@ ip nat kernel buffer size {{ ip_nat.kernel_buffer_size }}
 !
 {%         set nat_profile_def = "ip nat profile " ~ profile.name %}
 {%         if profile.vrf is arista.avd.defined %}
-{%             set nat_profile_def = nat_profile_def ~ " vrf " ~ profile.name %}
+{%             set nat_profile_def = nat_profile_def ~ " vrf " ~ profile.vrf %}
 {%         endif %}
 {{ nat_profile_def }}
 {%         set interface_ip_nat = profile %}


### PR DESCRIPTION
## Change Summary

As described in the issue - wrong VRF name

## Related Issue(s)

Fixes #4397 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Use the proper variable in the template...
Checked that doc template is correct

## How to test

molecule updated

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
