### PR TITLE
Refactor(eos_cli_config_gen): Rearrange the eos-cli config for `vlan-interfaces` to match with EOS

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -131,10 +131,10 @@ interface Loopback2
 ```eos
 !
 interface Vlan24
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.24
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
+   ip ospf area 0.0.0.24
    ip ospf message-digest-key 55 md5 7 <removed>
 ```
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -278,9 +278,7 @@ interface Vlan44
    description SVI Description
    no shutdown
    ipv6 dhcp relay destination a0::8
-   ipv6 dhcp relay destination a0::9 vrf AAAA
    ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
-   ipv6 dhcp relay destination a0::4 vrf ZZZZ
    ipv6 address a0::4/64
 !
 interface Vlan50

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -277,8 +277,10 @@ interface Vlan43
 interface Vlan44
    description SVI Description
    no shutdown
-   ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
    ipv6 dhcp relay destination a0::8
+   ipv6 dhcp relay destination a0::9 vrf AAAA
+   ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
+   ipv6 dhcp relay destination a0::4 vrf ZZZZ
    ipv6 address a0::4/64
 !
 interface Vlan50

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/vlan-interfaces.md
@@ -221,15 +221,15 @@ interface Vlan24
    ipv6 address 1b11:3a00:22b0:6::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:6::/64 infinite infinite no-autoconfig
-   ipv6 virtual-router address 1b11:3a00:22b0:6::1
    ip address virtual 10.10.24.1/24
+   ipv6 virtual-router address 1b11:3a00:22b0:6::1
 !
 interface Vlan25
    description SVI Description
    no shutdown
    ipv6 address 1b11:3a00:22b0:16::16/64
-   ipv6 virtual-router address 1b11:3a00:22b0:16::15
    ipv6 virtual-router address 1b11:3a00:22b0:16::14
+   ipv6 virtual-router address 1b11:3a00:22b0:16::15
 !
 interface Vlan41
    description SVI Description
@@ -301,17 +301,17 @@ interface Vlan75
    multicast ipv6 boundary ff00::/16 out
    multicast ipv6 boundary ff01::/16 out
    multicast ipv4 static
-   ipv6 virtual-router address 1b11:3a00:22b0:1000::1
    ip address virtual 10.10.75.1/24
+   ipv6 virtual-router address 1b11:3a00:22b0:1000::1
 !
 interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
    ipv6 enable
+   ip address virtual 10.10.81.1/24
    ipv6 address virtual fc00:10:10:81::1/64
    ipv6 address virtual fc00:10:11:81::1/64
    ipv6 address virtual fc00:10:12:81::1/64
-   ip address virtual 10.10.81.1/24
 !
 interface Vlan83
    description SVI Description
@@ -326,8 +326,8 @@ interface Vlan83
 interface Vlan84
    description SVI Description
    arp gratuitous accept
-   arp monitor mac-address
    ip address 10.10.84.1/24
+   arp monitor mac-address
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2 rx-disabled
    isis authentication key 0 password
@@ -336,20 +336,20 @@ interface Vlan84
 !
 interface Vlan85
    description SVI Description
-   arp cache dynamic capacity 50000
    ip address 10.10.84.1/24
+   arp cache dynamic capacity 50000
+   bfd interval 500 min-rx 500 multiplier 5
+   bfd echo
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
    isis authentication key 0 password
-   bfd interval 500 min-rx 500 multiplier 5
-   bfd echo
 !
 interface Vlan86
    description SVI Description
    ip address 10.10.83.1/24
+   ip attached-host route export 10
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
-   ip attached-host route export 10
 !
 interface Vlan87
    description SVI Description
@@ -388,32 +388,32 @@ interface Vlan89
    multicast ipv6 static
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
-   ipv6 virtual-router address 1b11:3a00:22b0:5200::3
    ip address virtual 10.10.144.3/20
+   ipv6 virtual-router address 1b11:3a00:22b0:5200::3
 !
 interface Vlan90
    description SVI Description
    ip address 10.10.83.1/24
+   ip attached-host route export
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile2 algorithm sha-1 level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
-   ip attached-host route export
 !
 interface Vlan91
    description PBR Description
    shutdown
+   service-policy type pbr input MyServicePolicy
    isis enable EVPN_UNDERLAY
    isis authentication mode md5 level-1
    isis authentication mode text level-2
    isis authentication key 0 password level-1
    isis authentication key 0 password level-2
-   service-policy type pbr input MyServicePolicy
 !
 interface Vlan92
    description SVI Description
    ip proxy-arp
-   ip directed-broadcast
    ip address 10.10.92.1/24
+   ip directed-broadcast
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile2 algorithm sha-1 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
@@ -421,18 +421,18 @@ interface Vlan92
 interface Vlan110
    description PVLAN Primary with vlan mapping
    no shutdown
+   pvlan mapping 111-112
    vrf Tenant_A
    ip address 10.0.101.1/24
    multicast ipv4 boundary ACL_MULTICAST out
    multicast ipv6 source route export 20
    multicast ipv4 static
-   pvlan mapping 111-112
 !
 interface Vlan333
    description Multiple VRIDs and tracking
    no shutdown
-   arp aging timeout 180
    ip address 192.0.2.2/25
+   arp aging timeout 180
    ipv6 enable
    ipv6 address 2001:db8:333::2/64
    ipv6 address fe80::2/64 link-local
@@ -497,8 +497,8 @@ interface Vlan501
 interface Vlan667
    description Multiple VRIDs
    no shutdown
-   arp aging timeout 180
    ip address 192.0.2.2/25
+   arp aging timeout 180
    ipv6 enable
    ipv6 address 2001:db8:667::2/64
    ipv6 address fe80::2/64 link-local
@@ -529,8 +529,8 @@ interface Vlan1002
 !
 interface Vlan2001
    description SVI Description
-   vrf Tenant_B
    logging event link-status
+   vrf Tenant_B
    ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -24,10 +24,10 @@ interface Management1
    ip address 10.73.255.122/24
 !
 interface Vlan24
