### PR TITLE
Feat(eos_cli_config_gen): Add support for OSPF graceful restart

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -251,6 +251,8 @@ router ospf 100
    max-lsa 12000
    maximum-paths 10
    default-information originate
+   graceful-restart
+   graceful-restart-helper
    mpls ldp sync default
 !
 router ospf 101 vrf CUSTOMER01
@@ -265,6 +267,8 @@ router ospf 101 vrf CUSTOMER01
    summary-address 20.0.0.0/8 tag 10
    summary-address 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY
    summary-address 40.0.0.0/8 not-advertise
+   graceful-restart grace-period 10
+   no graceful-restart-helper
    area 5 not-so-stubby lsa type-7 convert type-5
 
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-ospf.md
@@ -252,8 +252,8 @@ router ospf 100
    maximum-paths 10
    default-information originate
    graceful-restart
-   graceful-restart-helper
    mpls ldp sync default
+   graceful-restart-helper
 !
 router ospf 101 vrf CUSTOMER01
    router-id 1.0.1.1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -51,6 +51,8 @@ router ospf 100
    max-lsa 12000
    maximum-paths 10
    default-information originate
+   graceful-restart
+   graceful-restart-helper
    mpls ldp sync default
 !
 router ospf 101 vrf CUSTOMER01
@@ -65,6 +67,8 @@ router ospf 101 vrf CUSTOMER01
    summary-address 20.0.0.0/8 tag 10
    summary-address 30.0.0.0/8 attribute-map RM-OSPF_SUMMARY
    summary-address 40.0.0.0/8 not-advertise
+   graceful-restart grace-period 10
+   no graceful-restart-helper
    area 5 not-so-stubby lsa type-7 convert type-5
 
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-ospf.cfg
@@ -52,8 +52,8 @@ router ospf 100
    maximum-paths 10
    default-information originate
    graceful-restart
-   graceful-restart-helper
    mpls ldp sync default
+   graceful-restart-helper
 !
 router ospf 101 vrf CUSTOMER01
    router-id 1.0.1.1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -33,6 +33,9 @@ router_ospf:
         inter_area: 70
       distribute_list_in:
         route_map: RM-OSPF-DIST-IN
+      graceful_restart:
+        enabled: true
+      graceful_restart_helper: true
     - id: 101
       vrf: CUSTOMER01
       passive_interface_default: true
@@ -60,6 +63,9 @@ router_ospf:
           initial: 100
           min: 200
           max: 300
+      graceful_restart:
+        grace_period: 10
+      graceful_restart_helper: false
       eos_cli: |
         area 5 not-so-stubby lsa type-7 convert type-5
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-ospf.yml
@@ -64,6 +64,7 @@ router_ospf:
           min: 200
           max: 300
       graceful_restart:
+        enabled: true
         grace_period: 10
       graceful_restart_helper: false
       eos_cli: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-ospf.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-ospf.md
