### PR TITLE
Fix(eos_cli_config_gen): Remove primary key of system.control_plane.ipv4/6_access_group and make vrf key unique

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/system.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/system.md
@@ -52,9 +52,11 @@ interface Management1
 | -------- | --- | ------------|
 | IPv4 | default | acl4_1 |
 | IPv4 | red | acl4_2 |
+| IPv4 | red_1 | acl4_2 |
 | IPv4 | default | acl4_3 |
 | IPv6 | default | acl6_1 |
 | IPv6 | blue | acl6_2 |
+| IPv6 | blue_1 | acl6_2 |
 | IPv6 | default | acl6_3 |
 
 #### System Control-Plane Device Configuration
@@ -65,9 +67,11 @@ system control-plane
    tcp mss ceiling ipv4 1344 ipv6 1366
    ip access-group acl4_1 in
    ip access-group acl4_2 vrf red in
+   ip access-group acl4_2 vrf red_1 in
    ip access-group acl4_3 vrf default in
    ipv6 access-group acl6_1 in
    ipv6 access-group acl6_2 vrf blue in
+   ipv6 access-group acl6_2 vrf blue_1 in
    ipv6 access-group acl6_3 vrf default in
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/system.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/system.cfg
@@ -12,7 +12,9 @@ system control-plane
    tcp mss ceiling ipv4 1344 ipv6 1366
    ip access-group acl4_1 in
    ip access-group acl4_2 vrf red in
+   ip access-group acl4_2 vrf red_1 in
    ip access-group acl4_3 vrf default in
    ipv6 access-group acl6_1 in
    ipv6 access-group acl6_2 vrf blue in
+   ipv6 access-group acl6_2 vrf blue_1 in
    ipv6 access-group acl6_3 vrf default in

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/system.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/system.yml
@@ -7,12 +7,16 @@ system:
       - acl_name: "acl4_1"
       - acl_name: "acl4_2"
         vrf: red
+      - acl_name: "acl4_2"
+        vrf: red_1
       - acl_name: "acl4_3"
         vrf: default
     ipv6_access_groups:
       - acl_name: "acl6_1"
       - acl_name: "acl6_2"
         vrf: blue
+      - acl_name: "acl6_2"
+        vrf: blue_1
       - acl_name: "acl6_3"
         vrf: default
   l1:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/system.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/system.md
@@ -13,10 +13,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "system.control_plane.tcp_mss.ipv4") | Integer |  |  |  | Segment size. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "system.control_plane.tcp_mss.ipv6") | Integer |  |  |  | Segment size. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_access_groups</samp>](## "system.control_plane.ipv4_access_groups") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;acl_name</samp>](## "system.control_plane.ipv4_access_groups.[].acl_name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;acl_name</samp>](## "system.control_plane.ipv4_access_groups.[].acl_name") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "system.control_plane.ipv4_access_groups.[].vrf") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_access_groups</samp>](## "system.control_plane.ipv6_access_groups") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;acl_name</samp>](## "system.control_plane.ipv6_access_groups.[].acl_name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;acl_name</samp>](## "system.control_plane.ipv6_access_groups.[].acl_name") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "system.control_plane.ipv6_access_groups.[].vrf") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;l1</samp>](## "system.l1") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;unsupported_speed_action</samp>](## "system.l1.unsupported_speed_action") | String |  |  | Valid Values:<br>- <code>error</code><br>- <code>warn</code> |  |
@@ -35,10 +35,10 @@
           # Segment size.
           ipv6: <int>
         ipv4_access_groups:
-          - acl_name: <str; required; unique>
+          - acl_name: <str; required>
             vrf: <str>
         ipv6_access_groups:
-          - acl_name: <str; required; unique>
+          - acl_name: <str; required>
             vrf: <str>
       l1:
         unsupported_speed_action: <str; "error" | "warn">

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -17779,24 +17779,28 @@ keys:
                 description: Segment size.
           ipv4_access_groups:
             type: list
-            primary_key: acl_name
+            unique_keys:
+            - vrf
             items:
               type: dict
               keys:
                 acl_name:
                   type: str
+                  required: true
                 vrf:
                   type: str
                   convert_types:
                   - int
           ipv6_access_groups:
             type: list
-            primary_key: acl_name
+            unique_keys:
+            - vrf
             items:
               type: dict
               keys:
                 acl_name:
                   type: str
+                  required: true
                 vrf:
                   type: str
                   convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/system.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/system.schema.yml
@@ -24,24 +24,28 @@ keys:
                 description: Segment size.
           ipv4_access_groups:
             type: list
-            primary_key: acl_name
+            unique_keys:
+              - vrf
             items:
               type: dict
               keys:
                 acl_name:
                   type: str
+                  required: true
                 vrf:
                   type: str
                   convert_types:
                     - int
           ipv6_access_groups:
             type: list
-            primary_key: acl_name
+            unique_keys:
+              - vrf
             items:
               type: dict
               keys:
                 acl_name:
                   type: str
+                  required: true
                 vrf:
                   type: str
                   convert_types:


### PR DESCRIPTION
## Change Summary

Remove primary key of system.control_plane.ipv4/6_access_group and make vrf key unique

## Related Issue(s)

Fixes #4446 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Removed primary_key: acl_name and added `vrf` key in the list of unique_keys.

## How to test
CI will test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
