### PR TITLE
Feat(eos_cli_config_gen): Add support BGP Additional-Paths on Root of BGP

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-path-selection.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-path-selection.md
@@ -47,6 +47,11 @@ ASN Notation: asplain
 | ------ | --------- |
 | 65101 | 192.168.255.42 |
 
+| BGP Tuning |
+| ---------- |
+| bgp additional-paths receive |
+| bgp additional-paths send ecmp limit 30 |
+
 #### Router BGP Peer Groups
 
 ##### PATH-SELECTION-PG-1
@@ -122,6 +127,8 @@ ASN Notation: asplain
 !
 router bgp 65101
    router-id 192.168.255.42
+   bgp additional-paths receive
+   bgp additional-paths send ecmp limit 30
    neighbor PATH-SELECTION-PG-1 peer group
    neighbor PATH-SELECTION-PG-1 remote-as 65001
    neighbor PATH-SELECTION-PG-2 peer group

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-path-selection.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-path-selection.cfg
@@ -6,6 +6,8 @@ interface Management1
 !
 router bgp 65101
    router-id 192.168.255.42
+   bgp additional-paths receive
+   bgp additional-paths send ecmp limit 30
    neighbor PATH-SELECTION-PG-1 peer group
    neighbor PATH-SELECTION-PG-1 remote-as 65001
    neighbor PATH-SELECTION-PG-2 peer group

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-path-selection.yaml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-bgp-path-selection.yaml
@@ -3,6 +3,11 @@
 router_bgp:
   as: 65101
   router_id: 192.168.255.42
