### PR TITLE
Refactor(eos_cli_config_gen): Change the 'protocol' key to 'encapsulation' in interfaces-encapsulation model

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -1050,21 +1050,21 @@ ethernet_interfaces:
 -       dot1q:
 -         outer: 10
 -         inner: 12
-+       protocol: dot1q
++       encapsulation: dot1q
 +       outer_vlan: 10
 +       inner_vlan: 12
       network:
 -       dot1q:
 -         outer: 20
 -         inner: 22
-+       protocol: dot1q
++       encapsulation: dot1q
 +       outer_vlan: 20
 +       inner_vlan: 22
   - name: Ethernet1.30
     encapsulation_vlan:
       client:
 -       unmatched: true
-+       protocol: unmatched
++       encapsulation: unmatched
 
 !
 port_channel_interfaces:
@@ -1078,16 +1078,16 @@ port_channel_interfaces:
       client:
 -       dot1q:
 -         vlan: 50
-+       protocol: dot1q
++       encapsulation: dot1q
 +       vlan: 50
       network:
 -       client: true
-+       protocol: client
++       encapsulation: client
   - name: Port-Channel1.30
     encapsulation_vlan:
       client:
 -       unmatched: true
-+       protocol: unmatched
++       encapsulation: unmatched
 ```
 
 ### Removal of deprecated data models

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -153,7 +153,7 @@ sFlow is disabled.
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client Protocol | Client Inner Protocol | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Protocol | Network Inner Protocol | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client Encapsulation | Client Inner Encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Encapsulation | Network Inner Encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- |------------ | ---------------------- | ---------------------- |
 | Ethernet26.1 | TENANT_A pseudowire 1 interface | - | unmatched | - | - | - | - | - | - | - | - | - |
 | Ethernet26.100 | TENANT_A pseudowire 1 interface | 10 | dot1q | - | 100 | - | - | client | - | - | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -255,7 +255,7 @@ interface Ethernet50
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client encapsulation | Client Inner encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network encapsulation | Network Inner encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client Encapsulation | Client Inner Encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Encapsulation | Network Inner Encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- | ------------ | ---------------------- | ---------------------- |
 | Port-Channel111.1 | TENANT_A pseudowire 1 interface | - | unmatched | - | - | - | - | - | - | - | - | - |
 | Port-Channel111.100 | TENANT_A pseudowire 2 interface | - | dot1q | - | 100 | - | - | client | - | - | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/port-channel-interfaces.md
@@ -255,7 +255,7 @@ interface Ethernet50
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client Protocol | Client Inner Protocol | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Protocol | Network Inner Protocol | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client encapsulation | Client Inner encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network encapsulation | Network Inner encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- | ------------ | ---------------------- | ---------------------- |
 | Port-Channel111.1 | TENANT_A pseudowire 1 interface | - | unmatched | - | - | - | - | - | - | - | - | - |
 | Port-Channel111.100 | TENANT_A pseudowire 2 interface | - | dot1q | - | 100 | - | - | client | - | - | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ethernet-interfaces.yml
@@ -572,44 +572,44 @@ ethernet_interfaces:
     description: TENANT_A pseudowire 1 interface
     encapsulation_vlan:
       client:
-        protocol: unmatched
+        encapsulation: unmatched
 
   - name: Ethernet26.100
     description: TENANT_A pseudowire 1 interface
     vlan_id: 10
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 100
       network:
-        protocol: client
+        encapsulation: client
 
   - name: Ethernet26.200
     description: TENANT_A pseudowire 2 interface
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 200
 
   - name: Ethernet26.300
     description: TENANT_A pseudowire 3 interface
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 300
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 400
 
   - name: Ethernet26.400
     description: TENANT_A pseudowire 3 interface
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 400
         inner_vlan: 20
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 401
         inner_vlan: 21
 
@@ -617,11 +617,11 @@ ethernet_interfaces:
     description: TENANT_A pseudowire 3 interface
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 500
         inner_vlan: 50
       network:
-        protocol: client
+        encapsulation: client
 
   - name: Ethernet27
     switchport:
@@ -1252,22 +1252,22 @@ ethernet_interfaces:
       client:
         outer_vlan: 23
         inner_vlan: 45
-        protocol: dot1q
-        inner_protocol: dot1q
+        encapsulation: dot1q
+        inner_encapsulation: dot1q
       network:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 32
         inner_vlan: 54
-        inner_protocol: dot1ad
+        inner_encapsulation: dot1ad
 
   - name: Ethernet68.2
     description: Test_encapsulation_vlan2
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 10
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 32
         inner_vlan: 54
 
@@ -1275,35 +1275,35 @@ ethernet_interfaces:
     description: Test_encapsulation_vlan3
     encapsulation_vlan:
       client:
-        protocol: dot1ad
+        encapsulation: dot1ad
         vlan: 12
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 25
 
   - name: Ethernet68.4
     description: Test_encapsulation_vlan4
     encapsulation_vlan:
       client:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 35
         inner_vlan: 60
-        inner_protocol: dot1q
+        inner_encapsulation: dot1q
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 53
         inner_vlan: 6
-        inner_protocol: dot1ad
+        inner_encapsulation: dot1ad
 
   - name: Ethernet68.5
     description: Test_encapsulation_vlan5
     encapsulation_vlan:
       client:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 35
         inner_vlan: 60
       network:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 52
         inner_vlan: 62
 
@@ -1311,19 +1311,19 @@ ethernet_interfaces:
     description: Test_encapsulation_vlan6
     encapsulation_vlan:
       client:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 35
         inner_vlan: 60
       network:
-        protocol: client
+        encapsulation: client
 
   - name: Ethernet68.7
     description: Test_encapsulation_vlan7
     encapsulation_vlan:
       client:
-        protocol: untagged
+        encapsulation: untagged
       network:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 35
         inner_vlan: 60
 
@@ -1331,9 +1331,9 @@ ethernet_interfaces:
     description: Test_encapsulation_vlan8
     encapsulation_vlan:
       client:
-        protocol: untagged
+        encapsulation: untagged
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 35
         inner_vlan: 60
 
@@ -1341,19 +1341,19 @@ ethernet_interfaces:
     description: Test_encapsulation_vlan9
     encapsulation_vlan:
       client:
-        protocol: untagged
+        encapsulation: untagged
       network:
-        protocol: untagged
+        encapsulation: untagged
 
   - name: Ethernet68.10
     description: Test_encapsulation_vlan9
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 14
         inner_vlan: 11
       network:
-        protocol: client inner
+        encapsulation: client inner
   - name: Ethernet70
     description: dot1x_aaa_unresponsive
     shutdown: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/port-channel-interfaces.yml
@@ -457,43 +457,43 @@ port_channel_interfaces:
     description: TENANT_A pseudowire 1 interface
     encapsulation_vlan:
       client:
-        protocol: unmatched
+        encapsulation: unmatched
 
   - name: Port-Channel111.100
     description: TENANT_A pseudowire 2 interface
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 100
       network:
-        protocol: client
+        encapsulation: client
 
   - name: Port-Channel111.200
     description: TENANT_A pseudowire 3 interface
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 200
 
   - name: Port-Channel111.300
     description: TENANT_A pseudowire 4 interface
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 300
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 400
 
   - name: Port-Channel111.400
     description: TENANT_A pseudowire 3 interface
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 400
         inner_vlan: 20
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 401
         inner_vlan: 21
 
@@ -502,10 +502,10 @@ port_channel_interfaces:
     vlan_id: 1000
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 100
       network:
-        protocol: client
+        encapsulation: client
     evpn_ethernet_segment:
       identifier: 0000:0000:0303:0202:0101
       route_target: 03:03:02:02:01:01
@@ -633,22 +633,22 @@ port_channel_interfaces:
       client:
         outer_vlan: 23
         inner_vlan: 45
-        protocol: dot1q
-        inner_protocol: dot1q
+        encapsulation: dot1q
+        inner_encapsulation: dot1q
       network:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 32
         inner_vlan: 54
-        inner_protocol: dot1ad
+        inner_encapsulation: dot1ad
 
   - name: Port-Channel131.2
     description: Test_encapsulation_vlan2
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 10
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 32
         inner_vlan: 54
 
@@ -656,35 +656,35 @@ port_channel_interfaces:
     description: Test_encapsulation_vlan3
     encapsulation_vlan:
       client:
-        protocol: dot1ad
+        encapsulation: dot1ad
         vlan: 12
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         vlan: 25
 
   - name: Port-Channel131.4
     description: Test_encapsulation_vlan4
     encapsulation_vlan:
       client:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 35
         inner_vlan: 60
-        inner_protocol: dot1q
+        inner_encapsulation: dot1q
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 53
         inner_vlan: 6
-        inner_protocol: dot1ad
+        inner_encapsulation: dot1ad
 
   - name: Port-Channel131.5
     description: Test_encapsulation_vlan5
     encapsulation_vlan:
       client:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 35
         inner_vlan: 60
       network:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 52
         inner_vlan: 62
 
@@ -692,19 +692,19 @@ port_channel_interfaces:
     description: Test_encapsulation_vlan6
     encapsulation_vlan:
       client:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 35
         inner_vlan: 60
       network:
-        protocol: client
+        encapsulation: client
 
   - name: Port-Channel131.7
     description: Test_encapsulation_vlan7
     encapsulation_vlan:
       client:
-        protocol: untagged
+        encapsulation: untagged
       network:
-        protocol: dot1ad
+        encapsulation: dot1ad
         outer_vlan: 35
         inner_vlan: 60
 
@@ -712,9 +712,9 @@ port_channel_interfaces:
     description: Test_encapsulation_vlan8
     encapsulation_vlan:
       client:
-        protocol: untagged
+        encapsulation: untagged
       network:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 35
         inner_vlan: 60
 
@@ -722,19 +722,19 @@ port_channel_interfaces:
     description: Test_encapsulation_vlan9
     encapsulation_vlan:
       client:
-        protocol: untagged
+        encapsulation: untagged
       network:
-        protocol: untagged
+        encapsulation: untagged
 
   - name: Port-Channel131.10
     description: Test_encapsulation_vlan9
     encapsulation_vlan:
       client:
-        protocol: dot1q
+        encapsulation: dot1q
         outer_vlan: 14
         inner_vlan: 11
       network:
-        protocol: client inner
+        encapsulation: client inner
 
 # Children interfaces
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -293,7 +293,7 @@ interface Ethernet8
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client encapsulation | Client Inner encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network encapsulation | Network Inner encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client Encapsulation | Client Inner Encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Encapsulation | Network Inner Encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- | ------------ | ---------------------- | ---------------------- |
 | Port-Channel3.1000 | - | - | dot1q | - | 1000 | - | - | client | - | - | - | - |
 | Port-Channel3.1001 | - | - | dot1q | - | 1001 | - | - | client | - | - | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -293,7 +293,7 @@ interface Ethernet8
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client Protocol | Client Inner Protocol | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Protocol | Network Inner Protocol | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client encapsulation | Client Inner encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network encapsulation | Network Inner encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- | ------------ | ---------------------- | ---------------------- |
 | Port-Channel3.1000 | - | - | dot1q | - | 1000 | - | - | client | - | - | - | - |
 | Port-Channel3.1001 | - | - | dot1q | - | 1001 | - | - | client | - | - | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -287,7 +287,7 @@ interface Ethernet8
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client encapsulation | Client Inner encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network encapsulation | Network Inner encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client Encapsulation | Client Inner Encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Encapsulation | Network Inner Encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- | ------------ | ---------------------- | ---------------------- |
 | Port-Channel3.1000 | - | - | dot1q | - | 1000 | - | - | client | - | - | - | - |
 | Port-Channel3.1001 | - | - | dot1q | - | 1001 | - | - | client | - | - | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -287,7 +287,7 @@ interface Ethernet8
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client Protocol | Client Inner Protocol | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Protocol | Network Inner Protocol | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client encapsulation | Client Inner encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network encapsulation | Network Inner encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- | ------------ | ---------------------- | ---------------------- |
 | Port-Channel3.1000 | - | - | dot1q | - | 1000 | - | - | client | - | - | - | - |
 | Port-Channel3.1001 | - | - | dot1q | - | 1001 | - | - | client | - | - | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -341,7 +341,7 @@ interface Ethernet14
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client encapsulation | Client Inner encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network encapsulation | Network Inner encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client Encapsulation | Client Inner Encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Encapsulation | Network Inner Encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- | ------------ | ---------------------- | ---------------------- |
 | Port-Channel4.1000 | - | - | dot1q | - | 1000 | - | - | client | - | - | - | - |
 | Port-Channel4.1001 | - | - | dot1q | - | 1001 | - | - | client | - | - | - | - |

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -341,7 +341,7 @@ interface Ethernet14
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client Protocol | Client Inner Protocol | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Protocol | Network Inner Protocol | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client encapsulation | Client Inner encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network encapsulation | Network Inner encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- | ------------ | ---------------------- | ---------------------- |
 | Port-Channel4.1000 | - | - | dot1q | - | 1000 | - | - | client | - | - | - | - |
 | Port-Channel4.1001 | - | - | dot1q | - | 1001 | - | - | client | - | - | - | - |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -71,22 +71,22 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.outer") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  |  | Client Inner VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmatched</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.unmatched") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.protocol") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>unmatched</code><br>- <code>untagged</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client VLAN ID. Not applicable for `protocol==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. Not applicable for `protocol==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. Not applicable for `protocol==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_protocol</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner_protocol") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>unmatched</code><br>- <code>untagged</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_encapsulation</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner_encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulations are all optional and skipped if using client unmatched. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.outer") | Integer |  |  | Min: 1<br>Max: 4094 | Network outer VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.client") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.protocol") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>client</code><br>- <code>client inner</code><br>- <code>untagged</code> | `untagged` (no encapsulation) is applicable for `untagged` client only.<br>`client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. Not applicable for `protocol==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network outer VLAN ID. Not applicable for `protocol==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID. Not applicable for `protocol==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_protocol</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner_protocol") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>client</code><br>- <code>client inner</code><br>- <code>untagged</code> | `untagged` (no encapsulation) is applicable for `untagged` client only.<br>`client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. Not applicable for `encapsulation==untagged/client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_encapsulation</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner_encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "ethernet_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 | This setting can only be applied to sub-interfaces on EOS.<br>Warning: `vlan_id` should not be combined with `ethernet_interfaces[].type == l2dot1q`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask or "dhcp". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address_secondaries</samp>](## "ethernet_interfaces.[].ip_address_secondaries") | List, items: String |  |  |  |  |
@@ -654,17 +654,17 @@
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
             unmatched: <bool>
-            protocol: <str; "dot1q" | "dot1ad" | "unmatched" | "untagged">
+            encapsulation: <str; "dot1q" | "dot1ad" | "unmatched" | "untagged">
 
-            # Client VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+            # Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
             vlan: <int; 1-4094>
 
-            # Client Outer VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+            # Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
             outer_vlan: <int; 1-4094>
 
-            # Client Inner VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+            # Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
             inner_vlan: <int; 1-4094>
-            inner_protocol: <str; "dot1q" | "dot1ad">
+            inner_encapsulation: <str; "dot1q" | "dot1ad">
 
           # Network encapsulations are all optional and skipped if using client unmatched.
           network:
@@ -686,17 +686,17 @@
 
             # `untagged` (no encapsulation) is applicable for `untagged` client only.
             # `client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client.
-            protocol: <str; "dot1q" | "dot1ad" | "client" | "client inner" | "untagged">
+            encapsulation: <str; "dot1q" | "dot1ad" | "client" | "client inner" | "untagged">
 
-            # Network VLAN ID. Not applicable for `protocol==untagged/client`.
+            # Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
             vlan: <int; 1-4094>
 
-            # Network outer VLAN ID. Not applicable for `protocol==untagged/client`.
+            # Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
             outer_vlan: <int; 1-4094>
 
-            # Network inner VLAN ID. Not applicable for `protocol==untagged/client`.
+            # Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
             inner_vlan: <int; 1-4094>
-            inner_protocol: <str; "dot1q" | "dot1ad">
+            inner_encapsulation: <str; "dot1q" | "dot1ad">
 
         # This setting can only be applied to sub-interfaces on EOS.
         # Warning: `vlan_id` should not be combined with `ethernet_interfaces[].type == l2dot1q`.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -61,10 +61,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tunnel_flood_filter_time</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.mpls.tunnel_flood_filter_time") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_target</samp>](## "ethernet_interfaces.[].evpn_ethernet_segment.route_target") | String |  |  |  | EVPN Route Target for ESI with format xx:xx:xx:xx:xx:xx. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "ethernet_interfaces.[].encapsulation_dot1q_vlan") <span style="color:red">deprecated</span> | Integer |  |  |  | VLAN tag to configure on sub-interface.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>encapsulation_dot1q.vlan</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q</samp>](## "ethernet_interfaces.[].encapsulation_dot1q") | Dictionary |  |  |  | Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q</samp>](## "ethernet_interfaces.[].encapsulation_dot1q") | Dictionary |  |  |  | Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_dot1q.vlan") | Integer | Required |  | Min: 1<br>Max: 4094 | VLAD ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "ethernet_interfaces.[].encapsulation_dot1q.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Inner VLAN ID. This setting can only be applied to sub-interfaces on EOS. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan") | Dictionary |  |  |  | This setting can only be applied to sub-interfaces on EOS.<br>Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan") | Dictionary |  |  |  | This setting can only be applied to sub-interfaces on EOS.<br>Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client VLAN ID. |
@@ -72,9 +72,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  |  | Client Inner VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmatched</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.unmatched") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>unmatched</code><br>- <code>untagged</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_encapsulation</samp>](## "ethernet_interfaces.[].encapsulation_vlan.client.inner_encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulations are all optional and skipped if using client unmatched. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
@@ -83,9 +83,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.client") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>client</code><br>- <code>client inner</code><br>- <code>untagged</code> | `untagged` (no encapsulation) is applicable for `untagged` client only.<br>`client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. Not applicable for `encapsulation==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID.  Not applicable for `encapsulation: untagged` or `encapsulation: client`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_encapsulation</samp>](## "ethernet_interfaces.[].encapsulation_vlan.network.inner_encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "ethernet_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 | This setting can only be applied to sub-interfaces on EOS.<br>Warning: `vlan_id` should not be combined with `ethernet_interfaces[].type == l2dot1q`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "ethernet_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask or "dhcp". |
@@ -626,7 +626,7 @@
         # Use <samp>encapsulation_dot1q.vlan</samp> instead.
         encapsulation_dot1q_vlan: <int>
 
-        # Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`.
+        # Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
         encapsulation_dot1q:
 
           # VLAD ID.
@@ -636,7 +636,7 @@
           inner_vlan: <int; 1-4094>
 
         # This setting can only be applied to sub-interfaces on EOS.
-        # Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`.
+        # Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
         encapsulation_vlan:
           client:
             # This key is deprecated.
@@ -656,13 +656,13 @@
             unmatched: <bool>
             encapsulation: <str; "dot1q" | "dot1ad" | "unmatched" | "untagged">
 
-            # Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+            # Client VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
             vlan: <int; 1-4094>
 
-            # Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+            # Client Outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
             outer_vlan: <int; 1-4094>
 
-            # Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+            # Client Inner VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
             inner_vlan: <int; 1-4094>
             inner_encapsulation: <str; "dot1q" | "dot1ad">
 
@@ -688,13 +688,13 @@
             # `client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client.
             encapsulation: <str; "dot1q" | "dot1ad" | "client" | "client inner" | "untagged">
 
-            # Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
+            # Network VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
             vlan: <int; 1-4094>
 
-            # Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
+            # Network outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
             outer_vlan: <int; 1-4094>
 
-            # Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+            # Network inner VLAN ID.  Not applicable for `encapsulation: untagged` or `encapsulation: client`.
             inner_vlan: <int; 1-4094>
             inner_encapsulation: <str; "dot1q" | "dot1ad">
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -32,22 +32,22 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.dot1q.outer") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmatched</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.unmatched") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.protocol") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>unmatched</code><br>- <code>untagged</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client VLAN ID. Not applicable for `protocol==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. Not applicable for `protocol==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. Not applicable for `protocol==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_protocol</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.inner_protocol") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>unmatched</code><br>- <code>untagged</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_encapsulation</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.inner_encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulation are all optional, and skipped if using client unmatched. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.dot1q") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.dot1q.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.dot1q.outer") | Integer |  |  | Min: 1<br>Max: 4094 | Network Outer VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  | Min: 1<br>Max: 4094 | Network Inner VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.client") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.protocol") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>client</code><br>- <code>client inner</code><br>- <code>untagged</code> | `untagged` (no encapsulation) is applicable for `untagged` client only.<br>`client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. Not applicable for `protocol==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network outer VLAN ID. Not applicable for `protocol==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID. Not applicable for `protocol==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_protocol</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.inner_protocol") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>client</code><br>- <code>client inner</code><br>- <code>untagged</code> | `untagged` (no encapsulation) is applicable for `untagged` client only.<br>`client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. Not applicable for `encapsulation==untagged/client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_encapsulation</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.inner_encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "port_channel_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 | This setting can only be applied to sub-interfaces on EOS.<br>Warning: `vlan_id` should not be combined with `ethernet_interfaces[].type == l2dot1q`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "port_channel_interfaces.[].mode") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>access</code><br>- <code>dot1q-tunnel</code><br>- <code>trunk</code><br>- <code>trunk phone</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>port_channel_interfaces[].switchport.mode</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;native_vlan</samp>](## "port_channel_interfaces.[].native_vlan") <span style="color:red">deprecated</span> | Integer |  |  |  | If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>port_channel_interfaces[].switchport.trunk.native_vlan</samp> instead.</span> |
@@ -397,17 +397,17 @@
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
             unmatched: <bool>
-            protocol: <str; "dot1q" | "dot1ad" | "unmatched" | "untagged">
+            encapsulation: <str; "dot1q" | "dot1ad" | "unmatched" | "untagged">
 
-            # Client VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+            # Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
             vlan: <int; 1-4094>
 
-            # Client Outer VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+            # Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
             outer_vlan: <int; 1-4094>
 
-            # Client Inner VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+            # Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
             inner_vlan: <int; 1-4094>
-            inner_protocol: <str; "dot1q" | "dot1ad">
+            inner_encapsulation: <str; "dot1q" | "dot1ad">
 
           # Network encapsulation are all optional, and skipped if using client unmatched.
           network:
@@ -429,17 +429,17 @@
 
             # `untagged` (no encapsulation) is applicable for `untagged` client only.
             # `client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client.
-            protocol: <str; "dot1q" | "dot1ad" | "client" | "client inner" | "untagged">
+            encapsulation: <str; "dot1q" | "dot1ad" | "client" | "client inner" | "untagged">
 
-            # Network VLAN ID. Not applicable for `protocol==untagged/client`.
+            # Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
             vlan: <int; 1-4094>
 
-            # Network outer VLAN ID. Not applicable for `protocol==untagged/client`.
+            # Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
             outer_vlan: <int; 1-4094>
 
-            # Network inner VLAN ID. Not applicable for `protocol==untagged/client`.
+            # Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
             inner_vlan: <int; 1-4094>
-            inner_protocol: <str; "dot1q" | "dot1ad">
+            inner_encapsulation: <str; "dot1q" | "dot1ad">
 
         # This setting can only be applied to sub-interfaces on EOS.
         # Warning: `vlan_id` should not be combined with `ethernet_interfaces[].type == l2dot1q`.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -21,11 +21,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "port_channel_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "port_channel_interfaces.[].type") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>routed</code><br>- <code>switched</code><br>- <code>l3dot1q</code><br>- <code>l2dot1q</code> | l3dot1q and l2dot1q are used for sub-interfaces. The parent interface should be defined as routed.<br>Interface will not be listed in device documentation, unless "type" is set.<br><span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. See [here](https://avd.arista.com/stable/docs/release-notes/5.x.x.html#removal-of-type-key-dependency-for-rendering-ethernetport-channel-interfaces-configuration-and-documentation) for details.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q_vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q_vlan") <span style="color:red">deprecated</span> | Integer |  |  |  | VLAN tag to configure on sub-interface.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>encapsulation_dot1q.vlan</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q</samp>](## "port_channel_interfaces.[].encapsulation_dot1q") | Dictionary |  |  |  | Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q</samp>](## "port_channel_interfaces.[].encapsulation_dot1q") | Dictionary |  |  |  | Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q.vlan") | Integer | Required |  | Min: 1<br>Max: 4094 | VLAD ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Inner VLAN ID. This setting can only be applied to sub-interfaces on EOS. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "port_channel_interfaces.[].vrf") | String |  |  |  | VRF name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan") | Dictionary |  |  |  | This setting can only be applied to sub-interfaces on EOS.<br>Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan") | Dictionary |  |  |  | This setting can only be applied to sub-interfaces on EOS.<br>Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.dot1q") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.dot1q.vlan") | Integer |  |  |  | Client VLAN ID. |
@@ -33,9 +33,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.dot1q.inner") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unmatched</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.unmatched") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>unmatched</code><br>- <code>untagged</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Client Inner VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_encapsulation</samp>](## "port_channel_interfaces.[].encapsulation_vlan.client.inner_encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;network</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network") | Dictionary |  |  |  | Network encapsulation are all optional, and skipped if using client unmatched. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.dot1q") <span style="color:red">deprecated</span> | Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
@@ -44,9 +44,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.dot1q.inner") | Integer |  |  | Min: 1<br>Max: 4094 | Network Inner VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;client</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.client") <span style="color:red">deprecated</span> | Boolean |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encapsulation</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code><br>- <code>client</code><br>- <code>client inner</code><br>- <code>untagged</code> | `untagged` (no encapsulation) is applicable for `untagged` client only.<br>`client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. Not applicable for `encapsulation==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;outer_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.outer_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Network inner VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_encapsulation</samp>](## "port_channel_interfaces.[].encapsulation_vlan.network.inner_encapsulation") | String |  |  | Valid Values:<br>- <code>dot1q</code><br>- <code>dot1ad</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan_id</samp>](## "port_channel_interfaces.[].vlan_id") | Integer |  |  | Min: 1<br>Max: 4094 | This setting can only be applied to sub-interfaces on EOS.<br>Warning: `vlan_id` should not be combined with `ethernet_interfaces[].type == l2dot1q`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "port_channel_interfaces.[].mode") <span style="color:red">deprecated</span> | String |  |  | Valid Values:<br>- <code>access</code><br>- <code>dot1q-tunnel</code><br>- <code>trunk</code><br>- <code>trunk phone</code> | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>port_channel_interfaces[].switchport.mode</samp> instead.</span> |
@@ -366,7 +366,7 @@
         # Use <samp>encapsulation_dot1q.vlan</samp> instead.
         encapsulation_dot1q_vlan: <int>
 
-        # Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`.
+        # Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
         encapsulation_dot1q:
 
           # VLAD ID.
@@ -379,7 +379,7 @@
         vrf: <str>
 
         # This setting can only be applied to sub-interfaces on EOS.
-        # Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`.
+        # Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
         encapsulation_vlan:
           client:
             # This key is deprecated.
@@ -399,13 +399,13 @@
             unmatched: <bool>
             encapsulation: <str; "dot1q" | "dot1ad" | "unmatched" | "untagged">
 
-            # Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+            # Client VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
             vlan: <int; 1-4094>
 
-            # Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+            # Client Outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
             outer_vlan: <int; 1-4094>
 
-            # Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+            # Client Inner VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
             inner_vlan: <int; 1-4094>
             inner_encapsulation: <str; "dot1q" | "dot1ad">
 
@@ -431,13 +431,13 @@
             # `client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client.
             encapsulation: <str; "dot1q" | "dot1ad" | "client" | "client inner" | "untagged">
 
-            # Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
+            # Network VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
             vlan: <int; 1-4094>
 
-            # Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
+            # Network outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
             outer_vlan: <int; 1-4094>
 
-            # Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+            # Network inner VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
             inner_vlan: <int; 1-4094>
             inner_encapsulation: <str; "dot1q" | "dot1ad">
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -127,7 +127,7 @@
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%         if ethernet_interface.encapsulation_dot1q.vlan is arista.avd.defined %}
 {%             do encapsulation_dot1q_interfaces.append(ethernet_interface) %}
