### PR TITLE
Fix(eos_designs): Fix context vars for custom interface description templates

### DIFF
--- a/ansible_collections/arista/avd/docs/contribution/eos_designs_internal_notes.md
+++ b/ansible_collections/arista/avd/docs/contribution/eos_designs_internal_notes.md
@@ -371,10 +371,6 @@ outside of that, so any inline Jinja2 could not use these values.
 | switch.type | fabric-topology.j2 |
 | switch.mpls_overlay_role |interface_descriptions/loopback_interfaces/overlay-loopback.j2 |
 | switch.mpls_lsr |interface_descriptions/loopback_interfaces/overlay-loopback.j2 |
-| switch.mlag_peer | interface_descriptions/mlag/ethernet-interfaces.j2 |
-| switch.mlag_interfaces | interface_descriptions/mlag/port-channel-interfaces.j2 |
-| switch.mlag_peer | interface_descriptions/mlag/port-channel-interfaces.j2 |
-| switch.mlag_port_channel_id | interface_descriptions/mlag/port-channel-interfaces.j2 |
 | switch.uplink_ipv4_pool | ip_addressing/avd-v2-spine-p2p-uplinks-ip.j2 |
 | switch.id | ip_addressing/avd-v2-spine-p2p-uplinks-ip.j2 |
 | switch.max_parallel_uplinks | ip_addressing/avd-v2-spine-p2p-uplinks-ip.j2 |

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/connected_endpoints/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/connected_endpoints/ethernet-interfaces.j2
@@ -1,1 +1,1 @@
-{{ description_prefix }}_{{ peer }}_{{ peer_interface }}
+{{ description_prefix }}_{{ peer }}_{{ peer_interface }}_{{ adapter_description }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/connected_endpoints/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/connected_endpoints/port-channel-interfaces.j2
@@ -1,1 +1,1 @@
-{{ description_prefix }}_{{ peer }}_{{ adapter_port_channel_description }}
+{{ description_prefix }}_{{ peer }}_{{ adapter_description }}_{{ adapter_port_channel_description }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/mlag/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/mlag/ethernet-interfaces.j2
@@ -1,1 +1,1 @@
-{{ description_prefix }}_MLAG_PEER_{{ switch.mlag_peer }}_{{ mlag_interface }}
+{{ description_prefix }}_MLAG_PEER_{{ mlag_peer }}_{{ mlag_interface }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/mlag/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/mlag/port-channel-interfaces.j2
@@ -1,1 +1,1 @@
-{{ description_prefix }}_MLAG_PEER_{{ switch.mlag_peer }}_Po{{ switch.mlag_interfaces[0] | regex_findall("\d") | join }}
+{{ description_prefix }}_MLAG_PEER_{{ mlag_peer }}_Eth{{ mlag_interfaces[0] | regex_findall("\d") | join }}_Eth{{ mlag_interfaces[1] | regex_findall("\d") | join }}_Po{{ mlag_port_channel_id }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/underlay/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/custom_templates/interface_descriptions/underlay/port-channel-interfaces.j2
@@ -1,1 +1,1 @@
-{{ description_prefix }}_{{ link.channel_description | arista.avd.default(link.peer) | upper }}_Po{{ link.peer_channel_group_id }}
+{{ description_prefix }}_{{ link.peer | upper }}_To_Po{{ link.peer_channel_group_id }}_{{ link.channel_description }}

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L2LEAF1A.cfg
@@ -1,0 +1,88 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname CUSTOM-TEMPLATES-L2LEAF1A
+!
+no spanning-tree vlan-id 4094
+!
+no enable password
+no aaa root
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_To_Po5_CUSTOM_TEMPLATES_L3LEAF1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan none
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1B_Po3
+   no shutdown
+   switchport
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet5
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet5
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1B_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1B_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.103/24
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9214
+   no autostate
+   ip address 10.255.252.0/31
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id CUSTOM_TEMPLATES_L2LEAF1
+   local-interface Vlan4094
+   peer-address 10.255.252.1
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L2LEAF1B.cfg
@@ -1,0 +1,88 @@
+!RANCID-CONTENT-TYPE: arista
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname CUSTOM-TEMPLATES-L2LEAF1B
+!
+no spanning-tree vlan-id 4094
+!
+no enable password
+no aaa root
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel1
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_To_Po5_CUSTOM_TEMPLATES_L3LEAF1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan none
+   switchport mode trunk
+   mlag 1
+!
+interface Port-Channel3
+   description MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1A_Po3
+   no shutdown
+   switchport
+   switchport mode trunk
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet6
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet2
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet6
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet3
+   description MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1A_Ethernet3
+   no shutdown
+   channel-group 3 mode active
+!
+interface Ethernet4
+   description MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1A_Ethernet4
+   no shutdown
+   channel-group 3 mode active
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 192.168.200.103/24
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 9214
+   no autostate
+   ip address 10.255.252.1/31
+no ip routing vrf MGMT
+!
+mlag configuration
+   domain-id CUSTOM_TEMPLATES_L2LEAF1
+   local-interface Vlan4094
+   peer-address 10.255.252.0
+   peer-link Port-Channel3
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.200.1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
@@ -33,12 +33,20 @@ vrf instance MGMT
 vrf instance TEST_VRF
 !
 interface Port-Channel3
-   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Po3
+   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Eth3_Eth4_Po3
    no shutdown
    switchport
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
+!
+interface Port-Channel5
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1A_To_Po1_CUSTOM_TEMPLATES_L2LEAF1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan none
+   switchport mode trunk
+   mlag 5
 !
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-SPINE1_Ethernet1
@@ -57,8 +65,18 @@ interface Ethernet4
    no shutdown
    channel-group 3 mode active
 !
+interface Ethernet5
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1A_Ethernet1
+   no shutdown
+   channel-group 5 mode active
+!
+interface Ethernet6
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1B_Ethernet1
+   no shutdown
+   channel-group 5 mode active
+!
 interface Ethernet11
-   description TEST_CUSTOM_PREFIX_SERVER-1_Nic1
+   description TEST_CUSTOM_PREFIX_SERVER-1_Nic1_management
    no shutdown
    switchport mode trunk
    switchport

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
@@ -33,15 +33,23 @@ vrf instance MGMT
 vrf instance TEST_VRF
 !
 interface Port-Channel3
-   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Po3
+   description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Eth3_Eth4_Po3
    no shutdown
    switchport
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
 !
+interface Port-Channel5
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1A_To_Po1_CUSTOM_TEMPLATES_L2LEAF1
+   no shutdown
+   switchport
+   switchport trunk allowed vlan none
+   switchport mode trunk
+   mlag 5
+!
 interface Port-Channel12
-   description TEST_CUSTOM_PREFIX_SERVER-2_portchannel
+   description TEST_CUSTOM_PREFIX_SERVER-2_data_portchannel
    no shutdown
    switchport
    switchport mode trunk
@@ -63,13 +71,23 @@ interface Ethernet4
    no shutdown
    channel-group 3 mode active
 !
+interface Ethernet5
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1A_Ethernet2
+   no shutdown
+   channel-group 5 mode active
+!
+interface Ethernet6
+   description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1B_Ethernet2
+   no shutdown
+   channel-group 5 mode active
+!
 interface Ethernet12
-   description TEST_CUSTOM_PREFIX_SERVER-2_Nic1
+   description TEST_CUSTOM_PREFIX_SERVER-2_Nic1_data
    no shutdown
    channel-group 12 mode active
 !
 interface Ethernet13
-   description TEST_CUSTOM_PREFIX_SERVER-2_Nic2
+   description TEST_CUSTOM_PREFIX_SERVER-2_Nic2_data
    no shutdown
    channel-group 12 mode active
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L2LEAF1A.yml
@@ -1,0 +1,109 @@
+hostname: CUSTOM-TEMPLATES-L2LEAF1A
+is_deployed: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_interfaces:
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.103/24
+  gateway: 192.168.200.1
+  type: oob
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: '4094'
+vlans:
+- id: 4094
+  tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+vlan_interfaces:
+- name: Vlan4094
+  description: MLAG_PEER
+  shutdown: false
+  no_autostate: true
+  mtu: 9214
+  ip_address: 10.255.252.0/31
+port_channel_interfaces:
+- name: Port-Channel3
+  description: MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1B_Po3
+  type: switched
+  shutdown: false
+  mode: trunk
+  trunk_groups:
+  - MLAG
+- name: Port-Channel1
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_To_Po5_CUSTOM_TEMPLATES_L3LEAF1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: none
+  mlag: 1
+ethernet_interfaces:
+- name: Ethernet3
+  peer: CUSTOM-TEMPLATES-L2LEAF1B
+  peer_interface: Ethernet3
+  peer_type: mlag_peer
+  description: MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1B_Ethernet3
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+- name: Ethernet4
+  peer: CUSTOM-TEMPLATES-L2LEAF1B
+  peer_interface: Ethernet4
+  peer_type: mlag_peer
+  description: MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1B_Ethernet4
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+- name: Ethernet1
+  peer: CUSTOM-TEMPLATES-L3LEAF1A
+  peer_interface: Ethernet5
+  peer_type: l3leaf
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet5
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet2
+  peer: CUSTOM-TEMPLATES-L3LEAF1B
+  peer_interface: Ethernet5
+  peer_type: l3leaf
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet5
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 1
+    mode: active
+mlag_configuration:
+  domain_id: CUSTOM_TEMPLATES_L2LEAF1
+  local_interface: Vlan4094
+  peer_address: 10.255.252.1
+  peer_link: Port-Channel3
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
+ip_igmp_snooping:
+  globally_enabled: true
+metadata:
+  platform: vEOS-LAB

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L2LEAF1B.yml
@@ -1,0 +1,109 @@
+hostname: CUSTOM-TEMPLATES-L2LEAF1B
+is_deployed: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.200.1
+service_routing_protocols_model: multi-agent
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_interfaces:
+- name: Management1
+  description: oob_management
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.200.103/24
+  gateway: 192.168.200.1
+  type: oob
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+spanning_tree:
+  no_spanning_tree_vlan: '4094'
+vlans:
+- id: 4094
+  tenant: system
+  name: MLAG_PEER
+  trunk_groups:
+  - MLAG
+vlan_interfaces:
+- name: Vlan4094
+  description: MLAG_PEER
+  shutdown: false
+  no_autostate: true
+  mtu: 9214
+  ip_address: 10.255.252.1/31
+port_channel_interfaces:
+- name: Port-Channel3
+  description: MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1A_Po3
+  type: switched
+  shutdown: false
+  mode: trunk
+  trunk_groups:
+  - MLAG
+- name: Port-Channel1
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_To_Po5_CUSTOM_TEMPLATES_L3LEAF1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: none
+  mlag: 1
+ethernet_interfaces:
+- name: Ethernet3
+  peer: CUSTOM-TEMPLATES-L2LEAF1A
+  peer_interface: Ethernet3
+  peer_type: mlag_peer
+  description: MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1A_Ethernet3
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+- name: Ethernet4
+  peer: CUSTOM-TEMPLATES-L2LEAF1A
+  peer_interface: Ethernet4
+  peer_type: mlag_peer
+  description: MLAG_PEER_CUSTOM-TEMPLATES-L2LEAF1A_Ethernet4
+  type: port-channel-member
+  shutdown: false
+  channel_group:
+    id: 3
+    mode: active
+- name: Ethernet1
+  peer: CUSTOM-TEMPLATES-L3LEAF1A
+  peer_interface: Ethernet6
+  peer_type: l3leaf
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet6
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 1
+    mode: active
+- name: Ethernet2
+  peer: CUSTOM-TEMPLATES-L3LEAF1B
+  peer_interface: Ethernet6
+  peer_type: l3leaf
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1B_Ethernet6
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 1
+    mode: active
+mlag_configuration:
+  domain_id: CUSTOM_TEMPLATES_L2LEAF1
+  local_interface: Vlan4094
+  peer_address: 10.255.252.0
+  peer_link: Port-Channel3
+  reload_delay_mlag: '300'
+  reload_delay_non_mlag: '330'
+ip_igmp_snooping:
+  globally_enabled: true
+metadata:
+  platform: vEOS-LAB

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -170,13 +170,20 @@ vlan_interfaces:
   ip_address: 10.255.240.10/31
 port_channel_interfaces:
 - name: Port-Channel3
-  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Po3
+  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Eth3_Eth4_Po3
   type: switched
   shutdown: false
   mode: trunk
   trunk_groups:
   - LEAF_PEER_L3
   - MLAG
+- name: Port-Channel5
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1A_To_Po1_CUSTOM_TEMPLATES_L2LEAF1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: none
+  mlag: 5
 ethernet_interfaces:
 - name: Ethernet3
   peer: CUSTOM-TEMPLATES-L3LEAF1B
@@ -207,11 +214,31 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.31.255.21/31
+- name: Ethernet5
+  peer: CUSTOM-TEMPLATES-L2LEAF1A
+  peer_interface: Ethernet1
+  peer_type: l2leaf
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1A_Ethernet1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 5
+    mode: active
+- name: Ethernet6
+  peer: CUSTOM-TEMPLATES-L2LEAF1B
+  peer_interface: Ethernet1
+  peer_type: l2leaf
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1B_Ethernet1
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 5
+    mode: active
 - name: Ethernet11
   peer: SERVER-1
   peer_interface: Nic1
   peer_type: server
-  description: TEST_CUSTOM_PREFIX_SERVER-1_Nic1
+  description: TEST_CUSTOM_PREFIX_SERVER-1_Nic1_management
   shutdown: false
   type: switched
   mode: trunk

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -170,15 +170,22 @@ vlan_interfaces:
   ip_address: 10.255.240.11/31
 port_channel_interfaces:
 - name: Port-Channel3
-  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Po3
+  description: TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Eth3_Eth4_Po3
   type: switched
   shutdown: false
   mode: trunk
   trunk_groups:
   - LEAF_PEER_L3
   - MLAG
+- name: Port-Channel5
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1A_To_Po1_CUSTOM_TEMPLATES_L2LEAF1
+  type: switched
+  shutdown: false
+  mode: trunk
+  vlans: none
+  mlag: 5
 - name: Port-Channel12
-  description: TEST_CUSTOM_PREFIX_SERVER-2_portchannel
+  description: TEST_CUSTOM_PREFIX_SERVER-2_data_portchannel
   type: switched
   shutdown: false
   mode: trunk
@@ -212,11 +219,31 @@ ethernet_interfaces:
   mtu: 9214
   type: routed
   ip_address: 172.31.255.23/31
+- name: Ethernet5
+  peer: CUSTOM-TEMPLATES-L2LEAF1A
+  peer_interface: Ethernet2
+  peer_type: l2leaf
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1A_Ethernet2
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 5
+    mode: active
+- name: Ethernet6
+  peer: CUSTOM-TEMPLATES-L2LEAF1B
+  peer_interface: Ethernet2
+  peer_type: l2leaf
+  description: TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L2LEAF1B_Ethernet2
+  shutdown: false
+  type: port-channel-member
+  channel_group:
+    id: 5
+    mode: active
 - name: Ethernet12
   peer: SERVER-2
   peer_interface: Nic1
   peer_type: server
-  description: TEST_CUSTOM_PREFIX_SERVER-2_Nic1
+  description: TEST_CUSTOM_PREFIX_SERVER-2_Nic1_data
   shutdown: false
   type: port-channel-member
   channel_group:
@@ -226,7 +253,7 @@ ethernet_interfaces:
   peer: SERVER-2
   peer_interface: Nic2
   peer_type: server
-  description: TEST_CUSTOM_PREFIX_SERVER-2_Nic2
+  description: TEST_CUSTOM_PREFIX_SERVER-2_Nic2_data
   shutdown: false
   type: port-channel-member
   channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_TEMPLATES_L2LEAFS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_TEMPLATES_L2LEAFS.yml
@@ -1,0 +1,22 @@
+---
+
+type: l2leaf
+
+l2leaf:
+  defaults:
+    platform: vEOS-LAB
+    uplink_interfaces: [Ethernet1, Ethernet2]
+    uplink_switches: [CUSTOM-TEMPLATES-L3LEAF1A, CUSTOM-TEMPLATES-L3LEAF1B]
+    mlag_interfaces: [Ethernet3, Ethernet4]
+    mlag_peer_ipv4_pool: 10.255.252.0/24
+  node_groups:
+    - group: CUSTOM_TEMPLATES_L2LEAF1
+      nodes:
+        - name: CUSTOM-TEMPLATES-L2LEAF1A
+          id: 1
+          mgmt_ip: 192.168.200.103/24
+          uplink_switch_interfaces: [Ethernet5, Ethernet5 ]
+        - name: CUSTOM-TEMPLATES-L2LEAF1B
+          id: 1
+          mgmt_ip: 192.168.200.103/24
+          uplink_switch_interfaces: [Ethernet6, Ethernet6 ]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_TEMPLATES_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CUSTOM_TEMPLATES_TESTS.yml
@@ -48,6 +48,18 @@ node_type_keys:
       connected_endpoints_port_channel_interfaces: 'custom_templates/interface_descriptions/connected_endpoints/port-channel-interfaces.j2'
       overlay_loopback_interface: 'custom_templates/interface_descriptions/loopbacks/overlay-loopback.j2'
       vtep_loopback_interface: 'custom_templates/interface_descriptions/loopbacks/vtep-loopback.j2'
+  - key: l2leaf
+    type: l2leaf
+    connected_endpoints: true
+    mlag_support: true
+    network_services:
+      l2: true
+    underlay_router: false
+    uplink_type: port-channel
+    interface_descriptions:
+      # Override interface description templates with our custom templates
+      underlay_ethernet_interfaces: 'custom_templates/interface_descriptions/underlay/ethernet-interfaces.j2'
+      underlay_port_channel_interfaces: 'custom_templates/interface_descriptions/underlay/port-channel-interfaces.j2'
 
 ip_offset_10: 10
 ip_offset_20: 20
@@ -62,6 +74,7 @@ servers:
         switches: [ CUSTOM-TEMPLATES-L3LEAF1A ]
         mode: trunk
         enabled: true
+        description: management
   - name: SERVER-2
     adapters:
       - endpoint_ports: [ Nic1, Nic2 ]
@@ -69,6 +82,7 @@ servers:
         switches: [ CUSTOM-TEMPLATES-L3LEAF1B, CUSTOM-TEMPLATES-L3LEAF1B ]
         mode: trunk
         enabled: true
+        description: data
         port_channel:
           mode: active
           description: portchannel

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -185,6 +185,10 @@ all:
               hosts:
                 CUSTOM-TEMPLATES-L3LEAF1A:
                 CUSTOM-TEMPLATES-L3LEAF1B:
+            CUSTOM_TEMPLATES_L2LEAFS:
+              hosts:
+                CUSTOM-TEMPLATES-L2LEAF1A:
+                CUSTOM-TEMPLATES-L2LEAF1B:
         CUSTOM_PYTHON_MODULES_TESTS:
           children:
             CUSTOM_PYTHON_MODULES_SPINES:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/templates/interface-descriptions/mlag/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/templates/interface-descriptions/mlag/ethernet-interfaces.j2
@@ -1,1 +1,1 @@
-CUSTOM_MLAG_PEER_{{ switch.mlag_peer }}_{{ mlag_interface }}
+CUSTOM_MLAG_PEER_{{ mlag_peer }}_{{ mlag_interface }}

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/templates/interface-descriptions/mlag/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/templates/interface-descriptions/mlag/port-channel-interfaces.j2
@@ -1,1 +1,1 @@
-CUSTOM_MLAG_PEER_{{ switch.mlag_peer }}_Po{{ switch.mlag_interfaces[0] | regex_findall("\d") | join }}
+CUSTOM_MLAG_PEER_{{ mlag_peer }}_Po{{ mlag_interfaces[0] | regex_findall("\d") | join }}

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -381,7 +381,7 @@ underlay_ethernet_interfaces:
 underlay_port_channel_interfaces:
 
 - `{{ link.channel_description }}`
-- `{{ link.channel_group_id }}`
+- `{{ link.peer }}`
 - `{{ link.peer_channel_group_id }}`
 - All group/hostvars
 
@@ -393,20 +393,32 @@ mlag_ethernet_interfaces:
 
 mlag_port_channel_interfaces:
 
-- `{{ mlag_interfaces }}`
+- `{{ mlag_interfaces }}` (list of strings)
 - `{{ mlag_peer }}`
+- `{{ mlag_port_channel_id }}`
 - All group/hostvars
 
 connected_endpoints_ethernet_interfaces:
 
 - `{{ peer }}`
 - `{{ peer_interface }}`
+- `{{ adapter_description }}`
 - All group/hostvars
 
 connected_endpoints_port_channel_interfaces:
 
 - `{{ peer }}`
 - `{{ adapter_port_channel_description }}`
+- `{{ adapter_description }}`
+- All group/hostvars
+
+overlay_loopback_interface:
+
+- `{{ overlay_loopback_description }}`
+- All group/hostvars
+
+vtep_loopback_interface:
+
 - All group/hostvars
 
 While all templates can leverage the internal switch facts (switch.*) to customize the interface descriptions,

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/interface_descriptions/mlag/ethernet-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/interface_descriptions/mlag/ethernet-interfaces.j2
@@ -3,4 +3,4 @@
  Use of this source code is governed by the Apache License 2.0
  that can be found in the LICENSE file.
 #}
-MLAG_PEER_{{ switch.mlag_peer }}_{{ mlag_interface }}
+MLAG_PEER_{{ mlag_peer }}_{{ mlag_interface }}

--- a/ansible_collections/arista/avd/roles/eos_designs/templates/interface_descriptions/mlag/port-channel-interfaces.j2
+++ b/ansible_collections/arista/avd/roles/eos_designs/templates/interface_descriptions/mlag/port-channel-interfaces.j2
@@ -3,4 +3,4 @@
  Use of this source code is governed by the Apache License 2.0
  that can be found in the LICENSE file.
 #}
-MLAG_PEER_{{ switch.mlag_peer }}_Po{{ switch.mlag_port_channel_id }}
+MLAG_PEER_{{ mlag_peer }}_Po{{ mlag_port_channel_id }}

--- a/python-avd/pyavd/_eos_designs/interface_descriptions/__init__.py
+++ b/python-avd/pyavd/_eos_designs/interface_descriptions/__init__.py
@@ -118,6 +118,9 @@ class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
     def mlag_ethernet_interface(self, data: InterfaceDescriptionData) -> str:
         """
         Available data:
+            - interface
+            - peer_interface
+            - mlag_peer
             - peer_interface
             - mpls_overlay_role
             - mpls_lsr
@@ -129,7 +132,11 @@ class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
     def mlag_ethernet_interfaces(self, mlag_interface: str) -> str:
         """TODO: AVD5.0.0 move this to the new function."""
         if template_path := self.shared_utils.interface_descriptions_templates.get("mlag_ethernet_interfaces"):
-            return self._template(template_path, mlag_interface=mlag_interface)
+            return self._template(
+                template_path,
+                mlag_interface=mlag_interface,
+                mlag_peer=self._mlag_peer,
+            )
 
         return f"MLAG_PEER_{self._mlag_peer}_{mlag_interface}"
 
@@ -151,7 +158,12 @@ class AvdInterfaceDescriptions(AvdFacts, UtilsMixin):
     def mlag_port_channel_interfaces(self) -> str:
         """TODO: AVD5.0.0 move this to the new function."""
         if template_path := self.shared_utils.interface_descriptions_templates.get("mlag_port_channel_interfaces"):
-            return self._template(template_path)
+            return self._template(
+                template_path,
+                mlag_interfaces=self._mlag_interfaces,
+                mlag_peer=self._mlag_peer,
+                mlag_port_channel_id=self._mlag_port_channel_id,
+            )
 
         return f"MLAG_PEER_{self._mlag_peer}_Po{self._mlag_port_channel_id}"
 

--- a/python-avd/pyavd/_eos_designs/interface_descriptions/utils.py
+++ b/python-avd/pyavd/_eos_designs/interface_descriptions/utils.py
@@ -32,6 +32,11 @@ class UtilsMixin:
         return self.shared_utils.mlag_peer
 
     @cached_property
+    def _mlag_interfaces(self: AvdInterfaceDescriptions) -> list[str]:
+        """TODO: AVD5.0.0 remove this since it has been replaced by DescriptionData."""
+        return self.shared_utils.mlag_interfaces
+
+    @cached_property
     def _mlag_port_channel_id(self: AvdInterfaceDescriptions) -> str:
         """TODO: AVD5.0.0 remove this since it has been replaced by DescriptionData."""
         return self.shared_utils.mlag_port_channel_id


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix context vars for custom interface description templates

## Related Issue(s)

Fixes #4428 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Fixing various missing context variables.
- Adding all available context variables to documentation

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Updated molecule.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
