### PR TITLE
Fix(eos_cli_config_gen): Use the correct VRF name for ip nat profile (#4398)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-nat.md
@@ -195,7 +195,7 @@ ip nat profile NAT-PROFILE-NO-VRF-2
    ip nat destination dynamic access-list ACL5 pool POOL5 priority 4294967295 comment Priority high end
    ip nat destination dynamic access-list ACL6 pool POOL6 comment Priority default
 !
-ip nat profile NAT-PROFILE-TEST-VRF vrf NAT-PROFILE-TEST-VRF
+ip nat profile NAT-PROFILE-TEST-VRF vrf TEST
 !
 ip nat pool prefix_16 prefix-length 16
    range 10.0.0.1 10.0.255.254

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-nat.cfg
@@ -49,7 +49,7 @@ ip nat profile NAT-PROFILE-NO-VRF-2
    ip nat destination dynamic access-list ACL5 pool POOL5 priority 4294967295 comment Priority high end
    ip nat destination dynamic access-list ACL6 pool POOL6 comment Priority default
 !
-ip nat profile NAT-PROFILE-TEST-VRF vrf NAT-PROFILE-TEST-VRF
+ip nat profile NAT-PROFILE-TEST-VRF vrf TEST
 !
 hostname ip-nat
 !

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-nat-part1.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-nat-part1.j2
@@ -37,7 +37,7 @@ ip nat kernel buffer size {{ ip_nat.kernel_buffer_size }}
 !
 {%         set nat_profile_def = "ip nat profile " ~ profile.name %}
 {%         if profile.vrf is arista.avd.defined %}
-{%             set nat_profile_def = nat_profile_def ~ " vrf " ~ profile.name %}
+{%             set nat_profile_def = nat_profile_def ~ " vrf " ~ profile.vrf %}
 {%         endif %}
 {{ nat_profile_def }}
 {%         set interface_ip_nat = profile %}


### PR DESCRIPTION
## Change Summary
Cherry-pick PR https://github.com/aristanetworks/avd/pull/4398