### PR TITLE
Fix(eos_cli_config_gen): Fix wrong indentation of config for redistribute routes in `router_bgp.vrfs[].address_family_ipv6`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-address-families.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-bgp-vrf-address-families.md
@@ -172,12 +172,12 @@ router bgp 65001
          neighbor aa::2 rcf out VRF_AFIPV6_RCF_OUT()
          network aa::/64
          no bgp redistribute-internal
-      redistribute connected rcf VRF_AFIPV6_RCF_CONNECTED()
-      redistribute isis include leaked
-      redistribute ospfv3 match external
-      redistribute ospfv3 match internal include leaked
-      redistribute ospfv3 match nssa-external
-      redistribute static route-map VRF_AFIPV6_RM_STATIC
+         redistribute connected rcf VRF_AFIPV6_RCF_CONNECTED()
+         redistribute isis include leaked
+         redistribute ospfv3 match external
+         redistribute ospfv3 match internal include leaked
+         redistribute ospfv3 match nssa-external
+         redistribute static route-map VRF_AFIPV6_RM_STATIC
       !
       address-family ipv6 multicast
          bgp missing-policy direction in action deny

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-address-families.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-bgp-vrf-address-families.cfg
@@ -111,12 +111,12 @@ router bgp 65001
          neighbor aa::2 rcf out VRF_AFIPV6_RCF_OUT()
          network aa::/64
          no bgp redistribute-internal
-      redistribute connected rcf VRF_AFIPV6_RCF_CONNECTED()
-      redistribute isis include leaked
-      redistribute ospfv3 match external
-      redistribute ospfv3 match internal include leaked
-      redistribute ospfv3 match nssa-external
-      redistribute static route-map VRF_AFIPV6_RM_STATIC
+         redistribute connected rcf VRF_AFIPV6_RCF_CONNECTED()
+         redistribute isis include leaked
+         redistribute ospfv3 match external
+         redistribute ospfv3 match internal include leaked
+         redistribute ospfv3 match nssa-external
+         redistribute static route-map VRF_AFIPV6_RM_STATIC
       !
       address-family ipv6 multicast
          bgp missing-policy direction in action deny

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -2994,7 +2994,7 @@ router bgp {{ router_bgp.as }}
 {%                             set redistribute_route_cli = redistribute_route_cli ~ " rcf " ~ redistribute_route.rcf %}
 {%                         endif %}
 {%                     endif %}
-      {{ redistribute_route_cli }}
+         {{ redistribute_route_cli }}
 {%                 endif %}
 {%             endfor %}
 {%         endif %}


### PR DESCRIPTION
## Change Summary

Fix wrong indentation of config for redistribute routes in router_bgp.vrfs[].address_family_ipv6.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Fix wrong indentation of config for redistribute routes in router_bgp.vrfs[].address_family_ipv6.

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
