### PR TITLE
Feat(eos_cli_config_gen): Add integrity key under ike policy

### DIFF
--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/pf1.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/pf1.md
@@ -328,9 +328,9 @@ spanning-tree mode none
 
 ### IKE policies
 
-| Policy name | IKE lifetime | Encryption | DH group | Local ID |
-| ----------- | ------------ | ---------- | -------- | -------- |
-| CP-IKE-POLICY | - | - | - | 192.168.42.1 |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
+| ----------- | ------------ | ---------- | -------- | -------- | --------- |
+| CP-IKE-POLICY | - | - | - | 192.168.42.1 | - |
 
 ### Security Association policies
 

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/pf2.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/pf2.md
@@ -328,9 +328,9 @@ spanning-tree mode none
 
 ### IKE policies
 
-| Policy name | IKE lifetime | Encryption | DH group | Local ID |
-| ----------- | ------------ | ---------- | -------- | -------- |
-| CP-IKE-POLICY | - | - | - | 192.168.42.2 |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
+| ----------- | ------------ | ---------- | -------- | -------- | --------- |
+| CP-IKE-POLICY | - | - | - | 192.168.42.2 | - |
 
 ### Security Association policies
 

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-wan1.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-wan1.md
@@ -327,10 +327,10 @@ spanning-tree mode none
 
 ### IKE policies
 
-| Policy name | IKE lifetime | Encryption | DH group | Local ID |
-| ----------- | ------------ | ---------- | -------- | -------- |
-| CP-IKE-POLICY | - | - | - | 192.168.42.3 |
-| DP-IKE-POLICY | - | - | - | 192.168.42.3 |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
+| ----------- | ------------ | ---------- | -------- | -------- | --------- |
+| CP-IKE-POLICY | - | - | - | 192.168.42.3 | - |
+| DP-IKE-POLICY | - | - | - | 192.168.42.3 | - |
 
 ### Security Association policies
 

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-wan2.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-wan2.md
@@ -327,10 +327,10 @@ spanning-tree mode none
 
 ### IKE policies
 
-| Policy name | IKE lifetime | Encryption | DH group | Local ID |
-| ----------- | ------------ | ---------- | -------- | -------- |
-| CP-IKE-POLICY | - | - | - | 192.168.42.4 |
-| DP-IKE-POLICY | - | - | - | 192.168.42.4 |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
+| ----------- | ------------ | ---------- | -------- | -------- | --------- |
+| CP-IKE-POLICY | - | - | - | 192.168.42.4 | - |
+| DP-IKE-POLICY | - | - | - | 192.168.42.4 | - |
 
 ### Security Association policies
 

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site2-wan1.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site2-wan1.md
@@ -324,10 +324,10 @@ spanning-tree mode none
 
 ### IKE policies
 
-| Policy name | IKE lifetime | Encryption | DH group | Local ID |
-| ----------- | ------------ | ---------- | -------- | -------- |
-| CP-IKE-POLICY | - | - | - | 192.168.42.7 |
-| DP-IKE-POLICY | - | - | - | 192.168.42.7 |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
+| ----------- | ------------ | ---------- | -------- | -------- | --------- |
+| CP-IKE-POLICY | - | - | - | 192.168.42.7 | - |
+| DP-IKE-POLICY | - | - | - | 192.168.42.7 | - |
 
 ### Security Association policies
 

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site2-wan2.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site2-wan2.md
@@ -326,10 +326,10 @@ spanning-tree mode none
 
 ### IKE policies
 
-| Policy name | IKE lifetime | Encryption | DH group | Local ID |
-| ----------- | ------------ | ---------- | -------- | -------- |
-| CP-IKE-POLICY | - | - | - | 192.168.42.8 |
-| DP-IKE-POLICY | - | - | - | 192.168.42.8 |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
+| ----------- | ------------ | ---------- | -------- | -------- | --------- |
+| CP-IKE-POLICY | - | - | - | 192.168.42.8 | - |
+| DP-IKE-POLICY | - | - | - | 192.168.42.8 | - |
 
 ### Security Association policies
 

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site3-wan1.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site3-wan1.md
@@ -326,9 +326,9 @@ spanning-tree mode none
 
 ### IKE policies
 
-| Policy name | IKE lifetime | Encryption | DH group | Local ID |
-| ----------- | ------------ | ---------- | -------- | -------- |
-| CP-IKE-POLICY | - | - | - | 192.168.42.11 |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
+| ----------- | ------------ | ---------- | -------- | -------- | --------- |
+| CP-IKE-POLICY | - | - | - | 192.168.42.11 | - |
 
 ### Security Association policies
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -47,10 +47,8 @@ interface Management1
 
 | Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
 | ----------- | ------------ | ---------- | -------- | -------- | --------- |