+  bgp:
+    additional_paths:
+      receive: true
+      send:
+        ecmp_limit: 30
   peer_groups:
     - name: PATH-SELECTION-PG-1
       type: ipv4

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -41,6 +41,14 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;always</samp>](## "router_bgp.bgp.route_reflector_preserve_attributes.always") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;bestpath</samp>](## "router_bgp.bgp.bestpath") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;d_path</samp>](## "router_bgp.bgp.bestpath.d_path") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;additional_paths</samp>](## "router_bgp.bgp.additional_paths") | Dictionary |  |  |  | BGP additional-paths commands. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;receive</samp>](## "router_bgp.bgp.additional_paths.receive") | Boolean |  |  |  | Receive multiple paths. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;send</samp>](## "router_bgp.bgp.additional_paths.send") | Dictionary |  |  |  | Send multiple paths. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;any</samp>](## "router_bgp.bgp.additional_paths.send.any") | Boolean |  |  |  | Any eligible path. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;backup</samp>](## "router_bgp.bgp.additional_paths.send.backup") | Boolean |  |  |  | Best path and installed backup path. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp</samp>](## "router_bgp.bgp.additional_paths.send.ecmp") | Boolean |  |  |  | All paths in best path ECMP group. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecmp_limit</samp>](## "router_bgp.bgp.additional_paths.send.ecmp_limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of ECMP paths to send. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;limit</samp>](## "router_bgp.bgp.additional_paths.send.limit") | Integer |  |  | Min: 2<br>Max: 64 | Amount of paths to send. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;redistribute_internal</samp>](## "router_bgp.bgp.redistribute_internal") | Boolean |  |  |  | Allow redistribution of iBGP routes into an Interior Gateway Protocol (IGP). EOS default is true. |
     | [<samp>&nbsp;&nbsp;listen_ranges</samp>](## "router_bgp.listen_ranges") | List, items: Dictionary |  |  |  | Improved "listen_ranges" data model to support multiple listen ranges and additional filter capabilities.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "router_bgp.listen_ranges.[].prefix") | String |  |  |  | IPv4 prefix "A.B.C.D/E" or IPv6 prefix "A:B:C:D:E:F:G:H/I". |
@@ -932,6 +940,30 @@
           always: <bool>
         bestpath:
           d_path: <bool>
+
+        # BGP additional-paths commands.
+        additional_paths:
+
+          # Receive multiple paths.
+          receive: <bool>
+
+          # Send multiple paths.
+          send:
+
+            # Any eligible path.
+            any: <bool>
+
+            # Best path and installed backup path.
+            backup: <bool>
+
+            # All paths in best path ECMP group.
+            ecmp: <bool>
+
+            # Amount of ECMP paths to send.
+            ecmp_limit: <int; 2-64>
+
+            # Amount of paths to send.
+            limit: <int; 2-64>
 
         # Allow redistribution of iBGP routes into an Interior Gateway Protocol (IGP). EOS default is true.
         redistribute_internal: <bool>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-bgp.j2
@@ -49,6 +49,20 @@ ASN Notation: {{ router_bgp.as_notation | arista.avd.default('asplain') }}
 {%         if router_bgp.bgp.bestpath.d_path is arista.avd.defined(true) %}
 | bgp bestpath d-path |
 {%         endif %}
+{%         if router_bgp.bgp.additional_paths.receive is arista.avd.defined(true) %}
+| bgp additional-paths receive |
+{%         endif %}
+{%         if router_bgp.bgp.additional_paths.send.any is arista.avd.defined(true) %}
+| bgp additional-paths send any |
+{%         elif router_bgp.bgp.additional_paths.send.backup is arista.avd.defined(true) %}
+| bgp additional-paths send backup |
+{%         elif router_bgp.bgp.additional_paths.send.ecmp is arista.avd.defined(true) %}
+| bgp additional-paths send ecmp |
+{%         elif router_bgp.bgp.additional_paths.send.ecmp_limit is arista.avd.defined %}
+| bgp additional-paths send ecmp limit {{ router_bgp.bgp.additional_paths.send.ecmp_limit }} |
+{%         elif router_bgp.bgp.additional_paths.send.limit is arista.avd.defined %}
+| bgp additional-paths send limit {{ router_bgp.bgp.additional_paths.send.limit }} |
+{%         endif %}
 {%         if router_bgp.updates.wait_for_convergence is arista.avd.defined(true) %}
 | update wait-for-convergence |
 {%         endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -77,6 +77,20 @@ router bgp {{ router_bgp.as }}
 {%     if router_bgp.bgp.bestpath.d_path is arista.avd.defined(true) %}
    bgp bestpath d-path
 {%     endif %}
+{%     if router_bgp.bgp.additional_paths.receive is arista.avd.defined(true) %}
+   bgp additional-paths receive
+{%     endif %}
+{%     if router_bgp.bgp.additional_paths.send.any is arista.avd.defined(true) %}
+   bgp additional-paths send any
+{%     elif router_bgp.bgp.additional_paths.send.backup is arista.avd.defined(true) %}
+   bgp additional-paths send backup
+{%     elif router_bgp.bgp.additional_paths.send.ecmp is arista.avd.defined(true) %}
+   bgp additional-paths send ecmp
+{%     elif router_bgp.bgp.additional_paths.send.ecmp_limit is arista.avd.defined %}
+   bgp additional-paths send ecmp limit {{ router_bgp.bgp.additional_paths.send.ecmp_limit }}
+{%     elif router_bgp.bgp.additional_paths.send.limit is arista.avd.defined %}
+   bgp additional-paths send limit {{ router_bgp.bgp.additional_paths.send.limit }}
+{%     endif %}
 {%     if router_bgp.listen_ranges is arista.avd.defined %}
 {%         for listen_range in router_bgp.listen_ranges | arista.avd.natural_sort('peer_group') if listen_range.peer_group is arista.avd.defined and listen_range.prefix is arista.avd.defined
                and (listen_range.peer_filter is arista.avd.defined or listen_range.remote_as is arista.avd.defined) %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -11908,6 +11908,40 @@ keys:
             keys:
               d_path:
                 type: bool
+          additional_paths:
+            type: dict
+            description: BGP additional-paths commands.
+            keys:
+              receive:
+                type: bool
+                description: Receive multiple paths.
+              send:
+                type: dict
+                description: Send multiple paths.
+                keys:
+                  any:
+                    type: bool
+                    description: Any eligible path.
+                  backup:
+                    type: bool
+                    description: Best path and installed backup path.
+                  ecmp:
+                    type: bool
+                    description: All paths in best path ECMP group.
+                  ecmp_limit:
+                    type: int
+                    description: Amount of ECMP paths to send.
+                    convert_types:
+                    - str
+                    min: 2
+                    max: 64
+                  limit:
+                    type: int
+                    description: Amount of paths to send.
+                    convert_types:
+                    - str
+                    min: 2
+                    max: 64
           redistribute_internal:
             type: bool
             description: Allow redistribution of iBGP routes into an Interior Gateway

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
@@ -150,6 +150,40 @@ keys:
             keys:
               d_path:
                 type: bool
+          additional_paths:
+            type: dict
+            description: BGP additional-paths commands.
+            keys:
+              receive:
+                type: bool
+                description: Receive multiple paths.
+              send:
+                type: dict
+                description: Send multiple paths.
+                keys:
+                  any:
+                    type: bool
+                    description: Any eligible path.
+                  backup:
+                    type: bool
+                    description: Best path and installed backup path.
+                  ecmp:
+                    type: bool
+                    description: All paths in best path ECMP group.
+                  ecmp_limit:
+                    type: int
+                    description: Amount of ECMP paths to send.
+                    convert_types:
+                      - str
+                    min: 2
+                    max: 64
+                  limit:
+                    type: int
+                    description: Amount of paths to send.
+                    convert_types:
+                      - str
+                    min: 2
+                    max: 64
           redistribute_internal:
             type: bool
             description: Allow redistribution of iBGP routes into an Interior Gateway Protocol (IGP). EOS default is true.


### PR DESCRIPTION
## Change Summary

Add support for "bgp additional-paths" in root level of the BGP config.
Updated Doc to show the commands under "BGP Tuning" parameters.

## Related Issue(s)

Fixes #<N/A>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Using the same model as "additional-paths" in router_bgp for more specific sections

## How to test
Added molecule testing to "router-bgp-path-selection".
Let me know if dedicated test is preferred.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [X} My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
