### PR TITLE
Fix(eos_designs): Better error message when missing 'evpn_multicast' for PIM l3 interfaces (#4391)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-with-pim.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/failure-missing-evpn-multicast-with-pim.yml
@@ -1,6 +1,8 @@
 type: l3leaf
 underlay_multicast: true
-evpn_multicast: true
+# When this is set to false, the VRF won't have evpn_l3_multicast enabled
+# and PIM will fail
+evpn_multicast: false
 
 l3leaf:
   defaults:
@@ -9,7 +11,7 @@ l3leaf:
     vtep_loopback_ipv4_pool: 10.11.0.0/24
     vtep_loopback: Loopback1
   nodes:
-    - name: failure-missing-evpn-multicast-l3-with-pim
+    - name: failure-missing-evpn-multicast-with-pim
       id: 3
       bgp_as: 65101
       filter:
@@ -19,7 +21,7 @@ tenants:
   - name: FABRIC
     mac_vrf_vni_base: 10000
     evpn_l3_multicast:
-      enabled: false
+      enabled: true
       evpn_underlay_l3_multicast_group_ipv4_pool: 232.0.0.0/20
     vrfs:
       - name: Tenant_A_OP_Zone_MC
@@ -33,7 +35,7 @@ tenants:
             name: Tenant_A_OP_Zone_1
             tags: ['evpn-multicast-l3']
         l3_interfaces:
-          - nodes: [ failure-missing-evpn-multicast-l3-with-pim ]
+          - nodes: [ failure-missing-evpn-multicast-with-pim ]
             interfaces: [ Ethernet1 ]
             ip_addresses: [ 10.254.248.0/31 ]
             descriptions: [ "L3 Link to RPs" ]
@@ -42,5 +44,5 @@ tenants:
               enabled: true
 
 expected_error_message: >-
-  'pim: enabled' set on l3_interface 'Ethernet1' on 'failure-missing-evpn-multicast-l3-with-pim'
-  requires 'evpn_l3_multicast.enabled: true' under VRF 'Tenant_A_OP_Zone_MC' or Tenant 'FABRIC'
+  'pim: enabled' set on l3_interface 'Ethernet1' on 'failure-missing-evpn-multicast-with-pim'
+  requires 'evpn_multicast: true' at the fabric level

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -96,6 +96,7 @@ all:
             failure-missing-evpn-vlan-bundle_svi:
             failure-missing-evpn-multicast-l3-with-pim:
             failure-missing-evpn-multicast-peg-rps:
+            failure-missing-evpn-multicast-with-pim:
             failure-duplicate-evpn-vlan-bundle-name:
             failure-no-local-path-group-in-default-policy:
             ipv4-acl-in-missing-on-wan-interface:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ethernet_interfaces.py
@@ -132,10 +132,18 @@ class EthernetInterfacesMixin(UtilsMixin):
 
                             if get(l3_interface, "pim.enabled"):
                                 if not vrf.get("_evpn_l3_multicast_enabled"):
-                                    raise AristaAvdError(
-                                        f"'pim: enabled' set on l3_interface '{interface_name}' on '{self.shared_utils.hostname}' requires evpn_l3_multicast:"
-                                        f" enabled: true under VRF '{vrf['name']}' or Tenant '{tenant['name']}'"
-                                    )
+                                    # Possibly the key was not set because `evpn_multicast` is not set to `true`.
+                                    if not self.shared_utils.evpn_multicast:
+                                        msg = (
+                                            f"'pim: enabled' set on l3_interface '{interface_name}' on '{self.shared_utils.hostname}' requires "
+                                            "'evpn_multicast: true' at the fabric level"
+                                        )
+                                    else:
+                                        msg = (
+                                            f"'pim: enabled' set on l3_interface '{interface_name}' on '{self.shared_utils.hostname}' requires "
+                                            f"'evpn_l3_multicast.enabled: true' under VRF '{vrf['name']}' or Tenant '{tenant['name']}'"
+                                        )
+                                    raise AristaAvdError(msg)
 
                                 if not vrf.get("_pim_rp_addresses"):
                                     raise AristaAvdError(


### PR DESCRIPTION
## Change Summary

Cherry-pick #4391 