-| IKE-1 | 24 | aes256 | 20 | 192.168.100.1 | - |
-| IKE-2 | - | - | - | - | - |
-| IKE-3 | - | - | - | - | sha512 |
-| IKE-4 | - | - | - | - | md5 |
+| IKE-1 | 24 | aes256 | 20 | 192.168.100.1 | md5 |
+| IKE-2 | - | - | - | - | sha512 |
 | IKE-FQDN | - | - | - | fqdn.local | - |
 | IKE-UFQDN | - | - | - | my.awesome@fqdn.local | - |
 
@@ -87,18 +85,14 @@ interface Management1
 !
 ip security
    ike policy IKE-1
+      integrity md5
       ike-lifetime 24
       encryption aes256
       dh-group 20
       local-id 192.168.100.1
    !
    ike policy IKE-2
-   !
-   ike policy IKE-3
       integrity sha512
-   !
-   ike policy IKE-4
-      integrity md5
    !
    ike policy IKE-FQDN
       local-id fqdn fqdn.local

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -45,12 +45,13 @@ interface Management1
 
 ### IKE policies
 
-| Policy name | IKE lifetime | Encryption | DH group | Local ID |
-| ----------- | ------------ | ---------- | -------- | -------- |
-| IKE-1 | 24 | aes256 | 20 | 192.168.100.1 |
-| IKE-2 | - | - | - | - |
-| IKE-FQDN | - | - | - | fqdn.local |
-| IKE-UFQDN | - | - | - | my.awesome@fqdn.local |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
+| ----------- | ------------ | ---------- | -------- | -------- | --------- |
+| IKE-1 | 24 | aes256 | 20 | 192.168.100.1 | - |
+| IKE-2 | - | - | - | - | - |
+| IKE-3 | - | - | - | - | sha512 |
+| IKE-FQDN | - | - | - | fqdn.local | - |
+| IKE-UFQDN | - | - | - | my.awesome@fqdn.local | - |
 
 ### Security Association policies
 
@@ -91,6 +92,9 @@ ip security
       local-id 192.168.100.1
    !
    ike policy IKE-2
+   !
+   ike policy IKE-3
+      integrity sha512
    !
    ike policy IKE-FQDN
       local-id fqdn fqdn.local

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/ip-security.md
@@ -50,6 +50,7 @@ interface Management1
 | IKE-1 | 24 | aes256 | 20 | 192.168.100.1 | - |
 | IKE-2 | - | - | - | - | - |
 | IKE-3 | - | - | - | - | sha512 |
+| IKE-4 | - | - | - | - | md5 |
 | IKE-FQDN | - | - | - | fqdn.local | - |
 | IKE-UFQDN | - | - | - | my.awesome@fqdn.local | - |
 
@@ -95,6 +96,9 @@ ip security
    !
    ike policy IKE-3
       integrity sha512
+   !
+   ike policy IKE-4
+      integrity md5
    !
    ike policy IKE-FQDN
       local-id fqdn fqdn.local

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -1,18 +1,14 @@
 !
 ip security
    ike policy IKE-1
+      integrity md5
       ike-lifetime 24
       encryption aes256
       dh-group 20
       local-id 192.168.100.1
    !
    ike policy IKE-2
-   !
-   ike policy IKE-3
       integrity sha512
-   !
-   ike policy IKE-4
-      integrity md5
    !
    ike policy IKE-FQDN
       local-id fqdn fqdn.local

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -11,6 +11,9 @@ ip security
    ike policy IKE-3
       integrity sha512
    !
+   ike policy IKE-4
+      integrity md5
+   !
    ike policy IKE-FQDN
       local-id fqdn fqdn.local
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/ip-security.cfg
@@ -8,6 +8,9 @@ ip security
    !
    ike policy IKE-2
    !
+   ike policy IKE-3
+      integrity sha512
+   !
    ike policy IKE-FQDN
       local-id fqdn fqdn.local
    !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -14,6 +14,8 @@ ip_security:
       local_id_fqdn: my.awesome@fqdn.local
       # local_id won't be rendered as local_id_fqdn takes precedence
       local_id: 192.168.42.42
+    - name: IKE-3
+      integrity: sha512
   sa_policies:
     # Testing sorting
     - name: SA-7

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -3,7 +3,9 @@ ip_security:
   ike_policies:
     # Testing sorting
     - name: IKE-2
