### PR TITLE
Refactor(eos_cli_config_gen): Rearrange the order of `management api http` in eos-intended-config based on eos cli

### DIFF
--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -42,6 +35,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF1B.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -42,6 +35,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF2A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF2A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 230
    name IDF2-Guest
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3A.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -42,6 +35,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3B.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3B.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -42,6 +35,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3C.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3C.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 330
    name IDF3-Guest
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3D.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3D.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 330
    name IDF3-Guest
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3E.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/LEAF3E.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 330
    name IDF3-Guest
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -64,6 +57,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/configs/SPINE2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -64,6 +57,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authorization exec default local
 !

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc1-leaf1b_Port-Channel3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc1-leaf1a_Port-Channel3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1c.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf1c.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -42,6 +35,13 @@ vlan 3402
    name L2_VLAN3402
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_L3_LEAF1_Po8

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc1-leaf2b_Port-Channel3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc1-leaf2a_Port-Channel3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2c.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-leaf2c.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -42,6 +35,13 @@ vlan 3402
    name L2_VLAN3402
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_L3_LEAF2_Po8

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname dc1-spine1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc1-spine2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname dc1-spine2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet2

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1a.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc2-leaf1b_Port-Channel3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1b.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc2-leaf1a_Port-Channel3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1c.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf1c.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -42,6 +35,13 @@ vlan 3402
    name L2_VLAN3402
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC2_L3_LEAF1_Po8

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2a.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc2-leaf2b_Port-Channel3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2b.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc2-leaf2a_Port-Channel3

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2c.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-leaf2c.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -42,6 +35,13 @@ vlan 3402
    name L2_VLAN3402
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC2_L3_LEAF2_Po8

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname dc2-spine1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_dc2-leaf1a_Ethernet1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/configs/dc2-spine2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname dc2-spine2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_dc2-leaf1a_Ethernet2

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$QJUtFkyu9yoecsq.$ysGzlb2YXaIMvezqGEna7RE8CMALJHnv7Q1i.27VygyKUtSeX.n2xRTyOtCR8eOAl.4imBLyhXFc4o97P5n071
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname p1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    password encryption-key common

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$QJUtFkyu9yoecsq.$ysGzlb2YXaIMvezqGEna7RE8CMALJHnv7Q1i.27VygyKUtSeX.n2xRTyOtCR8eOAl.4imBLyhXFc4o97P5n071
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname p2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    password encryption-key common

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p3.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p3.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$QJUtFkyu9yoecsq.$ysGzlb2YXaIMvezqGEna7RE8CMALJHnv7Q1i.27VygyKUtSeX.n2xRTyOtCR8eOAl.4imBLyhXFc4o97P5n071
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname p3
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    password encryption-key common

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p4.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p4.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$QJUtFkyu9yoecsq.$ysGzlb2YXaIMvezqGEna7RE8CMALJHnv7Q1i.27VygyKUtSeX.n2xRTyOtCR8eOAl.4imBLyhXFc4o97P5n071
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname p4
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    password encryption-key common

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$QJUtFkyu9yoecsq.$ysGzlb2YXaIMvezqGEna7RE8CMALJHnv7Q1i.27VygyKUtSeX.n2xRTyOtCR8eOAl.4imBLyhXFc4o97P5n071
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vrf instance C1_VRF1
 vrf instance C2_VRF1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    password encryption-key common

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$QJUtFkyu9yoecsq.$ysGzlb2YXaIMvezqGEna7RE8CMALJHnv7Q1i.27VygyKUtSeX.n2xRTyOtCR8eOAl.4imBLyhXFc4o97P5n071
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vrf instance C1_VRF1
 vrf instance C2_VRF1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    password encryption-key common

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe3.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe3.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$QJUtFkyu9yoecsq.$ysGzlb2YXaIMvezqGEna7RE8CMALJHnv7Q1i.27VygyKUtSeX.n2xRTyOtCR8eOAl.4imBLyhXFc4o97P5n071
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vrf instance C1_VRF1
 vrf instance C2_VRF1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    password encryption-key common

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$QJUtFkyu9yoecsq.$ysGzlb2YXaIMvezqGEna7RE8CMALJHnv7Q1i.27VygyKUtSeX.n2xRTyOtCR8eOAl.4imBLyhXFc4o97P5n071
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname rr1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    password encryption-key common

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$QJUtFkyu9yoecsq.$ysGzlb2YXaIMvezqGEna7RE8CMALJHnv7Q1i.27VygyKUtSeX.n2xRTyOtCR8eOAl.4imBLyhXFc4o97P5n071
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ hostname rr2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    password encryption-key common

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 username arista privilege 15 role network-admin nopassword
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authentication policy local allow-nopassword-remote-login
 aaa authorization exec default local

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 username arista privilege 15 role network-admin nopassword
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authentication policy local allow-nopassword-remote-login
 aaa authorization exec default local

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF3.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 username arista privilege 15 role network-admin nopassword
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authentication policy local allow-nopassword-remote-login
 aaa authorization exec default local

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/LEAF4.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 username arista privilege 15 role network-admin nopassword
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authentication policy local allow-nopassword-remote-login
 aaa authorization exec default local

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 username arista privilege 15 role network-admin nopassword
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -40,6 +33,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authentication policy local allow-nopassword-remote-login
 aaa authorization exec default local

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/configs/SPINE2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin secret sha512 $6$eucN5ngreuExDgwS$xnD7T8jO..GBDX0DUlp.hn.W7yW94xTjSanqgaQGBzPIhDAsyAl9N4oScHvOMvf07uVBFI4mKMxwdVEUVKgY/.
 username arista privilege 15 role network-admin nopassword
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -40,6 +33,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 aaa authentication policy local allow-nopassword-remote-login
 aaa authorization exec default local

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1a.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -68,6 +61,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc1-leaf1b_Port-Channel3

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1b.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -68,6 +61,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc1-leaf1a_Port-Channel3

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1c.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf1c.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -47,6 +40,13 @@ vlan 3402
    name L2_VLAN3402
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_L3_LEAF1_Po8

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2a.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -68,6 +61,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc1-leaf2b_Port-Channel3

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2b.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -68,6 +61,13 @@ vrf instance MGMT
 vrf instance VRF10
 !
 vrf instance VRF11
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_dc1-leaf2a_Port-Channel3

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2c.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-leaf2c.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -47,6 +40,13 @@ vlan 3402
    name L2_VLAN3402
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_L3_LEAF2_Po8

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine1.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -28,6 +21,13 @@ ip name-server vrf MGMT 192.168.1.1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine2.cfg
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/configs/dc1-spine2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.1.12:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -28,6 +21,13 @@ ip name-server vrf MGMT 192.168.1.1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_dc1-leaf1a_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/banners_without_eof.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/banners_without_eof.cfg
@@ -1,13 +1,4 @@
 !
-management api http-commands
-   protocol https
-   protocol http
-   no shutdown
-   !
-   vrf mgt
-      no shutdown
-      ip access-group ACL-API
-!
 banner login
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !***!!!Unauthorized access prohibited!!!***!
@@ -22,6 +13,15 @@ banner motd
 .         Type help for information about the aliases           .
 EOF
 
+!
+management api http-commands
+   protocol https
+   protocol http
+   no shutdown
+   !
+   vrf mgt
+      no shutdown
+      ip access-group ACL-API
 !
 management console
    idle-timeout 300

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/base.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/base.cfg
@@ -1,13 +1,4 @@
 !
-management api http-commands
-   protocol https
-   protocol http
-   no shutdown
-   !
-   vrf mgt
-      no shutdown
-      ip access-group ACL-API
-!
 banner login
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 !***!!!Unauthorized access prohibited!!!***!
@@ -22,6 +13,15 @@ banner motd
 .         Type help for information about the aliases           .
 EOF
 
+!
+management api http-commands
+   protocol https
+   protocol http
+   no shutdown
+   !
+   vrf mgt
+      no shutdown
+      ip access-group ACL-API
 !
 management console
    idle-timeout 300

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -66,6 +59,13 @@ vrf instance Tenant_A_WAN_Zone
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-BL1B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-BL1B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -66,6 +59,13 @@ vrf instance Tenant_A_WAN_Zone
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-BL1A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -50,6 +43,13 @@ vlan 131
    name Tenant_A_APP_Zone_2
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po7

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -82,6 +75,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_SVC3_Po7

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-L2LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -82,6 +75,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_SVC3_Po7

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -48,6 +41,13 @@ vrf instance MGMT
 vrf instance Tenant_A_APP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -113,6 +106,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF2B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -113,6 +106,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF2A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE3.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SPINE4.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -140,6 +133,13 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-SVC3B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/configs/DC1-SVC3B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -140,6 +133,13 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-SVC3A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp-empty-filter/cv_server_configlets.yml
@@ -1,51 +1,50 @@
 cvp_configlets:
   AVD_DC1-BL1A: "!\nno enable password\nno aaa root\n!\nusername admin privilege 15
     role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-BL1A\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
-    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 150\n
-    \  name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-BL1A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
     350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3013\n   name MLAG_L3_VRF_Tenant_A_WAN_Zone\n
     \  trunk group MLAG\n!\nvlan 3020\n   name MLAG_L3_VRF_Tenant_B_WAN_Zone\n   trunk
     group MLAG\n!\nvlan 3030\n   name MLAG_L3_VRF_Tenant_C_WAN_Zone\n   trunk group
     MLAG\n!\nvlan 4093\n   name MLAG_L3\n   trunk group MLAG\n!\nvlan 4094\n   name
     MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
-    instance Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n
-    \  description MLAG_DC1-BL1B_Port-Channel5\n   no shutdown\n   switchport mode
-    trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Ethernet1\n
-    \  description P2P_DC1-SPINE1_Ethernet6\n   no shutdown\n   mtu 1500\n   no switchport\n
-    \  ip address 172.31.255.41/31\n!\ninterface Ethernet2\n   description P2P_DC1-SPINE2_Ethernet6\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.43/31\n!\ninterface
-    Ethernet3\n   description P2P_DC1-SPINE3_Ethernet6\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.45/31\n!\ninterface Ethernet4\n   description
-    P2P_DC1-SPINE4_Ethernet6\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.47/31\n!\ninterface Ethernet5\n   description MLAG_DC1-BL1B_Ethernet5\n
-    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet6\n   description
-    MLAG_DC1-BL1B_Ethernet6\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.10/32\n!\ninterface
-    Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.10/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.110/24\n!\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n
-    \  no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
-    Vlan250\n   description Tenant_B_WAN_Zone_1\n   no shutdown\n   vrf Tenant_B_WAN_Zone\n
-    \  ip address virtual 10.2.50.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n
-    \  no shutdown\n   vrf Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface
-    Vlan3013\n   description MLAG_L3_VRF_Tenant_A_WAN_Zone\n   no shutdown\n   mtu
-    1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan3020\n
-    \  description MLAG_L3_VRF_Tenant_B_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf
-    Tenant_B_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan3030\n   description
-    MLAG_L3_VRF_Tenant_C_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_C_WAN_Zone\n
-    \  ip address 10.255.251.10/31\n!\ninterface Vlan4093\n   description MLAG_L3\n
-    \  no shutdown\n   mtu 1500\n   ip address 10.255.251.10/31\n!\ninterface Vlan4094\n
-    \  description MLAG\n   no shutdown\n   mtu 1500\n   no autostate\n   ip address
-    10.255.252.10/31\n!\ninterface Vxlan1\n   description DC1-BL1A_VTEP\n   vxlan
-    source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
+    instance Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\nmanagement api
+    http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-BL1B_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet6\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.41/31\n!\ninterface Ethernet2\n   description
+    P2P_DC1-SPINE2_Ethernet6\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.43/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet6\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.45/31\n!\ninterface
+    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet6\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.47/31\n!\ninterface Ethernet5\n   description
+    MLAG_DC1-BL1B_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet6\n   description MLAG_DC1-BL1B_Ethernet6\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.10/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
+    \  no shutdown\n   ip address 192.168.254.10/32\n!\ninterface Management1\n   description
+    OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.110/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n
+    \  ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n   description MLAG_L3_VRF_Tenant_A_WAN_Zone\n
+    \  no shutdown\n   mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface
+    Vlan3020\n   description MLAG_L3_VRF_Tenant_B_WAN_Zone\n   no shutdown\n   mtu
+    1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan3030\n
+    \  description MLAG_L3_VRF_Tenant_C_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf
+    Tenant_C_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan4093\n   description
+    MLAG_L3\n   no shutdown\n   mtu 1500\n   ip address 10.255.251.10/31\n!\ninterface
+    Vlan4094\n   description MLAG\n   no shutdown\n   mtu 1500\n   no autostate\n
+    \  ip address 10.255.252.10/31\n!\ninterface Vxlan1\n   description DC1-BL1A_VTEP\n
+    \  vxlan source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
     mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan 150 vni 10150\n   vxlan
     vlan 250 vni 20250\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_WAN_Zone
     vni 14\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n   vxlan vrf Tenant_C_WAN_Zone
@@ -119,51 +118,50 @@ cvp_configlets:
     connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-BL1B: "!\nno enable password\nno aaa root\n!\nusername admin privilege 15
     role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-BL1B\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
-    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 150\n
-    \  name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-BL1B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
     350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3013\n   name MLAG_L3_VRF_Tenant_A_WAN_Zone\n
     \  trunk group MLAG\n!\nvlan 3020\n   name MLAG_L3_VRF_Tenant_B_WAN_Zone\n   trunk
     group MLAG\n!\nvlan 3030\n   name MLAG_L3_VRF_Tenant_C_WAN_Zone\n   trunk group
     MLAG\n!\nvlan 4093\n   name MLAG_L3\n   trunk group MLAG\n!\nvlan 4094\n   name
     MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
-    instance Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n
-    \  description MLAG_DC1-BL1A_Port-Channel5\n   no shutdown\n   switchport mode
-    trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Ethernet1\n
-    \  description P2P_DC1-SPINE1_Ethernet7\n   no shutdown\n   mtu 1500\n   no switchport\n
-    \  ip address 172.31.255.49/31\n!\ninterface Ethernet2\n   description P2P_DC1-SPINE2_Ethernet7\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.51/31\n!\ninterface
-    Ethernet3\n   description P2P_DC1-SPINE3_Ethernet7\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.53/31\n!\ninterface Ethernet4\n   description
-    P2P_DC1-SPINE4_Ethernet7\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.55/31\n!\ninterface Ethernet5\n   description MLAG_DC1-BL1A_Ethernet5\n
-    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet6\n   description
-    MLAG_DC1-BL1A_Ethernet6\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.11/32\n!\ninterface
-    Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.10/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.111/24\n!\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n
-    \  no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
-    Vlan250\n   description Tenant_B_WAN_Zone_1\n   no shutdown\n   vrf Tenant_B_WAN_Zone\n
-    \  ip address virtual 10.2.50.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n
-    \  no shutdown\n   vrf Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface
-    Vlan3013\n   description MLAG_L3_VRF_Tenant_A_WAN_Zone\n   no shutdown\n   mtu
-    1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan3020\n
-    \  description MLAG_L3_VRF_Tenant_B_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf
-    Tenant_B_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan3030\n   description
-    MLAG_L3_VRF_Tenant_C_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_C_WAN_Zone\n
-    \  ip address 10.255.251.11/31\n!\ninterface Vlan4093\n   description MLAG_L3\n
-    \  no shutdown\n   mtu 1500\n   ip address 10.255.251.11/31\n!\ninterface Vlan4094\n
-    \  description MLAG\n   no shutdown\n   mtu 1500\n   no autostate\n   ip address
-    10.255.252.11/31\n!\ninterface Vxlan1\n   description DC1-BL1B_VTEP\n   vxlan
-    source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
+    instance Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\nmanagement api
+    http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-BL1A_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet7\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.49/31\n!\ninterface Ethernet2\n   description
+    P2P_DC1-SPINE2_Ethernet7\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.51/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet7\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.53/31\n!\ninterface
+    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet7\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.55/31\n!\ninterface Ethernet5\n   description
+    MLAG_DC1-BL1A_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet6\n   description MLAG_DC1-BL1A_Ethernet6\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.11/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
+    \  no shutdown\n   ip address 192.168.254.10/32\n!\ninterface Management1\n   description
+    OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.111/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n
+    \  ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n   description MLAG_L3_VRF_Tenant_A_WAN_Zone\n
+    \  no shutdown\n   mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface
+    Vlan3020\n   description MLAG_L3_VRF_Tenant_B_WAN_Zone\n   no shutdown\n   mtu
+    1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan3030\n
+    \  description MLAG_L3_VRF_Tenant_C_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf
+    Tenant_C_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan4093\n   description
+    MLAG_L3\n   no shutdown\n   mtu 1500\n   ip address 10.255.251.11/31\n!\ninterface
+    Vlan4094\n   description MLAG\n   no shutdown\n   mtu 1500\n   no autostate\n
+    \  ip address 10.255.252.11/31\n!\ninterface Vxlan1\n   description DC1-BL1B_VTEP\n
+    \  vxlan source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
     mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan 150 vni 10150\n   vxlan
     vlan 250 vni 20250\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_WAN_Zone
     vni 14\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n   vxlan vrf Tenant_C_WAN_Zone
