### PR TITLE
Feat(eos_cli_config_gen): Add permit_response_traffic nat to ip-access-lists

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-access-lists.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-access-lists.md
@@ -55,6 +55,7 @@ ip access-list ACL_SEQUENCE_AND_COUNTERS
    40 permit tcp any gt 1023 host 172.16.16.16 eq 22
    50 permit tcp any range 1000 1100 any range 10 20
    4294967295 deny ip any any
+   permit response traffic nat
 !
 ip access-list ACL_NO_SEQUENCE
    remark test acl without sequence numbers

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-access-lists.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-access-lists.cfg
@@ -12,6 +12,7 @@ ip access-list ACL_SEQUENCE_AND_COUNTERS
    40 permit tcp any gt 1023 host 172.16.16.16 eq 22
    50 permit tcp any range 1000 1100 any range 10 20
    4294967295 deny ip any any
+   permit response traffic nat
 !
 ip access-list ACL_NO_SEQUENCE
    remark test acl without sequence numbers

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-access-lists.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-access-lists.yml
@@ -45,6 +45,7 @@ ip_access_lists:
         protocol: ip
         source: any
         destination: any
+    permit_response_traffic: nat
   - name: ACL_NO_SEQUENCE
     entries:
       - remark: test acl without sequence numbers

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-access-lists.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-access-lists.md
@@ -37,6 +37,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_number</samp>](## "ip_access_lists.[].entries.[].vlan_number") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_inner</samp>](## "ip_access_lists.[].entries.[].vlan_inner") | Boolean |  | `False` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_mask</samp>](## "ip_access_lists.[].entries.[].vlan_mask") | String |  |  |  | 0x000-0xFFF VLAN mask. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;permit_response_traffic</samp>](## "ip_access_lists.[].permit_response_traffic") | String |  |  | Valid Values:<br>- <code>nat</code> | Permit response traffic automatically based on NAT translations.<br>Minimum EOS version requirement 4.32.2F. |
 
 === "YAML"
 
@@ -118,4 +119,8 @@
 
             # 0x000-0xFFF VLAN mask.
             vlan_mask: <str>
+
+        # Permit response traffic automatically based on NAT translations.
+        # Minimum EOS version requirement 4.32.2F.
+        permit_response_traffic: <str; "nat">
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/ipv4-acls.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/ipv4-acls.md
@@ -37,6 +37,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_inner</samp>](## "ipv4_acls.[].entries.[].vlan_inner") | Boolean |  | `False` |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan_mask</samp>](## "ipv4_acls.[].entries.[].vlan_mask") | String |  |  |  | 0x000-0xFFF VLAN mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;counters_per_entry</samp>](## "ipv4_acls.[].counters_per_entry") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;permit_response_traffic</samp>](## "ipv4_acls.[].permit_response_traffic") | String |  |  | Valid Values:<br>- <code>nat</code> | Permit response traffic automatically based on NAT translations.<br>Minimum EOS version requirement 4.32.2F. |
 
 === "YAML"
 
@@ -127,4 +128,8 @@
             # 0x000-0xFFF VLAN mask.
             vlan_mask: <str>
         counters_per_entry: <bool>
+
+        # Permit response traffic automatically based on NAT translations.
+        # Minimum EOS version requirement 4.32.2F.
+        permit_response_traffic: <str; "nat">
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-access-lists.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-access-lists.j2
@@ -136,6 +136,9 @@ ip access-list {{ acl.name }}
 {%             endif %}
 {#         END ACL_ENTRY CYCLE: walk over the list of ACL entries #}
 {%         endfor %}
+{%         if acl.permit_response_traffic is arista.avd.defined %}
+   permit response traffic {{ acl.permit_response_traffic }}
+{%         endif %}
 {#     END ACL CYCLE: end walk over the list of defined ACLs #}
 {%     endfor %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -4812,6 +4812,13 @@ keys:
               vlan_mask:
                 type: str
                 description: 0x000-0xFFF VLAN mask.
+        permit_response_traffic:
+          type: str
+          valid_values:
+          - nat
+          description: 'Permit response traffic automatically based on NAT translations.
+
+            Minimum EOS version requirement 4.32.2F.'
   ip_access_lists_max_entries:
     type: int
     convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_access_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_access_lists.schema.yml
@@ -150,3 +150,10 @@ keys:
               vlan_mask:
                 type: str
                 description: 0x000-0xFFF VLAN mask.
+        permit_response_traffic:
+          type: str
+          valid_values:
+            - nat
+          description: |-
+            Permit response traffic automatically based on NAT translations.
+            Minimum EOS version requirement 4.32.2F.


### PR DESCRIPTION
## Change Summary

Add `permit_response_traffic: [ nat ]` to ip_access_lists 

## Related Issue(s)

Fixes #4282 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

as described in the issue

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
