### PR TITLE
Refactor(eos_cli_config_gen): Remove hack for ansible 2.12 for arp

### DIFF
--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/arp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/arp.j2
@@ -20,18 +20,12 @@
 Global ARP timeout: {{ arp.aging.timeout_default }}
 {%     endif %}
 {%     if arp.static_entries is arista.avd.defined %}
-{# TODO - remove when dropping support for ansible 2.12.6 and its jinja2 hack #}
-{%         for entry in arp.static_entries %}
-{%             if entry.vrf is not arista.avd.defined %}
-{%                 do entry.update({"vrf": "default"}) %}
-{%             endif %}
-{%         endfor %}
 
 #### ARP Static Entries
 
 | VRF | IPv4 address | MAC address |
 | --- | ------------ | ----------- |
-{%         for vrf, entries in arp.static_entries | groupby("vrf") | arista.avd.natural_sort %}
+{%         for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
 {%             for entry in entries | arista.avd.natural_sort("ipv4_address") %}
 | {{ vrf }} | {{ entry.ipv4_address }} | {{ entry.mac_address }} |
 {%             endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/arp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/arp.j2
@@ -25,7 +25,7 @@ Global ARP timeout: {{ arp.aging.timeout_default }}
 
 | VRF | IPv4 address | MAC address |
 | --- | ------------ | ----------- |
-{%         for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
+{%         for vrf, entries in arp.static_entries | groupby("vrf", default="default") | arista.avd.natural_sort %}
 {%             for entry in entries | arista.avd.natural_sort("ipv4_address") %}
 | {{ vrf }} | {{ entry.ipv4_address }} | {{ entry.mac_address }} |
 {%             endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/arp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/arp.j2
@@ -17,7 +17,7 @@
 arp aging timeout default {{ arp.aging.timeout_default }}
 {%     endif %}
 {%     if arp.static_entries is arista.avd.defined %}
-{%         for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
+{%         for vrf, entries in arp.static_entries | groupby("vrf", default="default") | arista.avd.natural_sort %}
 {%             for entry in entries | arista.avd.natural_sort("ipv4_address") %}
 {%                 set arp_entry_prefix = "arp" %}
 {%                 if vrf != "default" %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/arp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/arp.j2
@@ -17,14 +17,7 @@
 arp aging timeout default {{ arp.aging.timeout_default }}
 {%     endif %}
 {%     if arp.static_entries is arista.avd.defined %}
-{# TODO - remove when dropping support for ansible 2.12.6 and its jinja2 hack #}
-{%         for entry in arp.static_entries %}
-{%             if entry.vrf is not arista.avd.defined %}
-{%                 do entry.update({"vrf": "default"}) %}
-{%             endif %}
-{%         endfor %}
-{%         for vrf, entries in arp.static_entries | groupby("vrf") | arista.avd.natural_sort %}
-{# TODO {%     for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %} #}
+{%         for vrf, entries in arp.static_entries | arista.avd.default([]) | groupby("vrf", default="default") | arista.avd.natural_sort %}
 {%             for entry in entries | arista.avd.natural_sort("ipv4_address") %}
 {%                 set arp_entry_prefix = "arp" %}
 {%                 if vrf != "default" %}


### PR DESCRIPTION
## Change Summary

Remove a hack that was there for 2.12.6 in ansible

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Clean the templates

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