@@ -237,20 +235,20 @@ cvp_configlets:
     connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-L2LEAF1A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-L2LEAF1A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nspanning-tree mst 0 priority 16384\n!\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-L2LEAF1A\nip name-server
+    vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode
+    mstp\nspanning-tree mst 0 priority 16384\n!\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan
     111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
     121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
-    131\n   name Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n
-    \  description DC1_LEAF2_Po7\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n!\ninterface
+    131\n   name Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n
+    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface
+    Port-Channel1\n   description DC1_LEAF2_Po7\n   no shutdown\n   switchport trunk
+    allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n!\ninterface
     Ethernet1\n   description DC1-LEAF2A_Ethernet7\n   no shutdown\n   channel-group
     1 mode active\n!\ninterface Ethernet2\n   description DC1-LEAF2B_Ethernet7\n   no
     shutdown\n   channel-group 1 mode active\n!\ninterface Management1\n   description
@@ -259,15 +257,14 @@ cvp_configlets:
     vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nend\n"
   AVD_DC1-L2LEAF2A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-L2LEAF2A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-L2LEAF2A\nip name-server
+    vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode
+    mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nvlan
     110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
     120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
@@ -276,8 +273,9 @@ cvp_configlets:
     211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
     310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
     350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG\n   trunk group MLAG\n!\nvrf
-    instance MGMT\n!\ninterface Port-Channel1\n   description DC1_SVC3_Po7\n   no
-    shutdown\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
+    instance MGMT\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\ninterface Port-Channel1\n   description
+    DC1_SVC3_Po7\n   no shutdown\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
     \  switchport mode trunk\n   switchport\n   mlag 1\n!\ninterface Port-Channel3\n
     \  description MLAG_DC1-L2LEAF2B_Port-Channel3\n   no shutdown\n   switchport
     mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Ethernet1\n
@@ -295,15 +293,14 @@ cvp_configlets:
     local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nend\n"
   AVD_DC1-L2LEAF2B: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-L2LEAF2B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-L2LEAF2B\nip name-server
+    vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode
+    mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nvlan
     110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
     120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
@@ -312,8 +309,9 @@ cvp_configlets:
     211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
     310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
     350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG\n   trunk group MLAG\n!\nvrf
-    instance MGMT\n!\ninterface Port-Channel1\n   description DC1_SVC3_Po7\n   no
-    shutdown\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
+    instance MGMT\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\ninterface Port-Channel1\n   description
+    DC1_SVC3_Po7\n   no shutdown\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
     \  switchport mode trunk\n   switchport\n   mlag 1\n!\ninterface Port-Channel3\n
     \  description MLAG_DC1-L2LEAF2A_Port-Channel3\n   no shutdown\n   switchport
     mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Ethernet1\n
@@ -331,29 +329,29 @@ cvp_configlets:
     local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nend\n"
   AVD_DC1-LEAF1A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-LEAF1A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nspanning-tree mst 0 priority 4096\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
-    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
-    131\n   name Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
-    instance Tenant_A_WEB_Zone\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet1\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.1/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-SPINE2_Ethernet1\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.3/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-SPINE3_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.5/31\n!\ninterface Ethernet4\n   description P2P_DC1-SPINE4_Ethernet1\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.7/31\n!\ninterface
-    Ethernet6\n   description SERVER_server02_SINGLE_NODE_TRUNK_Eth1\n   no shutdown\n
-    \  switchport trunk allowed vlan 110-111,210-211\n   switchport mode trunk\n   switchport\n!\ninterface
-    Ethernet7\n   description SERVER_server02_SINGLE_NODE_Eth1\n   no shutdown\n   switchport
-    access vlan 110\n   switchport mode access\n   switchport\n!\ninterface Loopback0\n
-    \  description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.5/32\n!\ninterface
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF1A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nspanning-tree
+    mst 0 priority 4096\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name
+    Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name
+    Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nmanagement api http-commands\n   protocol https\n
+    \  no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-SPINE1_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.1/31\n!\ninterface Ethernet2\n   description P2P_DC1-SPINE2_Ethernet1\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.3/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-SPINE3_Ethernet1\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.5/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SPINE4_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.7/31\n!\ninterface Ethernet6\n   description SERVER_server02_SINGLE_NODE_TRUNK_Eth1\n
+    \  no shutdown\n   switchport trunk allowed vlan 110-111,210-211\n   switchport
+    mode trunk\n   switchport\n!\ninterface Ethernet7\n   description SERVER_server02_SINGLE_NODE_Eth1\n
+    \  no shutdown\n   switchport access vlan 110\n   switchport mode access\n   switchport\n!\ninterface
+    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.5/32\n!\ninterface
     Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.5/32\n!\ninterface
     Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
     address 192.168.200.105/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
@@ -412,17 +410,16 @@ cvp_configlets:
     192.168.255.5\n      redistribute connected\n!\nend\n"
   AVD_DC1-LEAF2A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-LEAF2A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
-    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
-    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF2A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
+    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 110\n
+    \  name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n
+    \  name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
     140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
     210\n   name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan
@@ -435,32 +432,34 @@ cvp_configlets:
     MLAG\n!\nvlan 4093\n   name MLAG_L3\n   trunk group MLAG\n!\nvlan 4094\n   name
     MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
     instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WEB_Zone\n!\nvrf
-    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n
-    \  description MLAG_DC1-LEAF2B_Port-Channel5\n   no shutdown\n   switchport mode
-    trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Port-Channel7\n
-    \  description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n   mlag 7\n!\ninterface
-    Port-Channel10\n   description SERVER_server01_MLAG\n   no shutdown\n   switchport
-    trunk allowed vlan 210-211\n   switchport mode trunk\n   switchport\n   mlag 10\n!\ninterface
-    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet2\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.9/31\n!\ninterface Ethernet2\n   description
-    P2P_DC1-SPINE2_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.11/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet2\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.13/31\n!\ninterface
-    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet2\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.15/31\n!\ninterface Ethernet5\n   description
-    MLAG_DC1-LEAF2B_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Ethernet6\n   description MLAG_DC1-LEAF2B_Ethernet6\n   no shutdown\n   channel-group
-    5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF1A_Ethernet1\n
-    \  no shutdown\n   channel-group 7 mode active\n!\ninterface Ethernet10\n   description
-    SERVER_server01_MLAG_Eth2\n   no shutdown\n   channel-group 10 mode active\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.6/32\n!\ninterface
-    Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.6/32\n!\ninterface
-    Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n
-    \  vrf Tenant_A_OP_Zone\n   ip address 10.255.1.6/32\n!\ninterface Management1\n
-    \  description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.106/24\n!\ninterface
-    Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
-    \  ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nmanagement api
+    http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-LEAF2B_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Port-Channel7\n   description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport
+    trunk allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n
+    \  mlag 7\n!\ninterface Port-Channel10\n   description SERVER_server01_MLAG\n
+    \  no shutdown\n   switchport trunk allowed vlan 210-211\n   switchport mode trunk\n
+    \  switchport\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.9/31\n!\ninterface
+    Ethernet2\n   description P2P_DC1-SPINE2_Ethernet2\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.11/31\n!\ninterface Ethernet3\n   description
+    P2P_DC1-SPINE3_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.13/31\n!\ninterface Ethernet4\n   description P2P_DC1-SPINE4_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.15/31\n!\ninterface
+    Ethernet5\n   description MLAG_DC1-LEAF2B_Ethernet5\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Ethernet6\n   description MLAG_DC1-LEAF2B_Ethernet6\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description
+    DC1-L2LEAF1A_Ethernet1\n   no shutdown\n   channel-group 7 mode active\n!\ninterface
+    Ethernet10\n   description SERVER_server01_MLAG_Eth2\n   no shutdown\n   channel-group
+    10 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.6/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
+    \  no shutdown\n   ip address 192.168.254.6/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.6/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.106/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
     \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT
     source-interface lo100\n   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n
     \  description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n
@@ -592,17 +591,16 @@ cvp_configlets:
     DC1-LEAF2B_Vlan3029\n      redistribute connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-LEAF2B: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-LEAF2B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
-    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
-    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF2B\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
+    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 110\n
+    \  name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n
+    \  name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
     140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
     210\n   name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan
@@ -615,32 +613,34 @@ cvp_configlets:
     MLAG\n!\nvlan 4093\n   name MLAG_L3\n   trunk group MLAG\n!\nvlan 4094\n   name
     MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
     instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WEB_Zone\n!\nvrf
-    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n
-    \  description MLAG_DC1-LEAF2A_Port-Channel5\n   no shutdown\n   switchport mode
-    trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Port-Channel7\n
-    \  description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n   mlag 7\n!\ninterface
-    Port-Channel10\n   description SERVER_server01_MLAG\n   no shutdown\n   switchport
-    trunk allowed vlan 210-211\n   switchport mode trunk\n   switchport\n   mlag 10\n!\ninterface
-    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet3\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.17/31\n!\ninterface Ethernet2\n   description
-    P2P_DC1-SPINE2_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.19/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet3\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.21/31\n!\ninterface
-    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet3\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.23/31\n!\ninterface Ethernet5\n   description
-    MLAG_DC1-LEAF2A_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Ethernet6\n   description MLAG_DC1-LEAF2A_Ethernet6\n   no shutdown\n   channel-group
-    5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF1A_Ethernet2\n
-    \  no shutdown\n   channel-group 7 mode active\n!\ninterface Ethernet10\n   description
-    SERVER_server01_MLAG_Eth3\n   no shutdown\n   channel-group 10 mode active\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.7/32\n!\ninterface
-    Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.6/32\n!\ninterface
-    Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n
-    \  vrf Tenant_A_OP_Zone\n   ip address 10.255.1.7/32\n!\ninterface Management1\n
-    \  description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.107/24\n!\ninterface
-    Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
-    \  ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nmanagement api
+    http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-LEAF2A_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Port-Channel7\n   description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport
+    trunk allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n
+    \  mlag 7\n!\ninterface Port-Channel10\n   description SERVER_server01_MLAG\n
+    \  no shutdown\n   switchport trunk allowed vlan 210-211\n   switchport mode trunk\n
+    \  switchport\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet3\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.17/31\n!\ninterface
+    Ethernet2\n   description P2P_DC1-SPINE2_Ethernet3\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.19/31\n!\ninterface Ethernet3\n   description
+    P2P_DC1-SPINE3_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.21/31\n!\ninterface Ethernet4\n   description P2P_DC1-SPINE4_Ethernet3\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.23/31\n!\ninterface
+    Ethernet5\n   description MLAG_DC1-LEAF2A_Ethernet5\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Ethernet6\n   description MLAG_DC1-LEAF2A_Ethernet6\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description
+    DC1-L2LEAF1A_Ethernet2\n   no shutdown\n   channel-group 7 mode active\n!\ninterface
+    Ethernet10\n   description SERVER_server01_MLAG_Eth3\n   no shutdown\n   channel-group
+    10 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.7/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
+    \  no shutdown\n   ip address 192.168.254.6/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.7/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.107/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
     \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT
     source-interface lo100\n   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n
     \  description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n
@@ -772,38 +772,37 @@ cvp_configlets:
     DC1-LEAF2A_Vlan3029\n      redistribute connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-SPINE1: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-SPINE1\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode none\n!\nvrf
-    instance MGMT\n!\ninterface Ethernet1\n   description P2P_DC1-LEAF1A_Ethernet1\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.0/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet1\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.8/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-LEAF2B_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.16/31\n!\ninterface Ethernet4\n   description P2P_DC1-SVC3A_Ethernet1\n
-    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.24/31\n!\ninterface
-    Ethernet5\n   description P2P_DC1-SVC3B_Ethernet1\n   shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.32/31\n!\ninterface Ethernet6\n   description
-    P2P_DC1-BL1A_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
-    172.31.255.40/31\n!\ninterface Ethernet7\n   description P2P_DC1-BL1B_Ethernet1\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.48/31\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.1/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.101/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
-    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
-    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface vrf MGMT Management1\nntp
-    server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
-    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
-    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.1\n
-    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
-    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
-    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SPINE1\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode none\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-LEAF1A_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.0/31\n!\ninterface Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet1\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.8/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-LEAF2B_Ethernet1\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.16/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SVC3A_Ethernet1\n   shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.24/31\n!\ninterface Ethernet5\n   description P2P_DC1-SVC3B_Ethernet1\n
+    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.32/31\n!\ninterface
+    Ethernet6\n   description P2P_DC1-BL1A_Ethernet1\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.40/31\n!\ninterface Ethernet7\n   description
+    P2P_DC1-BL1B_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.48/31\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.1/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.101/24\n!\nip routing\nno
+    ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit
+    192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP
+    permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.1\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
     maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
@@ -843,38 +842,37 @@ cvp_configlets:
     activate\n!\nend\n"
   AVD_DC1-SPINE2: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-SPINE2\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode none\n!\nvrf
-    instance MGMT\n!\ninterface Ethernet1\n   description P2P_DC1-LEAF1A_Ethernet2\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.2/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet2\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.10/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-LEAF2B_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.18/31\n!\ninterface Ethernet4\n   description P2P_DC1-SVC3A_Ethernet2\n
-    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.26/31\n!\ninterface
-    Ethernet5\n   description P2P_DC1-SVC3B_Ethernet2\n   shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.34/31\n!\ninterface Ethernet6\n   description
-    P2P_DC1-BL1A_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
-    172.31.255.42/31\n!\ninterface Ethernet7\n   description P2P_DC1-BL1B_Ethernet2\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.50/31\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.2/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.102/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
-    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
-    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface vrf MGMT Management1\nntp
-    server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
-    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
-    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.2\n
-    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
-    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
-    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SPINE2\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode none\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-LEAF1A_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.2/31\n!\ninterface Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.10/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-LEAF2B_Ethernet2\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.18/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SVC3A_Ethernet2\n   shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.26/31\n!\ninterface Ethernet5\n   description P2P_DC1-SVC3B_Ethernet2\n
+    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.34/31\n!\ninterface
+    Ethernet6\n   description P2P_DC1-BL1A_Ethernet2\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.42/31\n!\ninterface Ethernet7\n   description
+    P2P_DC1-BL1B_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.50/31\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.2/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.102/24\n!\nip routing\nno
+    ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit
+    192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP
+    permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.2\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
     maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
@@ -914,38 +912,37 @@ cvp_configlets:
     activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nend\n"
   AVD_DC1-SPINE3: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-SPINE3\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode none\n!\nvrf
