### PR TITLE
Refactor(eos_cli_config_gen): Reordering the config for switchport in ethernet and port-channel interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -391,17 +391,13 @@ interface Ethernet1
    l2 mru 8000
    bgp session tracker ST1
    switchport access vlan 200
-   switchport trunk allowed vlan 110-111,210-211
    switchport trunk native vlan tag
    switchport phone vlan 110
    switchport phone trunk tagged
    switchport vlan translation in required
    switchport dot1q vlan tag required
-   switchport mode dot1q-tunnel
    switchport dot1q ethertype 1536
    switchport vlan forwarding accept all
-   switchport trunk group g1
-   switchport trunk group g2
    switchport source-interface tx
    switchport vlan translation 12 20
    switchport vlan translation 24 inner 78 network 46
@@ -413,6 +409,10 @@ interface Ethernet1
    switchport vlan translation out 34 50
    switchport vlan translation out 10 45 inner 34
    switchport vlan translation out 45 dot1q-tunnel all
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode dot1q-tunnel
+   switchport trunk group g1
+   switchport trunk group g2
    no switchport
    switchport trunk private-vlan secondary
    switchport pvlan mapping 20-30
@@ -451,8 +451,8 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport trunk allowed vlan 110-111,210-211
    switchport dot1q vlan tag disallowed
+   switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
    tcp mss ceiling ipv4 70 ingress
@@ -473,8 +473,8 @@ interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    switchport trunk native vlan 5
-   switchport mode trunk
    switchport vlan translation out 23 dot1q-tunnel 50
+   switchport mode trunk
    no switchport
    no snmp trap link-change
    ip address 172.31.128.1/31
@@ -656,10 +656,10 @@ interface Ethernet15
 !
 interface Ethernet16
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport trunk allowed vlan 110-112
    switchport vlan translation out required
-   switchport mode trunk
    switchport vlan translation out 111-112 110
+   switchport trunk allowed vlan 110-112
+   switchport mode trunk
    switchport
 !
 interface Ethernet17

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -391,18 +391,17 @@ interface Ethernet1
    l2 mru 8000
    bgp session tracker ST1
    switchport access vlan 200
+   switchport trunk allowed vlan 110-111,210-211
    switchport trunk native vlan tag
    switchport phone vlan 110
    switchport phone trunk tagged
    switchport vlan translation in required
    switchport dot1q vlan tag required
-   switchport trunk allowed vlan 110-111,210-211
    switchport mode dot1q-tunnel
    switchport dot1q ethertype 1536
    switchport vlan forwarding accept all
    switchport trunk group g1
    switchport trunk group g2
-   no switchport
    switchport source-interface tx
    switchport vlan translation 12 20
    switchport vlan translation 24 inner 78 network 46
@@ -414,6 +413,7 @@ interface Ethernet1
    switchport vlan translation out 34 50
    switchport vlan translation out 10 45 inner 34
    switchport vlan translation out 45 dot1q-tunnel all
+   no switchport
    switchport trunk private-vlan secondary
    switchport pvlan mapping 20-30
    ip address 172.31.255.1/31
@@ -451,8 +451,8 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport dot1q vlan tag disallowed
    switchport trunk allowed vlan 110-111,210-211
+   switchport dot1q vlan tag disallowed
    switchport mode trunk
    switchport
    tcp mss ceiling ipv4 70 ingress
@@ -474,8 +474,8 @@ interface Ethernet3
    mtu 1500
    switchport trunk native vlan 5
    switchport mode trunk
-   no switchport
    switchport vlan translation out 23 dot1q-tunnel 50
+   no switchport
    no snmp trap link-change
    ip address 172.31.128.1/31
    switchport backup-link Ethernet4
@@ -656,11 +656,11 @@ interface Ethernet15
 !
 interface Ethernet16
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport vlan translation out required
    switchport trunk allowed vlan 110-112
+   switchport vlan translation out required
    switchport mode trunk
-   switchport
    switchport vlan translation out 111-112 110
+   switchport
 !
 interface Ethernet17
    description PVLAN Secondary Trunk

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/mac-security-eth-po-entropy.md
@@ -121,9 +121,9 @@ interface Ethernet3
 !
 interface Port-Channel3
    description L2-PORT
+   switchport
    switchport trunk allowed vlan 1-5
    switchport mode trunk
