### PR TITLE
Refactor(eos_cli_config_gen): Rearrange the eos-cli output to match eos order for router-isis

### DIFF
--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p1.md
@@ -382,8 +382,8 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router isis CORE
    net 49.0001.0102.5500.0001.00
-   is-type level-2
    router-id ipv4 10.255.0.1
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p2.md
@@ -382,8 +382,8 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router isis CORE
    net 49.0001.0102.5500.0002.00
-   is-type level-2
    router-id ipv4 10.255.0.2
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p3.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p3.md
@@ -362,8 +362,8 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router isis CORE
    net 49.0001.0102.5500.0003.00
-   is-type level-2
    router-id ipv4 10.255.0.3
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p4.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/p4.md
@@ -362,8 +362,8 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router isis CORE
    net 49.0001.0102.5500.0004.00
-   is-type level-2
    router-id ipv4 10.255.0.4
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe1.md
@@ -427,8 +427,8 @@ router ospf 10 vrf C1_VRF1
 !
 router isis CORE
    net 49.0001.0102.5500.1001.00
-   is-type level-2
    router-id ipv4 10.255.1.1
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe2.md
@@ -427,8 +427,8 @@ router ospf 10 vrf C1_VRF1
 !
 router isis CORE
    net 49.0001.0102.5500.1002.00
-   is-type level-2
    router-id ipv4 10.255.1.2
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe3.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/pe3.md
@@ -416,8 +416,8 @@ router ospf 10 vrf C1_VRF1
 !
 router isis CORE
    net 49.0001.0102.5500.1003.00
-   is-type level-2
    router-id ipv4 10.255.1.3
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr1.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr1.md
@@ -365,8 +365,8 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router isis CORE
    net 49.0001.0102.5500.2001.00
-   is-type level-2
    router-id ipv4 10.255.2.1
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr2.md
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/documentation/devices/rr2.md
@@ -365,8 +365,8 @@ ip route vrf MGMT 0.0.0.0/0 172.16.1.1
 !
 router isis CORE
    net 49.0001.0102.5500.2002.00
-   is-type level-2
    router-id ipv4 10.255.2.2
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p1.cfg
@@ -124,8 +124,8 @@ mpls ldp
 !
 router isis CORE
    net 49.0001.0102.5500.0001.00
-   is-type level-2
    router-id ipv4 10.255.0.1
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p2.cfg
@@ -124,8 +124,8 @@ mpls ldp
 !
 router isis CORE
    net 49.0001.0102.5500.0002.00
-   is-type level-2
    router-id ipv4 10.255.0.2
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p3.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p3.cfg
@@ -107,8 +107,8 @@ mpls ldp
 !
 router isis CORE
    net 49.0001.0102.5500.0003.00
-   is-type level-2
    router-id ipv4 10.255.0.3
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p4.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/p4.cfg
@@ -107,8 +107,8 @@ mpls ldp
 !
 router isis CORE
    net 49.0001.0102.5500.0004.00
-   is-type level-2
    router-id ipv4 10.255.0.4
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe1.cfg
@@ -166,8 +166,8 @@ router bgp 65001
 !
 router isis CORE
    net 49.0001.0102.5500.1001.00
-   is-type level-2
    router-id ipv4 10.255.1.1
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe2.cfg
@@ -166,8 +166,8 @@ router bgp 65001
 !
 router isis CORE
    net 49.0001.0102.5500.1002.00
-   is-type level-2
    router-id ipv4 10.255.1.2
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe3.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/pe3.cfg
@@ -162,8 +162,8 @@ router bgp 65001
 !
 router isis CORE
    net 49.0001.0102.5500.1003.00
-   is-type level-2
    router-id ipv4 10.255.1.3
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr1.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr1.cfg
@@ -148,8 +148,8 @@ router bgp 65001
 !
 router isis CORE
    net 49.0001.0102.5500.2001.00
-   is-type level-2
    router-id ipv4 10.255.2.1
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr2.cfg
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/configs/rr2.cfg
@@ -148,8 +148,8 @@ router bgp 65001
 !
 router isis CORE
    net 49.0001.0102.5500.2002.00