-    instance MGMT\n!\ninterface Ethernet1\n   description P2P_DC1-LEAF1A_Ethernet3\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.4/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet3\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.12/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-LEAF2B_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.20/31\n!\ninterface Ethernet4\n   description P2P_DC1-SVC3A_Ethernet3\n
-    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.28/31\n!\ninterface
-    Ethernet5\n   description P2P_DC1-SVC3B_Ethernet3\n   shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.36/31\n!\ninterface Ethernet6\n   description
-    P2P_DC1-BL1A_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
-    172.31.255.44/31\n!\ninterface Ethernet7\n   description P2P_DC1-BL1B_Ethernet3\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.52/31\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.3/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.103/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
-    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
-    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface vrf MGMT Management1\nntp
-    server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
-    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
-    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.3\n
-    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
-    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
-    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SPINE3\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode none\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-LEAF1A_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.4/31\n!\ninterface Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet3\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.12/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-LEAF2B_Ethernet3\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.20/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SVC3A_Ethernet3\n   shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.28/31\n!\ninterface Ethernet5\n   description P2P_DC1-SVC3B_Ethernet3\n
+    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.36/31\n!\ninterface
+    Ethernet6\n   description P2P_DC1-BL1A_Ethernet3\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.44/31\n!\ninterface Ethernet7\n   description
+    P2P_DC1-BL1B_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.52/31\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.3/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.103/24\n!\nip routing\nno
+    ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit
+    192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP
+    permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.3\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
     maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
@@ -985,38 +982,37 @@ cvp_configlets:
     activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nend\n"
   AVD_DC1-SPINE4: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-SPINE4\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode none\n!\nvrf
-    instance MGMT\n!\ninterface Ethernet1\n   description P2P_DC1-LEAF1A_Ethernet4\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.6/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet4\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.14/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-LEAF2B_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.22/31\n!\ninterface Ethernet4\n   description P2P_DC1-SVC3A_Ethernet4\n
-    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.30/31\n!\ninterface
-    Ethernet5\n   description P2P_DC1-SVC3B_Ethernet4\n   shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.38/31\n!\ninterface Ethernet6\n   description
-    P2P_DC1-BL1A_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
-    172.31.255.46/31\n!\ninterface Ethernet7\n   description P2P_DC1-BL1B_Ethernet4\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.54/31\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.4/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.104/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
-    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
-    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface vrf MGMT Management1\nntp
-    server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
-    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
-    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.4\n
-    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
-    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
-    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SPINE4\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode none\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-LEAF1A_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.6/31\n!\ninterface Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet4\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.14/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-LEAF2B_Ethernet4\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.22/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SVC3A_Ethernet4\n   shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.30/31\n!\ninterface Ethernet5\n   description P2P_DC1-SVC3B_Ethernet4\n
+    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.38/31\n!\ninterface
+    Ethernet6\n   description P2P_DC1-BL1A_Ethernet4\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.46/31\n!\ninterface Ethernet7\n   description
+    P2P_DC1-BL1B_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.54/31\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.4/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.104/24\n!\nip routing\nno
+    ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit
+    192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP
+    permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.4\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
     maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
@@ -1056,17 +1052,16 @@ cvp_configlets:
     activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nend\n"
   AVD_DC1-SVC3A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-SVC3A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
-    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
-    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SVC3A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
+    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 110\n
+    \  name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n
+    \  name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
     140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
     150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 210\n   name Tenant_B_OP_Zone_1\n!\nvlan
@@ -1084,36 +1079,37 @@ cvp_configlets:
     \  name MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
     instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
     instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
-    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
-    Port-Channel5\n   description MLAG_DC1-SVC3B_Port-Channel5\n   no shutdown\n   switchport
-    mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Port-Channel7\n
-    \  description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode
-    trunk\n   switchport\n   mlag 7\n!\ninterface Port-Channel10\n   description SERVER_server03_ESI\n
-    \  no shutdown\n   switchport trunk allowed vlan 110-111,210-211\n   switchport
-    mode trunk\n   switchport\n   evpn ethernet-segment\n      identifier 0000:0000:0303:0202:0101\n
-    \     route-target import 03:03:02:02:01:01\n   lacp system-id 0303.0202.0101\n!\ninterface
-    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet4\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.25/31\n!\ninterface Ethernet2\n   description
-    P2P_DC1-SPINE2_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.27/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet4\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.29/31\n!\ninterface
-    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet4\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.31/31\n!\ninterface Ethernet5\n   description
-    MLAG_DC1-SVC3B_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Ethernet6\n   description MLAG_DC1-SVC3B_Ethernet6\n   no shutdown\n   channel-group
-    5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF2A_Ethernet1\n
-    \  no shutdown\n   channel-group 7 mode active\n!\ninterface Ethernet8\n   description
-    DC1-L2LEAF2B_Ethernet1\n   no shutdown\n   channel-group 7 mode active\n!\ninterface
-    Ethernet10\n   description SERVER_server03_ESI_Eth1\n   no shutdown\n   channel-group
-    10 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
-    \  ip address 192.168.255.8/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
-    \  no shutdown\n   ip address 192.168.254.8/32\n!\ninterface Loopback100\n   description
-    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
-    address 10.255.1.8/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
-    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.108/24\n!\ninterface Vlan110\n
-    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
-    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-SVC3B_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Port-Channel7\n   description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport trunk
+    allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport
+    mode trunk\n   switchport\n   mlag 7\n!\ninterface Port-Channel10\n   description
+    SERVER_server03_ESI\n   no shutdown\n   switchport trunk allowed vlan 110-111,210-211\n
+    \  switchport mode trunk\n   switchport\n   evpn ethernet-segment\n      identifier
+    0000:0000:0303:0202:0101\n      route-target import 03:03:02:02:01:01\n   lacp
+    system-id 0303.0202.0101\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet4\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.25/31\n!\ninterface
+    Ethernet2\n   description P2P_DC1-SPINE2_Ethernet4\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.27/31\n!\ninterface Ethernet3\n   description
+    P2P_DC1-SPINE3_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.29/31\n!\ninterface Ethernet4\n   description P2P_DC1-SPINE4_Ethernet4\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.31/31\n!\ninterface
+    Ethernet5\n   description MLAG_DC1-SVC3B_Ethernet5\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Ethernet6\n   description MLAG_DC1-SVC3B_Ethernet6\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description
+    DC1-L2LEAF2A_Ethernet1\n   no shutdown\n   channel-group 7 mode active\n!\ninterface
+    Ethernet8\n   description DC1-L2LEAF2B_Ethernet1\n   no shutdown\n   channel-group
+    7 mode active\n!\ninterface Ethernet10\n   description SERVER_server03_ESI_Eth1\n
+    \  no shutdown\n   channel-group 10 mode active\n!\ninterface Loopback0\n   description
+    ROUTER_ID\n   no shutdown\n   ip address 192.168.255.8/32\n!\ninterface Loopback1\n
+    \  description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.8/32\n!\ninterface
+    Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n
+    \  vrf Tenant_A_OP_Zone\n   ip address 10.255.1.8/32\n!\ninterface Management1\n
+    \  description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.108/24\n!\ninterface
+    Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
     \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT
     source-interface lo100\n   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n
     \  description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n
@@ -1276,17 +1272,16 @@ cvp_configlets:
     connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-SVC3B: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-SVC3B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
-    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
-    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SVC3B\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
+    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 110\n
+    \  name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n
+    \  name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
     140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
     150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 210\n   name Tenant_B_OP_Zone_1\n!\nvlan
@@ -1304,12 +1299,13 @@ cvp_configlets:
     \  name MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
     instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
     instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
-    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
-    Port-Channel5\n   description MLAG_DC1-SVC3A_Port-Channel5\n   no shutdown\n   switchport
-    mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Port-Channel7\n
-    \  description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode
-    trunk\n   switchport\n   mlag 7\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet5\n
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-SVC3A_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Port-Channel7\n   description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport trunk
+    allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport
+    mode trunk\n   switchport\n   mlag 7\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet5\n
     \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.33/31\n!\ninterface
     Ethernet2\n   description P2P_DC1-SPINE2_Ethernet5\n   no shutdown\n   mtu 1500\n
     \  no switchport\n   ip address 172.31.255.35/31\n!\ninterface Ethernet3\n   description

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/cvp/cv_server_configlets.yml
@@ -1,51 +1,50 @@
 cvp_configlets:
   AVD_DC1-BL1A: "!\nno enable password\nno aaa root\n!\nusername admin privilege 15
     role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-BL1A\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
-    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 150\n
-    \  name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-BL1A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
     350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3013\n   name MLAG_L3_VRF_Tenant_A_WAN_Zone\n
     \  trunk group MLAG\n!\nvlan 3020\n   name MLAG_L3_VRF_Tenant_B_WAN_Zone\n   trunk
     group MLAG\n!\nvlan 3030\n   name MLAG_L3_VRF_Tenant_C_WAN_Zone\n   trunk group
     MLAG\n!\nvlan 4093\n   name MLAG_L3\n   trunk group MLAG\n!\nvlan 4094\n   name
     MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
-    instance Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n
-    \  description MLAG_DC1-BL1B_Port-Channel5\n   no shutdown\n   switchport mode
-    trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Ethernet1\n
-    \  description P2P_DC1-SPINE1_Ethernet6\n   no shutdown\n   mtu 1500\n   no switchport\n
-    \  ip address 172.31.255.41/31\n!\ninterface Ethernet2\n   description P2P_DC1-SPINE2_Ethernet6\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.43/31\n!\ninterface
-    Ethernet3\n   description P2P_DC1-SPINE3_Ethernet6\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.45/31\n!\ninterface Ethernet4\n   description
-    P2P_DC1-SPINE4_Ethernet6\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.47/31\n!\ninterface Ethernet5\n   description MLAG_DC1-BL1B_Ethernet5\n
-    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet6\n   description
-    MLAG_DC1-BL1B_Ethernet6\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.10/32\n!\ninterface
-    Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.10/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.110/24\n!\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n
-    \  no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
-    Vlan250\n   description Tenant_B_WAN_Zone_1\n   no shutdown\n   vrf Tenant_B_WAN_Zone\n
-    \  ip address virtual 10.2.50.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n
-    \  no shutdown\n   vrf Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface
-    Vlan3013\n   description MLAG_L3_VRF_Tenant_A_WAN_Zone\n   no shutdown\n   mtu
-    1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan3020\n
-    \  description MLAG_L3_VRF_Tenant_B_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf
-    Tenant_B_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan3030\n   description
-    MLAG_L3_VRF_Tenant_C_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_C_WAN_Zone\n
-    \  ip address 10.255.251.10/31\n!\ninterface Vlan4093\n   description MLAG_L3\n
-    \  no shutdown\n   mtu 1500\n   ip address 10.255.251.10/31\n!\ninterface Vlan4094\n
-    \  description MLAG\n   no shutdown\n   mtu 1500\n   no autostate\n   ip address
-    10.255.252.10/31\n!\ninterface Vxlan1\n   description DC1-BL1A_VTEP\n   vxlan
-    source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
+    instance Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\nmanagement api
+    http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-BL1B_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet6\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.41/31\n!\ninterface Ethernet2\n   description
+    P2P_DC1-SPINE2_Ethernet6\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.43/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet6\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.45/31\n!\ninterface
+    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet6\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.47/31\n!\ninterface Ethernet5\n   description
+    MLAG_DC1-BL1B_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet6\n   description MLAG_DC1-BL1B_Ethernet6\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.10/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
+    \  no shutdown\n   ip address 192.168.254.10/32\n!\ninterface Management1\n   description
+    OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.110/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n
+    \  ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n   description MLAG_L3_VRF_Tenant_A_WAN_Zone\n
+    \  no shutdown\n   mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface
+    Vlan3020\n   description MLAG_L3_VRF_Tenant_B_WAN_Zone\n   no shutdown\n   mtu
+    1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan3030\n
+    \  description MLAG_L3_VRF_Tenant_C_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf
+    Tenant_C_WAN_Zone\n   ip address 10.255.251.10/31\n!\ninterface Vlan4093\n   description
+    MLAG_L3\n   no shutdown\n   mtu 1500\n   ip address 10.255.251.10/31\n!\ninterface
+    Vlan4094\n   description MLAG\n   no shutdown\n   mtu 1500\n   no autostate\n
+    \  ip address 10.255.252.10/31\n!\ninterface Vxlan1\n   description DC1-BL1A_VTEP\n
+    \  vxlan source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
     mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan 150 vni 10150\n   vxlan
     vlan 250 vni 20250\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_WAN_Zone
     vni 14\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n   vxlan vrf Tenant_C_WAN_Zone
@@ -119,51 +118,50 @@ cvp_configlets:
     connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-BL1B: "!\nno enable password\nno aaa root\n!\nusername admin privilege 15
     role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-BL1B\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
-    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 150\n
-    \  name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-BL1B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
+    150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
     350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 3013\n   name MLAG_L3_VRF_Tenant_A_WAN_Zone\n
     \  trunk group MLAG\n!\nvlan 3020\n   name MLAG_L3_VRF_Tenant_B_WAN_Zone\n   trunk
     group MLAG\n!\nvlan 3030\n   name MLAG_L3_VRF_Tenant_C_WAN_Zone\n   trunk group
     MLAG\n!\nvlan 4093\n   name MLAG_L3\n   trunk group MLAG\n!\nvlan 4094\n   name
     MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
