### PR TITLE
Doc(eos_cli_config_gen): Removing deprecation info from description as it was already removed

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -16,7 +16,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- <code>3des</code><br>- <code>aes128</code><br>- <code>aes256</code> | IKE encryption algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dh_group</samp>](## "ip_security.ike_policies.[].dh_group") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>5</code><br>- <code>14</code><br>- <code>15</code><br>- <code>16</code><br>- <code>17</code><br>- <code>20</code><br>- <code>21</code><br>- <code>24</code> | Diffie-Hellman group for the key exchange. |
     | [<samp>&nbsp;&nbsp;sa_policies</samp>](## "ip_security.sa_policies") | List, items: Dictionary |  |  |  | Security Association policies. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sa_lifetime</samp>](## "ip_security.sa_policies.[].sa_lifetime") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;value</samp>](## "ip_security.sa_policies.[].sa_lifetime.value") | Integer |  |  |  | Lifetime value for this SA.<br>Valid range depends on the unit.<br><1-24>       Lifetime in hours ( default )<br><1-4000000>  Packet limit in thousands<br><1-6000>     Byte limit in GB ( 1024 MB )<br><1-6144000>  Byte limit in MB ( 1024 KB ) |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unit</samp>](## "ip_security.sa_policies.[].sa_lifetime.unit") | String |  | `hours` | Valid Values:<br>- <code>gigabytes</code><br>- <code>hours</code><br>- <code>megabytes</code><br>- <code>thousand-packets</code> |  |
@@ -72,7 +72,7 @@
       # Security Association policies.
       sa_policies:
 
-          # Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0.
+          # Name of the SA policy.
         - name: <str; required; unique>
           sa_lifetime:
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -5243,8 +5243,7 @@ keys:
           keys:
             name:
               type: str
-              description: Name of the SA policy. The "null" value is deprecated and
-                will be removed in AVD 5.0.0.
+              description: Name of the SA policy.
             sa_lifetime:
               type: dict
               keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
@@ -59,7 +59,7 @@ keys:
           keys:
             name:
               type: str
-              description: Name of the SA policy. The "null" value is deprecated and will be removed in AVD 5.0.0.
+              description: Name of the SA policy.
             sa_lifetime:
               type: dict
               keys:


### PR DESCRIPTION
## Change Summary

Removing the description for TODO: AVD5.0 as it is already fixed in PR #4336  

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