-   is-type level-2
    router-id ipv4 10.255.2.2
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -269,6 +269,8 @@ interface Vlan4094
 ```eos
 !
 router isis EVPN_UNDERLAY
+   no log-adjacency-changes
+   mpls ldp sync default
    redistribute connected
    redistribute isis instance route-map RM-REDIS-ISIS-INSTANCE
    redistribute ospf match internal
@@ -276,8 +278,6 @@ router isis EVPN_UNDERLAY
    redistribute ospf include leaked match nssa-external route-map RM-OSPF-NSSA_EXT-TO-ISIS
    redistribute ospfv3 match external
    redistribute static include leaked route-map RM-STATIC-TO-ISIS
-   no log-adjacency-changes
-   mpls ldp sync default
    timers local-convergence-delay protected-prefixes
    set-overload-bit
    advertise passive-only

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis.md
@@ -344,10 +344,10 @@ interface Vlan4094
 !
 router isis EVPN_UNDERLAY
    net 49.0001.0001.0001.0001.00
-   is-type level-2
-   redistribute bgp route-map RM-BGP
    router-id ipv4 192.168.255.3
+   is-type level-2
    log-adjacency-changes
+   redistribute bgp route-map RM-BGP
    timers local-convergence-delay 15000 protected-prefixes
    set-overload-bit on-startup wait-for-bgp
    advertise passive-only

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
@@ -58,6 +58,8 @@ interface Vlan4094
    ip address 10.255.252.0/31
 !
 router isis EVPN_UNDERLAY
+   no log-adjacency-changes
+   mpls ldp sync default
    redistribute connected
    redistribute isis instance route-map RM-REDIS-ISIS-INSTANCE
    redistribute ospf match internal
@@ -65,8 +67,6 @@ router isis EVPN_UNDERLAY
    redistribute ospf include leaked match nssa-external route-map RM-OSPF-NSSA_EXT-TO-ISIS
    redistribute ospfv3 match external
    redistribute static include leaked route-map RM-STATIC-TO-ISIS
-   no log-adjacency-changes
-   mpls ldp sync default
    timers local-convergence-delay protected-prefixes
    set-overload-bit
    advertise passive-only

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis.cfg
@@ -100,10 +100,10 @@ interface Vlan4094
 !
 router isis EVPN_UNDERLAY
    net 49.0001.0001.0001.0001.00
-   is-type level-2
-   redistribute bgp route-map RM-BGP
    router-id ipv4 192.168.255.3
+   is-type level-2
    log-adjacency-changes
+   redistribute bgp route-map RM-BGP
    timers local-convergence-delay 15000 protected-prefixes
    set-overload-bit on-startup wait-for-bgp
    advertise passive-only

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/documentation/devices/ISIS-SPINE1.md
@@ -354,11 +354,11 @@ ip route 10.1.0.0/16 10.1.100.100
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5001.00
+   router-id ipv4 192.168.255.1
    is-type level-2
+   log-adjacency-changes
    redistribute connected
    redistribute static
-   router-id ipv4 192.168.255.1
-   log-adjacency-changes
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/configs/ISIS-SPINE1.cfg
@@ -80,11 +80,11 @@ ip route 10.1.0.0/16 10.1.100.100
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5001.00
+   router-id ipv4 192.168.255.1
    is-type level-2
+   log-adjacency-changes
    redistribute connected
    redistribute static
-   router-id ipv4 192.168.255.1
-   log-adjacency-changes
    !
    address-family ipv4 unicast
       maximum-paths 4

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -591,8 +591,8 @@ router ospf 19 vrf TENANT_B_INTRA
 !
 router isis CORE
    net 49.0001.1000.7000.0005.00
-   is-type level-1-2
    router-id ipv4 100.70.0.5
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -556,8 +556,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis CORE
    net 49.0001.1000.7000.0006.00
-   is-type level-1-2
    router-id ipv4 100.70.0.6
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR1.md
@@ -374,8 +374,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis CORE
    net 49.0001.1000.7000.0001.00
-   is-type level-2
    router-id ipv4 100.70.0.1
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LSR2.md
@@ -349,8 +349,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis CORE
    net 49.0001.1000.7000.0002.00
-   is-type level-2
    router-id ipv4 100.70.0.2
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-RR1.md
@@ -327,8 +327,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis CORE
    net 49.0001.1000.7000.0008.00
-   is-type level-1-2
    router-id ipv4 100.70.0.8
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -662,8 +662,8 @@ router ospf 99 vrf TENANT_B_WAN
 !
 router isis CORE
    net 49.0001.1000.7000.0007.00
-   is-type level-1-2
    router-id ipv4 100.70.0.7
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR1.md
@@ -374,8 +374,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis CUSTOM_NAME
    net 49.0001.1000.7000.0003.00
-   is-type level-2
    router-id ipv4 100.70.0.3
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
@@ -435,8 +435,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis CUSTOM_NAME
    net 49.0001.1000.7000.0004.00
-   is-type level-2
    router-id ipv4 100.70.0.4
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-RR1.md
@@ -327,8 +327,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis CORE
    net 49.0001.1000.7000.0009.00
-   is-type level-1-2
    router-id ipv4 100.70.0.9
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE3-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE3-LER1.md
@@ -290,8 +290,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis CORE
    net 49.0001.1000.7000.0010.00
-   is-type level-1-2
    router-id ipv4 100.70.0.10
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -302,8 +302,8 @@ router bgp 65000
 !
 router isis CORE
    net 49.0001.1000.7000.0005.00
-   is-type level-1-2
    router-id ipv4 100.70.0.5
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -316,8 +316,8 @@ router bgp 65000
 !
 router isis CORE
    net 49.0001.1000.7000.0006.00
-   is-type level-1-2
    router-id ipv4 100.70.0.6
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR1.cfg
@@ -118,8 +118,8 @@ mpls ldp
 !
 router isis CORE
    net 49.0001.1000.7000.0001.00
-   is-type level-2
    router-id ipv4 100.70.0.1
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LSR2.cfg
@@ -97,8 +97,8 @@ mpls ldp
 !
 router isis CORE
    net 49.0001.1000.7000.0002.00
-   is-type level-2
    router-id ipv4 100.70.0.2
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-RR1.cfg
@@ -128,8 +128,8 @@ router bgp 65000
 !
 router isis CORE
    net 49.0001.1000.7000.0008.00
-   is-type level-1-2
    router-id ipv4 100.70.0.8
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LER1.cfg
@@ -374,8 +374,8 @@ router bgp 65000
 !
 router isis CORE
    net 49.0001.1000.7000.0007.00
-   is-type level-1-2
    router-id ipv4 100.70.0.7
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR1.cfg
@@ -118,8 +118,8 @@ mpls ldp
 !
 router isis CUSTOM_NAME
    net 49.0001.1000.7000.0003.00
-   is-type level-2
    router-id ipv4 100.70.0.3
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-LSR2.cfg
@@ -140,8 +140,8 @@ mpls ldp
 !
 router isis CUSTOM_NAME
    net 49.0001.1000.7000.0004.00
-   is-type level-2
    router-id ipv4 100.70.0.4
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE2-RR1.cfg
@@ -128,8 +128,8 @@ router bgp 65000
 !
 router isis CORE
    net 49.0001.1000.7000.0009.00
-   is-type level-1-2
    router-id ipv4 100.70.0.9
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE3-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE3-LER1.cfg
@@ -58,8 +58,8 @@ mpls ldp
 !
 router isis CORE
    net 49.0001.1000.7000.0010.00
-   is-type level-1-2
    router-id ipv4 100.70.0.10
+   is-type level-1-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host2.cfg
@@ -58,8 +58,8 @@ router bgp 102
 !
 router isis CORE
    net 49.0001.0100.4200.0102.00
-   is-type level-2
    router-id ipv4 10.42.0.102
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-3.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-3.cfg
@@ -72,8 +72,8 @@ router bgp 65001
 !
 router isis CORE
    net 49.0001.1921.6825.5114.00
-   is-type level-1-2
    router-id ipv4 192.168.255.114
+   is-type level-1-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-1-isis-sr-ldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-1-isis-sr-ldp.cfg
@@ -307,8 +307,8 @@ mpls ldp
 !
 router isis CORE
    net 49.0001.0100.0000.0001.00
-   is-type level-2
    router-id ipv4 10.0.0.1
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-3-isis-sr-ldp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/core-3-isis-sr-ldp.cfg
@@ -49,8 +49,8 @@ mpls ldp
 !
 router isis CORE
    net 49.0001.0100.0000.0003.00
-   is-type level-2
    router-id ipv4 10.0.0.3
+   is-type level-2
    log-adjacency-changes
    mpls ldp sync default
    timers local-convergence-delay 15000 protected-prefixes

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/isis-system-id-format-using-node-id.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/isis-system-id-format-using-node-id.cfg
@@ -58,8 +58,8 @@ router bgp 65000
 !
 router isis CORE
    net 49.0001.0000.0001.0099.00
-   is-type level-2
    router-id ipv4 172.28.4.99
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/isis-system-id-format-using-underlay-loopback.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/isis-system-id-format-using-underlay-loopback.cfg
@@ -58,8 +58,8 @@ router bgp 65000
 !
 router isis CORE
    net 49.0001.1720.2800.4099.00
-   is-type level-2
    router-id ipv4 172.28.4.99
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_isis.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_isis.cfg
@@ -85,8 +85,8 @@ no ip routing vrf MGMT
 !
 router isis EVPN_UNDERLAY
    net 49.0001.0010.0200.3001.00
-   is-type level-2
    router-id ipv4 1.2.3.1
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1A.md
@@ -616,8 +616,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5010.00
-   is-type level-2
    router-id ipv4 192.168.255.10
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-BL1B.md
@@ -600,8 +600,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5011.00
-   is-type level-2
    router-id ipv4 192.168.255.11
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF1A.md
@@ -450,8 +450,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5005.00
-   is-type level-2
    router-id ipv4 192.168.255.5
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2A.md
@@ -615,8 +615,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5006.00
-   is-type level-2
    router-id ipv4 192.168.255.6
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-LEAF2B.md
@@ -615,8 +615,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5007.00
-   is-type level-2
    router-id ipv4 192.168.255.7
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE1.md
@@ -449,8 +449,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5001.00
-   is-type level-2
    router-id ipv4 192.168.255.1
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE2.md
@@ -446,8 +446,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5002.00
-   is-type level-2
    router-id ipv4 192.168.255.2
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE3.md
@@ -446,8 +446,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5003.00
-   is-type level-2
    router-id ipv4 192.168.255.3
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SPINE4.md
@@ -449,8 +449,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5004.00
-   is-type level-2
    router-id ipv4 192.168.255.4
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3A.md
@@ -608,8 +608,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5008.00
-   is-type level-2
    router-id ipv4 192.168.255.8
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/documentation/devices/DC1-SVC3B.md
@@ -608,8 +608,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5009.00
-   is-type level-2
    router-id ipv4 192.168.255.9
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1A.cfg
@@ -220,8 +220,8 @@ router bgp 65000
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5010.00
-   is-type level-2
    router-id ipv4 192.168.255.10
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-BL1B.cfg
@@ -207,8 +207,8 @@ router bgp 65000
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5011.00
-   is-type level-2
    router-id ipv4 192.168.255.11
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF1A.cfg
@@ -148,8 +148,8 @@ router bgp 65000
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5005.00
-   is-type level-2
    router-id ipv4 192.168.255.5
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2A.cfg
@@ -220,8 +220,8 @@ router bgp 65000
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5006.00
-   is-type level-2
    router-id ipv4 192.168.255.6
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-LEAF2B.cfg
@@ -220,8 +220,8 @@ router bgp 65000
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5007.00
-   is-type level-2
    router-id ipv4 192.168.255.7
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE1.cfg
@@ -176,8 +176,8 @@ router bgp 65000
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5001.00
-   is-type level-2
    router-id ipv4 192.168.255.1
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE2.cfg
@@ -137,8 +137,8 @@ ntp server vrf MGMT 192.168.200.5 prefer
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5002.00
-   is-type level-2
    router-id ipv4 192.168.255.2
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE3.cfg
@@ -137,8 +137,8 @@ ntp server vrf MGMT 192.168.200.5 prefer
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5003.00
-   is-type level-2
    router-id ipv4 192.168.255.3
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SPINE4.cfg
@@ -176,8 +176,8 @@ router bgp 65000
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5004.00
-   is-type level-2
    router-id ipv4 192.168.255.4
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3A.cfg
@@ -215,8 +215,8 @@ router bgp 65000
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5008.00
-   is-type level-2
    router-id ipv4 192.168.255.8
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/configs/DC1-SVC3B.cfg
@@ -215,8 +215,8 @@ router bgp 65000
 !
 router isis EVPN_UNDERLAY
    net 49.0001.1921.6825.5009.00
-   is-type level-2
    router-id ipv4 192.168.255.9
+   is-type level-2
    log-adjacency-changes
    !
    address-family ipv4 unicast

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-isis.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-isis.j2
@@ -10,8 +10,19 @@ router isis {{ router_isis.instance }}
 {%     if router_isis.net is arista.avd.defined %}
    net {{ router_isis.net }}
 {%     endif %}
+{%     if router_isis.router_id is arista.avd.defined %}
+   router-id ipv4 {{ router_isis.router_id }}
+{%     endif %}
 {%     if router_isis.is_type is arista.avd.defined %}
    is-type {{ router_isis.is_type }}
+{%     endif %}
+{%     if router_isis.log_adjacency_changes is arista.avd.defined(true) %}
+   log-adjacency-changes
+{%     elif router_isis.log_adjacency_changes is arista.avd.defined(false) %}
+   no log-adjacency-changes
+{%     endif %}
+{%     if router_isis.mpls_ldp_sync_default is arista.avd.defined(true) %}
+   mpls ldp sync default
 {%     endif %}
 {%     for redistribute_route in router_isis.redistribute_routes | arista.avd.natural_sort('source_protocol') %}
 {%         if redistribute_route.source_protocol is arista.avd.defined %}
@@ -42,17 +53,6 @@ router isis {{ router_isis.instance }}
    {{ redistribute_route_cli }}
 {%         endif %}
 {%     endfor %}
-{%     if router_isis.router_id is arista.avd.defined %}
-   router-id ipv4 {{ router_isis.router_id }}
-{%     endif %}
-{%     if router_isis.log_adjacency_changes is arista.avd.defined(true) %}
-   log-adjacency-changes
-{%     elif router_isis.log_adjacency_changes is arista.avd.defined(false) %}
-   no log-adjacency-changes
-{%     endif %}
-{%     if router_isis.mpls_ldp_sync_default is arista.avd.defined(true) %}
-   mpls ldp sync default
-{%     endif %}
 {%     if router_isis.timers.local_convergence.protected_prefixes is arista.avd.defined(true) %}
 {%         if router_isis.timers.local_convergence.delay is arista.avd.defined %}
    timers local-convergence-delay {{ router_isis.timers.local_convergence.delay }} protected-prefixes
@@ -252,11 +252,11 @@ router isis {{ router_isis.instance }}
 {%     endif %}
 {%     if router_isis.address_family_ipv6.enabled is arista.avd.defined(true) %}
    address-family ipv6 unicast
-{%         if router_isis.address_family_ipv6.maximum_paths is arista.avd.defined %}
-      maximum-paths {{ router_isis.address_family_ipv6.maximum_paths }}
-{%         endif %}
 {%         if router_isis.address_family_ipv6.bfd_all_interfaces is arista.avd.defined(true) %}
       bfd all-interfaces
+{%         endif %}
+{%         if router_isis.address_family_ipv6.maximum_paths is arista.avd.defined %}
+      maximum-paths {{ router_isis.address_family_ipv6.maximum_paths }}
 {%         endif %}
 {%         if router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode is arista.avd.defined %}
 {%             set ti_lfa_cli = "fast-reroute ti-lfa mode " ~ router_isis.address_family_ipv6.fast_reroute_ti_lfa.mode %}


### PR DESCRIPTION
## Change Summary

Rearrange the eos-cli output to match eos order for router-isis

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
Match the generated config order with EOS CLI

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