-    instance Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface Port-Channel5\n
-    \  description MLAG_DC1-BL1A_Port-Channel5\n   no shutdown\n   switchport mode
-    trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Ethernet1\n
-    \  description P2P_DC1-SPINE1_Ethernet7\n   no shutdown\n   mtu 1500\n   no switchport\n
-    \  ip address 172.31.255.49/31\n!\ninterface Ethernet2\n   description P2P_DC1-SPINE2_Ethernet7\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.51/31\n!\ninterface
-    Ethernet3\n   description P2P_DC1-SPINE3_Ethernet7\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.53/31\n!\ninterface Ethernet4\n   description
-    P2P_DC1-SPINE4_Ethernet7\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.55/31\n!\ninterface Ethernet5\n   description MLAG_DC1-BL1A_Ethernet5\n
-    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet6\n   description
-    MLAG_DC1-BL1A_Ethernet6\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.11/32\n!\ninterface
-    Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.10/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.111/24\n!\ninterface Vlan150\n   description Tenant_A_WAN_Zone_1\n
-    \  no shutdown\n   vrf Tenant_A_WAN_Zone\n   ip address virtual 10.1.40.1/24\n!\ninterface
-    Vlan250\n   description Tenant_B_WAN_Zone_1\n   no shutdown\n   vrf Tenant_B_WAN_Zone\n
-    \  ip address virtual 10.2.50.1/24\n!\ninterface Vlan350\n   description Tenant_C_WAN_Zone_1\n
-    \  no shutdown\n   vrf Tenant_C_WAN_Zone\n   ip address virtual 10.3.50.1/24\n!\ninterface
-    Vlan3013\n   description MLAG_L3_VRF_Tenant_A_WAN_Zone\n   no shutdown\n   mtu
-    1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan3020\n
-    \  description MLAG_L3_VRF_Tenant_B_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf
-    Tenant_B_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan3030\n   description
-    MLAG_L3_VRF_Tenant_C_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf Tenant_C_WAN_Zone\n
-    \  ip address 10.255.251.11/31\n!\ninterface Vlan4093\n   description MLAG_L3\n
-    \  no shutdown\n   mtu 1500\n   ip address 10.255.251.11/31\n!\ninterface Vlan4094\n
-    \  description MLAG\n   no shutdown\n   mtu 1500\n   no autostate\n   ip address
-    10.255.252.11/31\n!\ninterface Vxlan1\n   description DC1-BL1B_VTEP\n   vxlan
-    source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
+    instance Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\nmanagement api
+    http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-BL1A_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet7\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.49/31\n!\ninterface Ethernet2\n   description
+    P2P_DC1-SPINE2_Ethernet7\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.51/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet7\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.53/31\n!\ninterface
+    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet7\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.55/31\n!\ninterface Ethernet5\n   description
+    MLAG_DC1-BL1A_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
+    Ethernet6\n   description MLAG_DC1-BL1A_Ethernet6\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.11/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
+    \  no shutdown\n   ip address 192.168.254.10/32\n!\ninterface Management1\n   description
+    OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.111/24\n!\ninterface
+    Vlan150\n   description Tenant_A_WAN_Zone_1\n   no shutdown\n   vrf Tenant_A_WAN_Zone\n
+    \  ip address virtual 10.1.40.1/24\n!\ninterface Vlan250\n   description Tenant_B_WAN_Zone_1\n
+    \  no shutdown\n   vrf Tenant_B_WAN_Zone\n   ip address virtual 10.2.50.1/24\n!\ninterface
+    Vlan350\n   description Tenant_C_WAN_Zone_1\n   no shutdown\n   vrf Tenant_C_WAN_Zone\n
+    \  ip address virtual 10.3.50.1/24\n!\ninterface Vlan3013\n   description MLAG_L3_VRF_Tenant_A_WAN_Zone\n
+    \  no shutdown\n   mtu 1500\n   vrf Tenant_A_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface
+    Vlan3020\n   description MLAG_L3_VRF_Tenant_B_WAN_Zone\n   no shutdown\n   mtu
+    1500\n   vrf Tenant_B_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan3030\n
+    \  description MLAG_L3_VRF_Tenant_C_WAN_Zone\n   no shutdown\n   mtu 1500\n   vrf
+    Tenant_C_WAN_Zone\n   ip address 10.255.251.11/31\n!\ninterface Vlan4093\n   description
+    MLAG_L3\n   no shutdown\n   mtu 1500\n   ip address 10.255.251.11/31\n!\ninterface
+    Vlan4094\n   description MLAG\n   no shutdown\n   mtu 1500\n   no autostate\n
+    \  ip address 10.255.252.11/31\n!\ninterface Vxlan1\n   description DC1-BL1B_VTEP\n
+    \  vxlan source-interface Loopback1\n   vxlan virtual-router encapsulation mac-address
     mlag-system-id\n   vxlan udp-port 4789\n   vxlan vlan 150 vni 10150\n   vxlan
     vlan 250 vni 20250\n   vxlan vlan 350 vni 30350\n   vxlan vrf Tenant_A_WAN_Zone
     vni 14\n   vxlan vrf Tenant_B_WAN_Zone vni 21\n   vxlan vrf Tenant_C_WAN_Zone
@@ -237,20 +235,20 @@ cvp_configlets:
     connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-L2LEAF1A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-L2LEAF1A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nspanning-tree mst 0 priority 16384\n!\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-L2LEAF1A\nip name-server
+    vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode
+    mstp\nspanning-tree mst 0 priority 16384\n!\nvlan 110\n   name Tenant_A_OP_Zone_1\n!\nvlan
     111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
     121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
-    131\n   name Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\ninterface Port-Channel1\n
-    \  description DC1_LEAF2_Po7\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n!\ninterface
+    131\n   name Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n
+    \  protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface
+    Port-Channel1\n   description DC1_LEAF2_Po7\n   no shutdown\n   switchport trunk
+    allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n!\ninterface
     Ethernet1\n   description DC1-LEAF2A_Ethernet7\n   no shutdown\n   channel-group
     1 mode active\n!\ninterface Ethernet2\n   description DC1-LEAF2B_Ethernet7\n   no
     shutdown\n   channel-group 1 mode active\n!\ninterface Management1\n   description
@@ -259,15 +257,14 @@ cvp_configlets:
     vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nend\n"
   AVD_DC1-L2LEAF2A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-L2LEAF2A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-L2LEAF2A\nip name-server
+    vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode
+    mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nvlan
     110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
     120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
@@ -276,8 +273,9 @@ cvp_configlets:
     211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
     310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
     350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG\n   trunk group MLAG\n!\nvrf
-    instance MGMT\n!\ninterface Port-Channel1\n   description DC1_SVC3_Po7\n   no
-    shutdown\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
+    instance MGMT\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\ninterface Port-Channel1\n   description
+    DC1_SVC3_Po7\n   no shutdown\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
     \  switchport mode trunk\n   switchport\n   mlag 1\n!\ninterface Port-Channel3\n
     \  description MLAG_DC1-L2LEAF2B_Port-Channel3\n   no shutdown\n   switchport
     mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Ethernet1\n
@@ -295,15 +293,14 @@ cvp_configlets:
     local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nend\n"
   AVD_DC1-L2LEAF2B: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-L2LEAF2B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-L2LEAF2B\nip name-server
+    vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode
+    mstp\nno spanning-tree vlan-id 4094\nspanning-tree mst 0 priority 16384\n!\nvlan
     110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
     120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
@@ -312,8 +309,9 @@ cvp_configlets:
     211\n   name Tenant_B_OP_Zone_2\n!\nvlan 250\n   name Tenant_B_WAN_Zone_1\n!\nvlan
     310\n   name Tenant_C_OP_Zone_1\n!\nvlan 311\n   name Tenant_C_OP_Zone_2\n!\nvlan
     350\n   name Tenant_C_WAN_Zone_1\n!\nvlan 4094\n   name MLAG\n   trunk group MLAG\n!\nvrf
-    instance MGMT\n!\ninterface Port-Channel1\n   description DC1_SVC3_Po7\n   no
-    shutdown\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
+    instance MGMT\n!\nmanagement api http-commands\n   protocol https\n   no shutdown\n
+    \  !\n   vrf MGMT\n      no shutdown\n!\ninterface Port-Channel1\n   description
+    DC1_SVC3_Po7\n   no shutdown\n   switchport trunk allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n
     \  switchport mode trunk\n   switchport\n   mlag 1\n!\ninterface Port-Channel3\n
     \  description MLAG_DC1-L2LEAF2A_Port-Channel3\n   no shutdown\n   switchport
     mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Ethernet1\n
@@ -331,29 +329,29 @@ cvp_configlets:
     local-interface vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nend\n"
   AVD_DC1-LEAF1A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-LEAF1A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nspanning-tree mst 0 priority 4096\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan
-    121\n   name Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan
-    131\n   name Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
-    instance Tenant_A_WEB_Zone\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet1\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.1/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-SPINE2_Ethernet1\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.3/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-SPINE3_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.5/31\n!\ninterface Ethernet4\n   description P2P_DC1-SPINE4_Ethernet1\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.7/31\n!\ninterface
-    Ethernet6\n   description SERVER_server02_SINGLE_NODE_TRUNK_Eth1\n   no shutdown\n
-    \  switchport trunk allowed vlan 110-111,210-211\n   switchport mode trunk\n   switchport\n!\ninterface
-    Ethernet7\n   description SERVER_server02_SINGLE_NODE_Eth1\n   no shutdown\n   switchport
-    access vlan 110\n   switchport mode access\n   switchport\n!\ninterface Loopback0\n
-    \  description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.5/32\n!\ninterface
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF1A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nspanning-tree
+    mst 0 priority 4096\n!\nvlan 120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name
+    Tenant_A_WEBZone_2\n!\nvlan 130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name
+    Tenant_A_APP_Zone_2\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
+    instance Tenant_A_WEB_Zone\n!\nmanagement api http-commands\n   protocol https\n
+    \  no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-SPINE1_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.1/31\n!\ninterface Ethernet2\n   description P2P_DC1-SPINE2_Ethernet1\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.3/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-SPINE3_Ethernet1\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.5/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SPINE4_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.7/31\n!\ninterface Ethernet6\n   description SERVER_server02_SINGLE_NODE_TRUNK_Eth1\n
+    \  no shutdown\n   switchport trunk allowed vlan 110-111,210-211\n   switchport
+    mode trunk\n   switchport\n!\ninterface Ethernet7\n   description SERVER_server02_SINGLE_NODE_Eth1\n
+    \  no shutdown\n   switchport access vlan 110\n   switchport mode access\n   switchport\n!\ninterface
+    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.5/32\n!\ninterface
     Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.5/32\n!\ninterface
     Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
     address 192.168.200.105/24\n!\ninterface Vlan120\n   description Tenant_A_WEB_Zone_1\n
@@ -412,17 +410,16 @@ cvp_configlets:
     192.168.255.5\n      redistribute connected\n!\nend\n"
   AVD_DC1-LEAF2A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-LEAF2A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
-    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
-    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF2A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
+    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 110\n
+    \  name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n
+    \  name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
     140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
     210\n   name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan
@@ -435,32 +432,34 @@ cvp_configlets:
     MLAG\n!\nvlan 4093\n   name MLAG_L3\n   trunk group MLAG\n!\nvlan 4094\n   name
     MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
     instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WEB_Zone\n!\nvrf
-    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n
-    \  description MLAG_DC1-LEAF2B_Port-Channel5\n   no shutdown\n   switchport mode
-    trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Port-Channel7\n
-    \  description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n   mlag 7\n!\ninterface
-    Port-Channel10\n   description SERVER_server01_MLAG\n   no shutdown\n   switchport
-    trunk allowed vlan 210-211\n   switchport mode trunk\n   switchport\n   mlag 10\n!\ninterface
-    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet2\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.9/31\n!\ninterface Ethernet2\n   description
-    P2P_DC1-SPINE2_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.11/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet2\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.13/31\n!\ninterface
-    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet2\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.15/31\n!\ninterface Ethernet5\n   description
-    MLAG_DC1-LEAF2B_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Ethernet6\n   description MLAG_DC1-LEAF2B_Ethernet6\n   no shutdown\n   channel-group
-    5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF1A_Ethernet1\n
-    \  no shutdown\n   channel-group 7 mode active\n!\ninterface Ethernet10\n   description
-    SERVER_server01_MLAG_Eth2\n   no shutdown\n   channel-group 10 mode active\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.6/32\n!\ninterface
-    Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.6/32\n!\ninterface
-    Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n
-    \  vrf Tenant_A_OP_Zone\n   ip address 10.255.1.6/32\n!\ninterface Management1\n
-    \  description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.106/24\n!\ninterface
-    Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
-    \  ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nmanagement api
+    http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-LEAF2B_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Port-Channel7\n   description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport
+    trunk allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n
+    \  mlag 7\n!\ninterface Port-Channel10\n   description SERVER_server01_MLAG\n
+    \  no shutdown\n   switchport trunk allowed vlan 210-211\n   switchport mode trunk\n
+    \  switchport\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.9/31\n!\ninterface
+    Ethernet2\n   description P2P_DC1-SPINE2_Ethernet2\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.11/31\n!\ninterface Ethernet3\n   description
+    P2P_DC1-SPINE3_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.13/31\n!\ninterface Ethernet4\n   description P2P_DC1-SPINE4_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.15/31\n!\ninterface
+    Ethernet5\n   description MLAG_DC1-LEAF2B_Ethernet5\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Ethernet6\n   description MLAG_DC1-LEAF2B_Ethernet6\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description
+    DC1-L2LEAF1A_Ethernet1\n   no shutdown\n   channel-group 7 mode active\n!\ninterface
+    Ethernet10\n   description SERVER_server01_MLAG_Eth2\n   no shutdown\n   channel-group
+    10 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.6/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
+    \  no shutdown\n   ip address 192.168.254.6/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.6/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.106/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
     \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT
     source-interface lo100\n   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n
     \  description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n
@@ -592,17 +591,16 @@ cvp_configlets:
     DC1-LEAF2B_Vlan3029\n      redistribute connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-LEAF2B: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-LEAF2B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
-    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
-    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-LEAF2B\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
+    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 110\n
+    \  name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n
+    \  name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
     140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
     210\n   name Tenant_B_OP_Zone_1\n!\nvlan 211\n   name Tenant_B_OP_Zone_2\n!\nvlan
@@ -615,32 +613,34 @@ cvp_configlets:
     MLAG\n!\nvlan 4093\n   name MLAG_L3\n   trunk group MLAG\n!\nvlan 4094\n   name
     MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
     instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WEB_Zone\n!\nvrf
-    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\ninterface Port-Channel5\n
-    \  description MLAG_DC1-LEAF2A_Port-Channel5\n   no shutdown\n   switchport mode
-    trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Port-Channel7\n
-    \  description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n   mlag 7\n!\ninterface
-    Port-Channel10\n   description SERVER_server01_MLAG\n   no shutdown\n   switchport
-    trunk allowed vlan 210-211\n   switchport mode trunk\n   switchport\n   mlag 10\n!\ninterface
-    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet3\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.17/31\n!\ninterface Ethernet2\n   description
-    P2P_DC1-SPINE2_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.19/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet3\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.21/31\n!\ninterface
-    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet3\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.23/31\n!\ninterface Ethernet5\n   description
-    MLAG_DC1-LEAF2A_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Ethernet6\n   description MLAG_DC1-LEAF2A_Ethernet6\n   no shutdown\n   channel-group
-    5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF1A_Ethernet2\n
-    \  no shutdown\n   channel-group 7 mode active\n!\ninterface Ethernet10\n   description
-    SERVER_server01_MLAG_Eth3\n   no shutdown\n   channel-group 10 mode active\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.7/32\n!\ninterface
-    Loopback1\n   description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.6/32\n!\ninterface
-    Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n
-    \  vrf Tenant_A_OP_Zone\n   ip address 10.255.1.7/32\n!\ninterface Management1\n
-    \  description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.107/24\n!\ninterface
-    Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
-    \  ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    instance Tenant_B_OP_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nmanagement api
+    http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-LEAF2A_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Port-Channel7\n   description DC1-L2LEAF1A_Po1\n   no shutdown\n   switchport
+    trunk allowed vlan 110-111,120-121,130-131\n   switchport mode trunk\n   switchport\n
+    \  mlag 7\n!\ninterface Port-Channel10\n   description SERVER_server01_MLAG\n
+    \  no shutdown\n   switchport trunk allowed vlan 210-211\n   switchport mode trunk\n
+    \  switchport\n   mlag 10\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet3\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.17/31\n!\ninterface
+    Ethernet2\n   description P2P_DC1-SPINE2_Ethernet3\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.19/31\n!\ninterface Ethernet3\n   description
+    P2P_DC1-SPINE3_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.21/31\n!\ninterface Ethernet4\n   description P2P_DC1-SPINE4_Ethernet3\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.23/31\n!\ninterface
+    Ethernet5\n   description MLAG_DC1-LEAF2A_Ethernet5\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Ethernet6\n   description MLAG_DC1-LEAF2A_Ethernet6\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description
+    DC1-L2LEAF1A_Ethernet2\n   no shutdown\n   channel-group 7 mode active\n!\ninterface
+    Ethernet10\n   description SERVER_server01_MLAG_Eth3\n   no shutdown\n   channel-group
+    10 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.7/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
+    \  no shutdown\n   ip address 192.168.254.6/32\n!\ninterface Loopback100\n   description
+    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address 10.255.1.7/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.107/24\n!\ninterface Vlan110\n
+    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
+    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
     \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT
     source-interface lo100\n   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n
     \  description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n
@@ -772,38 +772,37 @@ cvp_configlets:
     DC1-LEAF2A_Vlan3029\n      redistribute connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-SPINE1: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-SPINE1\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode none\n!\nvrf
