### PR TITLE
Fix(eos_designs): Fix the Invalid command of `vxlan vxlan vlan <vlan_id> flood vtep`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.cfg
@@ -75,10 +75,8 @@ interface Vxlan1
    vxlan vlan 3901 vni 13901
    vxlan vlan 3902 vni 13902
    vxlan vlan 2900 flood vtep 192.168.253.2 192.168.253.3
-   vxlan vlan 2901 flood vtep 
    vxlan vlan 2902 flood vtep 192.168.253.2
    vxlan vlan 3900 flood vtep 192.168.253.2 192.168.253.3
-   vxlan vlan 3901 flood vtep 
    vxlan vlan 3902 flood vtep 192.168.253.2
 !
 ip routing

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/OVERLAY_ROUTING_PROTOCOL_HER_L3LEAF1.yml
@@ -130,7 +130,6 @@ vxlan_interface:
         - 192.168.253.3
       - id: 3901
         vni: 13901
-        flood_vteps: []
       - id: 3902
         vni: 13902
         flood_vteps:
@@ -142,7 +141,6 @@ vxlan_interface:
         - 192.168.253.3
       - id: 2901
         vni: 12901
-        flood_vteps: []
       - id: 2902
         vni: 12902
         flood_vteps:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vxlan_interface.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vxlan_interface.py
@@ -49,8 +49,8 @@ class VxlanInterfaceMixin(UtilsMixin):
         if self.shared_utils.mlag_l3 and self.shared_utils.network_services_l3 and self.shared_utils.overlay_evpn:
             vxlan["virtual_router_encapsulation_mac_address"] = "mlag-system-id"
 
-        if self.shared_utils.overlay_her and self._overlay_her_flood_list_per_vni is False:
-            vxlan["flood_vteps"] = natural_sort(unique(self._overlay_her_flood_lists.get("common", [])))
+        if self.shared_utils.overlay_her and self._overlay_her_flood_list_per_vni is False and self._overlay_her_flood_lists.get("common"):
+            vxlan["flood_vteps"] = natural_sort(unique(self._overlay_her_flood_lists.get("common")))
 
         if self.shared_utils.overlay_cvx:
             vxlan["controller_client"] = {"enabled": True}
@@ -250,8 +250,8 @@ class VxlanInterfaceMixin(UtilsMixin):
                 underlay_l2_multicast_group_ipv4_pool_offset,
             )
 
-        if self.shared_utils.overlay_her and self._overlay_her_flood_list_per_vni:
-            vxlan_interface_vlan["flood_vteps"] = natural_sort(unique(self._overlay_her_flood_lists.get(vlan_id, [])))
+        if self.shared_utils.overlay_her and self._overlay_her_flood_list_per_vni and self._overlay_her_flood_lists.get(vlan_id):
+            vxlan_interface_vlan["flood_vteps"] = natural_sort(unique(self._overlay_her_flood_lists.get(vlan_id)))
 
         return vxlan_interface_vlan
 

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vxlan_interface.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vxlan_interface.py
@@ -49,8 +49,8 @@ class VxlanInterfaceMixin(UtilsMixin):
         if self.shared_utils.mlag_l3 and self.shared_utils.network_services_l3 and self.shared_utils.overlay_evpn:
             vxlan["virtual_router_encapsulation_mac_address"] = "mlag-system-id"
 
-        if self.shared_utils.overlay_her and self._overlay_her_flood_list_per_vni is False and self._overlay_her_flood_lists.get("common"):
-            vxlan["flood_vteps"] = natural_sort(unique(self._overlay_her_flood_lists.get("common")))
+        if self.shared_utils.overlay_her and self._overlay_her_flood_list_per_vni is False and (common := self._overlay_her_flood_lists.get("common")):
+            vxlan["flood_vteps"] = natural_sort(unique(common))
 
         if self.shared_utils.overlay_cvx:
             vxlan["controller_client"] = {"enabled": True}
@@ -250,8 +250,8 @@ class VxlanInterfaceMixin(UtilsMixin):
                 underlay_l2_multicast_group_ipv4_pool_offset,
             )
 
-        if self.shared_utils.overlay_her and self._overlay_her_flood_list_per_vni and self._overlay_her_flood_lists.get(vlan_id):
-            vxlan_interface_vlan["flood_vteps"] = natural_sort(unique(self._overlay_her_flood_lists.get(vlan_id)))
+        if self.shared_utils.overlay_her and self._overlay_her_flood_list_per_vni and (vlan_id_entry := self._overlay_her_flood_lists.get(vlan_id)):
+            vxlan_interface_vlan["flood_vteps"] = natural_sort(unique(vlan_id_entry))
 
         return vxlan_interface_vlan
 


### PR DESCRIPTION
## Change Summary

Fix the Invalid command of `vxlan vxlan vlan <vlan_id> flood vtep`.

## Related Issue(s)

Fixes #4513 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
flood_vteps rendering empty lists of vteps hence added the condition to be not empty.

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