-   ip ospf network point-to-point
-   ip ospf area 0.0.0.24
    ip ospf cost 99
+   ip ospf network point-to-point
    ip ospf authentication message-digest
+   ip ospf area 0.0.0.24
    ip ospf message-digest-key 55 md5 7 ABCDEFGHIJKLMNOPQRSTUVWXYZ
 !
 router ospf 100

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -10,15 +10,15 @@ interface Vlan24
    ipv6 address 1b11:3a00:22b0:6::15/64
    ipv6 nd managed-config-flag
    ipv6 nd prefix 1b11:3a00:22b0:6::/64 infinite infinite no-autoconfig
-   ipv6 virtual-router address 1b11:3a00:22b0:6::1
    ip address virtual 10.10.24.1/24
+   ipv6 virtual-router address 1b11:3a00:22b0:6::1
 !
 interface Vlan25
    description SVI Description
    no shutdown
    ipv6 address 1b11:3a00:22b0:16::16/64
-   ipv6 virtual-router address 1b11:3a00:22b0:16::15
    ipv6 virtual-router address 1b11:3a00:22b0:16::14
+   ipv6 virtual-router address 1b11:3a00:22b0:16::15
 !
 interface Vlan41
    description SVI Description
@@ -90,17 +90,17 @@ interface Vlan75
    multicast ipv6 boundary ff00::/16 out
    multicast ipv6 boundary ff01::/16 out
    multicast ipv4 static
-   ipv6 virtual-router address 1b11:3a00:22b0:1000::1
    ip address virtual 10.10.75.1/24
+   ipv6 virtual-router address 1b11:3a00:22b0:1000::1
 !
 interface Vlan81
    description IPv6 Virtual Address
    vrf Tenant_C
    ipv6 enable
+   ip address virtual 10.10.81.1/24
    ipv6 address virtual fc00:10:10:81::1/64
    ipv6 address virtual fc00:10:11:81::1/64
    ipv6 address virtual fc00:10:12:81::1/64
-   ip address virtual 10.10.81.1/24
 !
 interface Vlan83
    description SVI Description
@@ -115,8 +115,8 @@ interface Vlan83
 interface Vlan84
    description SVI Description
    arp gratuitous accept
-   arp monitor mac-address
    ip address 10.10.84.1/24
+   arp monitor mac-address
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2 rx-disabled
    isis authentication key 0 password
@@ -125,20 +125,20 @@ interface Vlan84
 !
 interface Vlan85
    description SVI Description
-   arp cache dynamic capacity 50000
    ip address 10.10.84.1/24
+   arp cache dynamic capacity 50000
+   bfd interval 500 min-rx 500 multiplier 5
+   bfd echo
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
    isis authentication key 0 password
-   bfd interval 500 min-rx 500 multiplier 5
-   bfd echo
 !
 interface Vlan86
    description SVI Description
    ip address 10.10.83.1/24
+   ip attached-host route export 10
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled
-   ip attached-host route export 10
 !
 interface Vlan87
    description SVI Description
@@ -177,32 +177,32 @@ interface Vlan89
    multicast ipv6 static
    pim ipv4 sparse-mode
    pim ipv4 local-interface Loopback0
-   ipv6 virtual-router address 1b11:3a00:22b0:5200::3
    ip address virtual 10.10.144.3/20
+   ipv6 virtual-router address 1b11:3a00:22b0:5200::3
 !
 interface Vlan90
    description SVI Description
    ip address 10.10.83.1/24
+   ip attached-host route export
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile2 algorithm sha-1 level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 level-2
-   ip attached-host route export
 !
 interface Vlan91
    description PBR Description
    shutdown
+   service-policy type pbr input MyServicePolicy
    isis enable EVPN_UNDERLAY
    isis authentication mode md5 level-1
    isis authentication mode text level-2
    isis authentication key 0 password level-1
    isis authentication key 0 password level-2
-   service-policy type pbr input MyServicePolicy
 !
 interface Vlan92
    description SVI Description
    ip proxy-arp
-   ip directed-broadcast
    ip address 10.10.92.1/24
+   ip directed-broadcast
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile2 algorithm sha-1 rx-disabled level-1
    isis authentication mode shared-secret profile profile1 algorithm sha-256 rx-disabled level-2
@@ -210,18 +210,18 @@ interface Vlan92
 interface Vlan110
    description PVLAN Primary with vlan mapping
    no shutdown
+   pvlan mapping 111-112
    vrf Tenant_A
    ip address 10.0.101.1/24
    multicast ipv4 boundary ACL_MULTICAST out
    multicast ipv6 source route export 20
    multicast ipv4 static
-   pvlan mapping 111-112
 !
 interface Vlan333
    description Multiple VRIDs and tracking
    no shutdown
-   arp aging timeout 180
    ip address 192.0.2.2/25
+   arp aging timeout 180
    ipv6 enable
    ipv6 address 2001:db8:333::2/64
    ipv6 address fe80::2/64 link-local
@@ -286,8 +286,8 @@ interface Vlan501
 interface Vlan667
    description Multiple VRIDs
    no shutdown
-   arp aging timeout 180
    ip address 192.0.2.2/25
+   arp aging timeout 180
    ipv6 enable
    ipv6 address 2001:db8:667::2/64
    ipv6 address fe80::2/64 link-local
@@ -318,8 +318,8 @@ interface Vlan1002
 !
 interface Vlan2001
    description SVI Description
-   vrf Tenant_B
    logging event link-status
+   vrf Tenant_B
    ip address virtual 10.2.1.1/24
    comment
    Comment created from eos_cli under vlan_interfaces.Vlan2001

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -66,8 +66,10 @@ interface Vlan43
 interface Vlan44
    description SVI Description
    no shutdown
-   ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
    ipv6 dhcp relay destination a0::8