-    instance MGMT\n!\ninterface Ethernet1\n   description P2P_DC1-LEAF1A_Ethernet1\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.0/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet1\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.8/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-LEAF2B_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.16/31\n!\ninterface Ethernet4\n   description P2P_DC1-SVC3A_Ethernet1\n
-    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.24/31\n!\ninterface
-    Ethernet5\n   description P2P_DC1-SVC3B_Ethernet1\n   shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.32/31\n!\ninterface Ethernet6\n   description
-    P2P_DC1-BL1A_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
-    172.31.255.40/31\n!\ninterface Ethernet7\n   description P2P_DC1-BL1B_Ethernet1\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.48/31\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.1/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.101/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
-    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
-    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface vrf MGMT Management1\nntp
-    server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
-    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
-    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.1\n
-    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
-    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
-    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SPINE1\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode none\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-LEAF1A_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.0/31\n!\ninterface Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet1\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.8/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-LEAF2B_Ethernet1\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.16/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SVC3A_Ethernet1\n   shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.24/31\n!\ninterface Ethernet5\n   description P2P_DC1-SVC3B_Ethernet1\n
+    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.32/31\n!\ninterface
+    Ethernet6\n   description P2P_DC1-BL1A_Ethernet1\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.40/31\n!\ninterface Ethernet7\n   description
+    P2P_DC1-BL1B_Ethernet1\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.48/31\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.1/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.101/24\n!\nip routing\nno
+    ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit
+    192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP
+    permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.1\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
     maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
@@ -843,38 +842,37 @@ cvp_configlets:
     activate\n!\nend\n"
   AVD_DC1-SPINE2: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-SPINE2\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode none\n!\nvrf
-    instance MGMT\n!\ninterface Ethernet1\n   description P2P_DC1-LEAF1A_Ethernet2\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.2/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet2\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.10/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-LEAF2B_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.18/31\n!\ninterface Ethernet4\n   description P2P_DC1-SVC3A_Ethernet2\n
-    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.26/31\n!\ninterface
-    Ethernet5\n   description P2P_DC1-SVC3B_Ethernet2\n   shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.34/31\n!\ninterface Ethernet6\n   description
-    P2P_DC1-BL1A_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
-    172.31.255.42/31\n!\ninterface Ethernet7\n   description P2P_DC1-BL1B_Ethernet2\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.50/31\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.2/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.102/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
-    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
-    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface vrf MGMT Management1\nntp
-    server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
-    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
-    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.2\n
-    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
-    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
-    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SPINE2\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode none\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-LEAF1A_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.2/31\n!\ninterface Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet2\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.10/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-LEAF2B_Ethernet2\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.18/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SVC3A_Ethernet2\n   shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.26/31\n!\ninterface Ethernet5\n   description P2P_DC1-SVC3B_Ethernet2\n
+    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.34/31\n!\ninterface
+    Ethernet6\n   description P2P_DC1-BL1A_Ethernet2\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.42/31\n!\ninterface Ethernet7\n   description
+    P2P_DC1-BL1B_Ethernet2\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.50/31\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.2/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.102/24\n!\nip routing\nno
+    ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit
+    192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP
+    permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.2\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
     maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
@@ -914,38 +912,37 @@ cvp_configlets:
     activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nend\n"
   AVD_DC1-SPINE3: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-SPINE3\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode none\n!\nvrf
-    instance MGMT\n!\ninterface Ethernet1\n   description P2P_DC1-LEAF1A_Ethernet3\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.4/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet3\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.12/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-LEAF2B_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.20/31\n!\ninterface Ethernet4\n   description P2P_DC1-SVC3A_Ethernet3\n
-    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.28/31\n!\ninterface
-    Ethernet5\n   description P2P_DC1-SVC3B_Ethernet3\n   shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.36/31\n!\ninterface Ethernet6\n   description
-    P2P_DC1-BL1A_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
-    172.31.255.44/31\n!\ninterface Ethernet7\n   description P2P_DC1-BL1B_Ethernet3\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.52/31\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.3/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.103/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
-    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
-    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface vrf MGMT Management1\nntp
-    server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
-    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
-    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.3\n
-    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
-    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
-    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SPINE3\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode none\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-LEAF1A_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.4/31\n!\ninterface Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet3\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.12/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-LEAF2B_Ethernet3\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.20/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SVC3A_Ethernet3\n   shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.28/31\n!\ninterface Ethernet5\n   description P2P_DC1-SVC3B_Ethernet3\n
+    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.36/31\n!\ninterface
+    Ethernet6\n   description P2P_DC1-BL1A_Ethernet3\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.44/31\n!\ninterface Ethernet7\n   description
+    P2P_DC1-BL1B_Ethernet3\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.52/31\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.3/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.103/24\n!\nip routing\nno
+    ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit
+    192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP
+    permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.3\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
     maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
@@ -985,38 +982,37 @@ cvp_configlets:
     activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nend\n"
   AVD_DC1-SPINE4: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
-    routing protocols model multi-agent\n!\nhostname DC1-SPINE4\nip name-server vrf
-    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode none\n!\nvrf
-    instance MGMT\n!\ninterface Ethernet1\n   description P2P_DC1-LEAF1A_Ethernet4\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.6/31\n!\ninterface
-    Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet4\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.14/31\n!\ninterface Ethernet3\n   description
-    P2P_DC1-LEAF2B_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.22/31\n!\ninterface Ethernet4\n   description P2P_DC1-SVC3A_Ethernet4\n
-    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.30/31\n!\ninterface
-    Ethernet5\n   description P2P_DC1-SVC3B_Ethernet4\n   shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.38/31\n!\ninterface Ethernet6\n   description
-    P2P_DC1-BL1A_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
-    172.31.255.46/31\n!\ninterface Ethernet7\n   description P2P_DC1-BL1B_Ethernet4\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.54/31\n!\ninterface
-    Loopback0\n   description ROUTER_ID\n   no shutdown\n   ip address 192.168.255.4/32\n!\ninterface
-    Management1\n   description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip
-    address 192.168.200.104/24\n!\nip routing\nno ip routing vrf MGMT\n!\nip prefix-list
-    PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit 192.168.255.0/24 eq 32\n!\nip route
-    vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface vrf MGMT Management1\nntp
-    server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP permit 10\n   match
-    ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter bfd\n   multihop interval
-    1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n   router-id 192.168.255.4\n
-    \  maximum-paths 4 ecmp 4\n   update wait-install\n   no bgp default ipv4-unicast\n
-    \  distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS peer group\n   neighbor
-    EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS update-source
-    Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\ntransceiver
+    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
+    DC1-SPINE4\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
+    mode none\n!\nvrf instance MGMT\n!\nmanagement api http-commands\n   protocol
+    https\n   no shutdown\n   !\n   vrf MGMT\n      no shutdown\n!\ninterface Ethernet1\n
+    \  description P2P_DC1-LEAF1A_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n
+    \  ip address 172.31.255.6/31\n!\ninterface Ethernet2\n   description P2P_DC1-LEAF2A_Ethernet4\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.14/31\n!\ninterface
+    Ethernet3\n   description P2P_DC1-LEAF2B_Ethernet4\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.22/31\n!\ninterface Ethernet4\n   description
+    P2P_DC1-SVC3A_Ethernet4\n   shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.30/31\n!\ninterface Ethernet5\n   description P2P_DC1-SVC3B_Ethernet4\n
+    \  shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.38/31\n!\ninterface
+    Ethernet6\n   description P2P_DC1-BL1A_Ethernet4\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.46/31\n!\ninterface Ethernet7\n   description
+    P2P_DC1-BL1B_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip address
+    172.31.255.54/31\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
+    \  ip address 192.168.255.4/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
+    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.104/24\n!\nip routing\nno
+    ip routing vrf MGMT\n!\nip prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n   seq 10 permit
+    192.168.255.0/24 eq 32\n!\nip route vrf MGMT 0.0.0.0/0 192.168.200.5\n!\nntp local-interface
+    vrf MGMT Management1\nntp server vrf MGMT 192.168.200.5 prefer\n!\nroute-map RM-CONN-2-BGP
+    permit 10\n   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY\n!\nrouter
+    bfd\n   multihop interval 1200 min-rx 1200 multiplier 3\n!\nrouter bgp 65001\n
+    \  router-id 192.168.255.4\n   maximum-paths 4 ecmp 4\n   update wait-install\n
+    \  no bgp default ipv4-unicast\n   distance bgp 20 200 200\n   neighbor EVPN-OVERLAY-PEERS
+    peer group\n   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged\n   neighbor EVPN-OVERLAY-PEERS
+    update-source Loopback0\n   neighbor EVPN-OVERLAY-PEERS bfd\n   neighbor EVPN-OVERLAY-PEERS
     ebgp-multihop 3\n   neighbor EVPN-OVERLAY-PEERS password 7 q+VNViP5i4rVjW1cxFv2wA==\n
     \  neighbor EVPN-OVERLAY-PEERS send-community\n   neighbor EVPN-OVERLAY-PEERS
     maximum-routes 0\n   neighbor IPv4-UNDERLAY-PEERS peer group\n   neighbor IPv4-UNDERLAY-PEERS
@@ -1056,17 +1052,16 @@ cvp_configlets:
     activate\n      neighbor IPv4-UNDERLAY-PEERS activate\n!\nend\n"
   AVD_DC1-SVC3A: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-SVC3A\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
-    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
-    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SVC3A\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
+    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 110\n
+    \  name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n
+    \  name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
     140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
     150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 210\n   name Tenant_B_OP_Zone_1\n!\nvlan
@@ -1084,36 +1079,37 @@ cvp_configlets:
     \  name MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
     instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
     instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
-    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
-    Port-Channel5\n   description MLAG_DC1-SVC3B_Port-Channel5\n   no shutdown\n   switchport
-    mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Port-Channel7\n
-    \  description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode
-    trunk\n   switchport\n   mlag 7\n!\ninterface Port-Channel10\n   description SERVER_server03_ESI\n
-    \  no shutdown\n   switchport trunk allowed vlan 110-111,210-211\n   switchport
-    mode trunk\n   switchport\n   evpn ethernet-segment\n      identifier 0000:0000:0303:0202:0101\n
-    \     route-target import 03:03:02:02:01:01\n   lacp system-id 0303.0202.0101\n!\ninterface
-    Ethernet1\n   description P2P_DC1-SPINE1_Ethernet4\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.25/31\n!\ninterface Ethernet2\n   description
-    P2P_DC1-SPINE2_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
-    address 172.31.255.27/31\n!\ninterface Ethernet3\n   description P2P_DC1-SPINE3_Ethernet4\n
-    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.29/31\n!\ninterface
-    Ethernet4\n   description P2P_DC1-SPINE4_Ethernet4\n   no shutdown\n   mtu 1500\n
-    \  no switchport\n   ip address 172.31.255.31/31\n!\ninterface Ethernet5\n   description
-    MLAG_DC1-SVC3B_Ethernet5\n   no shutdown\n   channel-group 5 mode active\n!\ninterface
-    Ethernet6\n   description MLAG_DC1-SVC3B_Ethernet6\n   no shutdown\n   channel-group
-    5 mode active\n!\ninterface Ethernet7\n   description DC1-L2LEAF2A_Ethernet1\n
-    \  no shutdown\n   channel-group 7 mode active\n!\ninterface Ethernet8\n   description
-    DC1-L2LEAF2B_Ethernet1\n   no shutdown\n   channel-group 7 mode active\n!\ninterface
-    Ethernet10\n   description SERVER_server03_ESI_Eth1\n   no shutdown\n   channel-group
-    10 mode active\n!\ninterface Loopback0\n   description ROUTER_ID\n   no shutdown\n
-    \  ip address 192.168.255.8/32\n!\ninterface Loopback1\n   description VXLAN_TUNNEL_SOURCE\n
-    \  no shutdown\n   ip address 192.168.254.8/32\n!\ninterface Loopback100\n   description
-    Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
-    address 10.255.1.8/32\n!\ninterface Management1\n   description OOB_MANAGEMENT\n
-    \  no shutdown\n   vrf MGMT\n   ip address 192.168.200.108/24\n!\ninterface Vlan110\n
-    \  description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n   ip
-    address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-SVC3B_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Port-Channel7\n   description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport trunk
+    allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport
+    mode trunk\n   switchport\n   mlag 7\n!\ninterface Port-Channel10\n   description
+    SERVER_server03_ESI\n   no shutdown\n   switchport trunk allowed vlan 110-111,210-211\n
+    \  switchport mode trunk\n   switchport\n   evpn ethernet-segment\n      identifier
+    0000:0000:0303:0202:0101\n      route-target import 03:03:02:02:01:01\n   lacp
+    system-id 0303.0202.0101\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet4\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.25/31\n!\ninterface
+    Ethernet2\n   description P2P_DC1-SPINE2_Ethernet4\n   no shutdown\n   mtu 1500\n
+    \  no switchport\n   ip address 172.31.255.27/31\n!\ninterface Ethernet3\n   description
+    P2P_DC1-SPINE3_Ethernet4\n   no shutdown\n   mtu 1500\n   no switchport\n   ip
+    address 172.31.255.29/31\n!\ninterface Ethernet4\n   description P2P_DC1-SPINE4_Ethernet4\n
+    \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.31/31\n!\ninterface
+    Ethernet5\n   description MLAG_DC1-SVC3B_Ethernet5\n   no shutdown\n   channel-group
+    5 mode active\n!\ninterface Ethernet6\n   description MLAG_DC1-SVC3B_Ethernet6\n
+    \  no shutdown\n   channel-group 5 mode active\n!\ninterface Ethernet7\n   description
+    DC1-L2LEAF2A_Ethernet1\n   no shutdown\n   channel-group 7 mode active\n!\ninterface
+    Ethernet8\n   description DC1-L2LEAF2B_Ethernet1\n   no shutdown\n   channel-group
+    7 mode active\n!\ninterface Ethernet10\n   description SERVER_server03_ESI_Eth1\n
+    \  no shutdown\n   channel-group 10 mode active\n!\ninterface Loopback0\n   description
+    ROUTER_ID\n   no shutdown\n   ip address 192.168.255.8/32\n!\ninterface Loopback1\n
+    \  description VXLAN_TUNNEL_SOURCE\n   no shutdown\n   ip address 192.168.254.8/32\n!\ninterface
+    Loopback100\n   description Tenant_A_OP_Zone_VTEP_DIAGNOSTICS\n   no shutdown\n
+    \  vrf Tenant_A_OP_Zone\n   ip address 10.255.1.8/32\n!\ninterface Management1\n
+    \  description OOB_MANAGEMENT\n   no shutdown\n   vrf MGMT\n   ip address 192.168.200.108/24\n!\ninterface
+    Vlan110\n   description Tenant_A_OP_Zone_1\n   no shutdown\n   vrf Tenant_A_OP_Zone\n
+    \  ip address virtual 10.1.10.1/24\n!\ninterface Vlan111\n   description Tenant_A_OP_Zone_2\n
     \  no shutdown\n   vrf Tenant_A_OP_Zone\n   ip helper-address 1.1.1.1 vrf MGMT
     source-interface lo100\n   ip address virtual 10.1.11.1/24\n!\ninterface Vlan120\n
     \  description Tenant_A_WEB_Zone_1\n   no shutdown\n   vrf Tenant_A_WEB_Zone\n
@@ -1276,17 +1272,16 @@ cvp_configlets:
     connected route-map RM-CONN-2-BGP-VRFS\n!\nend\n"
   AVD_DC1-SVC3B: "!\nno enable password\nno aaa root\n!\nusername admin privilege
     15 role network-admin nopassword\nusername cvpadmin privilege 15 role network-admin
