### PR TITLE
Fix(eos_designs)!: Make evpn_gateway.remote_peers override work as documented

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-key-evpn-gateway-remote-peer.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-key-evpn-gateway-remote-peer.yml
@@ -1,0 +1,23 @@
+---
+type: l3leaf
+
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 192.168.255.0/24
+    loopback_ipv4_offset: 8
+    vtep_loopback_ipv4_pool: 192.168.254.0/24
+    bgp_as: 65101
+  nodes:
+    - name: missing-key-evpn-gateway-remote-peer
+      id: 1
+      bgp_as: 65104
+      mgmt_ip: 192.168.200.110/24
+      evpn_gateway:
+        remote_peers:
+          # Missing bgp_as
+          - hostname: not-in-the-inventory
+            ip_address: 192.168.42.42
+
+expected_error_message: >-
+  The EVPN Gateway remote peer 'not-in-the-inventory' is missing either a `bpg_as`
+  or an `ip_address`.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -103,6 +103,7 @@ all:
             missing-prefix-list-in-cv-pathfinder:
             missing-prefix-list-definition-cv-pathfinder:
             missing-data-plane_cpu-allocation-max:
+            missing-key-evpn-gateway-remote-peer:
             ntp-settings-server-vrf-missing-mgmt-ip:
             ntp-settings-server-vrf-missing-inband-mgmt-interface:
             source-interfaces-domain-lookup-duplicate-vrf:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -330,6 +330,9 @@ router bgp 65104
    neighbor 172.31.254.166 peer group UNDERLAY-PEERS
    neighbor 172.31.254.166 remote-as 65001
    neighbor 172.31.254.166 description DC1-SPINE4_Ethernet22
+   neighbor 192.168.42.42 peer group EVPN-OVERLAY-CORE
+   neighbor 192.168.42.42 remote-as 65042
+   neighbor 192.168.42.42 description DC1-BL2B
    neighbor 192.168.255.1 peer group EVPN-OVERLAY-PEERS
    neighbor 192.168.255.1 remote-as 65001
    neighbor 192.168.255.1 description DC1-SPINE1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -91,6 +91,11 @@ router_bgp:
     peer: DC1-BL2A
     description: DC1-BL2A
     remote_as: '65106'
+  - ip_address: 192.168.42.42
+    peer_group: EVPN-OVERLAY-CORE
+    peer: DC1-BL2B
+    description: DC1-BL2B
+    remote_as: '65042'
   address_family_evpn:
     neighbor_default:
       next_hop_self_received_evpn_routes:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_FABRIC.yml
@@ -179,7 +179,11 @@ l3leaf:
           uplink_switch_interfaces: [ Ethernet22, Ethernet22, Ethernet22, Ethernet22 ]
           evpn_gateway:
             remote_peers:
-              - hostname: "DC1-BL2A"
+              - hostname: DC1-BL2A
+                # Testing below that the override is working
+              - hostname: DC1-BL2B
+                ip_address: 192.168.42.42  # Should be 192.168.255.17
+                bgp_as: 65042  # Should be 65107
             evpn_l2:
               enabled: true
             evpn_l3:
@@ -193,10 +197,10 @@ l3leaf:
           uplink_switch_interfaces: [ Ethernet23, Ethernet23, Ethernet23, Ethernet23 ]
           evpn_gateway:
             remote_peers:
-              - hostname: "MY_EVPN_GW1_USER_DEFINED"
+              - hostname: MY_EVPN_GW1_USER_DEFINED
                 ip_address: 1.1.1.1
                 bgp_as: 65555
-              - hostname: "MY_EVPN_GW2_USER_DEFINED"
+              - hostname: MY_EVPN_GW2_USER_DEFINED
                 ip_address: 2.2.2.2
                 bgp_as: 65555
             evpn_l2:

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/utils.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
-from pyavd._utils import get
+from pyavd._utils import get, strip_empties_from_dict
 from pyavd.j2filters import natural_sort
 
 if TYPE_CHECKING:
@@ -40,24 +40,23 @@ class UtilsMixin:
         evpn_gateway_remote_peers_list = get(self.shared_utils.switch_data_combined, "evpn_gateway.remote_peers", default=[])
 
         for gw_remote_peer_dict in natural_sort(evpn_gateway_remote_peers_list, sort_key="hostname"):
-            # These remote gw can be outside of the inventory
+            # These remote gateways can be outside of the inventory or in the inventory
             gw_remote_peer = gw_remote_peer_dict["hostname"]
+
+            gw_info = {
+                "bgp_as": str(_as) if (_as := gw_remote_peer_dict.get("bgp_as")) else None,
+                "ip_address": gw_remote_peer_dict.get("ip_address"),
+            }
+
             peer_facts = self.shared_utils.get_peer_facts(gw_remote_peer, required=False)
-
-            if peer_facts is not None:
-                # Found a matching server in inventory
-                self._append_peer(evpn_gateway_remote_peers, gw_remote_peer, peer_facts)
-
+            if peer_facts is None:
+                # No matching host found in the inventory for this remote gateway
+                evpn_gateway_remote_peers[gw_remote_peer] = gw_info
             else:
-                # Server not found in inventory, adding manually
-                # TODO: - what if the values are None - this is not handled by the template today
-                bgp_as = str(_as) if (_as := gw_remote_peer_dict.get("bgp_as")) else None
-                ip_address = gw_remote_peer_dict.get("ip_address")
-
-                evpn_gateway_remote_peers[gw_remote_peer] = {
-                    "bgp_as": bgp_as,
-                    "ip_address": ip_address,
-                }
+                # Found a matching name for this remote gateway in the inventory
+                self._append_peer(evpn_gateway_remote_peers, gw_remote_peer, peer_facts)
+                # Apply potential override if present in the input variables
+                evpn_gateway_remote_peers[gw_remote_peer].update(strip_empties_from_dict(gw_info))
 
         return evpn_gateway_remote_peers
 


### PR DESCRIPTION
## Change Summary

The schema describe that:

```
<node_type_keys.key>:
  defaults:
    evpn_gateway:
      # Define remote peers of the EVPN VXLAN Gateway.
      # If the hostname can be found in the inventory, ip_address and BGP ASN will be automatically populated. Manual override takes precedence.
      # If the peer's hostname can not be found in the inventory, ip_address and bgp_as must be defined.
      remote_peers:
        - hostname: <str>
          ip_address: <str>
          bgp_as: <str>
```

The key being `Manual override takes precedence.` for `remote_peers` which is not the case in the code

## Related Issue(s)

Fixes #3392

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Make the manual override take precedence.

The change is __breaking__ because it was not working as described in the schema and so users with overrides that were not triggered could see config change.

## How to test

Added a molecule test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
