### PR TITLE
Refactor(eos_designs): Remove "preview" from flow_tracking_settings

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-flow-tracking-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-flow-tracking-settings.md
@@ -35,7 +35,7 @@
     | [<samp>&nbsp;&nbsp;direct_wan_ha_links</samp>](## "fabric_flow_tracking.direct_wan_ha_links") | Dictionary |  |  |  | Enable flow-tracking on all direct WAN HA links. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "fabric_flow_tracking.direct_wan_ha_links.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "fabric_flow_tracking.direct_wan_ha_links.name") | String |  |  |  | Flow tracker name as defined in flow_tracking_settings. |
-    | [<samp>flow_tracking_settings</samp>](## "flow_tracking_settings") | Dictionary |  |  |  | PREVIEW: This key is currently not supported<br><br>Define the flow tracking parameters for this topology. |
+    | [<samp>flow_tracking_settings</samp>](## "flow_tracking_settings") | Dictionary |  |  |  | Define the flow tracking parameters for this topology. |
     | [<samp>&nbsp;&nbsp;sampled</samp>](## "flow_tracking_settings.sampled") | Dictionary |  |  |  | The options relevant only for flow tracker type sampled. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "flow_tracking_settings.sampled.encapsulation") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_ipv6</samp>](## "flow_tracking_settings.sampled.encapsulation.ipv4_ipv6") | Boolean |  |  |  |  |
@@ -138,8 +138,6 @@
         # Flow tracker name as defined in flow_tracking_settings.
         name: <str>
 
-    # PREVIEW: This key is currently not supported
-    #
     # Define the flow tracking parameters for this topology.
     flow_tracking_settings:
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -1416,10 +1416,7 @@ keys:
   flow_tracking_settings:
     documentation_options:
       table: management-flow-tracking-settings
-    description: 'PREVIEW: This key is currently not supported
-
-
-      Define the flow tracking parameters for this topology.'
+    description: Define the flow tracking parameters for this topology.
     type: dict
     keys:
       sampled:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/flow_tracking_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/flow_tracking_settings.schema.yml
@@ -10,8 +10,6 @@ keys:
     documentation_options:
       table: management-flow-tracking-settings
     description: |-
-      PREVIEW: This key is currently not supported
-
       Define the flow tracking parameters for this topology.
     type: dict
     keys:


### PR DESCRIPTION
## Change Summary

cf title

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Making `flow_tracking_settings` not preview anymore

## How to test

Check that PREVIEW is gone in schema and doc

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