-    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\nmanagement
-    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
-    shutdown\n!\ndaemon TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910
-    -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata
-    -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs\n   no shutdown\n!\nvlan
-    internal order ascending range 1006 1199\n!\nno ip igmp snooping vlan 120\n!\ntransceiver
-    qsfp default-mode 4x10G\n!\nservice routing protocols model multi-agent\n!\nhostname
-    DC1-SVC3B\nip name-server vrf MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree
-    mode mstp\nno spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan
-    110\n   name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan
-    120\n   name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
+    secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.\n!\ndaemon
+    TerminAttr\n   exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista
+    -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+    -taillogs\n   no shutdown\n!\nvlan internal order ascending range 1006 1199\n!\nno
+    ip igmp snooping vlan 120\n!\ntransceiver qsfp default-mode 4x10G\n!\nservice
+    routing protocols model multi-agent\n!\nhostname DC1-SVC3B\nip name-server vrf
+    MGMT 8.8.8.8\nip name-server vrf MGMT 192.168.200.5\n!\nspanning-tree mode mstp\nno
+    spanning-tree vlan-id 4093-4094\nspanning-tree mst 0 priority 4096\n!\nvlan 110\n
+    \  name Tenant_A_OP_Zone_1\n!\nvlan 111\n   name Tenant_A_OP_Zone_2\n!\nvlan 120\n
+    \  name Tenant_A_WEB_Zone_1\n!\nvlan 121\n   name Tenant_A_WEBZone_2\n!\nvlan
     130\n   name Tenant_A_APP_Zone_1\n!\nvlan 131\n   name Tenant_A_APP_Zone_2\n!\nvlan
     140\n   name Tenant_A_DB_BZone_1\n!\nvlan 141\n   name Tenant_A_DB_Zone_2\n!\nvlan
     150\n   name Tenant_A_WAN_Zone_1\n!\nvlan 210\n   name Tenant_B_OP_Zone_1\n!\nvlan
@@ -1304,12 +1299,13 @@ cvp_configlets:
     \  name MLAG\n   trunk group MLAG\n!\nvrf instance MGMT\n!\nvrf instance Tenant_A_APP_Zone\n!\nvrf
     instance Tenant_A_DB_Zone\n!\nvrf instance Tenant_A_OP_Zone\n!\nvrf instance Tenant_A_WAN_Zone\n!\nvrf
     instance Tenant_A_WEB_Zone\n!\nvrf instance Tenant_B_OP_Zone\n!\nvrf instance
-    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\ninterface
-    Port-Channel5\n   description MLAG_DC1-SVC3A_Port-Channel5\n   no shutdown\n   switchport
-    mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface Port-Channel7\n
-    \  description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport trunk allowed vlan
-    110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport mode
-    trunk\n   switchport\n   mlag 7\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet5\n
+    Tenant_B_WAN_Zone\n!\nvrf instance Tenant_C_OP_Zone\n!\nvrf instance Tenant_C_WAN_Zone\n!\nmanagement
+    api http-commands\n   protocol https\n   no shutdown\n   !\n   vrf MGMT\n      no
+    shutdown\n!\ninterface Port-Channel5\n   description MLAG_DC1-SVC3A_Port-Channel5\n
+    \  no shutdown\n   switchport mode trunk\n   switchport trunk group MLAG\n   switchport\n!\ninterface
+    Port-Channel7\n   description DC1_L2LEAF2_Po1\n   no shutdown\n   switchport trunk
+    allowed vlan 110-111,120-121,130-131,140-141,150,210-211,250,310-311,350\n   switchport
+    mode trunk\n   switchport\n   mlag 7\n!\ninterface Ethernet1\n   description P2P_DC1-SPINE1_Ethernet5\n
     \  no shutdown\n   mtu 1500\n   no switchport\n   ip address 172.31.255.33/31\n!\ninterface
     Ethernet2\n   description P2P_DC1-SPINE2_Ethernet5\n   no shutdown\n   mtu 1500\n
     \  no switchport\n   ip address 172.31.255.35/31\n!\ninterface Ethernet3\n   description

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description BGP_SPINES_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description BGP_SPINES_Po2

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -39,6 +32,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description BGP-LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/BGP-SPINE2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -39,6 +32,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description BGP-LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description ISIS-SPINE1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description ISIS-LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description L2ONLY_SPINES_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description L2ONLY_SPINES_Po2

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description L2ONLY-LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/L2ONLY-SPINE2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description L2ONLY-LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description OSPF_SPINES_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description OSPF_SPINES_Po2

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description OSPF-LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/OSPF-SPINE2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description OSPF-LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -32,6 +25,13 @@ vlan 2020
 vrf instance MGMT
 !
 vrf instance TENANT_B_INTRA
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -34,6 +27,13 @@ vrf instance MGMT
 vrf instance TENANT_B_INTRA
 !
 vrf instance TENANT_B_WAN
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname SITE1-LSR1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_SITE1-LER1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname SITE1-LSR2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_SITE1-LER2_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname SITE1-RR1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet4
    description P2P_SITE1-LSR1_Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -34,6 +27,13 @@ vrf instance MGMT
 vrf instance TENANT_B_INTRA
 !
 vrf instance TENANT_B_WAN
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel4
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname SITE2-LSR1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_SITE2-LER1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname SITE2-LSR2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel12
    description P2P_SITE2-LER1_Port-Channel11

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname SITE2-RR1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet4
    description P2P_SITE2-LSR1_Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE3-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE3-LER1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF1A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4085
    name L2LEAF_INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1-POD1-LEAF1A_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description RACK2_MLAG_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-L2LEAF2B.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description RACK2_MLAG_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF1A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vlan 4085
    name L2LEAF_INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description DC1-POD1-L2LEAF1A_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-LEAF2B.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -72,6 +65,13 @@ vrf instance vrf_with_loopbacks_dc1_pod1_only
 vrf instance vrf_with_loopbacks_from_overlapping_pool
 !
 vrf instance vrf_with_loopbacks_from_pod_pools
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description RACK2_MLAG_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC1 DC1_POD1 DC1-POD1-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SUPER-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD1-SPINE2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC1 DC1_POD1 DC1-POD1-SPINE2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SUPER-SPINE1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-LEAF1A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -63,6 +56,13 @@ vrf instance vrf_with_loopbacks_dc1_pod1_only
 vrf instance vrf_with_loopbacks_from_overlapping_pool
 !
 vrf instance vrf_with_loopbacks_from_pod_pools
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-POD2-SPINE1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC1 DC1_POD2 DC1-POD2-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SUPER-SPINE1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-POD2-SPINE2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC1 DC1_POD2 DC1-POD2-SPINE2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SUPER-SPINE1_Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC1 DC1-RS1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SUPER-SPINE1_Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-RS2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC1 DC1-RS2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SUPER-SPINE2_Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC1 DC1-SUPER-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-POD1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1-SUPER-SPINE2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC1 DC1-SUPER-SPINE2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-POD1-SPINE1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC1.POD1.LEAF2A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -73,6 +66,13 @@ vrf instance vrf_with_loopbacks_dc1_pod1_only
 vrf instance vrf_with_loopbacks_from_overlapping_pool
 !
 vrf instance vrf_with_loopbacks_from_pod_pools
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description RACK2_MLAG_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF1A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC2-POD1-LEAF1A_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-L2LEAF2A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC2-POD1-LEAF2A_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF1A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vrf instance vrf_with_loopbacks_dc1_pod1_only
 vrf instance vrf_with_loopbacks_from_overlapping_pool
 !
 vrf instance vrf_with_loopbacks_from_pod_pools
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description DC2-POD1-L2LEAF1A_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description DC2-POD1-L2LEAF2A_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC2 DC2_POD1 DC2-POD1-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC2-SUPER-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-SPINE2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC2 DC2_POD1 DC2-POD1-SPINE2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC2-SUPER-SPINE1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC2 DC2-RS1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC2-SUPER-SPINE1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-RS2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC2 DC2-RS2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC2-SUPER-SPINE1_Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC2 DC2-SUPER-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC2-POD1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-SUPER-SPINE2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 username admin privilege 15 role network-admin secret sha512 $6$eJ5TvI8oru5i9e8G$R1X/SbtGTk9xoEHEBQASc7SC2nHYmi.crVgp2pXuCXwxsXEA81e4E0cXgQ6kX08fIeQzauqhv2kS.RGJFCon5/
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ snmp-server location TWODC_5STAGE_CLOS DC2 DC2-SUPER-SPINE2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC2-POD1-SPINE1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname host1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description CUSTOM_ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname host2
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description MY_OVERLAY_LOOPBACK

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/7010TX-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/7010TX-LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_7010TX-LEAF2_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/7010TX-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/7010TX-LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_7010TX-LEAF1_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_AUTO_BGP_ASN_LEAF3B_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF3B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_AUTO_BGP_ASN_LEAF3A_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_AUTO_BGP_ASN_LEAF4B_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF4B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_AUTO_BGP_ASN_LEAF4A_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF5A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_AUTO_BGP_ASN_LEAF7B_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF7B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_AUTO_BGP_ASN_LEAF7A_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_ASN_LEAF8B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_BGP_UNGROUPED_LEAF6.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_LEAF01.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_AUTO_NODE_TYPE_SPINE01_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE01.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname AUTO_NODE_TYPE_SPINE01
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_AUTO_NODE_TYPE_LEAF01_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_SPINE02.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname AUTO_NODE_TYPE_SPINE02
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_AUTO_NODE_TYPE_LEAF01_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_AUTO_NODE_TYPE_SPINE01_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST_VRF
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1B_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST_VRF
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-PYTHON_MODULES-L3LEAF1A_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-L3LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ vlan 110
 vrf instance MGMT
 !
 vrf instance TEST_VRF
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-PYTHON_MODULES-SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname CUSTOM-PYTHON_MODULES-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-PYTHON_MODULES-L3LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L2LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_Po1_To_Po5_

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L2LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TEST_CUSTOM_PREFIX_CUSTOM-TEMPLATES-L3LEAF1A_Po1_To_Po5_

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST_VRF
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1B_Eth3_Eth4_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-L3LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST_VRF
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description TEST_CUSTOM_PREFIX_MLAG_PEER_CUSTOM-TEMPLATES-L3LEAF1A_Eth3_Eth4_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/CUSTOM-TEMPLATES-SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname CUSTOM-TEMPLATES-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description TEST_CUSTOM_PREFIX_P2P_LINK_TO_CUSTOM-TEMPLATES-L3LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key, -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -75,6 +67,14 @@ vrf instance Tenant_B_OP_Zone
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet22

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -72,6 +64,14 @@ vrf instance Tenant_B_OP_Zone
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet23

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -60,6 +52,14 @@ vrf instance Tenant_B_OP_Zone
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -58,6 +50,14 @@ vrf instance Tenant_B_OP_Zone
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet25

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -106,6 +98,14 @@ vlan 4092
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1151
    description MLAG_PEER_DC1-CL1B_Po1151

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -106,6 +98,14 @@ vlan 4092
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1311
    description MLAG_PEER_DC1-CL1A_Po1311

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -74,6 +66,14 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF1B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -74,6 +66,14 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po7

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -101,6 +93,14 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2B_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF2B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -101,6 +93,14 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-L2LEAF2A_Po3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF3A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -69,6 +61,14 @@ vlan 161
    name Tenant_A_NFS
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po9

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-L2LEAF4A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -69,6 +61,14 @@ vlan 161
    name Tenant_A_NFS
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1001
    description DC1_LEAF2_Po1013

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -79,6 +71,14 @@ vrf instance Tenant_A_OP_Zone
    description Tenant_A_OP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet6
    description server02_SINGLE_NODE_TRUNK_Eth1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -136,6 +128,14 @@ vrf instance Tenant_B_OP_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_D_OP_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -136,6 +128,14 @@ vrf instance Tenant_B_OP_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_D_OP_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel7
    description DC1_L2LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -39,6 +31,14 @@ snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1/1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet27

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -41,6 +33,14 @@ snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SPINE2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1/1/1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet28

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -39,6 +31,14 @@ snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SPINE3
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1/1/1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet29

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -39,6 +31,14 @@ snmp-server location EOS_DESIGNS_UNIT_TESTS DC1-SPINE4
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1/1
    description P2P_LINK_TO_DC1-LEAF1A_Ethernet30

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -161,6 +153,14 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel10
    description server03_ESI_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -161,6 +153,14 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel14
    description server07_inherit_all_from_profile_port_channel_ALL_WITH_SECURITY_PORT_CHANNEL

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -74,6 +66,14 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po141

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF5B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -74,6 +66,14 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po141

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -113,6 +105,14 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po30

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1.L2LEAF6B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -113,6 +105,14 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po30

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -169,6 +161,14 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel571
    description MLAG_PEER_DC1_UNDEPLOYED_LEAF1B_Po571

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -169,6 +161,14 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel571
    description MLAG_PEER_DC1_UNDEPLOYED_LEAF1A_Po571

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DUP-LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DUP-LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vrf instance MGMT
 !
 vrf instance TEST
    description TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DUP-LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DUP-LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vrf instance MGMT
 !
 vrf instance TEST
    description TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-DISABLED.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-DISABLED.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 230 querier