-{%         elif ethernet_interface.encapsulation_vlan.client.protocol is arista.avd.defined %}
+{%         elif ethernet_interface.encapsulation_vlan.client.encapsulation is arista.avd.defined %}
 {%             do flexencap_interfaces.append(ethernet_interface) %}
 {%         elif ethernet_interface.type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
 {%             if ethernet_interface.encapsulation_dot1q_vlan is arista.avd.defined %}
@@ -155,44 +155,44 @@
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client Protocol | Client Inner Protocol | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Protocol | Network Inner Protocol | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client Encapsulation | Client Inner Encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Encapsulation | Network Inner Encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- |------------ | ---------------------- | ---------------------- |
 {%         for ethernet_interface in flexencap_interfaces %}
 {%             set description = ethernet_interface.description | arista.avd.default("-") %}
 {%             set vlan_id = ethernet_interface.vlan_id | arista.avd.default('-') %}
-{%             set client_protocol = ethernet_interface.encapsulation_vlan.client.protocol | arista.avd.default('-') %}
-{# The below if condition is to get client protocol from deprecated keys #}
+{%             set client_encapsulation = ethernet_interface.encapsulation_vlan.client.encapsulation | arista.avd.default('-') %}
+{# The below if condition is to get client encapsulation from deprecated keys #}
 {# TODO: AVD6.0 below if block should be removed once the 'ethernet_interface.encapsulation_vlan.client.dot1q' and 'ethernet_interface.encapsulation_vlan.client.unmatched' are removed in AVD6.0 #}
-{%             if client_protocol == '-' %}
+{%             if client_encapsulation == '-' %}
 {%                 if ethernet_interface.encapsulation_vlan.client.dot1q is arista.avd.defined %}
-{%                     set client_protocol = 'dot1q' %}
+{%                     set client_encapsulation = 'dot1q' %}
 {%                 elif ethernet_interface.encapsulation_vlan.client.unmatched is arista.avd.defined(true) %}
-{%                     set client_protocol = 'unmatched' %}
+{%                     set client_encapsulation = 'unmatched' %}
 {%                 endif %}
 {%             endif %}
-{%             if client_protocol in ['dot1q', 'dot1ad'] %}
-{%                 set client_inner_protocol = ethernet_interface.encapsulation_vlan.client.inner_protocol | arista.avd.default('-') %}
+{%             if client_encapsulation in ['dot1q', 'dot1ad'] %}
+{%                 set client_inner_encapsulation = ethernet_interface.encapsulation_vlan.client.inner_encapsulation | arista.avd.default('-') %}
 {%                 set client_vlan = ethernet_interface.encapsulation_vlan.client.vlan | arista.avd.default(ethernet_interface.encapsulation_vlan.client.dot1q.vlan) %}
 {%                 set client_outer_vlan = ethernet_interface.encapsulation_vlan.client.outer_vlan | arista.avd.default(ethernet_interface.encapsulation_vlan.client.dot1q.outer) %}
 {%                 set client_inner_vlan = ethernet_interface.encapsulation_vlan.client.inner_vlan | arista.avd.default(ethernet_interface.encapsulation_vlan.client.dot1q.inner) %}
 {%             endif %}
-{%             set network_protocol = ethernet_interface.encapsulation_vlan.network.protocol | arista.avd.default('-') %}
-{# The below if condition is to get network protocol from deprecated keys #}
+{%             set network_encapsulation = ethernet_interface.encapsulation_vlan.network.encapsulation | arista.avd.default('-') %}
+{# The below if condition is to get network encapsulation from deprecated keys #}
 {# TODO: AVD6.0 below if block should be removed once the 'ethernet_interface.encapsulation_vlan.network.dot1q' and 'ethernet_interface.encapsulation_vlan.network.client' are removed in AVD6.0 #}
-{%             if network_protocol == '-' %}
+{%             if network_encapsulation == '-' %}
 {%                 if ethernet_interface.encapsulation_vlan.network.dot1q is arista.avd.defined %}
-{%                     set network_protocol = 'dot1q' %}
+{%                     set network_encapsulation = 'dot1q' %}
 {%                 elif ethernet_interface.encapsulation_vlan.network.client is arista.avd.defined(true) %}
-{%                     set network_protocol = 'client' %}
+{%                     set network_encapsulation = 'client' %}
 {%                 endif %}
 {%             endif %}
-{%             if network_protocol in ['dot1q', 'dot1ad'] %}
-{%                 set network_inner_protocol = ethernet_interface.encapsulation_vlan.network.inner_protocol | arista.avd.default('-') %}
+{%             if network_encapsulation in ['dot1q', 'dot1ad'] %}
+{%                 set network_inner_encapsulation = ethernet_interface.encapsulation_vlan.network.inner_encapsulation | arista.avd.default('-') %}
 {%                 set network_vlan = ethernet_interface.encapsulation_vlan.network.vlan | arista.avd.default(ethernet_interface.encapsulation_vlan.network.dot1q.vlan) %}
 {%                 set network_outer_vlan = ethernet_interface.encapsulation_vlan.network.outer_vlan | arista.avd.default(ethernet_interface.encapsulation_vlan.network.dot1q.outer) %}
 {%                 set network_inner_vlan = ethernet_interface.encapsulation_vlan.network.inner_vlan | arista.avd.default(ethernet_interface.encapsulation_vlan.network.dot1q.inner) %}
 {%             endif %}
-| {{ ethernet_interface.name }} | {{ description }} | {{ vlan_id }} | {{ client_protocol }} | {{ client_inner_protocol | arista.avd.default('-') }} | {{ client_vlan | arista.avd.default('-') }} | {{ client_outer_vlan | arista.avd.default('-') }} | {{ client_inner_vlan | arista.avd.default('-') }} | {{ network_protocol }} | {{ network_inner_protocol | arista.avd.default('-') }} | {{ network_vlan | arista.avd.default('-') }} | {{ network_outer_vlan | arista.avd.default('-') }} | {{ network_inner_vlan | arista.avd.default('-') }} |
+| {{ ethernet_interface.name }} | {{ description }} | {{ vlan_id }} | {{ client_encapsulation }} | {{ client_inner_encapsulation | arista.avd.default('-') }} | {{ client_vlan | arista.avd.default('-') }} | {{ client_outer_vlan | arista.avd.default('-') }} | {{ client_inner_vlan | arista.avd.default('-') }} | {{ network_encapsulation }} | {{ network_inner_encapsulation | arista.avd.default('-') }} | {{ network_vlan | arista.avd.default('-') }} | {{ network_outer_vlan | arista.avd.default('-') }} | {{ network_inner_vlan | arista.avd.default('-') }} |
 {%         endfor %}
 {%     endif %}
 {# PVLAN #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/port-channel-interfaces.j2
@@ -77,7 +77,7 @@
 {%     for port_channel_interface in port_channel_interfaces %}
 {%         if port_channel_interface.encapsulation_dot1q.vlan is arista.avd.defined %}
 {%             do encapsulation_dot1q_interfaces.append(port_channel_interface) %}
-{%         elif port_channel_interface.encapsulation_vlan.client.protocol is arista.avd.defined %}
+{%         elif port_channel_interface.encapsulation_vlan.client.encapsulation is arista.avd.defined %}
 {%             do flexencap_interfaces.append(port_channel_interface) %}
 {%         elif port_channel_interface.type | arista.avd.default in ['l3dot1q', 'l2dot1q'] %}
 {%             if port_channel_interface.encapsulation_dot1q_vlan is arista.avd.defined %}
@@ -105,44 +105,44 @@
 
 ##### Flexible Encapsulation Interfaces
 
-| Interface | Description | Vlan ID | Client Protocol | Client Inner Protocol | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Protocol | Network Inner Protocol | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
+| Interface | Description | Vlan ID | Client Encapsulation | Client Inner Encapsulation | Client VLAN | Client Outer VLAN Tag | Client Inner VLAN Tag | Network Encapsulation | Network Inner Encapsulation | Network VLAN | Network Outer VLAN Tag | Network Inner VLAN Tag |
 | --------- | ----------- | ------- | --------------- | --------------------- | ----------- | --------------------- | --------------------- | ---------------- | ---------------------- | ------------ | ---------------------- | ---------------------- |
 {%         for port_channel_interface in flexencap_interfaces %}
 {%             set description = port_channel_interface.description | arista.avd.default("-") %}
 {%             set vlan_id = port_channel_interface.vlan_id | arista.avd.default('-') %}
-{%             set client_protocol = port_channel_interface.encapsulation_vlan.client.protocol | arista.avd.default('-') %}
-{# The below if condition is to get client protocol from deprecated keys #}
+{%             set client_encapsulation = port_channel_interface.encapsulation_vlan.client.encapsulation | arista.avd.default('-') %}
+{# The below if condition is to get client encapsulation from deprecated keys #}
 {# TODO: AVD6.0 below if block should be removed once the 'port_channel_interface.encapsulation_vlan.client.dot1q' and 'port_channel_interface.encapsulation_vlan.client.unmatched' are removed in AVD6.0 #}
-{%             if client_protocol == '-' %}
+{%             if client_encapsulation == '-' %}
 {%                 if port_channel_interface.encapsulation_vlan.client.dot1q is arista.avd.defined %}
-{%                     set client_protocol = 'dot1q' %}
+{%                     set client_encapsulation = 'dot1q' %}
 {%                 elif port_channel_interface.encapsulation_vlan.client.unmatched is arista.avd.defined(true) %}
-{%                     set client_protocol = 'unmatched' %}
+{%                     set client_encapsulation = 'unmatched' %}
 {%                 endif %}
 {%             endif %}
-{%             if client_protocol in ['dot1q', 'dot1ad'] %}
-{%                 set client_inner_protocol = port_channel_interface.encapsulation_vlan.client.inner_protocol | arista.avd.default('-') %}
+{%             if client_encapsulation in ['dot1q', 'dot1ad'] %}
+{%                 set client_inner_encapsulation = port_channel_interface.encapsulation_vlan.client.inner_encapsulation | arista.avd.default('-') %}
 {%                 set client_vlan = port_channel_interface.encapsulation_vlan.client.vlan | arista.avd.default(port_channel_interface.encapsulation_vlan.client.dot1q.vlan) %}
 {%                 set client_outer_vlan = port_channel_interface.encapsulation_vlan.client.outer_vlan | arista.avd.default(port_channel_interface.encapsulation_vlan.client.dot1q.outer) %}
 {%                 set client_inner_vlan = port_channel_interface.encapsulation_vlan.client.inner_vlan | arista.avd.default(port_channel_interface.encapsulation_vlan.client.dot1q.inner) %}
 {%             endif %}
-{%             set network_protocol = port_channel_interface.encapsulation_vlan.network.protocol | arista.avd.default('-') %}
-{# The below if condition is to get network protocol from deprecated keys #}
+{%             set network_encapsulation = port_channel_interface.encapsulation_vlan.network.encapsulation | arista.avd.default('-') %}
+{# The below if condition is to get network encapsulation from deprecated keys #}
 {# TODO: AVD6.0 below if block should be removed once the 'port_channel_interface.encapsulation_vlan.network.dot1q' and 'port_channel_interface.encapsulation_vlan.network.client' are removed in AVD6.0 #}
-{%             if network_protocol == '-' %}
+{%             if network_encapsulation == '-' %}
 {%                 if port_channel_interface.encapsulation_vlan.network.dot1q is arista.avd.defined %}
-{%                     set network_protocol = 'dot1q' %}
+{%                     set network_encapsulation = 'dot1q' %}
 {%                 elif port_channel_interface.encapsulation_vlan.network.client is arista.avd.defined(true) %}
-{%                     set network_protocol = 'client' %}
+{%                     set network_encapsulation = 'client' %}
 {%                 endif %}
 {%             endif %}
-{%             if network_protocol in ['dot1q', 'dot1ad'] %}
-{%                 set network_inner_protocol = port_channel_interface.encapsulation_vlan.network.inner_protocol | arista.avd.default('-') %}
+{%             if network_encapsulation in ['dot1q', 'dot1ad'] %}
+{%                 set network_inner_encapsulation = port_channel_interface.encapsulation_vlan.network.inner_encapsulation | arista.avd.default('-') %}
 {%                 set network_vlan = port_channel_interface.encapsulation_vlan.network.vlan | arista.avd.default(port_channel_interface.encapsulation_vlan.network.dot1q.vlan) %}
 {%                 set network_outer_vlan = port_channel_interface.encapsulation_vlan.network.outer_vlan | arista.avd.default(port_channel_interface.encapsulation_vlan.network.dot1q.outer) %}
 {%                 set network_inner_vlan = port_channel_interface.encapsulation_vlan.network.inner_vlan | arista.avd.default(port_channel_interface.encapsulation_vlan.network.dot1q.inner) %}
 {%             endif %}
-| {{ port_channel_interface.name }} | {{ description }} | {{ vlan_id }} | {{ client_protocol }} | {{ client_inner_protocol | arista.avd.default('-') }} | {{ client_vlan | arista.avd.default('-') }} | {{ client_outer_vlan | arista.avd.default('-') }} | {{ client_inner_vlan | arista.avd.default('-') }} | {{ network_protocol }} | {{ network_inner_protocol | arista.avd.default('-') }} | {{ network_vlan | arista.avd.default('-') }} | {{ network_outer_vlan | arista.avd.default('-') }} | {{ network_inner_vlan | arista.avd.default('-') }} |
+| {{ port_channel_interface.name }} | {{ description }} | {{ vlan_id }} | {{ client_encapsulation }} | {{ client_inner_encapsulation | arista.avd.default('-') }} | {{ client_vlan | arista.avd.default('-') }} | {{ client_outer_vlan | arista.avd.default('-') }} | {{ client_inner_vlan | arista.avd.default('-') }} | {{ network_encapsulation }} | {{ network_inner_encapsulation | arista.avd.default('-') }} | {{ network_vlan | arista.avd.default('-') }} | {{ network_outer_vlan | arista.avd.default('-') }} | {{ network_inner_vlan | arista.avd.default('-') }} |
 {%         endfor %}
 {%     endif %}
 {# PVLAN #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -169,42 +169,42 @@ interface {{ ethernet_interface.name }}
 {%             set encapsulation_dot1q_cli = encapsulation_dot1q_cli ~ ' inner ' ~ ethernet_interface.encapsulation_dot1q.inner_vlan %}
 {%         endif %}
    {{ encapsulation_dot1q_cli }}
-{%     elif ethernet_interface.encapsulation_vlan.client.protocol is arista.avd.defined %}
-{%         set client_protocol = ethernet_interface.encapsulation_vlan.client.protocol %}
+{%     elif ethernet_interface.encapsulation_vlan.client.encapsulation is arista.avd.defined %}
+{%         set client_encapsulation = ethernet_interface.encapsulation_vlan.client.encapsulation %}
 {%         set network_flag = False %}
-{%         if client_protocol in ['dot1q', 'dot1ad'] %}
+{%         if client_encapsulation in ['dot1q', 'dot1ad'] %}
 {%             if ethernet_interface.encapsulation_vlan.client.vlan is arista.avd.defined %}
-{%                 set encapsulation_cli = 'client ' ~ client_protocol ~ ' ' ~ ethernet_interface.encapsulation_vlan.client.vlan %}
+{%                 set encapsulation_cli = 'client ' ~ client_encapsulation ~ ' ' ~ ethernet_interface.encapsulation_vlan.client.vlan %}
 {%             elif ethernet_interface.encapsulation_vlan.client.outer_vlan is arista.avd.defined and ethernet_interface.encapsulation_vlan.client.inner_vlan is arista.avd.defined %}
-{%                 if ethernet_interface.encapsulation_vlan.client.inner_protocol is arista.avd.defined %}
-{%                     set encapsulation_cli = 'client ' ~ client_protocol ~ ' outer ' ~ ethernet_interface.encapsulation_vlan.client.outer_vlan ~ ' inner ' ~ ethernet_interface.encapsulation_vlan.client.inner_protocol ~ ' ' ~ ethernet_interface.encapsulation_vlan.client.inner_vlan %}
+{%                 if ethernet_interface.encapsulation_vlan.client.inner_encapsulation is arista.avd.defined %}
+{%                     set encapsulation_cli = 'client ' ~ client_encapsulation ~ ' outer ' ~ ethernet_interface.encapsulation_vlan.client.outer_vlan ~ ' inner ' ~ ethernet_interface.encapsulation_vlan.client.inner_encapsulation ~ ' ' ~ ethernet_interface.encapsulation_vlan.client.inner_vlan %}
 {%                 else %}
-{%                     set encapsulation_cli = 'client ' ~ client_protocol ~ ' outer ' ~ ethernet_interface.encapsulation_vlan.client.outer_vlan ~ ' inner ' ~ ethernet_interface.encapsulation_vlan.client.inner_vlan %}
+{%                     set encapsulation_cli = 'client ' ~ client_encapsulation ~ ' outer ' ~ ethernet_interface.encapsulation_vlan.client.outer_vlan ~ ' inner ' ~ ethernet_interface.encapsulation_vlan.client.inner_vlan %}
 {%                 endif %}
-{%                 if ethernet_interface.encapsulation_vlan.network.protocol | arista.avd.default == 'client inner' %}
+{%                 if ethernet_interface.encapsulation_vlan.network.encapsulation | arista.avd.default == 'client inner' %}
 {%                     set network_flag = True %}
-{%                     set encapsulation_cli = encapsulation_cli ~ ' network ' ~ ethernet_interface.encapsulation_vlan.network.protocol %}
+{%                     set encapsulation_cli = encapsulation_cli ~ ' network ' ~ ethernet_interface.encapsulation_vlan.network.encapsulation %}
 {%                 endif %}
 {%             endif %}
-{%         elif client_protocol in ['untagged', 'unmatched'] %}
-{%             set encapsulation_cli = 'client ' ~ ethernet_interface.encapsulation_vlan.client.protocol %}
+{%         elif client_encapsulation in ['untagged', 'unmatched'] %}
+{%             set encapsulation_cli = 'client ' ~ ethernet_interface.encapsulation_vlan.client.encapsulation %}
 {%         endif %}
 {%         if encapsulation_cli is arista.avd.defined %}
-{%             if client_protocol in ['dot1q', 'dot1ad', 'untagged'] and ethernet_interface.encapsulation_vlan.network.protocol is arista.avd.defined and not network_flag %}
-{%                 set network_protocol = ethernet_interface.encapsulation_vlan.network.protocol %}
-{%                 if network_protocol in ['dot1q', 'dot1ad'] %}
+{%             if client_encapsulation in ['dot1q', 'dot1ad', 'untagged'] and ethernet_interface.encapsulation_vlan.network.encapsulation is arista.avd.defined and not network_flag %}
+{%                 set network_encapsulation = ethernet_interface.encapsulation_vlan.network.encapsulation %}
+{%                 if network_encapsulation in ['dot1q', 'dot1ad'] %}
 {%                     if ethernet_interface.encapsulation_vlan.network.vlan is arista.avd.defined %}
-{%                         set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_protocol ~ ' ' ~ ethernet_interface.encapsulation_vlan.network.vlan %}
+{%                         set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_encapsulation ~ ' ' ~ ethernet_interface.encapsulation_vlan.network.vlan %}
 {%                     elif ethernet_interface.encapsulation_vlan.network.outer_vlan is arista.avd.defined and ethernet_interface.encapsulation_vlan.network.inner_vlan is arista.avd.defined %}
-{%                         if ethernet_interface.encapsulation_vlan.network.inner_protocol is arista.avd.defined %}
-{%                             set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_protocol ~ ' outer ' ~ ethernet_interface.encapsulation_vlan.network.outer_vlan ~ ' inner ' ~ ethernet_interface.encapsulation_vlan.network.inner_protocol ~ ' ' ~ ethernet_interface.encapsulation_vlan.network.inner_vlan %}
+{%                         if ethernet_interface.encapsulation_vlan.network.inner_encapsulation is arista.avd.defined %}
+{%                             set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_encapsulation ~ ' outer ' ~ ethernet_interface.encapsulation_vlan.network.outer_vlan ~ ' inner ' ~ ethernet_interface.encapsulation_vlan.network.inner_encapsulation ~ ' ' ~ ethernet_interface.encapsulation_vlan.network.inner_vlan %}
 {%                         else %}
-{%                             set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_protocol ~ ' outer ' ~ ethernet_interface.encapsulation_vlan.network.outer_vlan ~ ' inner ' ~ ethernet_interface.encapsulation_vlan.network.inner_vlan %}
+{%                             set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_encapsulation ~ ' outer ' ~ ethernet_interface.encapsulation_vlan.network.outer_vlan ~ ' inner ' ~ ethernet_interface.encapsulation_vlan.network.inner_vlan %}
 {%                         endif %}
 {%                     endif %}
-{%                 elif network_protocol == 'untagged' and client_protocol == 'untagged' %}
+{%                 elif network_encapsulation == 'untagged' and client_encapsulation == 'untagged' %}
 {%                     set encapsulation_cli = encapsulation_cli ~ ' network untagged' %}
-{%                 elif network_protocol == 'client' and client_protocol != "untagged" %}
+{%                 elif network_encapsulation == 'client' and client_encapsulation != "untagged" %}
 {%                     set encapsulation_cli = encapsulation_cli ~ " network client" %}
 {%                 endif %}
 {%             endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -117,42 +117,42 @@ interface {{ port_channel_interface.name }}
 {%             set encapsulation_dot1q_cli = encapsulation_dot1q_cli ~ ' inner ' ~ port_channel_interface.encapsulation_dot1q.inner_vlan %}
 {%         endif %}
    {{ encapsulation_dot1q_cli }}
-{%     elif port_channel_interface.encapsulation_vlan.client.protocol is arista.avd.defined %}
-{%         set client_protocol = port_channel_interface.encapsulation_vlan.client.protocol %}
+{%     elif port_channel_interface.encapsulation_vlan.client.encapsulation is arista.avd.defined %}
+{%         set client_encapsulation = port_channel_interface.encapsulation_vlan.client.encapsulation %}
 {%         set network_flag = False %}
-{%         if client_protocol in ['dot1q', 'dot1ad'] %}
+{%         if client_encapsulation in ['dot1q', 'dot1ad'] %}
 {%             if port_channel_interface.encapsulation_vlan.client.vlan is arista.avd.defined %}
-{%                 set encapsulation_cli = 'client ' ~ client_protocol ~ ' ' ~ port_channel_interface.encapsulation_vlan.client.vlan %}
+{%                 set encapsulation_cli = 'client ' ~ client_encapsulation ~ ' ' ~ port_channel_interface.encapsulation_vlan.client.vlan %}
 {%             elif port_channel_interface.encapsulation_vlan.client.outer_vlan is arista.avd.defined and port_channel_interface.encapsulation_vlan.client.inner_vlan is arista.avd.defined %}
-{%                 if port_channel_interface.encapsulation_vlan.client.inner_protocol is arista.avd.defined %}
-{%                     set encapsulation_cli = 'client ' ~ client_protocol ~ ' outer ' ~ port_channel_interface.encapsulation_vlan.client.outer_vlan ~ ' inner ' ~ port_channel_interface.encapsulation_vlan.client.inner_protocol ~ ' ' ~ port_channel_interface.encapsulation_vlan.client.inner_vlan %}
+{%                 if port_channel_interface.encapsulation_vlan.client.inner_encapsulation is arista.avd.defined %}
+{%                     set encapsulation_cli = 'client ' ~ client_encapsulation ~ ' outer ' ~ port_channel_interface.encapsulation_vlan.client.outer_vlan ~ ' inner ' ~ port_channel_interface.encapsulation_vlan.client.inner_encapsulation ~ ' ' ~ port_channel_interface.encapsulation_vlan.client.inner_vlan %}
 {%                 else %}
-{%                     set encapsulation_cli = 'client ' ~ client_protocol ~ ' outer ' ~ port_channel_interface.encapsulation_vlan.client.outer_vlan ~ ' inner ' ~ port_channel_interface.encapsulation_vlan.client.inner_vlan %}
+{%                     set encapsulation_cli = 'client ' ~ client_encapsulation ~ ' outer ' ~ port_channel_interface.encapsulation_vlan.client.outer_vlan ~ ' inner ' ~ port_channel_interface.encapsulation_vlan.client.inner_vlan %}
 {%                 endif %}
-{%                 if port_channel_interface.encapsulation_vlan.network.protocol | arista.avd.default == 'client inner' %}
+{%                 if port_channel_interface.encapsulation_vlan.network.encapsulation | arista.avd.default == 'client inner' %}
 {%                     set network_flag = True %}
-{%                     set encapsulation_cli = encapsulation_cli ~ ' network ' ~ port_channel_interface.encapsulation_vlan.network.protocol %}
+{%                     set encapsulation_cli = encapsulation_cli ~ ' network ' ~ port_channel_interface.encapsulation_vlan.network.encapsulation %}
 {%                 endif %}
 {%             endif %}
-{%         elif client_protocol in ['untagged', 'unmatched'] %}
-{%             set encapsulation_cli = 'client ' ~ port_channel_interface.encapsulation_vlan.client.protocol %}
+{%         elif client_encapsulation in ['untagged', 'unmatched'] %}
+{%             set encapsulation_cli = 'client ' ~ port_channel_interface.encapsulation_vlan.client.encapsulation %}
 {%         endif %}
 {%         if encapsulation_cli is arista.avd.defined %}
-{%             if client_protocol in ['dot1q', 'dot1ad', 'untagged'] and port_channel_interface.encapsulation_vlan.network.protocol is arista.avd.defined and not network_flag %}
-{%                 set network_protocol = port_channel_interface.encapsulation_vlan.network.protocol %}
-{%                 if network_protocol in ['dot1q', 'dot1ad'] %}
+{%             if client_encapsulation in ['dot1q', 'dot1ad', 'untagged'] and port_channel_interface.encapsulation_vlan.network.encapsulation is arista.avd.defined and not network_flag %}
+{%                 set network_encapsulation = port_channel_interface.encapsulation_vlan.network.encapsulation %}
+{%                 if network_encapsulation in ['dot1q', 'dot1ad'] %}
 {%                     if port_channel_interface.encapsulation_vlan.network.vlan is arista.avd.defined %}
-{%                         set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_protocol ~ ' ' ~ port_channel_interface.encapsulation_vlan.network.vlan %}
+{%                         set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_encapsulation ~ ' ' ~ port_channel_interface.encapsulation_vlan.network.vlan %}
 {%                     elif port_channel_interface.encapsulation_vlan.network.outer_vlan is arista.avd.defined and port_channel_interface.encapsulation_vlan.network.inner_vlan is arista.avd.defined %}
-{%                         if port_channel_interface.encapsulation_vlan.network.inner_protocol is arista.avd.defined %}
-{%                             set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_protocol ~ ' outer ' ~ port_channel_interface.encapsulation_vlan.network.outer_vlan ~ ' inner ' ~ port_channel_interface.encapsulation_vlan.network.inner_protocol ~ ' ' ~ port_channel_interface.encapsulation_vlan.network.inner_vlan %}
+{%                         if port_channel_interface.encapsulation_vlan.network.inner_encapsulation is arista.avd.defined %}
+{%                             set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_encapsulation ~ ' outer ' ~ port_channel_interface.encapsulation_vlan.network.outer_vlan ~ ' inner ' ~ port_channel_interface.encapsulation_vlan.network.inner_encapsulation ~ ' ' ~ port_channel_interface.encapsulation_vlan.network.inner_vlan %}
 {%                         else %}
-{%                             set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_protocol ~ ' outer ' ~ port_channel_interface.encapsulation_vlan.network.outer_vlan ~ ' inner ' ~ port_channel_interface.encapsulation_vlan.network.inner_vlan %}
+{%                             set encapsulation_cli = encapsulation_cli ~ ' network ' ~ network_encapsulation ~ ' outer ' ~ port_channel_interface.encapsulation_vlan.network.outer_vlan ~ ' inner ' ~ port_channel_interface.encapsulation_vlan.network.inner_vlan %}
 {%                         endif %}
 {%                     endif %}
-{%                 elif network_protocol == 'untagged' and client_protocol == 'untagged' %}
+{%                 elif network_encapsulation == 'untagged' and client_encapsulation == 'untagged' %}
 {%                     set encapsulation_cli = encapsulation_cli ~ ' network untagged' %}
-{%                 elif network_protocol == 'client' and client_protocol != "untagged" %}
+{%                 elif network_encapsulation == 'client' and client_encapsulation != "untagged" %}
 {%                     set encapsulation_cli = encapsulation_cli ~ " network client" %}
 {%                 endif %}
 {%             endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -2246,7 +2246,8 @@ keys:
             new_key: encapsulation_dot1q.vlan
         encapsulation_dot1q:
           description: 'Warning: `encapsulation_dot1q` should not be combined with
-            `ethernet_interfaces[].type == l3dot1q/l2dot1q`.'
+            `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type:
+            l2dot1q`.'
           type: dict
           keys:
             vlan:
@@ -2269,8 +2270,8 @@ keys:
           type: dict
           description: 'This setting can only be applied to sub-interfaces on EOS.
 
-            Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type
-            == l3dot1q/l2dot1q`.'
+            Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type:
+            l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.'
           keys:
             client:
               type: dict
@@ -2318,21 +2319,24 @@ keys:
                   - str
                   min: 1
                   max: 4094
-                  description: Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: 'Client VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: unmatched`.'
                 outer_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: 'Client Outer VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: unmatched`.'
                 inner_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: 'Client Inner VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: unmatched`.'
                 inner_encapsulation:
                   type: str
                   valid_values:
@@ -2394,21 +2398,24 @@ keys:
                   - str
                   min: 1
                   max: 4094
-                  description: Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: 'Network VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: client`.'
                 outer_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: 'Network outer VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: client`.'
                 inner_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: 'Network inner VLAN ID.  Not applicable for `encapsulation:
+                    untagged` or `encapsulation: client`.'
                 inner_encapsulation:
                   type: str
                   valid_values:
@@ -9128,7 +9135,8 @@ keys:
             new_key: encapsulation_dot1q.vlan
         encapsulation_dot1q:
           description: 'Warning: `encapsulation_dot1q` should not be combined with
-            `ethernet_interfaces[].type == l3dot1q/l2dot1q`.'
+            `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type:
+            l2dot1q`.'
           type: dict
           keys:
             vlan:
@@ -9155,8 +9163,8 @@ keys:
         encapsulation_vlan:
           description: 'This setting can only be applied to sub-interfaces on EOS.
 
-            Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type
-            == l3dot1q/l2dot1q`.'
+            Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type:
+            l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.'
           type: dict
           keys:
             client:
@@ -9205,21 +9213,24 @@ keys:
                   - str
                   min: 1
                   max: 4094
-                  description: Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: 'Client VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: unmatched`.'
                 outer_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: 'Client Outer VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: unmatched`.'
                 inner_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: 'Client Inner VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: unmatched`.'
                 inner_encapsulation:
                   type: str
                   valid_values:
@@ -9281,21 +9292,24 @@ keys:
                   - str
                   min: 1
                   max: 4094
-                  description: Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: 'Network VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: client`.'
                 outer_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: 'Network outer VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: client`.'
                 inner_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: 'Network inner VLAN ID. Not applicable for `encapsulation:
+                    untagged` or `encapsulation: client`.'
                 inner_encapsulation:
                   type: str
                   valid_values:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -2305,7 +2305,7 @@ keys:
                   deprecation:
                     warning: true
                     remove_in_version: 6.0.0
-                protocol:
+                encapsulation:
                   type: str
                   valid_values:
                   - dot1q
@@ -2318,22 +2318,22 @@ keys:
                   - str
                   min: 1
                   max: 4094
-                  description: Client VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+                  description: Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
                 outer_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Client Outer VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+                  description: Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
                 inner_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Client Inner VLAN ID. Not applicable for `protocol==untagged/unmatched`.
-                inner_protocol:
+                  description: Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                inner_encapsulation:
                   type: str
                   valid_values:
                   - dot1q
@@ -2375,7 +2375,7 @@ keys:
                   deprecation:
                     warning: true
                     remove_in_version: 6.0.0
-                protocol:
+                encapsulation:
                   description: '`untagged` (no encapsulation) is applicable for `untagged`
                     client only.
 
@@ -2394,22 +2394,22 @@ keys:
                   - str
                   min: 1
                   max: 4094
-                  description: Network VLAN ID. Not applicable for `protocol==untagged/client`.
+                  description: Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
                 outer_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Network outer VLAN ID. Not applicable for `protocol==untagged/client`.
+                  description: Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
                 inner_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Network inner VLAN ID. Not applicable for `protocol==untagged/client`.
-                inner_protocol:
+                  description: Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                inner_encapsulation:
                   type: str
                   valid_values:
                   - dot1q
@@ -9192,7 +9192,7 @@ keys:
                   deprecation:
                     warning: true
                     remove_in_version: 6.0.0
-                protocol:
+                encapsulation:
                   type: str
                   valid_values:
                   - dot1q
@@ -9205,22 +9205,22 @@ keys:
                   - str
                   min: 1
                   max: 4094
-                  description: Client VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+                  description: Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
                 outer_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Client Outer VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+                  description: Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
                 inner_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Client Inner VLAN ID. Not applicable for `protocol==untagged/unmatched`.
-                inner_protocol:
+                  description: Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                inner_encapsulation:
                   type: str
                   valid_values:
                   - dot1q
@@ -9262,7 +9262,7 @@ keys:
                   deprecation:
                     warning: true
                     remove_in_version: 6.0.0
-                protocol:
+                encapsulation:
                   description: '`untagged` (no encapsulation) is applicable for `untagged`
                     client only.
 
@@ -9281,22 +9281,22 @@ keys:
                   - str
                   min: 1
                   max: 4094
-                  description: Network VLAN ID. Not applicable for `protocol==untagged/client`.
+                  description: Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
                 outer_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Network outer VLAN ID. Not applicable for `protocol==untagged/client`.
+                  description: Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
                 inner_vlan:
                   type: int
                   convert_types:
                   - str
                   min: 1
                   max: 4094
-                  description: Network inner VLAN ID. Not applicable for `protocol==untagged/client`.
-                inner_protocol:
+                  description: Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                inner_encapsulation:
                   type: str
                   valid_values:
                   - dot1q

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -261,7 +261,7 @@ keys:
         encapsulation_dot1q:
           # TODO: AVD 6.0 below warning should be removed when the `ethernet_interfaces[].type` key is removed in AVD 6.0
           description: |-
-            Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`.
+            Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
           type: dict
           keys:
             vlan:
@@ -284,7 +284,7 @@ keys:
           # TODO: AVD 6.0 below warning should be removed when the `ethernet_interfaces[].type` key is removed in AVD 6.0
           description: |-
             This setting can only be applied to sub-interfaces on EOS.
-            Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`.
+            Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
           keys:
             client:
               type: dict
@@ -333,21 +333,24 @@ keys:
                     - str
                   min: 1
                   max: 4094
-                  description: Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: |-
+                    Client VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
                 outer_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: |-
+                    Client Outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
                 inner_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: |-
+                    Client Inner VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
                 inner_encapsulation:
                   type: str
                   valid_values:
@@ -407,21 +410,24 @@ keys:
                     - str
                   min: 1
                   max: 4094
-                  description: Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: |-
+                    Network VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
                 outer_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: |-
+                    Network outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
                 inner_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: |-
+                    Network inner VLAN ID.  Not applicable for `encapsulation: untagged` or `encapsulation: client`.
                 inner_encapsulation:
                   type: str
                   valid_values:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -319,8 +319,8 @@ keys:
                   deprecation:
                     warning: true
                     remove_in_version: 6.0.0
-                # TODO: AVD6.0 the `protocol` key should be made required once the deprecated keys are removed in AVD6.0
-                protocol:
+                # TODO: AVD6.0 the `encapsulation` key should be made required once the deprecated keys are removed in AVD6.0
+                encapsulation:
                   type: str
                   valid_values:
                     - dot1q
@@ -333,22 +333,22 @@ keys:
                     - str
                   min: 1
                   max: 4094
-                  description: Client VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+                  description: Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
                 outer_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Client Outer VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+                  description: Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
                 inner_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Client Inner VLAN ID. Not applicable for `protocol==untagged/unmatched`.
-                inner_protocol:
+                  description: Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                inner_encapsulation:
                   type: str
                   valid_values:
                     - dot1q
@@ -389,8 +389,8 @@ keys:
                   deprecation:
                     warning: true
                     remove_in_version: 6.0.0
-                # TODO: AVD6.0 the `protocol` key should be made required once the deprecated keys are removed in AVD6.0
-                protocol:
+                # TODO: AVD6.0 the `encapsulation` key should be made required once the deprecated keys are removed in AVD6.0
+                encapsulation:
                   description: |-
                     `untagged` (no encapsulation) is applicable for `untagged` client only.
                     `client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client.
@@ -407,22 +407,22 @@ keys:
                     - str
                   min: 1
                   max: 4094
-                  description: Network VLAN ID. Not applicable for `protocol==untagged/client`.
+                  description: Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
                 outer_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Network outer VLAN ID. Not applicable for `protocol==untagged/client`.
+                  description: Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
                 inner_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Network inner VLAN ID. Not applicable for `protocol==untagged/client`.
-                inner_protocol:
+                  description: Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                inner_encapsulation:
                   type: str
                   valid_values:
                     - dot1q

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -87,7 +87,7 @@ keys:
         encapsulation_dot1q:
           # TODO: AVD 6.0 below warning should be removed when the `ethernet_interfaces[].type` key is removed in AVD 6.0
           description: |-
-            Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`.
+            Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
           type: dict
           keys:
             vlan:
@@ -114,7 +114,7 @@ keys:
           # TODO: AVD 6.0 below warning should be removed when the `ethernet_interfaces[].type` key is removed in AVD 6.0
           description: |-
             This setting can only be applied to sub-interfaces on EOS.
-            Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type == l3dot1q/l2dot1q`.
+            Warning: `encapsulation_vlan` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
           type: dict
           keys:
             client:
@@ -164,21 +164,24 @@ keys:
                     - str
                   min: 1
                   max: 4094
-                  description: Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: |-
+                    Client VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
                 outer_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: |-
+                    Client Outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
                 inner_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                  description: |-
+                    Client Inner VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: unmatched`.
                 inner_encapsulation:
                   type: str
                   valid_values:
@@ -238,21 +241,24 @@ keys:
                     - str
                   min: 1
                   max: 4094
-                  description: Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: |-
+                    Network VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
                 outer_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: |-
+                    Network outer VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
                 inner_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                  description: |-
+                    Network inner VLAN ID. Not applicable for `encapsulation: untagged` or `encapsulation: client`.
                 inner_encapsulation:
                   type: str
                   valid_values:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -150,8 +150,8 @@ keys:
                   deprecation:
                     warning: true
                     remove_in_version: 6.0.0
-                # TODO: AVD6.0 the `protocol` key should be made required once the deprecated keys are removed in AVD6.0
-                protocol:
+                # TODO: AVD6.0 the `encapsulation` key should be made required once the deprecated keys are removed in AVD6.0
+                encapsulation:
                   type: str
                   valid_values:
                     - dot1q
@@ -164,22 +164,22 @@ keys:
                     - str
                   min: 1
                   max: 4094
-                  description: Client VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+                  description: Client VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
                 outer_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Client Outer VLAN ID. Not applicable for `protocol==untagged/unmatched`.
+                  description: Client Outer VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
                 inner_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Client Inner VLAN ID. Not applicable for `protocol==untagged/unmatched`.
-                inner_protocol:
+                  description: Client Inner VLAN ID. Not applicable for `encapsulation==untagged/unmatched`.
+                inner_encapsulation:
                   type: str
                   valid_values:
                     - dot1q
@@ -220,8 +220,8 @@ keys:
                   deprecation:
                     warning: true
                     remove_in_version: 6.0.0
-                # TODO: AVD6.0 the `protocol` key should be made required once the deprecated keys are removed in AVD6.0
-                protocol:
+                # TODO: AVD6.0 the `encapsulation` key should be made required once the deprecated keys are removed in AVD6.0
+                encapsulation:
                   description: |-
                     `untagged` (no encapsulation) is applicable for `untagged` client only.
                     `client` and `client inner` (retain client encapsulation) is not applicable for `untagged` client.
@@ -238,22 +238,22 @@ keys:
                     - str
                   min: 1
                   max: 4094
-                  description: Network VLAN ID. Not applicable for `protocol==untagged/client`.
+                  description: Network VLAN ID. Not applicable for `encapsulation==untagged/client`.
                 outer_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Network outer VLAN ID. Not applicable for `protocol==untagged/client`.
+                  description: Network outer VLAN ID. Not applicable for `encapsulation==untagged/client`.
                 inner_vlan:
                   type: int
                   convert_types:
                     - str
                   min: 1
                   max: 4094
-                  description: Network inner VLAN ID. Not applicable for `protocol==untagged/client`.
-                inner_protocol:
+                  description: Network inner VLAN ID. Not applicable for `encapsulation==untagged/client`.
+                inner_encapsulation:
                   type: str
                   valid_values:
                     - dot1q


### PR DESCRIPTION

## Change Summary

Change the 'protocol' key to 'encapsulation' in interfaces-encapsulation model



## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
