### PR TITLE
Feat(eos_cli_config_gen): Set ssh authentication protocols and empty password

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
@@ -36,6 +36,13 @@ interface Management1
 
 ### Management SSH
 
+#### Authentication Settings
+
+| Authentication protocols | Empty passwords |
+| ------------ | -------------- |
+| keyboard-interactive,password,public-key | permit |
+
+
 #### IPv4 ACL
 
 | IPv4 ACL | VRF |
@@ -75,8 +82,10 @@ management ssh
    ip access-group ACL-SSH in
    ip access-group ACL-SSH-VRF vrf mgt in
    idle-timeout 15
+   authentication protocol keyboard-interactive password public-key
    connection limit 50
    connection per-host 10
+   authentication empty-passwords permit
    client-alive interval 666
    client-alive count-max 42
    fips restrictions

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/management-ssh.md
@@ -39,9 +39,8 @@ interface Management1
 #### Authentication Settings
 
 | Authentication protocols | Empty passwords |
-| ------------ | -------------- |
-| keyboard-interactive,password,public-key | permit |
-
+| ------------------------ | --------------- |
+| keyboard-interactive, password, public-key | permit |
 
 #### IPv4 ACL
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/management-ssh.cfg
@@ -8,8 +8,10 @@ management ssh
    ip access-group ACL-SSH in
    ip access-group ACL-SSH-VRF vrf mgt in
    idle-timeout 15
+   authentication protocol keyboard-interactive password public-key
    connection limit 50
    connection per-host 10
+   authentication empty-passwords permit
    client-alive interval 666
    client-alive count-max 42
    fips restrictions

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh.yml
@@ -1,4 +1,10 @@
 management_ssh:
+  authentication:
+    empty_passwords: permit
+    protocol:
+      - keyboard-interactive
+      - password
+      - public-key
   access_groups:
     - name: ACL-SSH
     - name: ACL-SSH-VRF

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/management-ssh.yml
@@ -1,7 +1,7 @@
 management_ssh:
   authentication:
     empty_passwords: permit