@@ -84,7 +84,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;summary_lsa</samp>](## "router_ospf.process_ids.[].max_metric.router_lsa.summary_lsa") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override_metric</samp>](## "router_ospf.process_ids.[].max_metric.router_lsa.summary_lsa.override_metric") | Integer |  |  | Min: 1<br>Max: 16777215 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;graceful_restart</samp>](## "router_ospf.process_ids.[].graceful_restart") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_ospf.process_ids.[].graceful_restart.enabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_ospf.process_ids.[].graceful_restart.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;grace_period</samp>](## "router_ospf.process_ids.[].graceful_restart.grace_period") | Integer |  |  | Min: 1<br>Max: 1800 | Specify maximum time in seconds to wait for graceful-restart to complete. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;graceful_restart_helper</samp>](## "router_ospf.process_ids.[].graceful_restart_helper") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mpls_ldp_sync_default</samp>](## "router_ospf.process_ids.[].mpls_ldp_sync_default") | Boolean |  |  |  |  |
@@ -217,7 +217,7 @@
               summary_lsa:
                 override_metric: <int; 1-16777215>
           graceful_restart:
-            enabled: <bool>
+            enabled: <bool; required>
 
             # Specify maximum time in seconds to wait for graceful-restart to complete.
             grace_period: <int; 1-1800>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-ospf.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-ospf.md
@@ -83,6 +83,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;on_startup</samp>](## "router_ospf.process_ids.[].max_metric.router_lsa.on_startup") | String |  |  |  | "wait-for-bgp" or Integer 5-86400.<br>Example: "wait-for-bgp" Or "222"<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;summary_lsa</samp>](## "router_ospf.process_ids.[].max_metric.router_lsa.summary_lsa") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;override_metric</samp>](## "router_ospf.process_ids.[].max_metric.router_lsa.summary_lsa.override_metric") | Integer |  |  | Min: 1<br>Max: 16777215 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;graceful_restart</samp>](## "router_ospf.process_ids.[].graceful_restart") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "router_ospf.process_ids.[].graceful_restart.enabled") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;grace_period</samp>](## "router_ospf.process_ids.[].graceful_restart.grace_period") | Integer |  |  | Min: 1<br>Max: 1800 | Specify maximum time in seconds to wait for graceful-restart to complete. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;graceful_restart_helper</samp>](## "router_ospf.process_ids.[].graceful_restart_helper") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mpls_ldp_sync_default</samp>](## "router_ospf.process_ids.[].mpls_ldp_sync_default") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "router_ospf.process_ids.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the Router OSPF process ID in the final EOS configuration. |
 
@@ -212,6 +216,12 @@
               on_startup: <str>
               summary_lsa:
                 override_metric: <int; 1-16777215>
+          graceful_restart:
+            enabled: <bool>
+
+            # Specify maximum time in seconds to wait for graceful-restart to complete.
+            grace_period: <int; 1-1800>
+          graceful_restart_helper: <bool>
           mpls_ldp_sync_default: <bool>
 
           # Multiline EOS CLI rendered directly on the Router OSPF process ID in the final EOS configuration.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-ospf.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-ospf.j2
@@ -200,6 +200,16 @@ router ospf {{ process_id.id }}
    summary-address {{ summary_address.prefix }}
 {%         endif %}
 {%     endfor %}
+{%     if process_id.graceful_restart.enabled is arista.avd.defined(true) %}
+   graceful-restart
+{%     elif process_id.graceful_restart.grace_period is arista.avd.defined %}
+   graceful-restart grace-period {{ process_id.graceful_restart.grace_period }}
+{%     endif %}
+{%     if process_id.graceful_restart_helper is arista.avd.defined(true) %}
+   graceful-restart-helper
+{%     elif process_id.graceful_restart_helper is arista.avd.defined(false) %}
+   no graceful-restart-helper
+{%     endif %}
 {%     if process_id.mpls_ldp_sync_default is arista.avd.defined(true) %}
    mpls ldp sync default
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-ospf.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-ospf.j2
@@ -207,13 +207,13 @@ router ospf {{ process_id.id }}
 {%         endif %}
    {{ graceful_restart_cli }}
 {%     endif %}
+{%     if process_id.mpls_ldp_sync_default is arista.avd.defined(true) %}
+   mpls ldp sync default
+{%     endif %}
 {%     if process_id.graceful_restart_helper is arista.avd.defined(true) %}
    graceful-restart-helper
 {%     elif process_id.graceful_restart_helper is arista.avd.defined(false) %}
    no graceful-restart-helper
-{%     endif %}
-{%     if process_id.mpls_ldp_sync_default is arista.avd.defined(true) %}
-   mpls ldp sync default
 {%     endif %}
 {%     if process_id.eos_cli is arista.avd.defined %}
    {{ process_id.eos_cli | indent(3, false) }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-ospf.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-ospf.j2
@@ -201,9 +201,11 @@ router ospf {{ process_id.id }}
 {%         endif %}
 {%     endfor %}
 {%     if process_id.graceful_restart.enabled is arista.avd.defined(true) %}
-   graceful-restart
-{%     elif process_id.graceful_restart.grace_period is arista.avd.defined %}
-   graceful-restart grace-period {{ process_id.graceful_restart.grace_period }}
+{%         set graceful_restart_cli = "graceful-restart" %}
+{%         if process_id.graceful_restart.grace_period is arista.avd.defined %}
+{%             set graceful_restart_cli = graceful_restart_cli ~ " grace-period " ~ process_id.graceful_restart.grace_period %}
+{%         endif %}
+   {{ graceful_restart_cli }}
 {%     endif %}
 {%     if process_id.graceful_restart_helper is arista.avd.defined(true) %}
    graceful-restart-helper

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -18722,6 +18722,7 @@ keys:
               keys:
                 enabled:
                   type: bool
+                  required: true
                 grace_period:
                   type: int
                   convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -18717,6 +18717,21 @@ keys:
                           - str
                           min: 1
                           max: 16777215
+            graceful_restart:
+              type: dict
+              keys:
+                enabled:
+                  type: bool
+                grace_period:
+                  type: int
+                  convert_types:
+                  - str
+                  min: 1
+                  max: 1800
+                  description: Specify maximum time in seconds to wait for graceful-restart
+                    to complete.
+            graceful_restart_helper:
+              type: bool
             mpls_ldp_sync_default:
               type: bool
             eos_cli:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_ospf.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_ospf.schema.yml
@@ -301,6 +301,20 @@ keys:
                             - str
                           min: 1
                           max: 16777215
+            graceful_restart:
+              type: dict
+              keys:
+                enabled:
+                  type: bool
+                grace_period:
+                  type: int
+                  convert_types:
+                    - str
+                  min: 1
+                  max: 1800
+                  description: Specify maximum time in seconds to wait for graceful-restart to complete.
+            graceful_restart_helper:
+              type: bool
             mpls_ldp_sync_default:
               type: bool
             eos_cli:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_ospf.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_ospf.schema.yml
@@ -306,6 +306,7 @@ keys:
               keys:
                 enabled:
                   type: bool
+                  required: true
                 grace_period:
                   type: int
                   convert_types:


### PR DESCRIPTION
## Change Summary

Add support for OSPF graceful restart

## Related Issue(s)

Fixes #4468 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
schema - 

```
router_ospf:
     process_ids:
         - graceful_restart:
                 enabled: <bool>

                 # Specify maximum time in seconds to wait for graceful-restart to complete.
                 grace_period: <int; 1-1800>
           graceful_restart_helper: <bool>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