+      integrity: sha512
     - name: IKE-1
+      integrity: md5
       local_id: 192.168.100.1
       ike_lifetime: 24
       encryption: aes256
@@ -14,10 +16,6 @@ ip_security:
       local_id_fqdn: my.awesome@fqdn.local
       # local_id won't be rendered as local_id_fqdn takes precedence
       local_id: 192.168.42.42
-    - name: IKE-3
-      integrity: sha512
-    - name: IKE-4
-      integrity: md5
   sa_policies:
     # Testing sorting
     - name: SA-7

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/ip-security.yml
@@ -16,6 +16,8 @@ ip_security:
       local_id: 192.168.42.42
     - name: IKE-3
       integrity: sha512
+    - name: IKE-4
+      integrity: md5
   sa_policies:
     # Testing sorting
     - name: SA-7

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -15,6 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ike_lifetime</samp>](## "ip_security.ike_policies.[].ike_lifetime") | Integer |  |  | Min: 1<br>Max: 24 | IKE lifetime in hours. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- <code>3des</code><br>- <code>aes128</code><br>- <code>aes256</code> | IKE encryption algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dh_group</samp>](## "ip_security.ike_policies.[].dh_group") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>5</code><br>- <code>14</code><br>- <code>15</code><br>- <code>16</code><br>- <code>17</code><br>- <code>20</code><br>- <code>21</code><br>- <code>24</code> | Diffie-Hellman group for the key exchange. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.ike_policies.[].integrity") | String |  |  | Valid Values:<br>- <code>sha1</code><br>- <code>sha256</code><br>- <code>sha384</code><br>- <code>sha512</code> | integrity algorithm |
     | [<samp>&nbsp;&nbsp;sa_policies</samp>](## "ip_security.sa_policies") | List, items: Dictionary |  |  |  | Security Association policies. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sa_lifetime</samp>](## "ip_security.sa_policies.[].sa_lifetime") | Dictionary |  |  |  |  |
@@ -68,6 +69,9 @@
 
           # Diffie-Hellman group for the key exchange.
           dh_group: <int; 1 | 2 | 5 | 14 | 15 | 16 | 17 | 20 | 21 | 24>
+
+          # integrity algorithm
+          integrity: <str; "sha1" | "sha256" | "sha384" | "sha512">
 
       # Security Association policies.
       sa_policies:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-security.md
@@ -15,7 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ike_lifetime</samp>](## "ip_security.ike_policies.[].ike_lifetime") | Integer |  |  | Min: 1<br>Max: 24 | IKE lifetime in hours. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;encryption</samp>](## "ip_security.ike_policies.[].encryption") | String |  |  | Valid Values:<br>- <code>3des</code><br>- <code>aes128</code><br>- <code>aes256</code> | IKE encryption algorithm. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dh_group</samp>](## "ip_security.ike_policies.[].dh_group") | Integer |  |  | Valid Values:<br>- <code>1</code><br>- <code>2</code><br>- <code>5</code><br>- <code>14</code><br>- <code>15</code><br>- <code>16</code><br>- <code>17</code><br>- <code>20</code><br>- <code>21</code><br>- <code>24</code> | Diffie-Hellman group for the key exchange. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.ike_policies.[].integrity") | String |  |  | Valid Values:<br>- <code>sha1</code><br>- <code>sha256</code><br>- <code>sha384</code><br>- <code>sha512</code> | integrity algorithm |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;integrity</samp>](## "ip_security.ike_policies.[].integrity") | String |  |  | Valid Values:<br>- <code>md5</code><br>- <code>sha1</code><br>- <code>sha256</code><br>- <code>sha384</code><br>- <code>sha512</code> | Integrity algorithm. |
     | [<samp>&nbsp;&nbsp;sa_policies</samp>](## "ip_security.sa_policies") | List, items: Dictionary |  |  |  | Security Association policies. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ip_security.sa_policies.[].name") | String | Required, Unique |  |  | Name of the SA policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sa_lifetime</samp>](## "ip_security.sa_policies.[].sa_lifetime") | Dictionary |  |  |  |  |
@@ -70,8 +70,8 @@
           # Diffie-Hellman group for the key exchange.
           dh_group: <int; 1 | 2 | 5 | 14 | 15 | 16 | 17 | 20 | 21 | 24>
 
-          # integrity algorithm
-          integrity: <str; "sha1" | "sha256" | "sha384" | "sha512">
+          # Integrity algorithm.
+          integrity: <str; "md5" | "sha1" | "sha256" | "sha384" | "sha512">
 
       # Security Association policies.
       sa_policies:

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-security.j2
@@ -15,10 +15,10 @@
 
 ### IKE policies
 
-| Policy name | IKE lifetime | Encryption | DH group | Local ID |
-| ----------- | ------------ | ---------- | -------- | -------- |
+| Policy name | IKE lifetime | Encryption | DH group | Local ID | Integrity |
+| ----------- | ------------ | ---------- | -------- | -------- | --------- |
 {%         for ike_policy in ip_security.ike_policies | arista.avd.natural_sort('name') %}
-| {{ ike_policy.name }} | {{ ike_policy.ike_lifetime | arista.avd.default("-") }} | {{ ike_policy.encryption | arista.avd.default("-") }} | {{ ike_policy.dh_group | arista.avd.default("-") }} | {{ ike_policy.local_id_fqdn | arista.avd.default(ike_policy.local_id, "-") }} |
+| {{ ike_policy.name }} | {{ ike_policy.ike_lifetime | arista.avd.default("-") }} | {{ ike_policy.encryption | arista.avd.default("-") }} | {{ ike_policy.dh_group | arista.avd.default("-") }} | {{ ike_policy.local_id_fqdn | arista.avd.default(ike_policy.local_id, "-") }} | {{ ike_policy.integrity | arista.avd.default("-") }} |
 {%         endfor %}
 {%     endif %}
 {%     if ip_security.sa_policies is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-security.j2
@@ -26,6 +26,9 @@ ip security
 {%         elif ike_policy.local_id is arista.avd.defined %}
       local-id {{ ike_policy.local_id }}
 {%         endif %}
+{%         if ike_policy.integrity is arista.avd.defined %}
+      integrity {{ ike_policy.integrity }}
+{%         endif %}
 {%     endfor %}
 {%     for sa_policy in ip_security.sa_policies | arista.avd.natural_sort('name') %}
    !

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-security.j2
@@ -12,6 +12,9 @@ ip security
    !
 {%         endif %}
    ike policy {{ ike_policy.name }}
+{%         if ike_policy.integrity is arista.avd.defined %}
+      integrity {{ ike_policy.integrity }}
+{%         endif %}
 {%         if ike_policy.ike_lifetime is arista.avd.defined %}
       ike-lifetime {{ ike_policy.ike_lifetime }}
 {%         endif %}
@@ -25,9 +28,6 @@ ip security
       local-id fqdn {{ ike_policy.local_id_fqdn }}
 {%         elif ike_policy.local_id is arista.avd.defined %}
       local-id {{ ike_policy.local_id }}
-{%         endif %}
-{%         if ike_policy.integrity is arista.avd.defined %}
-      integrity {{ ike_policy.integrity }}
 {%         endif %}
 {%     endfor %}
 {%     for sa_policy in ip_security.sa_policies | arista.avd.natural_sort('name') %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -5509,6 +5509,14 @@ keys:
               - 21
               - 24
               description: Diffie-Hellman group for the key exchange.
+            integrity:
+              type: str
+              valid_values:
+              - sha1
+              - sha256
+              - sha384
+              - sha512
+              description: integrity algorithm
       sa_policies:
         type: list
         description: Security Association policies.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -5512,11 +5512,12 @@ keys:
             integrity:
               type: str
               valid_values:
+              - md5
               - sha1
               - sha256
               - sha384
               - sha512
-              description: integrity algorithm
+              description: Integrity algorithm.
       sa_policies:
         type: list
         description: Security Association policies.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
@@ -53,11 +53,12 @@ keys:
             integrity:
               type: str
               valid_values:
+                - md5
                 - sha1
                 - sha256
                 - sha384
                 - sha512
-              description: integrity algorithm
+              description: Integrity algorithm.
       sa_policies:
         type: list
         description: Security Association policies.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
@@ -50,6 +50,14 @@ keys:
                 - str
               valid_values: [1, 2, 5, 14, 15, 16, 17, 20, 21, 24]
               description: Diffie-Hellman group for the key exchange.
+            integrity:
+              type: str
+              valid_values:
+                - sha1
+                - sha256
+                - sha384
+                - sha512
+              description: integrity algorithm
       sa_policies:
         type: list
         description: Security Association policies.


### PR DESCRIPTION
## Change Summary

Adding `integrity` key under `ike policies`

## Related Issue(s)

Fixes #4440 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
```yaml
ip_security:
  ike_policies:
    - name: CP-IKE-POLICY
      integrity: sha512
```

## How to test
`molecule converge -s eos_cli_config_gen -- --limit ip-security `

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
