### PR TITLE
Refactor(eos_cli_config_gen)!: Make router_traffic_engineering.enabled required

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -397,6 +397,28 @@ As of AVD 5.0.0 "null" option for esp integrity and encryption has been replaced
 +      encryption: disabled
 ```
 
+### `router_traffic_engineering.enabled` is required
+
+In AVD 4.0.0, setting `enabled: true` under `router_traffic_engineering` was not
+required and it was possible to render
+
+```eos
+router traffic-engineering
+```
+
+using the following input
+
+```yaml
+router_traffic_engineering:
+```
+
+As of AVD 5.0.0, the `enabled` keyword is required under `router_traffic_engineering`:
+
+```yaml
+router_traffic_engineering:
+  enabled: true
+```
+
 ### Removal of default type `switched` from ethernet interfaces and port-channel interfaces
 
 In AVD 4.0.0, we had "switched" as the default value for `ethernet_interfaces[].type` and `port_channel_interfaces[].type`.

--- a/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
@@ -84,11 +84,15 @@ See the [porting guide](../porting-guides/5.x.x.md#no-auto-conversion-of-old-dat
 
 See the [porting guide](../porting-guides/5.x.x.md#ip_securitysa_policiesespintegrity-and-encryption-null-option-has-been-replaced-with-disabled) for details.
 
+#### `router_traffic_engineering.enabled` is required
+
+See the [porting guide](../porting-guides/5.x.x.md#router_traffic_engineeringenabled-is-required) for details.
+
 #### Removal of schema in JSON format
 
 The `eos_cli_config_gen.jsonschema.json` is no longer generated. This schema was not being used and had never been complete.
 
-### Removal of default type `switched` from ethernet interfaces and port-channel interfaces
+#### Removal of default type `switched` from ethernet interfaces and port-channel interfaces
 
 Starting AVD 5.0.0, the default value for `type` in `ethernet_interfaces` and `port_channel_interfaces` is no longer supported. The `type` key must now be explicitly defined in the input variables if it is needed in the configuration and documentation.
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-traffic-engineering.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-traffic-engineering.md
@@ -8,7 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>router_traffic_engineering</samp>](## "router_traffic_engineering") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;enabled</samp>](## "router_traffic_engineering.enabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;enabled</samp>](## "router_traffic_engineering.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;router_id</samp>](## "router_traffic_engineering.router_id") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "router_traffic_engineering.router_id.ipv4") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "router_traffic_engineering.router_id.ipv6") | String |  |  |  |  |
@@ -34,7 +34,7 @@
 
     ```yaml
     router_traffic_engineering:
-      enabled: <bool>
+      enabled: <bool; required>
       router_id:
         ipv4: <str>
         ipv6: <str>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-traffic-engineering.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-traffic-engineering.j2
@@ -4,14 +4,11 @@
  that can be found in the LICENSE file.
 #}
 {# doc - router traffic engineering #}
-{# for AVD 5.0.0, the first part of the if statement will be removed #}
-{% if router_traffic_engineering is arista.avd.defined or router_traffic_engineering.enabled is arista.avd.defined(true) %}
+{% if router_traffic_engineering.enabled is arista.avd.defined(true) %}
 
 ### Router Traffic-Engineering
-{%     if router_traffic_engineering.enabled is arista.avd.defined(true) %}
 
 - Traffic Engineering is enabled.
-{%     endif %}
 {%     if router_traffic_engineering.segment_routing is arista.avd.defined %}
 
 #### Segment Routing Summary

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-traffic-engineering.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-traffic-engineering.j2
@@ -4,8 +4,7 @@
  that can be found in the LICENSE file.
 #}
 {# eos - router traffic engineering #}
-{# for AVD 5.0.0, the first part of the if statement will be removed #}
-{% if router_traffic_engineering is arista.avd.defined or router_traffic_engineering.enabled is arista.avd.defined(true) %}
+{% if router_traffic_engineering.enabled is arista.avd.defined(true) %}
 !
 router traffic-engineering
 {%     if router_traffic_engineering.segment_routing is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -16583,6 +16583,7 @@ keys:
     keys:
       enabled:
         type: bool
+        required: true
       router_id:
         type: dict
         keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_traffic_engineering.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_traffic_engineering.schema.yml
@@ -11,6 +11,7 @@ keys:
     keys:
       enabled:
         type: bool
+        required: true
       router_id:
         type: dict
         keys:


### PR DESCRIPTION
## Change Summary

As described in the issue - right now AVD 4.0.0 renders config with an empty dict which we don't want.

## Related Issue(s)

Fixes #3281 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Make `enabled` required in schema and fix the template logic

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