-   switchport
 ```
 
 ## MACsec

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -381,20 +381,20 @@ interface Ethernet50
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
-   switchport
    no snmp trap link-change
    shape rate 200000 kbps
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
    bgp session tracker ST2
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
-   switchport
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
    ip igmp host-proxy 239.0.0.2 exclude 10.0.2.1
@@ -441,9 +441,9 @@ interface Port-Channel9
 !
 interface Port-Channel10
    description SRV01_bond0
+   switchport
    switchport trunk allowed vlan 2-3000
    switchport mode trunk
-   switchport
    evpn ethernet-segment
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
@@ -451,11 +451,11 @@ interface Port-Channel10
 !
 interface Port-Channel12
    description interface_in_mode_access_with_voice
+   switchport
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
    switchport mode trunk phone
-   switchport
 !
 interface Port-Channel13
    description EVPN-Vxlan single-active redundancy
@@ -479,20 +479,20 @@ interface Port-Channel14
 !
 interface Port-Channel15
    description DC1_L2LEAF3_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
-   switchport
    mlag 15
    spanning-tree guard loop
    link tracking group EVPN_MH_ES2 upstream
 !
 interface Port-Channel16
    description DC1_L2LEAF4_Po1
+   switchport
+   switchport trunk allowed vlan 110,201
    switchport trunk native vlan 10
    switchport dot1q vlan tag disallowed
-   switchport trunk allowed vlan 110,201
    switchport mode trunk
-   switchport
    switchport vlan translation out 23 dot1q-tunnel 22
    snmp trap link-change
    mlag 16
@@ -509,16 +509,16 @@ interface Port-Channel17
 !
 interface Port-Channel20
    description Po_in_mode_access_accepting_tagged_LACP_frames
+   switchport
    switchport access vlan 200
    switchport mode access
-   switchport
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1
+   switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
-   switchport
    evpn ethernet-segment
       identifier 0000:0000:0303:0202:0101
       route-target import 03:03:02:02:01:01
@@ -526,9 +526,9 @@ interface Port-Channel50
 !
 interface Port-Channel51
    description ipv6_prefix
+   switchport
    switchport trunk allowed vlan 1-500
    switchport mode trunk
-   switchport
    switchport port-security
    no switchport port-security mac-address maximum disabled
    switchport port-security vlan 1 mac-address maximum 3
@@ -550,19 +550,19 @@ interface Port-Channel99
 !
 interface Port-Channel100
    logging event link-status
+   no switchport
    switchport access vlan 200
+   switchport trunk allowed vlan 10-11
    switchport trunk native vlan tag
    switchport phone vlan 110
    switchport phone trunk tagged
    switchport vlan translation in required
    switchport dot1q vlan tag required
-   switchport trunk allowed vlan 10-11
    switchport mode dot1q-tunnel
    switchport dot1q ethertype 1536
    switchport vlan forwarding accept all
    switchport trunk group g1
    switchport trunk group g2
-   no switchport
    switchport source-interface tx multicast
    switchport vlan translation 12 20
    switchport vlan translation 23 inner 74 42
@@ -603,32 +603,32 @@ interface Port-Channel100.102
 !
 interface Port-Channel101
    description PVLAN Promiscuous Access - only one secondary
+   switchport
    switchport access vlan 110
    switchport mode access
-   switchport
    switchport pvlan mapping 111
    no qos trust
 !
 interface Port-Channel102
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport vlan translation out required
-   switchport trunk allowed vlan 110-112
-   switchport mode trunk
    switchport
+   switchport trunk allowed vlan 110-112
+   switchport vlan translation out required
+   switchport mode trunk
    switchport vlan translation out 111-112 110
 !
 interface Port-Channel103
    description PVLAN Secondary Trunk
+   switchport
    switchport trunk allowed vlan 110-112
    switchport mode trunk
-   switchport
    switchport trunk private-vlan secondary
 !
 interface Port-Channel104
    description LACP fallback individual
+   switchport
    switchport trunk allowed vlan 112
    switchport mode trunk
-   switchport
    port-channel lacp fallback timeout 300
    port-channel lacp fallback individual
 !
@@ -656,9 +656,9 @@ interface Port-Channel108
 !
 interface Port-Channel109
    description Molecule ACLs
+   switchport
    switchport access vlan 110
    switchport mode access
-   switchport
    ip access-group IPV4_ACL_IN in
    ip access-group IPV4_ACL_OUT out
    ipv6 access-group IPV6_ACL_IN in
@@ -719,9 +719,9 @@ interface Port-Channel111.1000
 !
 interface Port-Channel112
    description LACP fallback individual
+   switchport
    switchport trunk allowed vlan 112
    switchport mode trunk
-   switchport
    port-channel lacp fallback timeout 5
    port-channel lacp fallback individual
 !
@@ -742,9 +742,9 @@ interface Port-Channel114
 !
 interface Port-Channel115
    description native-vlan-tag-precedence
+   switchport
    switchport trunk native vlan tag
    switchport mode trunk
-   switchport
 !
 interface Port-Channel117
    description interface_with_sflow_ingress_egress_enabled
@@ -772,13 +772,13 @@ interface Port-Channel120
 !
 interface Port-Channel121
    description access_port_with_no_vlans
-   switchport mode access
    switchport
+   switchport mode access
 !
 interface Port-Channel122
    description trunk_port_with_no_vlans
-   switchport mode trunk
    switchport
+   switchport mode trunk
 !
 interface Port-Channel130
    description IP NAT Testing
@@ -790,9 +790,9 @@ interface Port-Channel130
 !
 interface Port-Channel131
    description dot1q-tunnel mode
+   switchport
    switchport access vlan 115
    switchport mode dot1q-tunnel
-   switchport
 !
 interface Port-Channel131.1
    description Test_encapsulation_vlan1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -491,8 +491,8 @@ interface Port-Channel16
    switchport
    switchport trunk allowed vlan 110,201
    switchport trunk native vlan 10
-   switchport dot1q vlan tag disallowed
    switchport mode trunk
+   switchport dot1q vlan tag disallowed
    switchport vlan translation out 23 dot1q-tunnel 22
    snmp trap link-change
    mlag 16
@@ -556,13 +556,15 @@ interface Port-Channel100
    switchport trunk native vlan tag
    switchport phone vlan 110
    switchport phone trunk tagged
-   switchport vlan translation in required
-   switchport dot1q vlan tag required
    switchport mode dot1q-tunnel
-   switchport dot1q ethertype 1536
-   switchport vlan forwarding accept all
    switchport trunk group g1
    switchport trunk group g2
+   switchport trunk private-vlan secondary
+   switchport pvlan mapping 20-30
+   switchport vlan translation in required
+   switchport dot1q vlan tag required
+   switchport dot1q ethertype 1536
+   switchport vlan forwarding accept all
    switchport source-interface tx multicast
    switchport vlan translation 12 20
    switchport vlan translation 23 inner 74 42
@@ -574,8 +576,6 @@ interface Port-Channel100
    switchport vlan translation out 34 50
    switchport vlan translation out 10 45 inner 34
    switchport vlan translation out 45 dot1q-tunnel all
-   switchport trunk private-vlan secondary
-   switchport pvlan mapping 20-30
    switchport port-security
    switchport port-security mac-address maximum disabled
    switchport backup-link Port-channel51
@@ -613,8 +613,8 @@ interface Port-Channel102
    description PVLAN Promiscuous Trunk - vlan translation out
    switchport
    switchport trunk allowed vlan 110-112
-   switchport vlan translation out required
    switchport mode trunk
+   switchport vlan translation out required
    switchport vlan translation out 111-112 110
 !
 interface Port-Channel103

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ptp.md
@@ -149,9 +149,9 @@ interface Ethernet6
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
-   switchport
    mlag 5
    ptp enable
    ptp mpass

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/qos.md
@@ -130,11 +130,11 @@ interface Ethernet7
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
-   switchport
    qos trust cos
    qos cos 2
    service-profile experiment

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -7,18 +7,17 @@ interface Ethernet1
    l2 mru 8000
    bgp session tracker ST1
    switchport access vlan 200
+   switchport trunk allowed vlan 110-111,210-211
    switchport trunk native vlan tag
    switchport phone vlan 110
    switchport phone trunk tagged
    switchport vlan translation in required
    switchport dot1q vlan tag required
-   switchport trunk allowed vlan 110-111,210-211
    switchport mode dot1q-tunnel
    switchport dot1q ethertype 1536
    switchport vlan forwarding accept all
    switchport trunk group g1
    switchport trunk group g2
-   no switchport
    switchport source-interface tx
    switchport vlan translation 12 20
    switchport vlan translation 24 inner 78 network 46
@@ -30,6 +29,7 @@ interface Ethernet1
    switchport vlan translation out 34 50
    switchport vlan translation out 10 45 inner 34
    switchport vlan translation out 45 dot1q-tunnel all
+   no switchport
    switchport trunk private-vlan secondary
    switchport pvlan mapping 20-30
    ip address 172.31.255.1/31
@@ -67,8 +67,8 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport dot1q vlan tag disallowed
    switchport trunk allowed vlan 110-111,210-211
+   switchport dot1q vlan tag disallowed
    switchport mode trunk
    switchport
    tcp mss ceiling ipv4 70 ingress
@@ -90,8 +90,8 @@ interface Ethernet3
    mtu 1500
    switchport trunk native vlan 5
    switchport mode trunk
-   no switchport
    switchport vlan translation out 23 dot1q-tunnel 50
+   no switchport
    no snmp trap link-change
    ip address 172.31.128.1/31
    switchport backup-link Ethernet4
@@ -272,11 +272,11 @@ interface Ethernet15
 !
 interface Ethernet16
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport vlan translation out required
    switchport trunk allowed vlan 110-112
+   switchport vlan translation out required
    switchport mode trunk
-   switchport
    switchport vlan translation out 111-112 110
+   switchport
 !
 interface Ethernet17
    description PVLAN Secondary Trunk

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -7,17 +7,13 @@ interface Ethernet1
    l2 mru 8000
    bgp session tracker ST1
    switchport access vlan 200
-   switchport trunk allowed vlan 110-111,210-211
    switchport trunk native vlan tag
    switchport phone vlan 110
    switchport phone trunk tagged
    switchport vlan translation in required
    switchport dot1q vlan tag required
-   switchport mode dot1q-tunnel
    switchport dot1q ethertype 1536
    switchport vlan forwarding accept all
-   switchport trunk group g1
-   switchport trunk group g2
    switchport source-interface tx
    switchport vlan translation 12 20
    switchport vlan translation 24 inner 78 network 46
@@ -29,6 +25,10 @@ interface Ethernet1
    switchport vlan translation out 34 50
    switchport vlan translation out 10 45 inner 34
    switchport vlan translation out 45 dot1q-tunnel all
+   switchport trunk allowed vlan 110-111,210-211
+   switchport mode dot1q-tunnel
+   switchport trunk group g1
+   switchport trunk group g2
    no switchport
    switchport trunk private-vlan secondary
    switchport pvlan mapping 20-30
@@ -67,8 +67,8 @@ interface Ethernet1
 !
 interface Ethernet2
    description SRV-POD02_Eth1
-   switchport trunk allowed vlan 110-111,210-211
    switchport dot1q vlan tag disallowed
+   switchport trunk allowed vlan 110-111,210-211
    switchport mode trunk
    switchport
    tcp mss ceiling ipv4 70 ingress
@@ -89,8 +89,8 @@ interface Ethernet3
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    switchport trunk native vlan 5
-   switchport mode trunk
    switchport vlan translation out 23 dot1q-tunnel 50
+   switchport mode trunk
    no switchport
    no snmp trap link-change
    ip address 172.31.128.1/31
@@ -272,10 +272,10 @@ interface Ethernet15
 !
 interface Ethernet16
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport trunk allowed vlan 110-112
    switchport vlan translation out required
-   switchport mode trunk
    switchport vlan translation out 111-112 110
+   switchport trunk allowed vlan 110-112
+   switchport mode trunk
    switchport
 !
 interface Ethernet17

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/mac-security-eth-po-entropy.cfg
@@ -29,9 +29,9 @@ mac security
 !
 interface Port-Channel3
    description L2-PORT
+   switchport
    switchport trunk allowed vlan 1-5
    switchport mode trunk
-   switchport
 !
 interface Ethernet1
    mac security profile A1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -1,20 +1,20 @@
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
-   switchport
    no snmp trap link-change
    shape rate 200000 kbps
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
    bgp session tracker ST2
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
-   switchport
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
    ip igmp host-proxy 239.0.0.2 exclude 10.0.2.1
@@ -61,9 +61,9 @@ interface Port-Channel9
 !
 interface Port-Channel10
    description SRV01_bond0
+   switchport
    switchport trunk allowed vlan 2-3000
    switchport mode trunk
-   switchport
    evpn ethernet-segment
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
@@ -71,11 +71,11 @@ interface Port-Channel10
 !
 interface Port-Channel12
    description interface_in_mode_access_with_voice
+   switchport
    switchport trunk native vlan 100
    switchport phone vlan 70
    switchport phone trunk untagged
    switchport mode trunk phone
-   switchport
 !
 interface Port-Channel13
    description EVPN-Vxlan single-active redundancy
@@ -99,20 +99,20 @@ interface Port-Channel14
 !
 interface Port-Channel15
    description DC1_L2LEAF3_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
-   switchport
    mlag 15
    spanning-tree guard loop
    link tracking group EVPN_MH_ES2 upstream
 !
 interface Port-Channel16
    description DC1_L2LEAF4_Po1
+   switchport
+   switchport trunk allowed vlan 110,201
    switchport trunk native vlan 10
    switchport dot1q vlan tag disallowed
-   switchport trunk allowed vlan 110,201
    switchport mode trunk
-   switchport
    switchport vlan translation out 23 dot1q-tunnel 22
    snmp trap link-change
    mlag 16
@@ -129,16 +129,16 @@ interface Port-Channel17
 !
 interface Port-Channel20
    description Po_in_mode_access_accepting_tagged_LACP_frames
+   switchport
    switchport access vlan 200
    switchport mode access
-   switchport
    l2-protocol encapsulation dot1q vlan 200
 !
 interface Port-Channel50
    description SRV-POD03_PortChanne1
+   switchport
    switchport trunk allowed vlan 1-4000
    switchport mode trunk
-   switchport
    evpn ethernet-segment
       identifier 0000:0000:0303:0202:0101
       route-target import 03:03:02:02:01:01
@@ -146,9 +146,9 @@ interface Port-Channel50
 !
 interface Port-Channel51
    description ipv6_prefix
+   switchport
    switchport trunk allowed vlan 1-500
    switchport mode trunk
-   switchport
    switchport port-security
    no switchport port-security mac-address maximum disabled
    switchport port-security vlan 1 mac-address maximum 3
@@ -170,19 +170,19 @@ interface Port-Channel99
 !
 interface Port-Channel100
    logging event link-status
+   no switchport
    switchport access vlan 200
+   switchport trunk allowed vlan 10-11
    switchport trunk native vlan tag
    switchport phone vlan 110
    switchport phone trunk tagged
    switchport vlan translation in required
    switchport dot1q vlan tag required
-   switchport trunk allowed vlan 10-11
    switchport mode dot1q-tunnel
    switchport dot1q ethertype 1536
    switchport vlan forwarding accept all
    switchport trunk group g1
    switchport trunk group g2
-   no switchport
    switchport source-interface tx multicast
    switchport vlan translation 12 20
    switchport vlan translation 23 inner 74 42
@@ -223,32 +223,32 @@ interface Port-Channel100.102
 !
 interface Port-Channel101
    description PVLAN Promiscuous Access - only one secondary
+   switchport
    switchport access vlan 110
    switchport mode access
-   switchport
    switchport pvlan mapping 111
    no qos trust
 !
 interface Port-Channel102
    description PVLAN Promiscuous Trunk - vlan translation out
-   switchport vlan translation out required
-   switchport trunk allowed vlan 110-112
-   switchport mode trunk
    switchport
+   switchport trunk allowed vlan 110-112
+   switchport vlan translation out required
+   switchport mode trunk
    switchport vlan translation out 111-112 110
 !
 interface Port-Channel103
    description PVLAN Secondary Trunk
+   switchport
    switchport trunk allowed vlan 110-112
    switchport mode trunk
-   switchport
    switchport trunk private-vlan secondary
 !
 interface Port-Channel104
    description LACP fallback individual
+   switchport
    switchport trunk allowed vlan 112
    switchport mode trunk
-   switchport
    port-channel lacp fallback timeout 300
    port-channel lacp fallback individual
 !
@@ -276,9 +276,9 @@ interface Port-Channel108
 !
 interface Port-Channel109
    description Molecule ACLs
+   switchport
    switchport access vlan 110
    switchport mode access
-   switchport
    ip access-group IPV4_ACL_IN in
    ip access-group IPV4_ACL_OUT out
    ipv6 access-group IPV6_ACL_IN in
@@ -339,9 +339,9 @@ interface Port-Channel111.1000
 !
 interface Port-Channel112
    description LACP fallback individual
+   switchport
    switchport trunk allowed vlan 112
    switchport mode trunk
-   switchport
    port-channel lacp fallback timeout 5
    port-channel lacp fallback individual
 !
@@ -362,9 +362,9 @@ interface Port-Channel114
 !
 interface Port-Channel115
    description native-vlan-tag-precedence
+   switchport
    switchport trunk native vlan tag
    switchport mode trunk
-   switchport
 !
 interface Port-Channel117
    description interface_with_sflow_ingress_egress_enabled
@@ -392,13 +392,13 @@ interface Port-Channel120
 !
 interface Port-Channel121
    description access_port_with_no_vlans
-   switchport mode access
    switchport
+   switchport mode access
 !
 interface Port-Channel122
    description trunk_port_with_no_vlans
-   switchport mode trunk
    switchport
+   switchport mode trunk
 !
 interface Port-Channel130
    description IP NAT Testing
@@ -410,9 +410,9 @@ interface Port-Channel130
 !
 interface Port-Channel131
    description dot1q-tunnel mode
+   switchport
    switchport access vlan 115
    switchport mode dot1q-tunnel
-   switchport
 !
 interface Port-Channel131.1
    description Test_encapsulation_vlan1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/port-channel-interfaces.cfg
@@ -111,8 +111,8 @@ interface Port-Channel16
    switchport
    switchport trunk allowed vlan 110,201
    switchport trunk native vlan 10
-   switchport dot1q vlan tag disallowed
    switchport mode trunk
+   switchport dot1q vlan tag disallowed
    switchport vlan translation out 23 dot1q-tunnel 22
    snmp trap link-change
    mlag 16
@@ -176,13 +176,15 @@ interface Port-Channel100
    switchport trunk native vlan tag
    switchport phone vlan 110
    switchport phone trunk tagged
-   switchport vlan translation in required
-   switchport dot1q vlan tag required
    switchport mode dot1q-tunnel
-   switchport dot1q ethertype 1536
-   switchport vlan forwarding accept all
    switchport trunk group g1
    switchport trunk group g2
+   switchport trunk private-vlan secondary
+   switchport pvlan mapping 20-30
+   switchport vlan translation in required
+   switchport dot1q vlan tag required
+   switchport dot1q ethertype 1536
+   switchport vlan forwarding accept all
    switchport source-interface tx multicast
    switchport vlan translation 12 20
    switchport vlan translation 23 inner 74 42
@@ -194,8 +196,6 @@ interface Port-Channel100
    switchport vlan translation out 34 50
    switchport vlan translation out 10 45 inner 34
    switchport vlan translation out 45 dot1q-tunnel all
-   switchport trunk private-vlan secondary
-   switchport pvlan mapping 20-30
    switchport port-security
    switchport port-security mac-address maximum disabled
    switchport backup-link Port-channel51
@@ -233,8 +233,8 @@ interface Port-Channel102
    description PVLAN Promiscuous Trunk - vlan translation out
    switchport
    switchport trunk allowed vlan 110-112
-   switchport vlan translation out required
    switchport mode trunk
+   switchport vlan translation out required
    switchport vlan translation out 111-112 110
 !
 interface Port-Channel103

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ptp.cfg
@@ -25,9 +25,9 @@ ptp monitor threshold missing-message sync 204 sequence-ids
 !
 interface Port-Channel5
    description DC1_L2LEAF1_Po1
+   switchport
    switchport trunk allowed vlan 110,201
    switchport mode trunk
-   switchport
    mlag 5
    ptp enable
    ptp mpass

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/qos.cfg
@@ -163,11 +163,11 @@ qos profile wred_uc_queues_test
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3
+   switchport
    switchport trunk allowed vlan 2-4094
    switchport mode trunk
    switchport trunk group LEAF_PEER_L3
    switchport trunk group MLAG
-   switchport
    qos trust cos
    qos cos 2
    service-profile experiment

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -215,6 +215,9 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.switchport.access_vlan is arista.avd.defined %}
    switchport access vlan {{ ethernet_interface.switchport.access_vlan }}
 {%     endif %}
+{%     if ethernet_interface.switchport.trunk.allowed_vlan is arista.avd.defined %}
+   switchport trunk allowed vlan {{ ethernet_interface.switchport.trunk.allowed_vlan }}
+{%     endif %}
 {%     if ethernet_interface.switchport.trunk.native_vlan_tag is arista.avd.defined(true) %}
    switchport trunk native vlan tag
 {%     elif ethernet_interface.switchport.trunk.native_vlan is arista.avd.defined %}
@@ -235,9 +238,6 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.switchport.dot1q.vlan_tag is arista.avd.defined %}
    switchport dot1q vlan tag {{ ethernet_interface.switchport.dot1q.vlan_tag }}
 {%     endif %}
-{%     if ethernet_interface.switchport.trunk.allowed_vlan is arista.avd.defined %}
-   switchport trunk allowed vlan {{ ethernet_interface.switchport.trunk.allowed_vlan }}
-{%     endif %}
 {%     if ethernet_interface.switchport.mode is arista.avd.defined %}
    switchport mode {{ ethernet_interface.switchport.mode }}
 {%     endif %}
@@ -250,11 +250,6 @@ interface {{ ethernet_interface.name }}
 {%     for trunk_group in ethernet_interface.switchport.trunk.groups | arista.avd.natural_sort %}
    switchport trunk group {{ trunk_group }}
 {%     endfor %}
-{%     if ethernet_interface.switchport.enabled is arista.avd.defined(true) %}
-   switchport
-{%     elif ethernet_interface.switchport.enabled is arista.avd.defined(false) %}
-   no switchport
-{%     endif %}
 {%     if ethernet_interface.switchport.source_interface is arista.avd.defined %}
    switchport source-interface {{ ethernet_interface.switchport.source_interface }}
 {%     endif %}
@@ -297,6 +292,11 @@ interface {{ ethernet_interface.name }}
    {{ vlan_translation_out_cli }}
 {%             endif %}
 {%         endfor %}
+{%     endif %}
+{%     if ethernet_interface.switchport.enabled is arista.avd.defined(true) %}
+   switchport
+{%     elif ethernet_interface.switchport.enabled is arista.avd.defined(false) %}
+   no switchport
 {%     endif %}
 {%     if ethernet_interface.switchport.trunk.private_vlan_secondary is arista.avd.defined(true) %}
    switchport trunk private-vlan secondary

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -215,9 +215,6 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.switchport.access_vlan is arista.avd.defined %}
    switchport access vlan {{ ethernet_interface.switchport.access_vlan }}
 {%     endif %}
-{%     if ethernet_interface.switchport.trunk.allowed_vlan is arista.avd.defined %}
-   switchport trunk allowed vlan {{ ethernet_interface.switchport.trunk.allowed_vlan }}
-{%     endif %}
 {%     if ethernet_interface.switchport.trunk.native_vlan_tag is arista.avd.defined(true) %}
    switchport trunk native vlan tag
 {%     elif ethernet_interface.switchport.trunk.native_vlan is arista.avd.defined %}
@@ -238,18 +235,12 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.switchport.dot1q.vlan_tag is arista.avd.defined %}
    switchport dot1q vlan tag {{ ethernet_interface.switchport.dot1q.vlan_tag }}
 {%     endif %}
-{%     if ethernet_interface.switchport.mode is arista.avd.defined %}
-   switchport mode {{ ethernet_interface.switchport.mode }}
-{%     endif %}
 {%     if ethernet_interface.switchport.dot1q.ethertype is arista.avd.defined %}
    switchport dot1q ethertype {{ ethernet_interface.switchport.dot1q.ethertype }}
 {%     endif %}
 {%     if ethernet_interface.switchport.vlan_forwarding_accept_all is arista.avd.defined(true) %}
    switchport vlan forwarding accept all
 {%     endif %}
-{%     for trunk_group in ethernet_interface.switchport.trunk.groups | arista.avd.natural_sort %}
-   switchport trunk group {{ trunk_group }}
-{%     endfor %}
 {%     if ethernet_interface.switchport.source_interface is arista.avd.defined %}
    switchport source-interface {{ ethernet_interface.switchport.source_interface }}
 {%     endif %}
@@ -293,6 +284,15 @@ interface {{ ethernet_interface.name }}
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{%     if ethernet_interface.switchport.trunk.allowed_vlan is arista.avd.defined %}
+   switchport trunk allowed vlan {{ ethernet_interface.switchport.trunk.allowed_vlan }}
+{%     endif %}
+{%     if ethernet_interface.switchport.mode is arista.avd.defined %}
+   switchport mode {{ ethernet_interface.switchport.mode }}
+{%     endif %}
+{%     for trunk_group in ethernet_interface.switchport.trunk.groups | arista.avd.natural_sort %}
+   switchport trunk group {{ trunk_group }}
+{%     endfor %}
 {%     if ethernet_interface.switchport.enabled is arista.avd.defined(true) %}
    switchport
 {%     elif ethernet_interface.switchport.enabled is arista.avd.defined(false) %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -160,8 +160,16 @@ interface {{ port_channel_interface.name }}
       {{ encapsulation_cli }}
 {%         endif %}
 {%     endif %}
+{%     if port_channel_interface.switchport.enabled is arista.avd.defined(true) %}
+   switchport
+{%     elif port_channel_interface.switchport.enabled is arista.avd.defined(false) %}
+   no switchport
+{%     endif %}
 {%     if port_channel_interface.switchport.access_vlan is arista.avd.defined %}
    switchport access vlan {{ port_channel_interface.switchport.access_vlan }}
+{%     endif %}
+{%     if port_channel_interface.switchport.trunk.allowed_vlan is arista.avd.defined %}
+   switchport trunk allowed vlan {{ port_channel_interface.switchport.trunk.allowed_vlan }}
 {%     endif %}
 {%     if port_channel_interface.switchport.trunk.native_vlan_tag is arista.avd.defined(true) %}
    switchport trunk native vlan tag
@@ -183,9 +191,6 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.switchport.dot1q.vlan_tag is arista.avd.defined %}
    switchport dot1q vlan tag {{ port_channel_interface.switchport.dot1q.vlan_tag }}
 {%     endif %}
-{%     if port_channel_interface.switchport.trunk.allowed_vlan is arista.avd.defined %}
-   switchport trunk allowed vlan {{ port_channel_interface.switchport.trunk.allowed_vlan }}
-{%     endif %}
 {%     if port_channel_interface.switchport.mode is arista.avd.defined %}
    switchport mode {{ port_channel_interface.switchport.mode }}
 {%     endif %}
@@ -198,11 +203,6 @@ interface {{ port_channel_interface.name }}
 {%     for trunk_group in port_channel_interface.switchport.trunk.groups | arista.avd.natural_sort %}
    switchport trunk group {{ trunk_group }}
 {%     endfor %}
-{%     if port_channel_interface.switchport.enabled is arista.avd.defined(true) %}
-   switchport
-{%     elif port_channel_interface.switchport.enabled is arista.avd.defined(false) %}
-   no switchport
-{%     endif %}
 {%     if port_channel_interface.switchport.source_interface is arista.avd.defined %}
    switchport source-interface {{ port_channel_interface.switchport.source_interface }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -182,6 +182,18 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.switchport.phone.trunk is arista.avd.defined %}
    switchport phone trunk {{ port_channel_interface.switchport.phone.trunk }}
 {%     endif %}
+{%     if port_channel_interface.switchport.mode is arista.avd.defined %}
+   switchport mode {{ port_channel_interface.switchport.mode }}
+{%     endif %}
+{%     for trunk_group in port_channel_interface.switchport.trunk.groups | arista.avd.natural_sort %}
+   switchport trunk group {{ trunk_group }}
+{%     endfor %}
+{%     if port_channel_interface.switchport.trunk.private_vlan_secondary is arista.avd.defined(true) %}
+   switchport trunk private-vlan secondary
+{%     endif %}
+{%     if port_channel_interface.switchport.pvlan_mapping is arista.avd.defined %}
+   switchport pvlan mapping {{ port_channel_interface.switchport.pvlan_mapping }}
+{%     endif %}
 {%     if port_channel_interface.switchport.vlan_translations.in_required is arista.avd.defined(true) %}
    switchport vlan translation in required
 {%     endif %}
@@ -191,18 +203,12 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.switchport.dot1q.vlan_tag is arista.avd.defined %}
    switchport dot1q vlan tag {{ port_channel_interface.switchport.dot1q.vlan_tag }}
 {%     endif %}
-{%     if port_channel_interface.switchport.mode is arista.avd.defined %}
-   switchport mode {{ port_channel_interface.switchport.mode }}
-{%     endif %}
 {%     if port_channel_interface.switchport.dot1q.ethertype is arista.avd.defined %}
    switchport dot1q ethertype {{ port_channel_interface.switchport.dot1q.ethertype }}
 {%     endif %}
 {%     if port_channel_interface.switchport.vlan_forwarding_accept_all is arista.avd.defined(true) %}
    switchport vlan forwarding accept all
 {%     endif %}
-{%     for trunk_group in port_channel_interface.switchport.trunk.groups | arista.avd.natural_sort %}
-   switchport trunk group {{ trunk_group }}
-{%     endfor %}
 {%     if port_channel_interface.switchport.source_interface is arista.avd.defined %}
    switchport source-interface {{ port_channel_interface.switchport.source_interface }}
 {%     endif %}
@@ -245,12 +251,6 @@ interface {{ port_channel_interface.name }}
    {{ vlan_translation_out_cli }}
 {%             endif %}
 {%         endfor %}
-{%     endif %}
-{%     if port_channel_interface.switchport.trunk.private_vlan_secondary is arista.avd.defined(true) %}
-   switchport trunk private-vlan secondary
-{%     endif %}
-{%     if port_channel_interface.switchport.pvlan_mapping is arista.avd.defined %}
-   switchport pvlan mapping {{ port_channel_interface.switchport.pvlan_mapping }}
 {%     endif %}
 {%     if port_channel_interface.l2_protocol.encapsulation_dot1q_vlan is arista.avd.defined %}
    l2-protocol encapsulation dot1q vlan {{ port_channel_interface.l2_protocol.encapsulation_dot1q_vlan }}


### PR DESCRIPTION
## Change Summary

Reordering the config for switchport in ethernet and port-channel interfaces
This change is to keep same ordering of the config generated by old and new data-model

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
