### PR TITLE
Fix(plugins): Support zeroes in interface numbers for range_expand

### DIFF
--- a/python-avd/pyavd/j2filters/range_expand.py
+++ b/python-avd/pyavd/j2filters/range_expand.py
@@ -5,9 +5,10 @@
 from __future__ import annotations
 
 import re
+from typing import Any
 
 
-def range_expand(range_to_expand):
+def range_expand(range_to_expand: Any) -> list:
     if not isinstance(range_to_expand, (list, str)):
         raise TypeError(f"value must be of type list or str, got {type(range_to_expand)}")
 
@@ -115,7 +116,7 @@ def range_expand(range_to_expand):
 
                     def expand_parent_interfaces(interface_string):
                         result = []
-                        if last_parent_interface:
+                        if last_parent_interface is not None:
                             if first_parent_interface > last_parent_interface:
                                 raise ValueError(
                                     f"Range {one_range} could not be expanded because the first interface {first_parent_interface} is larger than last"
@@ -131,7 +132,7 @@ def range_expand(range_to_expand):
 
                     def expand_module(interface_string):
                         result = []
-                        if last_module:
+                        if last_module is not None:
                             if first_module > last_module:
                                 raise ValueError(
                                     f"Range {one_range} could not be expanded because the first module {first_module} is larger than last module"

--- a/python-avd/tests/pyavd/j2filters/test_range_expand.py
+++ b/python-avd/tests/pyavd/j2filters/test_range_expand.py
@@ -37,54 +37,40 @@ RANGE_TO_EXPAND_INVALID_VALUES = [
     ),
 ]
 
-RANGE_TO_EXPAND_VALID_VALUES = [
-    "Ethernet1",
-    "Ethernet1-2",
-    "Eth 3-5,7-8",
-    "et2-6,po1-2",
-    ["Ethernet1"],
-    ["Ethernet 1-2", "Eth3-5", "7-8"],
-    ["Ethernet2-6", "Port-channel1-2"],
-    ["Ethernet1/1-2", "Eth1-2/3-5,5/1-2"],
-    ["Eth1.1,9-10.1", "Eth2.2-3", "Eth3/1-2.3-4"],
-    "1-3",
-    ["1", "2", "3"],
-    "vlan1-3",
-    "Et1-2/3-4/5-6",
-    "65100.0",
-    "65100.0-4",
-    "65100.0-2,65200.1-2",
-    "1-2.0-1",
-]
-
-EXPECTED_RESULT_VALID_VALUES = [
-    ["Ethernet1"],
-    ["Ethernet1", "Ethernet2"],
-    ["Eth 3", "Eth 4", "Eth 5", "Eth 7", "Eth 8"],
-    ["et2", "et3", "et4", "et5", "et6", "po1", "po2"],
-    ["Ethernet1"],
-    ["Ethernet 1", "Ethernet 2", "Eth3", "Eth4", "Eth5", "7", "8"],
-    ["Ethernet2", "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6", "Port-channel1", "Port-channel2"],
-    ["Ethernet1/1", "Ethernet1/2", "Eth1/3", "Eth1/4", "Eth1/5", "Eth2/3", "Eth2/4", "Eth2/5", "Eth5/1", "Eth5/2"],
-    ["Eth1.1", "Eth9.1", "Eth10.1", "Eth2.2", "Eth2.3", "Eth3/1.3", "Eth3/1.4", "Eth3/2.3", "Eth3/2.4"],
-    ["1", "2", "3"],
-    ["1", "2", "3"],
-    ["vlan1", "vlan2", "vlan3"],
-    ["Et1/3/5", "Et1/3/6", "Et1/4/5", "Et1/4/6", "Et2/3/5", "Et2/3/6", "Et2/4/5", "Et2/4/6"],
-    ["65100.0"],
-    ["65100.0", "65100.1", "65100.2", "65100.3", "65100.4"],
-    ["65100.0", "65100.1", "65100.2", "65200.1", "65200.2"],
-    ["1.0", "1.1", "2.0", "2.1"],
+RANGE_TO_EXPAND_VALID_TESTS = [
+    # (<input>, <expected_output>)
+    pytest.param("Ethernet1", ["Ethernet1"]),
+    pytest.param("Ethernet1-2", ["Ethernet1", "Ethernet2"]),
+    pytest.param("Eth 3-5,7-8", ["Eth 3", "Eth 4", "Eth 5", "Eth 7", "Eth 8"]),
+    pytest.param("et2-6,po1-2", ["et2", "et3", "et4", "et5", "et6", "po1", "po2"]),
+    pytest.param(["Ethernet1"], ["Ethernet1"]),
+    pytest.param(["Ethernet 1-2", "Eth3-5", "7-8"], ["Ethernet 1", "Ethernet 2", "Eth3", "Eth4", "Eth5", "7", "8"]),
+    pytest.param(["Ethernet2-6", "Port-channel1-2"], ["Ethernet2", "Ethernet3", "Ethernet4", "Ethernet5", "Ethernet6", "Port-channel1", "Port-channel2"]),
+    pytest.param(
+        ["Ethernet1/1-2", "Eth1-2/3-5,5/1-2"], ["Ethernet1/1", "Ethernet1/2", "Eth1/3", "Eth1/4", "Eth1/5", "Eth2/3", "Eth2/4", "Eth2/5", "Eth5/1", "Eth5/2"]
+    ),
+    pytest.param(
+        ["Eth1.1,9-10.1", "Eth2.2-3", "Eth3/1-2.3-4"], ["Eth1.1", "Eth9.1", "Eth10.1", "Eth2.2", "Eth2.3", "Eth3/1.3", "Eth3/1.4", "Eth3/2.3", "Eth3/2.4"]
+    ),
+    pytest.param("1-3", ["1", "2", "3"]),
+    pytest.param(["1", "2", "3"], ["1", "2", "3"]),
+    pytest.param("vlan1-3", ["vlan1", "vlan2", "vlan3"]),
+    pytest.param("Et1-2/3-4/5-6", ["Et1/3/5", "Et1/3/6", "Et1/4/5", "Et1/4/6", "Et2/3/5", "Et2/3/6", "Et2/4/5", "Et2/4/6"]),
+    pytest.param("65100.0", ["65100.0"]),
+    pytest.param("65100.0-4", ["65100.0", "65100.1", "65100.2", "65100.3", "65100.4"]),
+    pytest.param("65100.0-2,65200.1-2", ["65100.0", "65100.1", "65100.2", "65200.1", "65200.2"]),
+    pytest.param("1-2.0-1", ["1.0", "1.1", "2.0", "2.1"]),
+    pytest.param("Gi1/0/1-2", ["Gi1/0/1", "Gi1/0/2"]),
 ]
 
 
 class TestRangeExpandFilter:
     @pytest.mark.parametrize("input_value, expected_raise, expected_raise_message", RANGE_TO_EXPAND_INVALID_VALUES)
-    def test_range_expand_invalid(self, input_value, expected_raise, expected_raise_message):
+    def test_range_expand_invalid(self, input_value, expected_raise, expected_raise_message) -> None:
         with pytest.raises(expected_raise, match=expected_raise_message):
             range_expand(input_value)
 
-    @pytest.mark.parametrize("RANGE_TO_EXPAND_VALID", RANGE_TO_EXPAND_VALID_VALUES)
-    def test_range_expand_valid(self, RANGE_TO_EXPAND_VALID):
-        resp = range_expand(RANGE_TO_EXPAND_VALID)
-        assert resp in EXPECTED_RESULT_VALID_VALUES
+    @pytest.mark.parametrize(("range_to_expand", "expected_output"), RANGE_TO_EXPAND_VALID_TESTS)
+    def test_range_expand_valid(self, range_to_expand: list | str, expected_output: list) -> None:
+        resp = range_expand(range_to_expand)
+        assert resp == expected_output


### PR DESCRIPTION
Cherry-pick of PR #4420

## Change Summary
Support zeroes in interface numbers for range_expand

<!-- Enter short PR description -->

## Related Issue(s)

Fixes issue where zeroes in interfaces got ignored. Gi1/0/1-2 resolved to [Gi1/1, Gi1/2].
## Component(s) name

`arista.avd.range_expand`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Check that values are not None instead of boolean checks.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added test case to pytest (failed until fix was applied)
- Refactored tests to be better.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