@@ -174,6 +167,13 @@ vrf instance TEN_E_L3_MULTICAST_TRANSIT
 !
 vrf instance TEN_E_PEG_L3_MULTICAST_ENABLED
    description PEG_L3_MULTICAST_ENABLED in Tenant E
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_EVPN-MULTICAST-SPINE1_Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L2LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -126,6 +119,13 @@ vlan 4092
    name MULTICAST_ENABLED_4092
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description EVPN_MULTICAST_L3LEAF1_Po6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 1 querier
@@ -285,6 +278,13 @@ vrf instance TEN_E_L3_MULTICAST_TRANSIT
 !
 vrf instance TEN_E_PEG_L3_MULTICAST_ENABLED
    description PEG_L3_MULTICAST_ENABLED in Tenant E
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_EVPN-MULTICAST-L3LEAF1B_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 1 querier
@@ -285,6 +278,13 @@ vrf instance TEN_E_L3_MULTICAST_TRANSIT
 !
 vrf instance TEN_E_PEG_L3_MULTICAST_ENABLED
    description PEG_L3_MULTICAST_ENABLED in Tenant E
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_EVPN-MULTICAST-L3LEAF1A_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 1 querier
@@ -214,6 +207,13 @@ vrf instance TEN_E_L3_MULTICAST_TRANSIT
 !
 vrf instance TEN_E_PEG_L3_MULTICAST_ENABLED
    description PEG_L3_MULTICAST_ENABLED in Tenant E
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_EVPN-MULTICAST-SPINE1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 1 querier
@@ -215,6 +208,13 @@ vrf instance TEN_E_L3_MULTICAST_TRANSIT
 !
 vrf instance TEN_E_PEG_L3_MULTICAST_ENABLED
    description PEG_L3_MULTICAST_ENABLED in Tenant E
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_EVPN-MULTICAST-SPINE1_Ethernet4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 1 querier
@@ -215,6 +208,13 @@ vrf instance TEN_E_L3_MULTICAST_TRANSIT
 !
 vrf instance TEN_E_PEG_L3_MULTICAST_ENABLED
    description PEG_L3_MULTICAST_ENABLED in Tenant E
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_EVPN-MULTICAST-SPINE1_Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname EVPN-MULTICAST-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_EVPN-MULTICAST-L3LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -69,6 +62,13 @@ vlan 123
    name VLAN_123
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description IGMP-QUERIER-L3LEAF1A_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 1 querier
@@ -118,6 +111,13 @@ vrf instance IGMP_QUERIER_TEST_3
    description IGMP_QUERIER_TEST_3
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description IGMP-QUERIER-L2LEAF1A_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-L2LEAF1A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -46,6 +38,14 @@ vlan 310
    name Tenant_X_OP_Zone_1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description MH-LEAF2A_Po2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -47,6 +39,14 @@ vlan 310
 vrf instance MGMT
 !
 vrf instance Tenant_X_OP_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel10
    description server01_ES1_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -47,6 +39,14 @@ vlan 310
 vrf instance MGMT
 !
 vrf instance Tenant_X_OP_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel10
    description server01_ES1_PortChanne1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -50,6 +42,14 @@ vlan 311
 vrf instance MGMT
 !
 vrf instance Tenant_X_OP_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel2
    description MH-L2LEAF1A_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -43,6 +35,14 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_PEER_MLAG-OSPF-L3LEAF1B_Po5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -43,6 +35,14 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_PEER_MLAG-OSPF-L3LEAF1A_Po5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_IPV6_L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_IPV6_L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_MLAG_IPV6_L3LEAF1B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_IPV6_L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_IPV6_L3LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_MLAG_IPV6_L3LEAF1A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_ODD_ID_L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_ODD_ID_L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_MLAG_ODD_ID_L3LEAF1B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_ODD_ID_L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_ODD_ID_L3LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_MLAG_ODD_ID_L3LEAF1A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_MLAG_SAME_SUBNET_L3LEAF1B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_MLAG_SAME_SUBNET_L3LEAF1A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_MLAG_SAME_SUBNET_L3LEAF2B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MLAG_SAME_SUBNET_L3LEAF2B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_MLAG_SAME_SUBNET_L3LEAF2A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -29,6 +22,13 @@ vlan 3910
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management cvx
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_L3LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -29,6 +22,13 @@ vlan 3910
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management cvx
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname OVERLAY_ROUTING_PROTOCOL_CVX_SERVER1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 cvx
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname OVERLAY_ROUTING_PROTOCOL_CVX_SERVER2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 cvx
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -38,6 +31,13 @@ vlan 3902
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -38,6 +31,13 @@ vlan 3903
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -46,6 +39,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description MLAG_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B_Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -46,6 +39,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TEST
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description MLAG_OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF3A_Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERRIDE_VTEP_L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERRIDE_VTEP_L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_OVERRIDE_VTEP_L3LEAF1B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERRIDE_VTEP_L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERRIDE_VTEP_L3LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_OVERRIDE_VTEP_L3LEAF1A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/P2P-UPLINKS-IPV4-PREFIX-LENGTH.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/P2P-UPLINKS-IPV4-PREFIX-LENGTH.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname P2P-UPLINKS-IPV4-PREFIX-LENGTH
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_MLAG_ODD_ID_L3LEAF1A_Ethernet10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance MGMT
 !
 vrf instance TEST1
    description TEST1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance MGMT
 !
 vrf instance TEST1
    description TEST1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance MGMT
 !
 vrf instance TEST1
    description TEST1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance MGMT
 !
 vrf instance TEST1
    description TEST1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance MGMT
 !
 vrf instance TEST1
    description TEST1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance MGMT
 !
 vrf instance TEST1
    description TEST1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance MGMT
 !
 vrf instance TEST1
    description TEST1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF0A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF0A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel25
    description MLAG_SL-LEAF0B_Port-Channel25

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF0B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF0B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel25
    description MLAG_SL-LEAF0A_Port-Channel25

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel25
    description MLAG_SL-LEAF1B_Port-Channel25

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel25
    description MLAG_SL-LEAF1A_Port-Channel25

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF2A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel25
    description MLAG_SL-LEAF2B_Port-Channel25

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-LEAF2B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel25
    description MLAG_SL-LEAF2A_Port-Channel25

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-MLEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SL-MLEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname SL-MLEAF1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel16
    description SL-LEAF1_Po28

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_AUTOGEN_ENGINEID.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_AUTOGEN_ENGINEID.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -26,6 +19,13 @@ snmp-server user usertest-no-auth-no-priv usergroup v3
 snmp-server user usertest-v2c usergroup v2c
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 no ip routing vrf MGMT
 !
 ip route vrf MGMT 0.0.0.0/0 1.1.1.1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_SYSTEM_MAC_ENGINEID_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_SYSTEM_MAC_ENGINEID_1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -26,6 +19,13 @@ snmp-server user usertest-no-auth-no-priv usergroup v3
 snmp-server user usertest-v2c usergroup v2c
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_SYSTEM_MAC_ENGINEID_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SNMP_SYSTEM_MAC_ENGINEID_2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -26,6 +19,13 @@ snmp-server user usertest-no-auth-no-priv usergroup v3
 snmp-server user usertest-v2c usergroup v2c
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 210
@@ -84,6 +77,13 @@ vlan 512
 vrf instance MGMT
 !
 vrf instance svi_profile_tests_vrf
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/SVI_PROFILE_NODE_2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 210
@@ -84,6 +77,13 @@ vlan 512
 vrf instance MGMT
 !
 vrf instance svi_profile_tests_vrf
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/TEST-MGMT-GATEWAY-IN-NODE-GROUP.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/TEST-MGMT-GATEWAY-IN-NODE-GROUP.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname TEST-MGMT-GATEWAY-IN-NODE-GROUP
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Management1
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L2LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname UNDERLAY-MULTICAST-L2LEAF1A
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF1_Po6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_UNDERLAY-MULTICAST-L3LEAF1B_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_UNDERLAY-MULTICAST-L3LEAF1A_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_UNDERLAY-MULTICAST-L3LEAF2B_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_UNDERLAY-MULTICAST-L3LEAF2A_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname UNDERLAY-MULTICAST-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname UNDERLAY-MULTICAST-SPINE2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_UNDERLAY-MULTICAST-L3LEAF1A_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_L3LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname UNDERLAY_FILTER_PEER_AS_L3LEAF1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_UNDERLAY_FILTER_PEER_AS_SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname UNDERLAY_FILTER_PEER_AS_SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_UNDERLAY_FILTER_PEER_AS_L3LEAF1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY_FILTER_PEER_AS_SPINE2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname UNDERLAY_FILTER_PEER_AS_SPINE2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_UNDERLAY_FILTER_PEER_AS_L3LEAF1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -26,6 +19,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF1_Po5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -26,6 +19,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF1_Po5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_L2LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_L2LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ vlan 66
    name TEST-L2VLAN-ATTRACTION
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description UPLINK_P2P_VRFS_TESTS_LEAF1_Po51

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_LEAF1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vrf instance MGMT
 vrf instance ONLY-ON-L2LEAF
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel51
    description UPLINK_P2P_VRFS_TESTS_L2LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_SPINE1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vrf instance MGMT
 vrf instance ONLY-ON-L2LEAF
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_UPLINK_P2P_VRFS_TESTS_LEAF1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UPLINK_P2P_VRFS_TESTS_SPINE2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet2
    description P2P_UPLINK_P2P_VRFS_TESTS_LEAF1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/always-configure-ip-routing.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/always-configure-ip-routing.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname always-configure-ip-routing
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 ip routing ipv6 interfaces
 no ip routing vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-from-network-services-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-from-network-services-1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -29,6 +22,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel10
    description MLAG_bgp-from-network-services-2_Port-Channel10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-from-network-services-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-from-network-services-2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -25,6 +18,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel10
    description MLAG_bgp-from-network-services-1_Port-Channel10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-options.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-options.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname bgp-options
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_bgp-peer-groups-2_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel3
    description MLAG_bgp-peer-groups-1_Port-Channel3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-3.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname bgp-peer-groups-3
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ link tracking group LT_GROUP1
 hostname connected_endpoints
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description Port channel description server_OLD_SW-1/2_Po1_ENDPOINT_PORT_CHANNEL_INTERFACE DESCRIPTION SERVER_OLD_SW-1/2_ENDPOINT_PORT_CHANNEL

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-1-isis-sr-ldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-1-isis-sr-ldp.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname core-1-isis-sr-ldp
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel12
    description P2P_LINK_TO_core-2-ospf-ldp_Port-Channel12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-2-ospf-ldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-2-ospf-ldp.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname core-2-ospf-ldp
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel12
    description P2P_LINK_TO_core-1-isis-sr-ldp_Port-Channel12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-3-isis-sr-ldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-3-isis-sr-ldp.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname core-3-isis-sr-ldp
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-4-multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-4-multicast.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname core-4-multicast
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_LINK_TO_PEER1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -109,6 +102,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -109,6 +102,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-3.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -109,6 +102,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -130,6 +123,13 @@ platform sfe data-plane cpu allocation maximum 1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-custom-default-policy.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker custom_flow_track_name
       record export on inactive timeout 50000
@@ -121,6 +114,13 @@ spanning-tree mode none
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-no-default-policy.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -115,6 +108,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -248,6 +241,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -247,6 +240,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -187,6 +180,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -188,6 +181,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -166,6 +159,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3B.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -167,6 +160,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge4A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -165,6 +158,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge4B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge4B.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -165,6 +158,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -224,6 +217,13 @@ platform sfe data-plane cpu allocation maximum 1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -227,6 +220,13 @@ platform sfe data-plane cpu allocation maximum 3
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -234,6 +227,13 @@ platform sfe data-plane cpu allocation maximum 3
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -255,6 +248,13 @@ vrf instance NOT-WAN-VRF
 vrf instance PROD
 !
 vrf instance TRANSIT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -237,6 +230,13 @@ vrf instance NOT-WAN-VRF
 vrf instance PROD
 !
 vrf instance TRANSIT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=cv-staging.corp.arista.io:443 -cvauth=token-secure,/tmp/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -24,6 +17,13 @@ hostname cvp-instance-ips-cvaas
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-onprem-token.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-onprem-token.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=myonpremcvpserver:9910 -cvauth=token,/tmp/token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -22,6 +15,13 @@ service routing protocols model multi-agent
 hostname cvp-instance-ips-onprem-token
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_interface_mtu_hostvars.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_interface_mtu_hostvars.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ service routing protocols model multi-agent
 hostname default_interface_mtu_hostvars
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_interface_mtu_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_interface_mtu_platform.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ service routing protocols model multi-agent
 hostname default_interface_mtu_platform
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_cvx.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_cvx.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname default_overlay_protocol_cvx
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_her.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/default_overlay_protocol_her.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname default_overlay_protocol_her
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname device.with.dots.in.hostname
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-l3leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-l3leaf1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname downlink-pools-l3leaf1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_downlink-pools-spine1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-l3leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-l3leaf2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname downlink-pools-l3leaf2
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_downlink-pools-spine2_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-l3leaf3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-l3leaf3.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname downlink-pools-l3leaf3
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_downlink-pools-spine1_Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-l3leaf4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-l3leaf4.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname downlink-pools-l3leaf4
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_downlink-pools-spine1_Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-spine1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname downlink-pools-spine1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet3
    description P2P_downlink-pools-l3leaf1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/downlink-pools-spine2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname downlink-pools-spine2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet3
    description P2P_downlink-pools-l3leaf2_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/duplicate-vrfs.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/duplicate-vrfs.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -26,6 +19,13 @@ vlan 200
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn-to-ipvpn-gateway.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn-to-ipvpn-gateway.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ vlan 10
 vrf instance MGMT
 !
 vrf instance testvrf
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn-vtep-with-default-vrf-not-evpn.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn-vtep-with-default-vrf-not-evpn.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ vlan 110
    name SVI-110
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -161,6 +153,14 @@ vrf instance Tenant_C_OP_Zone
 vrf instance Tenant_C_WAN_Zone
 !
 vrf instance Tenant_D_OP_Zone
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -138,6 +130,14 @@ vlan 1234
    name VRF_DEFAULT_SVI_WITH_OSPF
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_vlan_bundle.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_vlan_bundle.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -86,6 +79,13 @@ vrf instance SIT2
 vrf instance SIT3
 !
 vrf instance SIT_VRF
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_vlan_bundle_svi_l2vlan.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_vlan_bundle_svi_l2vlan.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -41,6 +34,13 @@ vlan 1010
 vrf instance MGMT
 !
 vrf instance SIT_VRF
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.only_vlans_in_use.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.only_vlans_in_use.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 2
    name vlan2
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description SERVER_testserver_Nic1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.vrfs.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/filter.vrfs.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vrf instance VRF2
 !
 vrf instance VRF5
    description This VRF will be configured because of always_include_vrfs_in_tenants and it is permitted by filter.allow_vrfs
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 flow tracking sampled
@@ -35,6 +28,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description flow-tracking-tests-leaf-mlag_Po31

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-l2-leaf2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 flow tracking sampled
@@ -35,6 +28,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description flow-tracking-tests-leaf-mlag_Po32

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 flow tracking hardware
@@ -44,6 +37,13 @@ vlan 11
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_flow-tracking-tests-spine1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 flow tracking sampled
@@ -48,6 +41,13 @@ vlan 11
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_flow-tracking-tests-spine1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf3.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 flow tracking hardware
@@ -60,6 +53,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel14
    description SERVER_port-channel-interface-true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-leaf4.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 flow tracking hardware
@@ -60,6 +53,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel14
    description SERVER_port-channel-interface-true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-spine1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 flow tracking sampled
@@ -41,6 +34,13 @@ hostname flow-tracking-tests-spine1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_flow-tracking-tests-leaf1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/flow-tracking-tests-spine2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 flow tracking hardware
@@ -39,6 +32,13 @@ hostname flow-tracking-tests-spine2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet2
    description P2P_flow-tracking-tests-leaf1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/generate-cv-tags-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/generate-cv-tags-1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname generate-cv-tags-1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description Test interface

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/generate-cv-tags-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/generate-cv-tags-2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname generate-cv-tags-2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/hardware_counters.cfg
@@ -13,13 +13,6 @@ hardware counter feature route ipv6 2001:db8:cafe::/64
 hardware counter feature vlan-interface in
 hardware counter feature vlan-interface out
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -29,6 +22,13 @@ service routing protocols model multi-agent
 hostname hardware_counters
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ignore-custom-keys-in-data-models.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ignore-custom-keys-in-data-models.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname ignore-custom-keys-in-data-models
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    switchport

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-dualstack-ips.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-dualstack-ips.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ vlan 105
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description inband-mgmt-parents-dualstack_Po25

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-dualstack-subnets.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-dualstack-subnets.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ vlan 104
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description inband-mgmt-parents-dualstack_Po24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ip.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ip.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ vlan 103
 vrf instance INBANDMGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description INBAND-MGMT-PARENT_Po23

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only-vrf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only-vrf.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ vlan 107
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description inband-mgmt-parents-ipv6_Po27

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ vlan 106
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description inband-mgmt-parents-ipv6_Po26

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-mlag-a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-mlag-a.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description INBAND-MGMT-PARENT_Po101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-mlag-b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-mlag-b.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description INBAND-MGMT-PARENT_Po101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -40,6 +33,13 @@ vlan 4094
 vrf instance INBANDMGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel11
    description MLAG_inband-mgmt-parent-dualstack2_Port-Channel11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-dualstack2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -40,6 +33,13 @@ vlan 4094
 vrf instance INBANDMGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel11
    description MLAG_inband-mgmt-parent-dualstack1_Port-Channel11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-ipv6-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-ipv6-1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -34,6 +27,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel11
    description MLAG_inband-mgmt-parent-ipv6-2_Port-Channel11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-ipv6-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-ipv6-2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -36,6 +29,13 @@ vlan 4094
 vrf instance INBANDMGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel11
    description MLAG_inband-mgmt-parent-ipv6-1_Port-Channel11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-vrf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-vrf.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -29,6 +22,13 @@ vlan 103
 vrf instance INBANDMGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel21
    description INBAND-MGMT-SUBNET_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -29,6 +22,13 @@ vlan 103
 vrf instance INBANDMGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel21
    description INBAND-MGMT-SUBNET_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-subnet-vrf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-subnet-vrf.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ vlan 102
 vrf instance INBANDMGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description INBAND-MGMT-PARENT_Po22

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-subnet.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-subnet.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ vlan 101
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description INBAND-MGMT-PARENT_Po21

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ipv4-acls.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ipv4-acls.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname ipv4-acls
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/isis-system-id-format-using-node-id.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/isis-system-id-format-using-node-id.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname isis-system-id-format-using-node-id
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/isis-system-id-format-using-underlay-loopback.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/isis-system-id-format-using-underlay-loopback.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname isis-system-id-format-using-underlay-loopback
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname l3_edge_bgp
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description P2P_peer5_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_isis.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname l3_edge_isis
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface ethernet1
    description P2P_peer1_ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_multicast.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname l3_edge_multicast
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface ethernet1
    description P2P_peer1_ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_ospf.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname l3_edge_ospf
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface ethernet1
    description P2P_peer1_ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/legacy-autovpn-edge-no-default-policy.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/legacy-autovpn-edge-no-default-policy.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -73,6 +66,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/legacy-autovpn-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/legacy-autovpn-edge.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -98,6 +91,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 ip security
    ike policy AUTOVPN-IKE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/legacy-autovpn-rr1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/legacy-autovpn-rr1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -87,6 +80,13 @@ platform sfe data-plane cpu allocation maximum 2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 ip security
    ike policy AUTOVPN-IKE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/legacy-autovpn-rr2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/legacy-autovpn-rr2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -87,6 +80,13 @@ platform sfe data-plane cpu allocation maximum 2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 ip security
    ike policy AUTOVPN-IKE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -138,6 +130,14 @@ vlan 1234
    name VRF_DEFAULT_SVI_WITH_OSPF
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Management1
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_description.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_description.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname mgmt_interface_description
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Management1
    description Custom Management Interface Description

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_dualstack.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_dualstack.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname mgmt_interface_dualstack
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Management1
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -138,6 +130,14 @@ vlan 1234
    name VRF_DEFAULT_SVI_WITH_OSPF
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface MY_INTERFACE_FABRIC
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -140,6 +132,14 @@ vlan 1234
    name VRF_DEFAULT_SVI_WITH_OSPF
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface MY_INTERFACE_HOST
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_ipv6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_ipv6.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname mgmt_interface_ipv6
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Management1
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -9,14 +9,6 @@ username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAW
 username cvpadmin ssh-key ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkU= cvpadmin@hostmachine.local
 username cvpadmin ssh-key secondary ssh-rsa AAAAB3NzaC1yc2EAA82spi2mkxp4FgaLi4CjWkpnL1A/MD7WhrSNgqXToF7QCb9Lidagy9IHafQxfu7LwkFdyQIMu8XNwDZIycuf29wHbDdz1N+YNVK8zwyNAbMOeKMqblsEm2YIorgjzQX1m9+/rJeFBKz77PSgeMp/Rc3txFVuSmFmeTy3aMkz= cvpadmin@hostmachine.local
 !
