### PR TITLE
Feat: New node type keys for m&e devices

### DIFF
--- a/python-avd/pyavd/_eos_designs/shared_utils/node_type_keys.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/node_type_keys.py
@@ -86,7 +86,6 @@ L2LS_DEFAULT_NODE_TYPE_KEYS = [
         "uplink_type": "port-channel",
     },
 ]
-
 # NOTE: There is a static list of default node_type_keys in the fabric documentation templates which must be updated as well
 
 DEFAULT_NODE_TYPE_KEYS = {
@@ -173,6 +172,39 @@ DEFAULT_NODE_TYPE_KEYS = {
             "network_services": {
                 "l3": True,
             },
+        },
+        {
+            "key": "ptp_leaf",
+            "type": "ptp_leaf",
+            "connected_endpoints": True,
+            "network_services": {
+                "l2": True,
+                "l3": True,
+            },
+            "default_overlay_routing_protocol": "none",
+            "default_ptp_priority1": 10,
+        },
+        {
+            "key": "media_spine",
+            "type": "media_spine",
+            "connected_endpoints": True,
+            "network_services": {
+                "l2": True,
+                "l3": True,
+            },
+            "default_overlay_routing_protocol": "none",
+            "default_ptp_priority1": 20,
+        },
+        {
+            "key": "media_leaf",
+            "type": "media_leaf",
+            "connected_endpoints": True,
+            "network_services": {
+                "l2": True,
+                "l3": True,
+            },
+            "default_overlay_routing_protocol": "none",
+            "default_ptp_priority1": 30,
         },
         # Avoiding duplicate code
         *MPLS_DEFAULT_NODE_TYPE_KEYS,


### PR DESCRIPTION
## Change Summary

Introducing a new default Node type Keys for M&E devices

## Related Issue(s)

Fixes #4484 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
```yaml
node_type_keys:
  - key: ptp_leaf
    type: ptp_leaf
    default_overlay_routing_protocol: none
    connected_endpoints: true
    network_services:
      l2: true
      l3: true
    default_ptp_priority1: 10
  - key: media_spine
    type: media_spine
    default_overlay_routing_protocol: none
    connected_endpoints: true
    network_services:
      l2: true
      l3: true
    default_ptp_priority1: 20
  - key: media_leaf
    type: media_leaf
    default_overlay_routing_protocol: none
    connected_endpoints: true
    network_services:
      l2: true
      l3: true
    default_ptp_priority1: 30
```

## How to test
Please test with this PR.
https://github.com/aristanetworks/avd/pull/3048

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