+   ipv6 dhcp relay destination a0::9 vrf AAAA
+   ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
+   ipv6 dhcp relay destination a0::4 vrf ZZZZ
    ipv6 address a0::4/64
 !
 interface Vlan50

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/vlan-interfaces.cfg
@@ -67,9 +67,7 @@ interface Vlan44
    description SVI Description
    no shutdown
    ipv6 dhcp relay destination a0::8
-   ipv6 dhcp relay destination a0::9 vrf AAAA
    ipv6 dhcp relay destination a0::5 vrf TEST source-address a0::6 link-address a0::7
-   ipv6 dhcp relay destination a0::4 vrf ZZZZ
    ipv6 address a0::4/64
 !
 interface Vlan50

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -358,15 +358,11 @@ vlan_interfaces:
     shutdown: false
     ipv6_address: a0::4/64
     ipv6_dhcp_relay_destinations:
-      - address: a0::4
-        vrf: ZZZZ
       - address: a0::5
         vrf: TEST
         source_address: a0::6
         link_address: a0::7
       - address: a0::8
-      - address: a0::9
-        vrf: AAAA
 
   - name: Vlan50
     description: IP NAT Testing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/vlan-interfaces.yml
@@ -358,11 +358,15 @@ vlan_interfaces:
     shutdown: false
     ipv6_address: a0::4/64
     ipv6_dhcp_relay_destinations:
+      - address: a0::4
+        vrf: ZZZZ
       - address: a0::5
         vrf: TEST
         source_address: a0::6
         link_address: a0::7
       - address: a0::8
+      - address: a0::9
+        vrf: AAAA
 
   - name: Vlan50
     description: IP NAT Testing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -206,10 +206,10 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf area 1
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -196,10 +196,10 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf area 1
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -113,10 +113,10 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf area 1
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
@@ -111,10 +111,10 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf area 1
    ip address virtual 10.1.40.1/24
 !
 interface Vlan250

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -174,8 +174,8 @@ interface Vlan113
    no shutdown
    vrf Tenant_A_OP_Zone
    ip ospf network point-to-point
-   ip ospf area 0
    ip ospf authentication message-digest
+   ip ospf area 0
    ip ospf message-digest-key 1 sha1 7 AQQvKeimxJu+uGQ/yYvv9w==
    ip ospf message-digest-key 2 sha512 7 AQQvKeimxJu+uGQ/yYvv9w==
 !
@@ -236,8 +236,8 @@ interface Vlan452
    no shutdown
    mtu 1560
    vrf 12345678
-   ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
+   ipv6 address virtual 2001:db8:412::1/64
 !
 interface Vxlan1
    description DC1-LEAF1A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -538,10 +538,10 @@ interface Vlan410
    no shutdown
    vrf Tenant_D_OP_Zone
    ipv6 enable
+   ip address virtual 10.3.10.1/24
    ipv6 address virtual 2001:db8:310::1/64
    ipv6 address virtual 2001:db8:311::1/64
    ipv6 address virtual 2001:db8:312::1/64
-   ip address virtual 10.3.10.1/24
 !
 interface Vlan411
    description Tenant_D_v6_OP_Zone_2
@@ -549,16 +549,16 @@ interface Vlan411
    vrf Tenant_D_OP_Zone
    ip address 10.3.11.2/24
    ipv6 address 2001:db8:311::2/64
-   ipv6 virtual-router address 2001:db8:311::1
    ip virtual-router address 10.3.11.1/24
+   ipv6 virtual-router address 2001:db8:311::1
 !
 interface Vlan412
    description Tenant_D_v6_OP_Zone_1
    no shutdown
    mtu 1560
    vrf Tenant_D_OP_Zone
-   ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
+   ipv6 address virtual 2001:db8:412::1/64
 !
 interface Vlan413
    description Tenant_D_v6_OP_Zone_3
@@ -568,8 +568,8 @@ interface Vlan413
    ip address 11.4.13.2/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo101
    ipv6 address 2001:db9:413::2/64
-   ipv6 virtual-router address 2001:db9:413::1
    ip virtual-router address 11.4.13.1
+   ipv6 virtual-router address 2001:db9:413::1
 !
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
@@ -591,8 +591,8 @@ interface Vlan452
    no shutdown
    mtu 1560
    vrf 12345678
-   ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
+   ipv6 address virtual 2001:db8:412::1/64
 !
 interface Vxlan1
    description DC1-LEAF2A_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -503,10 +503,10 @@ interface Vlan410
    no shutdown
    vrf Tenant_D_OP_Zone
    ipv6 enable
+   ip address virtual 10.3.10.1/24
    ipv6 address virtual 2001:db8:310::1/64
    ipv6 address virtual 2001:db8:311::1/64
    ipv6 address virtual 2001:db8:312::1/64
-   ip address virtual 10.3.10.1/24
 !
 interface Vlan411
    description Tenant_D_v6_OP_Zone_2
@@ -514,16 +514,16 @@ interface Vlan411
    vrf Tenant_D_OP_Zone
    ip address 10.3.11.3/24
    ipv6 address 2001:db8:311::3/64
-   ipv6 virtual-router address 2001:db8:311::1
    ip virtual-router address 10.3.11.1/24
+   ipv6 virtual-router address 2001:db8:311::1
 !
 interface Vlan412
    description Tenant_D_v6_OP_Zone_1
    no shutdown
    mtu 1560
    vrf Tenant_D_OP_Zone
-   ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
+   ipv6 address virtual 2001:db8:412::1/64
 !
 interface Vlan413
    description Tenant_D_v6_OP_Zone_3
@@ -533,8 +533,8 @@ interface Vlan413
    ip address 101.4.13.2/24
    ip helper-address 1.1.1.1 vrf TEST source-interface lo101
    ipv6 address 2002:db9:413::2/64
-   ipv6 virtual-router address 2002:db9:413::1
    ip virtual-router address 101.4.13.1
+   ipv6 virtual-router address 2002:db9:413::1
 !
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
@@ -556,8 +556,8 @@ interface Vlan452
    no shutdown
    mtu 1560
    vrf 12345678
