### PR TITLE
Fix(eos_cli_config_gen): Fixing poe link down power-off action command in j2 template

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ethernet-interfaces.md
@@ -942,7 +942,7 @@ interface Ethernet56
    switchport
    poe priority low
    poe reboot action power-off
-   poe link down action power-off 10
+   poe link down action power-off 10 seconds
    poe shutdown action maintain
    poe limit 30.00 watts
    poe negotiation lldp disabled

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ethernet-interfaces.cfg
@@ -558,7 +558,7 @@ interface Ethernet56
    switchport
    poe priority low
    poe reboot action power-off
-   poe link down action power-off 10
+   poe link down action power-off 10 seconds
    poe shutdown action maintain
    poe limit 30.00 watts
    poe negotiation lldp disabled

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -805,8 +805,8 @@ interface {{ ethernet_interface.name }}
 {%     endif %}
 {%     if ethernet_interface.poe.link_down.action is arista.avd.defined %}
 {%         set poe_link_down_action_cli = 'poe link down action ' ~ ethernet_interface.poe.link_down.action %}
-{%         if ethernet_interface.poe.link_down.power_off_delay is arista.avd.defined %}
-{%             set poe_link_down_action_cli = poe_link_down_action_cli ~ ' ' ~ ethernet_interface.poe.link_down.power_off_delay %}
+{%         if ethernet_interface.poe.link_down.power_off_delay is arista.avd.defined and ethernet_interface.poe.link_down.action == 'power-off' %}
+{%             set poe_link_down_action_cli = poe_link_down_action_cli ~ ' ' ~ ethernet_interface.poe.link_down.power_off_delay ~ ' seconds' %}
 {%         endif %}
    {{ poe_link_down_action_cli }}
 {%     endif %}


### PR DESCRIPTION
## Change Summary

`poe link down action power-off 10` is missing `seconds` at the end.
Also, this command should only work when `action` is `power-off` .

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
