### PR TITLE
Test: Fix examples not being run because remaining tags in molecule

### DIFF
--- a/ansible_collections/arista/avd/molecule/example-isis-ldp-ipvpn/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/example-isis-ldp-ipvpn/molecule.yml
@@ -27,8 +27,5 @@ provisioner:
   ansible_args:
     - --inventory
     - ${MOLECULE_SCENARIO_DIRECTORY}/../../examples/isis-ldp-ipvpn/inventory.yml
-    # Running with tags build to avoid deploy_eapi to run.
-    - --tags
-    - build
 verifier:
   name: ansible

--- a/ansible_collections/arista/avd/molecule/example-single-dc-l3ls/molecule.yml
+++ b/ansible_collections/arista/avd/molecule/example-single-dc-l3ls/molecule.yml
@@ -27,8 +27,5 @@ provisioner:
   ansible_args:
     - --inventory
     - ${MOLECULE_SCENARIO_DIRECTORY}/../../examples/single-dc-l3ls/inventory.yml
-    # Running with tags build to avoid deploy_eapi to run.
-    - --tags
-    - build
 verifier:
   name: ansible


### PR DESCRIPTION
## Change Summary

Following #4427 some examples are not running because still using `tags` in `molecule.yml`
Fixing this.

## Component(s) name

`examples`
`molecule`

## Proposed changes

Remove tags from `molecule.yml`

## How to test

Examples run

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