-   ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
+   ipv6 address virtual 2001:db8:412::1/64
 !
 interface Vxlan1
    description DC1-LEAF2B_VTEP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -699,10 +699,10 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf area 1
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -665,10 +665,10 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf area 1
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -318,10 +318,10 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf area 1
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -318,10 +318,10 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf area 1
    ip address virtual 10.1.40.1/24
 !
 interface Vlan210

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -211,8 +211,8 @@ interface Vlan113
    no shutdown
    vrf Tenant_A_OP_Zone
    ip ospf network point-to-point
-   ip ospf area 0
    ip ospf authentication message-digest
+   ip ospf area 0
    ip ospf message-digest-key 1 sha1 7 AQQvKeimxJu+uGQ/yYvv9w==
    ip ospf message-digest-key 2 sha512 7 AQQvKeimxJu+uGQ/yYvv9w==
 !
@@ -265,10 +265,10 @@ interface Vlan150
    description Tenant_A_WAN_Zone_1
    no shutdown
    vrf Tenant_A_WAN_Zone
-   ip ospf area 1
    ip ospf cost 100
    ip ospf authentication
    ip ospf authentication-key 7 AQQvKeimxJu+uGQ/yYvv9w==
+   ip ospf area 1
    ip address virtual 10.1.40.1/24
 !
 interface Vlan151
@@ -318,10 +318,10 @@ interface Vlan410
    no shutdown
    vrf Tenant_D_OP_Zone
    ipv6 enable
+   ip address virtual 10.3.10.1/24
    ipv6 address virtual 2001:db8:310::1/64
    ipv6 address virtual 2001:db8:311::1/64
    ipv6 address virtual 2001:db8:312::1/64
-   ip address virtual 10.3.10.1/24
 !
 interface Vlan411
    description Tenant_D_v6_OP_Zone_2
@@ -329,16 +329,16 @@ interface Vlan411
    vrf Tenant_D_OP_Zone
    ip address 10.3.11.4/24
    ipv6 address 2001:db8:311::4/64
-   ipv6 virtual-router address 2001:db8:311::1
    ip virtual-router address 10.3.11.1/24
+   ipv6 virtual-router address 2001:db8:311::1
 !
 interface Vlan412
    description Tenant_D_v6_OP_Zone_1
    no shutdown
    mtu 1560
    vrf Tenant_D_OP_Zone
-   ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
+   ipv6 address virtual 2001:db8:412::1/64
 !
 interface Vlan413
    description Tenant_D_v6_OP_Zone_3
@@ -348,8 +348,8 @@ interface Vlan413
    ip address 12.4.13.2/24
    ip helper-address 1.1.1.2 vrf TEST source-interface lo102
    ipv6 address 2012:db9:413::2/64
-   ipv6 virtual-router address 2012:db9:413::1
    ip virtual-router address 12.4.13.1
+   ipv6 virtual-router address 2012:db9:413::1
 !
 interface Vlan450
    description Tenant_D_v6_WAN_Zone_1
@@ -371,8 +371,8 @@ interface Vlan452
    no shutdown
    mtu 1560
    vrf 12345678
-   ipv6 address virtual 2001:db8:412::1/64
    ip address virtual 10.4.12.254/24
+   ipv6 address virtual 2001:db8:412::1/64
 !
 interface Vlan1234
    description VRF_DEFAULT_SVI_WITH_OSPF

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack1.cfg
@@ -149,12 +149,12 @@ interface Vlan104
    no shutdown
    mtu 1500
    ip address 192.168.104.2/24
+   ip attached-host route export 19
    ipv6 attached-host route export 19
    ipv6 enable
    ipv6 address 2a00:104::2/64
-   ipv6 virtual-router address 2a00:104::1
-   ip attached-host route export 19
    ip virtual-router address 192.168.104.1
+   ipv6 virtual-router address 2a00:104::1
 !
 interface Vlan105
    description Inband_management_vlan_ipv6
@@ -163,8 +163,8 @@ interface Vlan105
    ip address 192.168.105.2/24
    ipv6 enable
    ipv6 address 2a00:105::2/64
-   ipv6 virtual-router address 2a00:105::1
    ip virtual-router address 192.168.105.1
+   ipv6 virtual-router address 2a00:105::1
 !
 interface Vlan3000
    description MLAG_L3_VRF_INBANDMGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack2.cfg
@@ -149,12 +149,12 @@ interface Vlan104
    no shutdown
    mtu 1500
    ip address 192.168.104.3/24
+   ip attached-host route export 19
    ipv6 attached-host route export 19
    ipv6 enable
    ipv6 address 2a00:104::3/64
-   ipv6 virtual-router address 2a00:104::1
-   ip attached-host route export 19
    ip virtual-router address 192.168.104.1
+   ipv6 virtual-router address 2a00:104::1
 !
 interface Vlan105
    description Inband_management_vlan_ipv6
@@ -163,8 +163,8 @@ interface Vlan105
    ip address 192.168.105.3/24
    ipv6 enable
    ipv6 address 2a00:105::3/64
-   ipv6 virtual-router address 2a00:105::1
    ip virtual-router address 192.168.105.1
+   ipv6 virtual-router address 2a00:105::1
 !
 interface Vlan3000
    description MLAG_L3_VRF_INBANDMGMT

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -58,19 +58,17 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.arp_cache_dynamic_capacity is arista.avd.defined %}
    arp cache dynamic capacity {{ vlan_interface.arp_cache_dynamic_capacity }}
 {%     endif %}
-{%     if vlan_interface.ipv6_nd_cache is arista.avd.defined() %}
-{%         if vlan_interface.ipv6_nd_cache.expire is arista.avd.defined() %}
+{%     if vlan_interface.ipv6_nd_cache.expire is arista.avd.defined() %}
    ipv6 nd cache expire {{ vlan_interface.ipv6_nd_cache.expire }}