-management api http-commands
-   protocol https
-   no default-services
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -140,6 +132,14 @@ vlan 1234
    name VRF_DEFAULT_SVI_WITH_OSPF
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no default-services
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Management0
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description AP1 with port_channel

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel101
    description MLAG_network-ports-tests-2_Port-Channel101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_gateway.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_gateway.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname no_mgmt_gateway
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Management1
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_interface.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/no_mgmt_interface.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname no_mgmt_interface
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-interfaces.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ sflow run
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description peer1_eth1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ntp-settings-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ntp-settings-1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname ntp-settings-1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Management1
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ntp-settings-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ntp-settings-2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -23,6 +16,13 @@ vlan 4092
 vrf instance INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Vlan4092
    description Inband Management

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-d.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-d.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname override_uplink_type-d
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description OVERRIDE_UPLINK_TYPE-U_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-u.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/override_uplink_type-u.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -20,6 +13,13 @@ hostname override_uplink_type-u
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description OVERRIDE_UPLINK_TYPE-D_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/platform_settings.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/platform_settings.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname platform_settings
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    entropy source hardware haveged cpu jitter

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf1-ptp-disabled.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf1-ptp-disabled.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -24,6 +17,13 @@ vlan 11
    name VLAN11
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description ptp-test-leaf_Po11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf2-ptp-enabled-uplink-disabled.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf2-ptp-enabled-uplink-disabled.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 11
    name VLAN11
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description ptp-test-leaf_Po14

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf2-ptp-enabled.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-l2leaf2-ptp-enabled.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -37,6 +30,13 @@ vlan 11
    name VLAN11
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description ptp-test-leaf_Po12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -52,6 +45,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel6
    description SERVER_Endpoint-with-mpass

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-leaf2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -59,6 +52,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel6
    description SERVER_Endpoint-with-mpass

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ ptp monitor threshold missing-message announce 3 sequence-ids
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_ptp-tests-leaf1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -41,6 +34,13 @@ ptp monitor threshold missing-message announce 11 sequence-ids
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet6
    description P2P_ptp-tests-spine1_Ethernet6

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ptp-tests-spine3.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -32,6 +25,13 @@ ptp monitor threshold missing-message announce 3 sequence-ids
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -32,6 +25,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description sflow-tests-leaf-mlag_Po16

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-l2-leaf2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -32,6 +25,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description sflow-tests-leaf-mlag_Po17

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vlan 11
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_sflow-tests-spine1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vlan 11
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_sflow-tests-spine1_Ethernet3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf3.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -49,6 +42,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel11
    description SERVER_port-channel-interface-true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-leaf4.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -49,6 +42,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel11
    description SERVER_port-channel-interface-true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-spine1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ sflow run
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_sflow-tests-leaf1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/sflow-tests-spine2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -27,6 +20,13 @@ sflow run
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet9
    description P2P_sflow-tests-spine1_Ethernet9

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-disabled-leaf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-disabled-leaf.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_cv-pathfinder-edge_Ethernet52

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_cv-pathfinder-transit1A_Ethernet52

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf2A.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_cv-pathfinder-edge2A_Ethernet52

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/site-ha-enabled-leaf2B.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -33,6 +26,13 @@ vrf instance IT
 vrf instance MGMT
 !
 vrf instance PROD
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_cv-pathfinder-edge2A_Ethernet53

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -43,6 +36,13 @@ no snmp-server vrf default
 snmp-server vrf MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Management1
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Vlan123
    description Inband Management

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/source-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/source-interfaces.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf default
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -26,6 +19,13 @@ vlan 4092
    name INBAND_MGMT
 !
 vrf instance INBANDMGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf default
+      no shutdown
 !
 interface Management1
    description OOB_MANAGEMENT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/spanning-tree-mode-rapid-pvst.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/spanning-tree-mode-rapid-pvst.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -47,6 +40,13 @@ vlan 23
    name PRIORITY8192
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1a.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -76,6 +69,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TRUNK_GROUP_TESTS_L3LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf1b.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -68,6 +61,13 @@ vlan 4094
    trunk group CUSTOM_MLAG_TG_NAME
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TRUNK_GROUP_TESTS_L3LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf3.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vlan 210
    trunk group UPLINK
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TRUNK_GROUP_TESTS_L3LEAF1_Po5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l2leaf4.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -30,6 +23,13 @@ vlan 210
    trunk group UPLINK
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TRUNK_GROUP_TESTS_L3LEAF2_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1a.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -112,6 +105,13 @@ vrf instance TG_100
 vrf instance TG_200
 !
 vrf instance TG_300
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TRUNK_GROUP_TESTS_L2LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf1b.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -100,6 +93,13 @@ vrf instance TG_100
 vrf instance TG_200
 !
 vrf instance TG_300
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TRUNK_GROUP_TESTS_L2LEAF1_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2a.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -48,6 +41,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TG_200
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TRUNK-GROUP-TESTS-L2LEAF4_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/trunk-group-tests-l3leaf2b.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -44,6 +37,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance TG_200
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description TRUNK-GROUP-TESTS-L2LEAF4_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/underlay_filter_peer_as_evpn_1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/underlay_filter_peer_as_evpn_1.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname underlay_filter_peer_as_evpn_1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_underlay_filter_peer_as_evpn_2_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/underlay_filter_peer_as_evpn_2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/underlay_filter_peer_as_evpn_2.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname underlay_filter_peer_as_evpn_2
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_underlay_filter_peer_as_evpn_1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/underlay_filter_peer_as_evpn_3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/underlay_filter_peer_as_evpn_3.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -18,6 +11,13 @@ service routing protocols model multi-agent
 hostname underlay_filter_peer_as_evpn_3
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_underlay_filter_peer_as_evpn_1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-child.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -25,6 +18,13 @@ vlan 200
    state suspend
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel2
    description UPLINK-NATIVE-VLAN-PARENT_Po2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-grandparent.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -21,6 +14,13 @@ vlan 100
    name NETWORK_SERVICES_VLAN
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description UPLINK-NATIVE-VLAN-PARENT_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink-native-vlan-parent.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -25,6 +18,13 @@ vlan 200
    state suspend
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description UPLINK-NATIVE-VLAN-GRANDPARENT_Po1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_l2leaf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_l2leaf.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 flow tracking sampled
@@ -38,6 +31,13 @@ vlan 102
    name VLAN102
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description UPLINK_LAN_WAN_ROUTER1_Ethernet2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router1.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -79,6 +72,13 @@ spanning-tree mode none
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/uplink_lan_wan_router2.cfg
@@ -4,13 +4,6 @@ no aaa root
 !
 agent KernelFib environment KERNELFIB_PROGRAM_ALL_ECMP=1
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 flow tracking hardware
    tracker FLOW-TRACKER
       record export on inactive timeout 70000
@@ -79,6 +72,13 @@ spanning-tree mode none
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 management security
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/varpv6.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/varpv6.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -35,6 +28,13 @@ vlan 500
 vrf instance MGMT
 !
 vrf instance VRF1
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/vrfs_rd_rt_override.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/vrfs_rd_rt_override.cfg
@@ -2,13 +2,6 @@
 no enable password
 no aaa root
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 vlan internal order ascending range 1006 1199
 !
 transceiver qsfp default-mode 4x10G
@@ -28,6 +21,13 @@ vrf instance MGMT
 vrf instance VRF1
 !
 vrf instance VRF2
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Loopback0
    description ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -66,6 +59,13 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_WAN_Zone
 !
 vrf instance Tenant_L3_VRF_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet7
    description test

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -65,6 +58,13 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_WAN_Zone
 !
 vrf instance Tenant_L3_VRF_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet7
    description test

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -82,6 +75,13 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description CUSTOM_DC1-LEAF2A_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF1B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -82,6 +75,13 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description CUSTOM_DC1-LEAF2A_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -109,6 +102,13 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description CUSTOM_DC1-SVC3A_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -109,6 +102,13 @@ vlan 4091
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description CUSTOM_DC1-SVC3A_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-L2LEAF3A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -77,6 +70,13 @@ vlan 162
    name Tenant_A_FTP
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description CUSTOM_DC1-LEAF2A_Po9

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -65,6 +58,13 @@ vrf instance MGMT
 vrf instance Tenant_A_APP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -116,6 +109,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel7
    description CUSTOM_DC1-L2LEAF1A_Po1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -116,6 +109,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel7
    description CUSTOM_DC1-L2LEAF1A_Po1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -36,6 +29,13 @@ snmp-server location DC1_FABRIC DC1-SPINE1
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -36,6 +29,13 @@ snmp-server location DC1_FABRIC DC1-SPINE2
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -36,6 +29,13 @@ snmp-server location DC1_FABRIC DC1-SPINE3
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -36,6 +29,13 @@ snmp-server location DC1_FABRIC DC1-SPINE4
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description CUSTOM_P2P_LINK_TO_DC1-LEAF1A_Ethernet4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -164,6 +157,13 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description CUSTOM_MLAG_PEER_DC1-SVC3B_Po5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -164,6 +157,13 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description CUSTOM_MLAG_PEER_DC1-SVC3A_Po5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -39,6 +32,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-BL1B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -39,6 +32,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-BL1A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -30,6 +23,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 16384
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -35,6 +28,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_SVC3_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -35,6 +28,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_SVC3_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -30,6 +23,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -39,6 +32,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF2B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -39,6 +32,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF2A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -35,6 +28,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-SVC3B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -disableaaa -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -35,6 +28,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-SVC3A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -39,6 +32,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-BL1B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -39,6 +32,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-BL1A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -33,6 +26,13 @@ vlan 210
    name Tenant_B_OP_Zone_1
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -38,6 +31,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_SVC3_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -38,6 +31,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_SVC3_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -30,6 +23,13 @@ spanning-tree mode mstp
 spanning-tree mst 0 priority 4096
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -48,6 +41,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance Tenant_B_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF2B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -48,6 +41,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance Tenant_B_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF2A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -44,6 +37,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance Tenant_B_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-SVC3B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -44,6 +37,13 @@ vlan 4094
 vrf instance MGMT
 !
 vrf instance Tenant_B_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-SVC3A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -47,6 +40,13 @@ vrf instance Tenant_A_WAN_Zone
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SPINE1_Ethernet6

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-BL1B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -47,6 +40,13 @@ vrf instance Tenant_A_WAN_Zone
 vrf instance Tenant_B_WAN_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SPINE1_Ethernet7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -56,6 +49,13 @@ vlan 161
    name Tenant_A_NFS
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_LEAF2_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -88,6 +81,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_SVC3_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-L2LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -88,6 +81,13 @@ vlan 4094
    trunk group MLAG
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel1
    description DC1_SVC3_Po7

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF1A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -50,6 +43,13 @@ vrf instance MGMT
 vrf instance Tenant_A_APP_Zone
 !
 vrf instance Tenant_A_WEB_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -121,6 +114,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF2B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF2B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -121,6 +114,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF2A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -121,6 +114,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF3B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF3B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -121,6 +114,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF3A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -121,6 +114,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF4B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-LEAF4B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -121,6 +114,13 @@ vrf instance Tenant_A_WEB_Zone
 vrf instance Tenant_B_OP_Zone
 !
 vrf instance Tenant_C_OP_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-LEAF4A_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE1.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE2.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE3.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet3

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE4.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF1A_Ethernet4

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE5.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE5.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF3A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE6.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SPINE6.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -29,6 +22,13 @@ ip name-server vrf MGMT 192.168.200.5
 spanning-tree mode none
 !
 vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Ethernet1
    description P2P_DC1-LEAF4A_Ethernet1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3A.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -148,6 +141,13 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-SVC3B_Port-Channel5

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/configs/DC1-SVC3B.cfg
@@ -5,13 +5,6 @@ no aaa root
 username admin privilege 15 role network-admin nopassword
 username cvpadmin privilege 15 role network-admin secret sha512 $6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj.
 !
-management api http-commands
-   protocol https
-   no shutdown
-   !
-   vrf MGMT
-      no shutdown
-!
 daemon TerminAttr
    exec /usr/bin/TerminAttr -cvaddr=192.168.200.11:9910 -cvauth=key,telarista -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
@@ -148,6 +141,13 @@ vrf instance Tenant_B_WAN_Zone
 vrf instance Tenant_C_OP_Zone
 !
 vrf instance Tenant_C_WAN_Zone
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
 !
 interface Port-Channel5
    description MLAG_DC1-SVC3A_Port-Channel5

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-intended-config.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-intended-config.j2
@@ -24,8 +24,6 @@
 {% include 'eos/hardware-counters.j2' %}
 {# service routing configuration #}
 {% include 'eos/service-routing-configuration-bgp.j2' %}
-{# management api http #}
-{% include 'eos/management-api-http.j2' %}
 {# cli prompt #}
 {% include 'eos/prompt.j2' %}
 {# terminal settings #}
@@ -158,6 +156,8 @@
 {% include 'eos/banners.j2' %}
 {# management accounts #}
 {% include 'eos/management-accounts.j2' %}
+{# management api http #}
+{% include 'eos/management-api-http.j2' %}
 {# management console #}
 {% include 'eos/management-console.j2' %}
 {# management cvx #}


### PR DESCRIPTION
## Change Summary

Fixing the order of `management api http` upon checking different EOS versions.

## Related Issue(s)

Fixes #4466 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