-    protocol:
+    protocols:
       - keyboard-interactive
       - password
       - public-key

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
@@ -9,7 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>management_ssh</samp>](## "management_ssh") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;authentication</samp>](## "management_ssh.authentication") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;empty_passwords</samp>](## "management_ssh.authentication.empty_passwords") | String |  | `auto` | Valid Values:<br>- <code>auto</code><br>- <code>deny</code><br>- <code>permit</code> | Permit or deny empty passwords for SSH authentication. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;empty_passwords</samp>](## "management_ssh.authentication.empty_passwords") | String |  |  | Valid Values:<br>- <code>auto</code><br>- <code>deny</code><br>- <code>permit</code> | Permit or deny empty passwords for SSH authentication. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "management_ssh.authentication.protocols") | List, items: String |  |  |  | Allowed SSH authentication methods. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "management_ssh.authentication.protocols.[]") | String |  |  | Valid Values:<br>- <code>keyboard-interactive</code><br>- <code>password</code><br>- <code>public-key</code> |  |
     | [<samp>&nbsp;&nbsp;access_groups</samp>](## "management_ssh.access_groups") | List, items: Dictionary |  |  |  |  |
@@ -50,7 +50,7 @@
       authentication:
 
         # Permit or deny empty passwords for SSH authentication.
-        empty_passwords: <str; "auto" | "deny" | "permit"; default="auto">
+        empty_passwords: <str; "auto" | "deny" | "permit">
 
         # Allowed SSH authentication methods.
         protocols:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
@@ -8,6 +8,10 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>management_ssh</samp>](## "management_ssh") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;authentication</samp>](## "management_ssh.authentication") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;empty_passwords</samp>](## "management_ssh.authentication.empty_passwords") | String |  | `auto` | Valid Values:<br>- <code>auto</code><br>- <code>deny</code><br>- <code>permit</code> | setting to allow or deny empty passwords for ssh authentication<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "management_ssh.authentication.protocol") | List, items: String |  |  |  | set allowed ssh authentication methods<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "management_ssh.authentication.protocol.[]") | String |  |  | Valid Values:<br>- <code>keyboard-interactive</code><br>- <code>password</code><br>- <code>public-key</code> |  |
     | [<samp>&nbsp;&nbsp;access_groups</samp>](## "management_ssh.access_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "management_ssh.access_groups.[].name") | String |  |  |  | Standard ACL Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "management_ssh.access_groups.[].vrf") | String |  |  |  | VRF Name. |
@@ -43,6 +47,14 @@
 
     ```yaml
     management_ssh:
+      authentication:
+
+        # setting to allow or deny empty passwords for ssh authentication
+        empty_passwords: <str; "auto" | "deny" | "permit"; default="auto">
+
+        # set allowed ssh authentication methods
+        protocol:
+          - <str; "keyboard-interactive" | "password" | "public-key">
       access_groups:
 
           # Standard ACL Name.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
@@ -9,9 +9,9 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>management_ssh</samp>](## "management_ssh") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;authentication</samp>](## "management_ssh.authentication") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;empty_passwords</samp>](## "management_ssh.authentication.empty_passwords") | String |  | `auto` | Valid Values:<br>- <code>auto</code><br>- <code>deny</code><br>- <code>permit</code> | setting to allow or deny empty passwords for ssh authentication<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "management_ssh.authentication.protocol") | List, items: String |  |  |  | set allowed ssh authentication methods<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "management_ssh.authentication.protocol.[]") | String |  |  | Valid Values:<br>- <code>keyboard-interactive</code><br>- <code>password</code><br>- <code>public-key</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;empty_passwords</samp>](## "management_ssh.authentication.empty_passwords") | String |  | `auto` | Valid Values:<br>- <code>auto</code><br>- <code>deny</code><br>- <code>permit</code> | Permit or deny empty passwords for SSH authentication. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;protocols</samp>](## "management_ssh.authentication.protocols") | List, items: String |  |  |  | Allowed SSH authentication methods. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "management_ssh.authentication.protocols.[]") | String |  |  | Valid Values:<br>- <code>keyboard-interactive</code><br>- <code>password</code><br>- <code>public-key</code> |  |
     | [<samp>&nbsp;&nbsp;access_groups</samp>](## "management_ssh.access_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "management_ssh.access_groups.[].name") | String |  |  |  | Standard ACL Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "management_ssh.access_groups.[].vrf") | String |  |  |  | VRF Name. |
@@ -49,11 +49,11 @@
     management_ssh:
       authentication:
 
-        # setting to allow or deny empty passwords for ssh authentication
+        # Permit or deny empty passwords for SSH authentication.
         empty_passwords: <str; "auto" | "deny" | "permit"; default="auto">
 
-        # set allowed ssh authentication methods
-        protocol:
+        # Allowed SSH authentication methods.
+        protocols:
           - <str; "keyboard-interactive" | "password" | "public-key">
       access_groups:
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-ssh.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-ssh.j2
@@ -16,11 +16,11 @@
 {%         if management_ssh.authentication.protocols is arista.avd.defined  %}
 {%             set protocols = management_ssh.authentication.protocols | join(", ") %}
 {%         else %}
-{%             set protocols = 'keyboard-interactive public-key' %}
+{%             set protocols = 'keyboard-interactive, public-key' %}
 {%         endif %}
 {%         set empty_passwords = management_ssh.authentication.empty_passwords | arista.avd.default('auto') %}
 | {{ protocols }} | {{ empty_passwords }} |
-{%    endif %}
+{%     endif %}
 {%     if management_ssh.access_groups is arista.avd.defined %}
 
 #### IPv4 ACL

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-ssh.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-ssh.j2
@@ -12,19 +12,14 @@
 #### Authentication Settings
 
 | Authentication protocols | Empty passwords |
-| ------------ | -------------- |
-{%         if management_ssh.authentication.protocol is arista.avd.defined  %}
-{%             set protocol = management_ssh.authentication.protocol | join(",") %}
+| ------------------------ | --------------- |
+{%         if management_ssh.authentication.protocols is arista.avd.defined  %}
+{%             set protocols = management_ssh.authentication.protocols | join(", ") %}
 {%         else %}
-{%             set protocol = 'keyboard-interactive public-key' %}
+{%             set protocols = 'keyboard-interactive public-key' %}
 {%         endif %}
-{%         if management_ssh.authentication.empty_passwords is arista.avd.defined  %}
-{%             set empty_passwords = management_ssh.authentication.empty_passwords %}
-{%         else %}
-{%             set empty_passwords = 'auto' %}
-{%         endif %}
-| {{ protocol }} | {{ empty_passwords }} |
-
+{%         set empty_passwords = management_ssh.authentication.empty_passwords | arista.avd.default('auto') %}
+| {{ protocols }} | {{ empty_passwords }} |
 {%    endif %}
 {%     if management_ssh.access_groups is arista.avd.defined %}
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-ssh.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-ssh.j2
@@ -7,6 +7,25 @@
 {% if management_ssh is arista.avd.defined %}
 
 ### Management SSH
+{%     if management_ssh.authentication is arista.avd.defined %}
+
+#### Authentication Settings
+
+| Authentication protocols | Empty passwords |
+| ------------ | -------------- |
+{%         if management_ssh.authentication.protocol is arista.avd.defined  %}
+{%             set protocol = management_ssh.authentication.protocol | join(",") %}
+{%         else %}
+{%             set protocol = 'keyboard-interactive public-key' %}
+{%         endif %}
+{%         if management_ssh.authentication.empty_passwords is arista.avd.defined  %}
+{%             set empty_passwords = management_ssh.authentication.empty_passwords %}
+{%         else %}
+{%             set empty_passwords = 'auto' %}
+{%         endif %}
+| {{ protocol }} | {{ empty_passwords }} |
+
+{%    endif %}
 {%     if management_ssh.access_groups is arista.avd.defined %}
 
 #### IPv4 ACL

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-ssh.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-ssh.j2
@@ -30,8 +30,8 @@ management ssh
 {%     if management_ssh.idle_timeout is arista.avd.defined %}
    idle-timeout {{ management_ssh.idle_timeout }}
 {%     endif %}
-{%     if management_ssh.authentication is arista.avd.defined and management_ssh.authentication.protocol is arista.avd.defined  %}
-   authentication protocol {{ management_ssh.authentication.protocol | join(" ") }}
+{%     if management_ssh.authentication.protocols is arista.avd.defined  %}
+   authentication protocol {{ management_ssh.authentication.protocols | join(" ") }}
 {%     endif %}
 {%     if management_ssh.connection.limit is arista.avd.defined %}
    connection limit {{ management_ssh.connection.limit }}
@@ -39,7 +39,7 @@ management ssh
 {%     if management_ssh.connection.per_host is arista.avd.defined %}
    connection per-host {{ management_ssh.connection.per_host }}
 {%     endif %}
-{%     if management_ssh.authentication is arista.avd.defined and management_ssh.authentication.empty_passwords is arista.avd.defined  %}
+{%     if management_ssh.authentication.empty_passwords is arista.avd.defined  %}
    authentication empty-passwords {{ management_ssh.authentication.empty_passwords }}
 {%     endif %}
 {%     if management_ssh.client_alive.interval is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-ssh.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/management-ssh.j2
@@ -30,11 +30,17 @@ management ssh
 {%     if management_ssh.idle_timeout is arista.avd.defined %}
    idle-timeout {{ management_ssh.idle_timeout }}
 {%     endif %}
+{%     if management_ssh.authentication is arista.avd.defined and management_ssh.authentication.protocol is arista.avd.defined  %}
+   authentication protocol {{ management_ssh.authentication.protocol | join(" ") }}
+{%     endif %}
 {%     if management_ssh.connection.limit is arista.avd.defined %}
    connection limit {{ management_ssh.connection.limit }}
 {%     endif %}
 {%     if management_ssh.connection.per_host is arista.avd.defined %}
    connection per-host {{ management_ssh.connection.per_host }}
+{%     endif %}
+{%     if management_ssh.authentication is arista.avd.defined and management_ssh.authentication.empty_passwords is arista.avd.defined  %}
+   authentication empty-passwords {{ management_ssh.authentication.empty_passwords }}
 {%     endif %}
 {%     if management_ssh.client_alive.interval is arista.avd.defined %}
    client-alive interval {{ management_ssh.client_alive.interval }}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7198,11 +7198,9 @@ keys:
             - auto
             - deny
             - permit
-            description: 'setting to allow or deny empty passwords for ssh authentication
-
-              '
+            description: Permit or deny empty passwords for SSH authentication.
             default: auto
-          protocol:
+          protocols:
             type: list
             items:
               type: str
@@ -7210,9 +7208,7 @@ keys:
               - keyboard-interactive
               - password
               - public-key
-            description: 'set allowed ssh authentication methods
-
-              '
+            description: Allowed SSH authentication methods.
       access_groups:
         type: list
         items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7189,6 +7189,30 @@ keys:
   management_ssh:
     type: dict
     keys:
+      authentication:
+        type: dict
+        keys:
+          empty_passwords:
+            type: str
+            valid_values:
+            - auto
+            - deny
+            - permit
+            description: 'setting to allow or deny empty passwords for ssh authentication
+
+              '
+            default: auto
+          protocol:
+            type: list
+            items:
+              type: str
+              valid_values:
+              - keyboard-interactive
+              - password
+              - public-key
+            description: 'set allowed ssh authentication methods
+
+              '
       access_groups:
         type: list
         items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7199,7 +7199,6 @@ keys:
             - deny
             - permit
             description: Permit or deny empty passwords for SSH authentication.
-            default: auto
           protocols:
             type: list
             items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
@@ -17,7 +17,6 @@ keys:
             type: str
             valid_values: ["auto", "deny", "permit"]
             description: Permit or deny empty passwords for SSH authentication.
-            default: "auto"
           protocols:
             type: list
             items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
@@ -16,16 +16,14 @@ keys:
           empty_passwords:
             type: str
             valid_values: ["auto", "deny", "permit"]
-            description: |
-              setting to allow or deny empty passwords for ssh authentication
+            description: Permit or deny empty passwords for SSH authentication.
             default: "auto"
-          protocol:
+          protocols:
             type: list
             items:
               type: str
               valid_values: ["keyboard-interactive", "password", "public-key"]
-            description: |
-              set allowed ssh authentication methods
+            description: Allowed SSH authentication methods.
       access_groups:
         type: list
         items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
@@ -10,6 +10,22 @@ keys:
   management_ssh:
     type: dict
     keys:
+      authentication:
+        type: dict
+        keys:
+          empty_passwords:
+            type: str
+            valid_values: ["auto", "deny", "permit"]
+            description: |
+              setting to allow or deny empty passwords for ssh authentication
+            default: "auto"
+          protocol:
+            type: list
+            items:
+              type: str
+              valid_values: ["keyboard-interactive", "password", "public-key"]
+            description: |
+              set allowed ssh authentication methods
       access_groups:
         type: list
         items:


### PR DESCRIPTION
## Change Summary

This PR adds a new key with two sub keys to management_ssh.

```
authentication:
    empty_passwords:
    protocol:
```

## Related Issue(s)

Fixes #4435 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

- add the new keys to the "management_ssh.schema.yml" schema file
- use these in the "eos/management-ssh.j2" and "documentation/management-ssh.j2" templates
- add options to molecule tests

## How to test

Run eos_cli_config_gen molecule tests:

```
python -m molecule converge -s eos_cli_config_gen
```

Test added to: "management-ssh" host.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