-{%         endif %}
-{%         if vlan_interface.ipv6_nd_cache.dynamic_capacity is arista.avd.defined() %}
+{%     endif %}
+{%     if vlan_interface.ipv6_nd_cache.dynamic_capacity is arista.avd.defined() %}
    ipv6 nd cache dynamic capacity {{ vlan_interface.ipv6_nd_cache.dynamic_capacity }}
-{%         endif %}
-{%         if vlan_interface.ipv6_nd_cache.refresh_always is arista.avd.defined(true) %}
-   ipv6 nd cache refresh always
-{%         endif %}
 {%     endif %}
 {%     if vlan_interface.arp_monitor_mac_address is arista.avd.defined(true) %}
    arp monitor mac-address
+{%     endif %}
+{%     if vlan_interface.ipv6_nd_cache.refresh_always is arista.avd.defined(true) %}
+   ipv6 nd cache refresh always
 {%     endif %}
 {%     if vlan_interface.bfd.interval is arista.avd.defined and
           vlan_interface.bfd.min_rx is arista.avd.defined and
@@ -98,7 +96,12 @@ interface {{ vlan_interface.name }}
 {%         endif %}
    {{ ip_helper_cli }}
 {%     endfor %}
-{%     for destination in vlan_interface.ipv6_dhcp_relay_destinations | arista.avd.natural_sort('address') %}
+{%     if vlan_interface.ipv6_dhcp_relay_destinations is arista.avd.defined %}
+{%         set with_vrf_dest = vlan_interface.ipv6_dhcp_relay_destinations | selectattr('vrf', 'arista.avd.defined') | arista.avd.natural_sort('vrf') %}
+{%         set without_vrf_dest = vlan_interface.ipv6_dhcp_relay_destinations | rejectattr('vrf', 'arista.avd.defined') | arista.avd.natural_sort('address') %}
+{%         set sorted_ipv6_dhcp_relay_destinations =  without_vrf_dest | list + with_vrf_dest | list %}
+{%     endif %}
+{%     for destination in sorted_ipv6_dhcp_relay_destinations | arista.avd.default([])%}
 {%         set destination_cli = "ipv6 dhcp relay destination " ~ destination.address %}
 {%         if destination.vrf is arista.avd.defined %}
 {%             set destination_cli = destination_cli ~ " vrf " ~ destination.vrf %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -140,7 +140,7 @@ interface {{ vlan_interface.name }}
 {%         set host_proxy_cli =  "ip igmp host-proxy" %}
    {{ host_proxy_cli }}
 {%         if vlan_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
-{%             for proxy_group in vlan_interface.ip_igmp_host_proxy.groups %}
+{%             for proxy_group in vlan_interface.ip_igmp_host_proxy.groups | arista.avd.natural_sort %}
 {%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
 {%                     if proxy_group.include is arista.avd.defined %}
 {%                         for include_source in proxy_group.include %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -97,11 +97,11 @@ interface {{ vlan_interface.name }}
    {{ ip_helper_cli }}
 {%     endfor %}
 {%     if vlan_interface.ipv6_dhcp_relay_destinations is arista.avd.defined %}
-{%         set with_vrf_dest = vlan_interface.ipv6_dhcp_relay_destinations | selectattr('vrf', 'arista.avd.defined') | arista.avd.natural_sort('vrf') %}
+{%         set with_vrf_dest = vlan_interface.ipv6_dhcp_relay_destinations | selectattr('vrf', 'arista.avd.defined') | arista.avd.natural_sort('address') | arista.avd.natural_sort('vrf') %}
 {%         set without_vrf_dest = vlan_interface.ipv6_dhcp_relay_destinations | rejectattr('vrf', 'arista.avd.defined') | arista.avd.natural_sort('address') %}
 {%         set sorted_ipv6_dhcp_relay_destinations =  without_vrf_dest | list + with_vrf_dest | list %}
 {%     endif %}
-{%     for destination in sorted_ipv6_dhcp_relay_destinations | arista.avd.default([])%}
+{%     for destination in sorted_ipv6_dhcp_relay_destinations | arista.avd.default([]) %}
 {%         set destination_cli = "ipv6 dhcp relay destination " ~ destination.address %}
 {%         if destination.vrf is arista.avd.defined %}
 {%             set destination_cli = destination_cli ~ " vrf " ~ destination.vrf %}
@@ -143,7 +143,7 @@ interface {{ vlan_interface.name }}
 {%         set host_proxy_cli =  "ip igmp host-proxy" %}
    {{ host_proxy_cli }}
 {%         if vlan_interface.ip_igmp_host_proxy.groups is arista.avd.defined %}
-{%             for proxy_group in vlan_interface.ip_igmp_host_proxy.groups | arista.avd.natural_sort %}
+{%             for proxy_group in vlan_interface.ip_igmp_host_proxy.groups %}
 {%                 if proxy_group.exclude is arista.avd.defined or proxy_group.include is arista.avd.defined %}
 {%                     if proxy_group.include is arista.avd.defined %}
 {%                         for include_source in proxy_group.include %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -18,25 +18,42 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.mtu is arista.avd.defined %}
    mtu {{ vlan_interface.mtu }}
 {%     endif %}
+{%     if vlan_interface.logging.event.link_status is arista.avd.defined(true) %}
+   logging event link-status
+{%     elif vlan_interface.logging.event.link_status is arista.avd.defined(false) %}
+   no logging event link-status
+{%     endif %}
+{%     if vlan_interface.pvlan_mapping is arista.avd.defined %}
+   pvlan mapping {{ vlan_interface.pvlan_mapping }}
+{%     endif %}
 {%     if vlan_interface.no_autostate is arista.avd.defined(true) %}
    no autostate
 {%     endif %}
 {%     if vlan_interface.vrf is arista.avd.defined %}
    vrf {{ vlan_interface.vrf }}
 {%     endif %}
-{%     if vlan_interface.logging.event.link_status is arista.avd.defined(true) %}
-   logging event link-status
-{%     elif vlan_interface.logging.event.link_status is arista.avd.defined(false) %}
-   no logging event link-status
-{%     endif %}
-{%     if vlan_interface.arp_aging_timeout is arista.avd.defined %}
-   arp aging timeout {{ vlan_interface.arp_aging_timeout }}
+{%     if vlan_interface.ip_proxy_arp is arista.avd.defined(true) %}
+   ip proxy-arp
 {%     endif %}
 {%     if vlan_interface.arp_gratuitous_accept is arista.avd.defined(true) %}
    arp gratuitous accept
 {%     endif %}
-{%     if vlan_interface.arp_monitor_mac_address is arista.avd.defined(true) %}
-   arp monitor mac-address
+{%     if vlan_interface.ip_address is arista.avd.defined %}
+   ip address {{ vlan_interface.ip_address }}
+{%         if vlan_interface.ip_address_secondaries is arista.avd.defined %}
+{%             for ip_address_secondary in vlan_interface.ip_address_secondaries | arista.avd.natural_sort %}
+   ip address {{ ip_address_secondary }} secondary
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{%     if vlan_interface.ip_verify_unicast_source_reachable_via is arista.avd.defined %}
+   ip verify unicast source reachable-via {{ vlan_interface.ip_verify_unicast_source_reachable_via }}
+{%     endif %}
+{%     if vlan_interface.ip_directed_broadcast is arista.avd.defined(true) %}
+   ip directed-broadcast
+{%     endif %}
+{%     if vlan_interface.arp_aging_timeout is arista.avd.defined %}
+   arp aging timeout {{ vlan_interface.arp_aging_timeout }}
 {%     endif %}
 {%     if vlan_interface.arp_cache_dynamic_capacity is arista.avd.defined %}
    arp cache dynamic capacity {{ vlan_interface.arp_cache_dynamic_capacity }}
@@ -52,22 +69,18 @@ interface {{ vlan_interface.name }}
    ipv6 nd cache refresh always
 {%         endif %}
 {%     endif %}
-{%     if vlan_interface.ip_proxy_arp is arista.avd.defined(true) %}
-   ip proxy-arp
+{%     if vlan_interface.arp_monitor_mac_address is arista.avd.defined(true) %}
+   arp monitor mac-address
 {%     endif %}
-{%     if vlan_interface.ip_directed_broadcast is arista.avd.defined(true) %}
-   ip directed-broadcast
+{%     if vlan_interface.bfd.interval is arista.avd.defined and
+          vlan_interface.bfd.min_rx is arista.avd.defined and
+          vlan_interface.bfd.multiplier is arista.avd.defined %}
+   bfd interval {{ vlan_interface.bfd.interval }} min-rx {{ vlan_interface.bfd.min_rx }} multiplier {{ vlan_interface.bfd.multiplier }}
 {%     endif %}
-{%     if vlan_interface.ip_address is arista.avd.defined %}
-   ip address {{ vlan_interface.ip_address }}
-{%         if vlan_interface.ip_address_secondaries is arista.avd.defined %}
-{%             for ip_address_secondary in vlan_interface.ip_address_secondaries %}
-   ip address {{ ip_address_secondary }} secondary
-{%             endfor %}
-{%         endif %}
-{%     endif %}
-{%     if vlan_interface.ip_verify_unicast_source_reachable_via is arista.avd.defined %}
-   ip verify unicast source reachable-via {{ vlan_interface.ip_verify_unicast_source_reachable_via }}
+{%     if vlan_interface.bfd.echo is arista.avd.defined(true) %}
+   bfd echo
+{%     elif vlan_interface.bfd.echo is arista.avd.defined(false) %}
+   no bfd echo
 {%     endif %}
 {%     if vlan_interface.ip_dhcp_relay_all_subnets is arista.avd.defined(true) %}
    ip dhcp relay all-subnets
@@ -100,6 +113,13 @@ interface {{ vlan_interface.name }}
 {%         endif %}
    {{ destination_cli }}
 {%     endfor %}
+{%     if vlan_interface.ip_attached_host_route_export.enabled is arista.avd.defined(true) %}
+{%         set ip_attached_host_route_export_cli = "ip attached-host route export" %}
+{%         if vlan_interface.ip_attached_host_route_export.distance is arista.avd.defined %}
+{%             set ip_attached_host_route_export_cli = ip_attached_host_route_export_cli ~ " " ~ vlan_interface.ip_attached_host_route_export.distance %}
+{%         endif %}
+   {{ ip_attached_host_route_export_cli }}
+{%     endif %}
 {%     if vlan_interface.ipv6_attached_host_route_export.enabled is arista.avd.defined(true) %}
 {%         set ipv6_attached_host_route_export_cli = "ipv6 attached-host route export" %}
 {%         if vlan_interface.ipv6_attached_host_route_export.distance is arista.avd.defined %}
@@ -158,9 +178,6 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.ipv6_address_link_local is arista.avd.defined %}
    ipv6 address {{ vlan_interface.ipv6_address_link_local }} link-local
 {%     endif %}
-{%     for ipv6_address_virtual in vlan_interface.ipv6_address_virtuals | arista.avd.natural_sort %}
-   ipv6 address virtual {{ ipv6_address_virtual }}
-{%     endfor %}
 {%     if vlan_interface.ipv6_nd_ra_disabled is arista.avd.defined(true) %}
    ipv6 nd ra disabled
 {%     endif %}
@@ -171,7 +188,7 @@ interface {{ vlan_interface.name }}
    ipv6 nd other-config-flag
 {%     endif %}
 {%     if vlan_interface.ipv6_nd_prefixes is arista.avd.defined %}
-{%         for prefix in vlan_interface.ipv6_nd_prefixes %}
+{%         for prefix in vlan_interface.ipv6_nd_prefixes | arista.avd.natural_sort("ipv6_prefix") %}
 {%             set ipv6_nd_prefix_cli = "ipv6 nd prefix " ~ prefix.ipv6_prefix %}
 {%             if prefix.valid_lifetime is arista.avd.defined %}
 {%                 set ipv6_nd_prefix_cli = ipv6_nd_prefix_cli ~ " " ~ prefix.valid_lifetime %}
@@ -185,9 +202,21 @@ interface {{ vlan_interface.name }}
    {{ ipv6_nd_prefix_cli }}
 {%         endfor %}
 {%     endif %}
+{%     if vlan_interface.access_group_in is arista.avd.defined %}
+   ip access-group {{ vlan_interface.access_group_in }} in
+{%     endif %}
+{%     if vlan_interface.access_group_out is arista.avd.defined %}
+   ip access-group {{ vlan_interface.access_group_out }} out
+{%     endif %}
+{%     if vlan_interface.ipv6_access_group_in is arista.avd.defined %}
+   ipv6 access-group {{ vlan_interface.ipv6_access_group_in }} in
+{%     endif %}
+{%     if vlan_interface.ipv6_access_group_out is arista.avd.defined %}
+   ipv6 access-group {{ vlan_interface.ipv6_access_group_out }} out
+{%     endif %}
 {%     if vlan_interface.multicast is arista.avd.defined %}
 {%         if vlan_interface.multicast.ipv4.boundaries is arista.avd.defined %}
-{%             for boundary in vlan_interface.multicast.ipv4.boundaries %}
+{%             for boundary in vlan_interface.multicast.ipv4.boundaries | arista.avd.natural_sort("boundary") %}
 {%                 set boundary_cli = "multicast ipv4 boundary " ~ boundary.boundary %}
 {%                 if boundary.out is arista.avd.defined(true) %}
 {%                     set boundary_cli = boundary_cli ~ " out" %}
@@ -196,7 +225,7 @@ interface {{ vlan_interface.name }}
 {%             endfor %}
 {%         endif %}
 {%         if vlan_interface.multicast.ipv6.boundaries is arista.avd.defined %}
-{%             for boundary in vlan_interface.multicast.ipv6.boundaries %}
+{%             for boundary in vlan_interface.multicast.ipv6.boundaries | arista.avd.natural_sort("boundary") %}
    multicast ipv6 boundary {{ boundary.boundary }} out
 {%             endfor %}
 {%         endif %}
@@ -225,26 +254,11 @@ interface {{ vlan_interface.name }}
 {%         set interface_ip_nat = vlan_interface.ip_nat %}
 {%         include 'eos/interface-ip-nat.j2' %}
 {%     endif %}
-{%     if vlan_interface.access_group_in is arista.avd.defined %}
-   ip access-group {{ vlan_interface.access_group_in }} in
-{%     endif %}
-{%     if vlan_interface.access_group_out is arista.avd.defined %}
-   ip access-group {{ vlan_interface.access_group_out }} out
-{%     endif %}
-{%     if vlan_interface.ipv6_access_group_in is arista.avd.defined %}
-   ipv6 access-group {{ vlan_interface.ipv6_access_group_in }} in
-{%     endif %}
-{%     if vlan_interface.ipv6_access_group_out is arista.avd.defined %}
-   ipv6 access-group {{ vlan_interface.ipv6_access_group_out }} out
+{%     if vlan_interface.ospf_cost is arista.avd.defined %}
+   ip ospf cost {{ vlan_interface.ospf_cost }}
 {%     endif %}
 {%     if vlan_interface.ospf_network_point_to_point is arista.avd.defined(true) %}
    ip ospf network point-to-point
-{%     endif %}
-{%     if vlan_interface.ospf_area is arista.avd.defined %}
-   ip ospf area {{ vlan_interface.ospf_area }}
-{%     endif %}
-{%     if vlan_interface.ospf_cost is arista.avd.defined %}
-   ip ospf cost {{ vlan_interface.ospf_cost }}
 {%     endif %}
 {%     if vlan_interface.ospf_authentication is arista.avd.defined %}
 {%         if vlan_interface.ospf_authentication == "simple" %}
@@ -256,12 +270,18 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.ospf_authentication_key is arista.avd.defined %}
    ip ospf authentication-key 7 {{ vlan_interface.ospf_authentication_key | arista.avd.hide_passwords(hide_passwords) }}
 {%     endif %}
+{%     if vlan_interface.ospf_area is arista.avd.defined %}
+   ip ospf area {{ vlan_interface.ospf_area }}
+{%     endif %}
 {%     for ospf_message_digest_key in vlan_interface.ospf_message_digest_keys | arista.avd.natural_sort('id') %}
 {%         if ospf_message_digest_key.hash_algorithm is arista.avd.defined and
               ospf_message_digest_key.key is arista.avd.defined %}
    ip ospf message-digest-key {{ ospf_message_digest_key.id }} {{ ospf_message_digest_key.hash_algorithm }} 7 {{ ospf_message_digest_key.key | arista.avd.hide_passwords(hide_passwords) }}
 {%         endif %}
 {%     endfor %}
+{%     if vlan_interface.service_policy.pbr.input is arista.avd.defined %}
+   service-policy type pbr input {{ vlan_interface.service_policy.pbr.input }}
+{%     endif %}
 {%     if vlan_interface.pim.ipv4.sparse_mode is arista.avd.defined(true) %}
    pim ipv4 sparse-mode
 {%     endif %}
@@ -286,22 +306,17 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.pim.ipv4.local_interface is arista.avd.defined %}
    pim ipv4 local-interface {{ vlan_interface.pim.ipv4.local_interface }}
 {%     endif %}
-{%     if vlan_interface.ipv6_virtual_router_addresses is arista.avd.defined %}
-{%         for ipv6_virtual_router_address in vlan_interface.ipv6_virtual_router_addresses %}
-   ipv6 virtual-router address {{ ipv6_virtual_router_address }}
-{%         endfor %}
-{%     endif %}
 {%     if vlan_interface.isis_enable is arista.avd.defined %}
    isis enable {{ vlan_interface.isis_enable }}
 {%     endif %}
 {%     if vlan_interface.isis_bfd is arista.avd.defined(true) %}
    isis bfd
 {%     endif %}
-{%     if vlan_interface.isis_passive is arista.avd.defined(true) %}
-   isis passive
-{%     endif %}
 {%     if vlan_interface.isis_metric is arista.avd.defined %}
    isis metric {{ vlan_interface.isis_metric }}
+{%     endif %}
+{%     if vlan_interface.isis_passive is arista.avd.defined(true) %}
+   isis passive
 {%     endif %}
 {%     if vlan_interface.isis_network_point_to_point is arista.avd.defined(true) %}
    isis network point-to-point
@@ -412,6 +427,27 @@ interface {{ vlan_interface.name }}
 {%             endif %}
 {%         endif %}
 {%     endif %}
+{%     if vlan_interface.ip_address_virtual is arista.avd.defined %}
+   ip address virtual {{ vlan_interface.ip_address_virtual }}
+{%         if vlan_interface.ip_address_virtual_secondaries is arista.avd.defined %}
+{%             for ip_address_virtual_secondary in vlan_interface.ip_address_virtual_secondaries | arista.avd.natural_sort %}
+   ip address virtual {{ ip_address_virtual_secondary }} secondary
+{%             endfor %}
+{%         endif %}
+{%     endif %}
+{%     for ipv6_address_virtual in vlan_interface.ipv6_address_virtuals | arista.avd.natural_sort %}
+   ipv6 address virtual {{ ipv6_address_virtual }}
+{%     endfor %}
+{%     if vlan_interface.ip_virtual_router_addresses is arista.avd.defined %}
+{%         for ip_virtual_router_address in vlan_interface.ip_virtual_router_addresses | arista.avd.natural_sort %}
+   ip virtual-router address {{ ip_virtual_router_address }}
+{%         endfor %}
+{%     endif %}
+{%     if vlan_interface.ipv6_virtual_router_addresses is arista.avd.defined %}
+{%         for ipv6_virtual_router_address in vlan_interface.ipv6_virtual_router_addresses | arista.avd.natural_sort %}
+   ipv6 virtual-router address {{ ipv6_virtual_router_address }}
+{%         endfor %}
+{%     endif %}
 {%     if vlan_interface.vrrp_ids is arista.avd.defined %}
 {%         for vrid in vlan_interface.vrrp_ids | arista.avd.natural_sort('id') if vrid.id is arista.avd.defined %}
 {%             if vrid.priority_level is arista.avd.defined %}
@@ -458,42 +494,6 @@ interface {{ vlan_interface.name }}
 {%                 endif %}
 {%             endfor %}
 {%         endfor %}
-{%     endif %}
-{%     if vlan_interface.ip_attached_host_route_export.enabled is arista.avd.defined(true) %}
-{%         set ip_attached_host_route_export_cli = "ip attached-host route export" %}
-{%         if vlan_interface.ip_attached_host_route_export.distance is arista.avd.defined %}
-{%             set ip_attached_host_route_export_cli = ip_attached_host_route_export_cli ~ " " ~ vlan_interface.ip_attached_host_route_export.distance %}
-{%         endif %}
-   {{ ip_attached_host_route_export_cli }}
-{%     endif %}
-{%     if vlan_interface.bfd.interval is arista.avd.defined and
-          vlan_interface.bfd.min_rx is arista.avd.defined and
-          vlan_interface.bfd.multiplier is arista.avd.defined %}
-   bfd interval {{ vlan_interface.bfd.interval }} min-rx {{ vlan_interface.bfd.min_rx }} multiplier {{ vlan_interface.bfd.multiplier }}
-{%     endif %}
-{%     if vlan_interface.bfd.echo is arista.avd.defined(true) %}
-   bfd echo
-{%     elif vlan_interface.bfd.echo is arista.avd.defined(false) %}
-   no bfd echo
-{%     endif %}
-{%     if vlan_interface.service_policy.pbr.input is arista.avd.defined %}
-   service-policy type pbr input {{ vlan_interface.service_policy.pbr.input }}
-{%     endif %}
-{%     if vlan_interface.pvlan_mapping is arista.avd.defined %}
-   pvlan mapping {{ vlan_interface.pvlan_mapping }}
-{%     endif %}
-{%     if vlan_interface.ip_virtual_router_addresses is arista.avd.defined %}
-{%         for ip_virtual_router_address in vlan_interface.ip_virtual_router_addresses %}
-   ip virtual-router address {{ ip_virtual_router_address }}
-{%         endfor %}
-{%     endif %}
-{%     if vlan_interface.ip_address_virtual is arista.avd.defined %}
-   ip address virtual {{ vlan_interface.ip_address_virtual }}
-{%         if vlan_interface.ip_address_virtual_secondaries is arista.avd.defined %}
-{%             for ip_address_virtual_secondary in vlan_interface.ip_address_virtual_secondaries %}
-   ip address virtual {{ ip_address_virtual_secondary }} secondary
-{%             endfor %}
-{%         endif %}
 {%     endif %}
 {%     if vlan_interface.eos_cli is arista.avd.defined %}
    {{ vlan_interface.eos_cli | indent(3, false) }}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -238,6 +238,8 @@ keys:
         ipv6_dhcp_relay_destinations:
           type: list
           primary_key: address
+          # TODO: Allow duplicate primary key as per for different vrf we can still have same address
+          # allow_duplicate_primary_key: True
           items:
             type: dict
             keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -238,7 +238,7 @@ keys:
         ipv6_dhcp_relay_destinations:
           type: list
           primary_key: address
-          # TODO: Allow duplicate primary key as per for different vrf we can still have same address
+          # TODO: Allow duplicate primary keys, as we can have the same address for different VRFs.
           # allow_duplicate_primary_key: True
           items:
             type: dict


### PR DESCRIPTION
## Change Summary

Rearrange the eos-cli config for `vlan-interfaces` to match with EOS.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Rearrange the eos-cli config for `vlan-interfaces` to match with EOS.

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
