### PR TITLE
Fix(eos_designs)!: Endpoints PoE and 802.1x configuration for port-channel members

### DIFF
--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -401,6 +401,44 @@ It is possible to forcefully add or remove BGP configuration per VRF by setting:
           enabled: <bool>  # <-- New optional setting to either always or never configure BGP for the VRF
 ```
 
+### Connected endpoints and network ports now renders PoE and 802.1x configuration for port-channel members and ignores PoE and 802.1x from LACP fallback individual profile
+
+With AVD version 5.0.0, port-channel members generated from connected endpoints or `network_ports` will now include 802.1x (`dot1x`) and PoE (`poe`) configuration.
+Previously the member interface configuration only included `dot1x` or `poe` if it was defined under the port profile set in `lacp_fallback.individual.profile`.
+The LACP fallback individual profiles now ignores any `dot1x` or `poe` settings.
+
+It may be required to move the `dot1x` and `poe` settings from the fallback profile to the adapter profile:
+
+```diff
+ port_profiles:
+   - name: MY_LACP_INDIVIDUAL_FALLBACK_PROFILE
+     <...>
+-    poe:
+-      <...>
+-    dot1x:
+-      <...>
+   - name: MY_SERVER_PROFILE
+     <...>
++    poe:
++      <...>
++    dot1x:
++      <...>
+
+servers:
+  - name: MYSERVER1
+    adapters:
+      - <...>
+        profile: MY_SERVER_PROFILE
+        port_channel:
+          <...>
+          lacp_fallback:
+            mode: individual
+            individual:
+              profile: MY_LACP_INDIVIDUAL_FALLBACK_PROFILE
+```
+
+No changes are needed if the LACP fallback individual profile is the same as the adapter profile
+
 ### Default interface descriptions are changed for more consistency
 
 With AVD version 5.0.0, the default interface descriptions have been changed to improve consistency. The detailed changes are described in the subsections below.

--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -404,7 +404,7 @@ It is possible to forcefully add or remove BGP configuration per VRF by setting:
 ### Connected endpoints and network ports now renders PoE and 802.1x configuration for port-channel members and ignores PoE and 802.1x from LACP fallback individual profile
 
 With AVD version 5.0.0, port-channel members generated from connected endpoints or `network_ports` will now include 802.1x (`dot1x`) and PoE (`poe`) configuration.
-Previously the member interface configuration only included `dot1x` or `poe` if it was defined under the port profile set in `lacp_fallback.individual.profile`.
+Previously, the member interface configuration only included `dot1x` or `poe` if it was defined under the port profile set in `lacp_fallback.individual.profile`.
 The LACP fallback individual profiles now ignores any `dot1x` or `poe` settings.
 
 It may be required to move the `dot1x` and `poe` settings from the fallback profile to the adapter profile:

--- a/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/porting-guides/5.x.x.md
@@ -437,7 +437,7 @@ servers:
               profile: MY_LACP_INDIVIDUAL_FALLBACK_PROFILE
 ```
 
-No changes are needed if the LACP fallback individual profile is the same as the adapter profile
+No changes are needed if the LACP fallback individual profile is the same as the adapter profile.
 
 ### Default interface descriptions are changed for more consistency
 

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
@@ -142,16 +142,6 @@ ethernet_interfaces:
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -169,21 +159,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -201,21 +191,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -233,21 +223,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -265,21 +255,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -297,21 +287,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -329,21 +319,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -361,21 +351,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -393,21 +383,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -425,21 +415,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -457,21 +447,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -489,21 +479,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -521,21 +511,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -553,21 +543,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -585,21 +575,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -617,21 +607,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -649,21 +639,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -681,21 +671,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -713,21 +703,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -745,21 +735,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -777,21 +767,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -809,21 +799,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -841,21 +831,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -873,21 +863,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -905,21 +895,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -937,21 +927,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -969,21 +959,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1001,21 +991,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1033,21 +1023,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1065,21 +1055,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1097,21 +1087,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1129,21 +1119,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1161,21 +1151,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1193,21 +1183,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1225,21 +1215,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1257,21 +1247,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1289,21 +1279,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1321,21 +1311,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1353,21 +1343,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1385,21 +1375,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1417,21 +1407,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1449,21 +1439,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1481,21 +1471,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1513,21 +1503,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1545,21 +1535,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1577,21 +1567,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1609,21 +1599,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1641,21 +1631,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1673,6 +1663,16 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 mlag_configuration:
   domain_id: IDF1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
@@ -142,16 +142,6 @@ ethernet_interfaces:
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -169,21 +159,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -201,21 +191,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -233,21 +223,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -265,21 +255,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -297,21 +287,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -329,21 +319,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -361,21 +351,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -393,21 +383,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -425,21 +415,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -457,21 +447,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -489,21 +479,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -521,21 +511,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -553,21 +543,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -585,21 +575,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -617,21 +607,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -649,21 +639,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -681,21 +671,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -713,21 +703,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -745,21 +735,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -777,21 +767,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -809,21 +799,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -841,21 +831,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -873,21 +863,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -905,21 +895,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -937,21 +927,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -969,21 +959,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1001,21 +991,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1033,21 +1023,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1065,21 +1055,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1097,21 +1087,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1129,21 +1119,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1161,21 +1151,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1193,21 +1183,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1225,21 +1215,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1257,21 +1247,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1289,21 +1279,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1321,21 +1311,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1353,21 +1343,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1385,21 +1375,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1417,21 +1407,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1449,21 +1439,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1481,21 +1471,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1513,21 +1503,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1545,21 +1535,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1577,21 +1567,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1609,21 +1599,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1641,21 +1631,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF1 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 110
-    phone:
-      trunk: untagged
-      vlan: 120
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1673,6 +1663,16 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 130
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 110
+    phone:
+      trunk: untagged
+      vlan: 120
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 mlag_configuration:
   domain_id: IDF1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
@@ -82,16 +82,6 @@ ethernet_interfaces:
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -119,21 +109,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -161,21 +151,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -203,21 +193,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -245,21 +235,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -287,21 +277,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -329,21 +319,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -371,21 +361,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -413,21 +403,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -455,21 +445,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -497,21 +487,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -539,21 +529,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -581,21 +571,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -623,21 +613,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -665,21 +655,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -707,21 +697,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -749,21 +739,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -791,21 +781,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -833,21 +823,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -875,21 +865,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -917,21 +907,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -959,21 +949,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1001,21 +991,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1043,21 +1033,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1085,21 +1075,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1127,21 +1117,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1169,21 +1159,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1211,21 +1201,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1253,21 +1243,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1295,21 +1285,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1337,21 +1327,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1379,21 +1369,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1421,21 +1411,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1463,21 +1453,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1505,21 +1495,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1547,21 +1537,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1589,21 +1579,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1631,21 +1621,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1673,21 +1663,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1715,21 +1705,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1757,21 +1747,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1799,21 +1789,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1841,21 +1831,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1883,21 +1873,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1925,21 +1915,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1967,21 +1957,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2009,21 +1999,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2051,21 +2041,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3/48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2093,21 +2083,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/1
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2135,21 +2125,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2177,21 +2167,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2219,21 +2209,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2261,21 +2251,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2303,21 +2293,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2345,21 +2335,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2387,21 +2377,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2429,21 +2419,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2471,21 +2461,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2513,21 +2503,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2555,21 +2545,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2597,21 +2587,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2639,21 +2629,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2681,21 +2671,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2723,21 +2713,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2765,21 +2755,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2807,21 +2797,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2849,21 +2839,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2891,21 +2881,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2933,21 +2923,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2975,21 +2965,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3017,21 +3007,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3059,21 +3049,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3101,21 +3091,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3143,21 +3133,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3185,21 +3175,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3227,21 +3217,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3269,21 +3259,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3311,21 +3301,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3353,21 +3343,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3395,21 +3385,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3437,21 +3427,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3479,21 +3469,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3521,21 +3511,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3563,21 +3553,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3605,21 +3595,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3647,21 +3637,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3689,21 +3679,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3731,21 +3721,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3773,21 +3763,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3815,21 +3805,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3857,21 +3847,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3899,21 +3889,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3941,21 +3931,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3983,21 +3973,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4025,21 +4015,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4067,21 +4057,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4/48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4109,21 +4099,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/1
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4151,21 +4141,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4193,21 +4183,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4235,21 +4225,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4277,21 +4267,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4319,21 +4309,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4361,21 +4351,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4403,21 +4393,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4445,21 +4435,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4487,21 +4477,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4529,21 +4519,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4571,21 +4561,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4613,21 +4603,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4655,21 +4645,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4697,21 +4687,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4739,21 +4729,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4781,21 +4771,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4823,21 +4813,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4865,21 +4855,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4907,21 +4897,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4949,21 +4939,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -4991,21 +4981,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5033,21 +5023,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5075,21 +5065,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5117,21 +5107,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5159,21 +5149,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5201,21 +5191,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5243,21 +5233,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5285,21 +5275,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5327,21 +5317,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5369,21 +5359,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5411,21 +5401,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5453,21 +5443,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5495,21 +5485,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5537,21 +5527,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5579,21 +5569,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5621,21 +5611,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5663,21 +5653,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5705,21 +5695,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5747,21 +5737,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5789,21 +5779,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5831,21 +5821,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5873,21 +5863,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5915,21 +5905,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5957,21 +5947,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -5999,21 +5989,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6041,21 +6031,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6083,21 +6073,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5/48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6125,21 +6115,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/1
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6167,21 +6157,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6209,21 +6199,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6251,21 +6241,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6293,21 +6283,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6335,21 +6325,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6377,21 +6367,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6419,21 +6409,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6461,21 +6451,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6503,21 +6493,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6545,21 +6535,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6587,21 +6577,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6629,21 +6619,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6671,21 +6661,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6713,21 +6703,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6755,21 +6745,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6797,21 +6787,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6839,21 +6829,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6881,21 +6871,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6923,21 +6913,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -6965,21 +6955,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7007,21 +6997,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7049,21 +7039,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7091,21 +7081,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7133,21 +7123,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7175,21 +7165,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7217,21 +7207,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7259,21 +7249,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7301,21 +7291,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7343,21 +7333,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7385,21 +7375,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7427,21 +7417,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7469,21 +7459,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7511,21 +7501,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7553,21 +7543,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7595,21 +7585,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7637,21 +7627,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7679,21 +7669,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7721,21 +7711,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7763,21 +7753,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7805,21 +7795,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7847,21 +7837,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7889,21 +7879,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7931,21 +7921,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -7973,21 +7963,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8015,21 +8005,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8057,21 +8047,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8099,21 +8089,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6/48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8141,21 +8131,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/1
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8183,21 +8173,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8225,21 +8215,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8267,21 +8257,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8309,21 +8299,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8351,21 +8341,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8393,21 +8383,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8435,21 +8425,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8477,21 +8467,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8519,21 +8509,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8561,21 +8551,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8603,21 +8593,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8645,21 +8635,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8687,21 +8677,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8729,21 +8719,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8771,21 +8761,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8813,21 +8803,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8855,21 +8845,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8897,21 +8887,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8939,21 +8929,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -8981,21 +8971,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9023,21 +9013,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9065,21 +9055,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9107,21 +9097,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9149,21 +9139,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9191,21 +9181,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9233,21 +9223,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9275,21 +9265,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9317,21 +9307,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9359,21 +9349,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9401,21 +9391,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9443,21 +9433,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9485,21 +9475,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9527,21 +9517,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9569,21 +9559,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9611,21 +9601,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9653,21 +9643,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9695,21 +9685,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9737,21 +9727,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9779,21 +9769,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9821,21 +9811,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9863,21 +9853,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9905,21 +9895,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9947,21 +9937,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -9989,21 +9979,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -10031,21 +10021,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -10073,21 +10063,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -10115,21 +10105,21 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7/48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF2 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 210
-    phone:
-      trunk: untagged
-      vlan: 220
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -10157,6 +10147,16 @@ ethernet_interfaces:
       action: power-off
     limit:
       class: 4
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 210
+    phone:
+      trunk: untagged
+      vlan: 220
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 port_channel_interfaces:
 - name: Port-Channel11
   description: L2_SPINES_Port-Channel491

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
@@ -205,16 +205,6 @@ ethernet_interfaces:
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -232,21 +222,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -264,21 +254,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -296,21 +286,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -328,21 +318,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -360,21 +350,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -392,21 +382,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -424,21 +414,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -456,21 +446,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -488,21 +478,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -520,21 +510,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -552,21 +542,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -584,21 +574,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -616,21 +606,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -648,21 +638,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -680,21 +670,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -712,21 +702,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -744,21 +734,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -776,21 +766,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -808,21 +798,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -840,21 +830,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -872,21 +862,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -904,21 +894,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -936,21 +926,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -968,21 +958,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1000,21 +990,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1032,21 +1022,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1064,21 +1054,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1096,21 +1086,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1128,21 +1118,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1160,21 +1150,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1192,21 +1182,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1224,21 +1214,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1256,21 +1246,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1288,21 +1278,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1320,21 +1310,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1352,21 +1342,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1384,21 +1374,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1416,21 +1406,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1448,21 +1438,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1480,21 +1470,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1512,21 +1502,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1544,21 +1534,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1576,21 +1566,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1608,21 +1598,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1640,21 +1630,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1672,21 +1662,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1704,21 +1694,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1736,21 +1726,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet49
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1768,21 +1758,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet50
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1800,21 +1790,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet51
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1832,21 +1822,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet52
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1864,21 +1854,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet53
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1896,21 +1886,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet54
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1928,21 +1918,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet55
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1960,21 +1950,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet56
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1992,21 +1982,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet57
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2024,21 +2014,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet58
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2056,21 +2046,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet59
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2088,21 +2078,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet60
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2120,21 +2110,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet61
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2152,21 +2142,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet62
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2184,21 +2174,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet63
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2216,21 +2206,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet64
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2248,21 +2238,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet65
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2280,21 +2270,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet66
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2312,21 +2302,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet67
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2344,21 +2334,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet68
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2376,21 +2366,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet69
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2408,21 +2398,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet70
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2440,21 +2430,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet71
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2472,21 +2462,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet72
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2504,21 +2494,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet73
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2536,21 +2526,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet74
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2568,21 +2558,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet75
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2600,21 +2590,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet76
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2632,21 +2622,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet77
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2664,21 +2654,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet78
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2696,21 +2686,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet79
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2728,21 +2718,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet80
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2760,21 +2750,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet81
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2792,21 +2782,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet82
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2824,21 +2814,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet83
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2856,21 +2846,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet84
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2888,21 +2878,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet85
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2920,21 +2910,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet86
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2952,21 +2942,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet87
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2984,21 +2974,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet88
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3016,21 +3006,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet89
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3048,21 +3038,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet90
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3080,21 +3070,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet91
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3112,21 +3102,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet92
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3144,21 +3134,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet93
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3176,21 +3166,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet94
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3208,21 +3198,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet95
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3240,21 +3230,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet96
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3272,6 +3262,16 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 mlag_configuration:
   domain_id: IDF3_AGG
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
@@ -205,16 +205,6 @@ ethernet_interfaces:
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -232,21 +222,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -264,21 +254,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -296,21 +286,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -328,21 +318,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -360,21 +350,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -392,21 +382,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -424,21 +414,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -456,21 +446,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -488,21 +478,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -520,21 +510,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -552,21 +542,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -584,21 +574,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -616,21 +606,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -648,21 +638,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -680,21 +670,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -712,21 +702,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -744,21 +734,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -776,21 +766,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -808,21 +798,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -840,21 +830,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -872,21 +862,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -904,21 +894,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -936,21 +926,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -968,21 +958,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1000,21 +990,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1032,21 +1022,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1064,21 +1054,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1096,21 +1086,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1128,21 +1118,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1160,21 +1150,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1192,21 +1182,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1224,21 +1214,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1256,21 +1246,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1288,21 +1278,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1320,21 +1310,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1352,21 +1342,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1384,21 +1374,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1416,21 +1406,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1448,21 +1438,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1480,21 +1470,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1512,21 +1502,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1544,21 +1534,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1576,21 +1566,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1608,21 +1598,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1640,21 +1630,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1672,21 +1662,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1704,21 +1694,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1736,21 +1726,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet49
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1768,21 +1758,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet50
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1800,21 +1790,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet51
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1832,21 +1822,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet52
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1864,21 +1854,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet53
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1896,21 +1886,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet54
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1928,21 +1918,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet55
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1960,21 +1950,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet56
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1992,21 +1982,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet57
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2024,21 +2014,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet58
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2056,21 +2046,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet59
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2088,21 +2078,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet60
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2120,21 +2110,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet61
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2152,21 +2142,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet62
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2184,21 +2174,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet63
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2216,21 +2206,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet64
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2248,21 +2238,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet65
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2280,21 +2270,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet66
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2312,21 +2302,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet67
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2344,21 +2334,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet68
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2376,21 +2366,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet69
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2408,21 +2398,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet70
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2440,21 +2430,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet71
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2472,21 +2462,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet72
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2504,21 +2494,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet73
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2536,21 +2526,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet74
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2568,21 +2558,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet75
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2600,21 +2590,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet76
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2632,21 +2622,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet77
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2664,21 +2654,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet78
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2696,21 +2686,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet79
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2728,21 +2718,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet80
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2760,21 +2750,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet81
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2792,21 +2782,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet82
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2824,21 +2814,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet83
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2856,21 +2846,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet84
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2888,21 +2878,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet85
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2920,21 +2910,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet86
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2952,21 +2942,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet87
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2984,21 +2974,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet88
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3016,21 +3006,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet89
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3048,21 +3038,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet90
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3080,21 +3070,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet91
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3112,21 +3102,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet92
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3144,21 +3134,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet93
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3176,21 +3166,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet94
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3208,21 +3198,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet95
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3240,21 +3230,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet96
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3272,6 +3262,16 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 mlag_configuration:
   domain_id: IDF3_AGG
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
@@ -82,16 +82,6 @@ ethernet_interfaces:
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -109,21 +99,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -141,21 +131,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -173,21 +163,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -205,21 +195,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -237,21 +227,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -269,21 +259,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -301,21 +291,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -333,21 +323,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -365,21 +355,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -397,21 +387,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -429,21 +419,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -461,21 +451,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -493,21 +483,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -525,21 +515,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -557,21 +547,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -589,21 +579,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -621,21 +611,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -653,21 +643,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -685,21 +675,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -717,21 +707,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -749,21 +739,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -781,21 +771,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -813,21 +803,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -845,21 +835,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -877,21 +867,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -909,21 +899,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -941,21 +931,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -973,21 +963,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1005,21 +995,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1037,21 +1027,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1069,21 +1059,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1101,21 +1091,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1133,21 +1123,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1165,21 +1155,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1197,21 +1187,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1229,21 +1219,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1261,21 +1251,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1293,21 +1283,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1325,21 +1315,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1357,21 +1347,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1389,21 +1379,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1421,21 +1411,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1453,21 +1443,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1485,21 +1475,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1517,21 +1507,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1549,21 +1539,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1581,21 +1571,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1613,21 +1603,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet49
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1645,21 +1635,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet50
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1677,21 +1667,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet51
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1709,21 +1699,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet52
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1741,21 +1731,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet53
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1773,21 +1763,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet54
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1805,21 +1795,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet55
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1837,21 +1827,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet56
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1869,21 +1859,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet57
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1901,21 +1891,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet58
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1933,21 +1923,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet59
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1965,21 +1955,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet60
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1997,21 +1987,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet61
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2029,21 +2019,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet62
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2061,21 +2051,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet63
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2093,21 +2083,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet64
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2125,21 +2115,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet65
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2157,21 +2147,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet66
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2189,21 +2179,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet67
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2221,21 +2211,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet68
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2253,21 +2243,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet69
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2285,21 +2275,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet70
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2317,21 +2307,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet71
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2349,21 +2339,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet72
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2381,21 +2371,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet73
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2413,21 +2403,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet74
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2445,21 +2435,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet75
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2477,21 +2467,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet76
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2509,21 +2499,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet77
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2541,21 +2531,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet78
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2573,21 +2563,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet79
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2605,21 +2595,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet80
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2637,21 +2627,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet81
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2669,21 +2659,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet82
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2701,21 +2691,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet83
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2733,21 +2723,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet84
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2765,21 +2755,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet85
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2797,21 +2787,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet86
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2829,21 +2819,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet87
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2861,21 +2851,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet88
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2893,21 +2883,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet89
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2925,21 +2915,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet90
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2957,21 +2947,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet91
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2989,21 +2979,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet92
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3021,21 +3011,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet93
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3053,21 +3043,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet94
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3085,21 +3075,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet95
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3117,21 +3107,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet96
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3149,6 +3139,16 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 port_channel_interfaces:
 - name: Port-Channel971
   description: L2_IDF3_AGG_Port-Channel973

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
@@ -82,16 +82,6 @@ ethernet_interfaces:
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -109,21 +99,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -141,21 +131,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -173,21 +163,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -205,21 +195,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -237,21 +227,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -269,21 +259,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -301,21 +291,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -333,21 +323,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -365,21 +355,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -397,21 +387,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -429,21 +419,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -461,21 +451,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -493,21 +483,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -525,21 +515,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -557,21 +547,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -589,21 +579,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -621,21 +611,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -653,21 +643,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -685,21 +675,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -717,21 +707,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -749,21 +739,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -781,21 +771,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -813,21 +803,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -845,21 +835,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -877,21 +867,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -909,21 +899,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -941,21 +931,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -973,21 +963,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1005,21 +995,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1037,21 +1027,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1069,21 +1059,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1101,21 +1091,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1133,21 +1123,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1165,21 +1155,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1197,21 +1187,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1229,21 +1219,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1261,21 +1251,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1293,21 +1283,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1325,21 +1315,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1357,21 +1347,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1389,21 +1379,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1421,21 +1411,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1453,21 +1443,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1485,21 +1475,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1517,21 +1507,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1549,21 +1539,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1581,21 +1571,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1613,21 +1603,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet49
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1645,21 +1635,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet50
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1677,21 +1667,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet51
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1709,21 +1699,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet52
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1741,21 +1731,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet53
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1773,21 +1763,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet54
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1805,21 +1795,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet55
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1837,21 +1827,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet56
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1869,21 +1859,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet57
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1901,21 +1891,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet58
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1933,21 +1923,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet59
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1965,21 +1955,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet60
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1997,21 +1987,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet61
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2029,21 +2019,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet62
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2061,21 +2051,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet63
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2093,21 +2083,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet64
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2125,21 +2115,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet65
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2157,21 +2147,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet66
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2189,21 +2179,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet67
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2221,21 +2211,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet68
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2253,21 +2243,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet69
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2285,21 +2275,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet70
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2317,21 +2307,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet71
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2349,21 +2339,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet72
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2381,21 +2371,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet73
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2413,21 +2403,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet74
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2445,21 +2435,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet75
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2477,21 +2467,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet76
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2509,21 +2499,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet77
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2541,21 +2531,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet78
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2573,21 +2563,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet79
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2605,21 +2595,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet80
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2637,21 +2627,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet81
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2669,21 +2659,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet82
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2701,21 +2691,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet83
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2733,21 +2723,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet84
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2765,21 +2755,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet85
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2797,21 +2787,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet86
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2829,21 +2819,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet87
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2861,21 +2851,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet88
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2893,21 +2883,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet89
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2925,21 +2915,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet90
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2957,21 +2947,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet91
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2989,21 +2979,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet92
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3021,21 +3011,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet93
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3053,21 +3043,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet94
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3085,21 +3075,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet95
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3117,21 +3107,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet96
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3149,6 +3139,16 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 port_channel_interfaces:
 - name: Port-Channel971
   description: L2_IDF3_AGG_Port-Channel974

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
@@ -82,16 +82,6 @@ ethernet_interfaces:
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -109,21 +99,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet2
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -141,21 +131,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet3
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -173,21 +163,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet4
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -205,21 +195,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet5
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -237,21 +227,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet6
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -269,21 +259,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet7
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -301,21 +291,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet8
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -333,21 +323,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet9
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -365,21 +355,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet10
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -397,21 +387,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet11
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -429,21 +419,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet12
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -461,21 +451,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet13
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -493,21 +483,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet14
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -525,21 +515,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet15
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -557,21 +547,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet16
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -589,21 +579,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet17
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -621,21 +611,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet18
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -653,21 +643,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet19
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -685,21 +675,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet20
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -717,21 +707,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet21
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -749,21 +739,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet22
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -781,21 +771,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet23
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -813,21 +803,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet24
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -845,21 +835,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet25
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -877,21 +867,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet26
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -909,21 +899,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet27
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -941,21 +931,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet28
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -973,21 +963,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet29
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1005,21 +995,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet30
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1037,21 +1027,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet31
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1069,21 +1059,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet32
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1101,21 +1091,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet33
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1133,21 +1123,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet34
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1165,21 +1155,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet35
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1197,21 +1187,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet36
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1229,21 +1219,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet37
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1261,21 +1251,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet38
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1293,21 +1283,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet39
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1325,21 +1315,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet40
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1357,21 +1347,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet41
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1389,21 +1379,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet42
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1421,21 +1411,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet43
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1453,21 +1443,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet44
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1485,21 +1475,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet45
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1517,21 +1507,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet46
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1549,21 +1539,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet47
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1581,21 +1571,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet48
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1613,21 +1603,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet49
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1645,21 +1635,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet50
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1677,21 +1667,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet51
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1709,21 +1699,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet52
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1741,21 +1731,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet53
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1773,21 +1763,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet54
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1805,21 +1795,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet55
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1837,21 +1827,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet56
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1869,21 +1859,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet57
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1901,21 +1891,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet58
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1933,21 +1923,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet59
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1965,21 +1955,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet60
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -1997,21 +1987,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet61
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2029,21 +2019,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet62
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2061,21 +2051,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet63
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2093,21 +2083,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet64
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2125,21 +2115,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet65
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2157,21 +2147,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet66
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2189,21 +2179,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet67
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2221,21 +2211,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet68
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2253,21 +2243,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet69
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2285,21 +2275,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet70
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2317,21 +2307,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet71
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2349,21 +2339,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet72
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2381,21 +2371,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet73
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2413,21 +2403,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet74
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2445,21 +2435,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet75
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2477,21 +2467,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet76
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2509,21 +2499,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet77
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2541,21 +2531,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet78
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2573,21 +2563,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet79
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2605,21 +2595,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet80
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2637,21 +2627,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet81
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2669,21 +2659,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet82
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2701,21 +2691,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet83
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2733,21 +2723,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet84
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2765,21 +2755,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet85
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2797,21 +2787,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet86
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2829,21 +2819,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet87
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2861,21 +2851,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet88
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2893,21 +2883,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet89
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2925,21 +2915,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet90
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2957,21 +2947,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet91
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -2989,21 +2979,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet92
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3021,21 +3011,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet93
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3053,21 +3043,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet94
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3085,21 +3075,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet95
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3117,21 +3107,21 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 - name: Ethernet96
   peer_type: network_port
   port_profile: PP-DOT1X
   description: IDF3 Standard Port
   shutdown: false
-  switchport:
-    enabled: true
-    mode: trunk phone
-    trunk:
-      native_vlan: 310
-    phone:
-      trunk: untagged
-      vlan: 320
-  spanning_tree_portfast: edge
-  spanning_tree_bpduguard: enabled
   dot1x:
     port_control: auto
     reauthentication: true
@@ -3149,6 +3139,16 @@ ethernet_interfaces:
     authentication_failure:
       action: allow
       allow_vlan: 330
+  switchport:
+    enabled: true
+    mode: trunk phone
+    trunk:
+      native_vlan: 310
+    phone:
+      trunk: untagged
+      vlan: 320
+  spanning_tree_portfast: edge
+  spanning_tree_bpduguard: enabled
 port_channel_interfaces:
 - name: Port-Channel971
   description: L2_IDF3_AGG_Port-Channel981

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/connected_endpoints.cfg
@@ -61,6 +61,25 @@ interface Port-Channel15
    port-channel lacp fallback individual
    port-channel lacp fallback timeout 90
 !
+interface Port-Channel17
+   description SERVER_DOT1X_UNAUTHORIZED_PORT_CHANNEL
+   no shutdown
+   switchport trunk native vlan 123
+   switchport trunk allowed vlan 1,2,3,4,5,6,7,123,234
+   switchport mode trunk
+   switchport
+   ptp enable
+   ptp announce interval 0
+   ptp announce timeout 3
+   ptp delay-req interval -3
+   ptp role master
+   ptp sync-message interval -3
+   ptp transport ipv4
+   service-profile MYQOS
+   no sflow enable
+   spanning-tree portfast
+   spanning-tree bpdufilter enable
+!
 interface Ethernet1
    description Interface description server_OLD_SW-1/2_ENDPOINT_PORT1
    no shutdown
@@ -124,7 +143,6 @@ interface Ethernet12
    switchport mode trunk
    switchport
    channel-group 12 mode active
-   poe disabled
    ptp enable
    ptp announce interval 0
    ptp announce timeout 3
@@ -136,8 +154,6 @@ interface Ethernet12
    no sflow enable
    spanning-tree portfast
    spanning-tree bpdufilter enable
-   dot1x unauthorized access vlan membership egress
-   dot1x unauthorized native vlan membership egress
 !
 interface Ethernet13
    description SERVER_INDIVIDUAL_1
@@ -147,7 +163,6 @@ interface Ethernet13
    switchport mode trunk
    switchport
    channel-group 12 mode active
-   poe disabled
    ptp enable
    ptp announce interval 0
    ptp announce timeout 3
@@ -159,8 +174,6 @@ interface Ethernet13
    no sflow enable
    spanning-tree portfast
    spanning-tree bpdufilter enable
-   dot1x unauthorized access vlan membership egress
-   dot1x unauthorized native vlan membership egress
 !
 interface Ethernet14
    description SERVER_DOT1X_UNAUTHORIZED
@@ -203,6 +216,22 @@ interface Ethernet16
    switchport
    channel-group 15 mode active
    link tracking group LT_GROUP1 downstream
+!
+interface Ethernet17
+   description SERVER_DOT1X_UNAUTHORIZED_PORT_CHANNEL
+   no shutdown
+   channel-group 17 mode active
+   poe disabled
+   dot1x unauthorized access vlan membership egress
+   dot1x unauthorized native vlan membership egress
+!
+interface Ethernet18
+   description SERVER_DOT1X_UNAUTHORIZED_PORT_CHANNEL
+   no shutdown
+   channel-group 17 mode active
+   poe disabled
+   dot1x unauthorized access vlan membership egress
+   dot1x unauthorized native vlan membership egress
 no ip routing vrf MGMT
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -653,8 +653,6 @@ ethernet_interfaces:
   port_profile: DOT1X_PORT_PROFILE
   description: PC
   shutdown: false
-  switchport:
-    enabled: true
   dot1x:
     port_control: auto
     reauthentication: true
@@ -672,13 +670,13 @@ ethernet_interfaces:
       reauth_period: server
       tx_period: 3
     reauthorization_request_limit: 3
+  switchport:
+    enabled: true
 - name: Ethernet25
   peer_type: network_port
   port_profile: DOT1X_PORT_PROFILE
   description: PC
   shutdown: false
-  switchport:
-    enabled: true
   dot1x:
     port_control: auto
     reauthentication: true
@@ -696,6 +694,8 @@ ethernet_interfaces:
       reauth_period: server
       tx_period: 3
     reauthorization_request_limit: 3
+  switchport:
+    enabled: true
 - name: Ethernet10
   peer: server01_MLAG
   peer_interface: Eth2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/connected_endpoints.yml
@@ -131,12 +131,6 @@ ethernet_interfaces:
       native_vlan: 123
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: 'True'
-  dot1x:
-    unauthorized:
-      access_vlan_membership_egress: true
-      native_vlan_membership_egress: true
-  poe:
-    disabled: true
   ptp:
     announce:
       interval: 0
@@ -167,12 +161,6 @@ ethernet_interfaces:
       native_vlan: 123
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: 'True'
-  dot1x:
-    unauthorized:
-      access_vlan_membership_egress: true
-      native_vlan_membership_egress: true
-  poe:
-    disabled: true
   ptp:
     announce:
       interval: 0
@@ -192,6 +180,12 @@ ethernet_interfaces:
   port_profile: INDIVIDUAL_TRUNK
   description: SERVER_DOT1X_UNAUTHORIZED
   shutdown: false
+  dot1x:
+    unauthorized:
+      access_vlan_membership_egress: true
+      native_vlan_membership_egress: true
+  poe:
+    disabled: true
   switchport:
     enabled: true
     mode: trunk
@@ -201,12 +195,6 @@ ethernet_interfaces:
       native_vlan: 123
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: 'True'
-  dot1x:
-    unauthorized:
-      access_vlan_membership_egress: true
-      native_vlan_membership_egress: true
-  poe:
-    disabled: true
   ptp:
     announce:
       interval: 0
@@ -256,6 +244,36 @@ ethernet_interfaces:
   link_tracking_groups:
   - name: LT_GROUP1
     direction: downstream
+- name: Ethernet17
+  peer: DOT1X_UNAUTHORIZED_PORT_CHANNEL
+  peer_type: server
+  port_profile: INDIVIDUAL_TRUNK
+  description: SERVER_DOT1X_UNAUTHORIZED_PORT_CHANNEL
+  shutdown: false
+  dot1x:
+    unauthorized:
+      access_vlan_membership_egress: true
+      native_vlan_membership_egress: true
+  poe:
+    disabled: true
+  channel_group:
+    id: 17
+    mode: active
+- name: Ethernet18
+  peer: DOT1X_UNAUTHORIZED_PORT_CHANNEL
+  peer_type: server
+  port_profile: INDIVIDUAL_TRUNK
+  description: SERVER_DOT1X_UNAUTHORIZED_PORT_CHANNEL
+  shutdown: false
+  dot1x:
+    unauthorized:
+      access_vlan_membership_egress: true
+      native_vlan_membership_egress: true
+  poe:
+    disabled: true
+  channel_group:
+    id: 17
+    mode: active
 port_channel_interfaces:
 - name: Port-Channel1
   description: Port channel description server_OLD_SW-1/2_Po1_ENDPOINT_PORT_CHANNEL_INTERFACE DESCRIPTION SERVER_OLD_SW-1/2_ENDPOINT_PORT_CHANNEL
@@ -296,5 +314,30 @@ port_channel_interfaces:
     enabled: true
   lacp_fallback_mode: individual
   lacp_fallback_timeout: 90
+- name: Port-Channel17
+  description: SERVER_DOT1X_UNAUTHORIZED_PORT_CHANNEL
+  shutdown: false
+  service_profile: MYQOS
+  ptp:
+    announce:
+      interval: 0
+      timeout: 3
+    delay_req: -3
+    sync_message:
+      interval: -3
+    transport: ipv4
+    enable: true
+    role: master
+  sflow:
+    enable: false
+  switchport:
+    enabled: true
+    mode: trunk
+    trunk:
+      allowed_vlan: 1,2,3,4,5,6,7,123,234
+      native_vlan_tag: false
+      native_vlan: 123
+  spanning_tree_portfast: edge
+  spanning_tree_bpdufilter: 'True'
 metadata:
   platform: 720XP

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/connected_endpoints.yml
@@ -82,12 +82,12 @@ servers:
           lacp_fallback:
             mode: individual
             individual:
-              profile: INDIVIDUAL_TRUNK
+              profile: INDIVIDUAL_TRUNK  # Notice that poe and dot1x are _not_ inherited from the fallback profile.
   - name: DOT1X_UNAUTHORIZED
     adapters:
       - switches: [connected_endpoints]
         switch_ports: [Ethernet14]
-        profile: INDIVIDUAL_TRUNK
+        profile: INDIVIDUAL_TRUNK  # Notice that poe and dot1x _are_ inherited from the main profile.
   - name: INDIVIDUAL_2_TRUNK_PHONE
     adapters:
       - switches: [connected_endpoints, connected_endpoints]
@@ -98,6 +98,13 @@ servers:
             mode: individual
             individual:
               profile: INDIVIDUAL_TRUNK_PHONE
+  - name: DOT1X_UNAUTHORIZED_PORT_CHANNEL
+    adapters:
+      - switches: [connected_endpoints, connected_endpoints]
+        switch_ports: [Ethernet17, Ethernet18]
+        profile: INDIVIDUAL_TRUNK  # Notice that poe and dot1x _are_ inherited from the main profile and applied to the member interfaces.
+        port_channel:
+          mode: active
 port_profiles:
   - profile: INDIVIDUAL_TRUNK
     mode: trunk

--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/ethernet_interfaces.py
@@ -105,8 +105,6 @@ class EthernetInterfacesMixin(UtilsMixin):
                 "spanning_tree_bpdufilter": adapter.get("spanning_tree_bpdufilter"),
                 "spanning_tree_bpduguard": adapter.get("spanning_tree_bpduguard"),
                 "storm_control": self._get_adapter_storm_control(adapter),
-                "dot1x": adapter.get("dot1x"),
-                "poe": self._get_adapter_poe(adapter),
                 "ptp": self._get_adapter_ptp(adapter),
                 "service_profile": adapter.get("qos_profile"),
                 "sflow": self._get_adapter_sflow(adapter),
@@ -166,6 +164,8 @@ class EthernetInterfacesMixin(UtilsMixin):
             "speed": adapter.get("speed"),
             "shutdown": not adapter.get("enabled", True),
             "validate_state": None if adapter.get("validate_state", True) else False,
+            "dot1x": adapter.get("dot1x"),
+            "poe": self._get_adapter_poe(adapter),
             "eos_cli": adapter.get("raw_eos_cli"),
             "struct_cfg": adapter.get("structured_config"),
         }


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Endpoints PoE and 802.1x configuration for port-channel members

## Related Issue(s)

Fixes #4600

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

### Connected endpoints and network ports now renders PoE and 802.1x configuration for port-channel members and ignores PoE and 802.1x from LACP fallback individual profile

With AVD version 5.0.0, port-channel members generated from connected endpoints or `network_ports` will now include 802.1x (`dot1x`) and PoE (`poe`) configuration.
Previously the member interface configuration only included `dot1x` or `poe` if it was defined under the port profile set in `lacp_fallback.individual.profile`.
The LACP fallback individual profiles now ignores any `dot1x` or `poe` settings.

It may be required to move the `dot1x` and `poe` settings from the fallback profile to the adapter profile:

```diff
 port_profiles:
   - name: MY_LACP_INDIVIDUAL_FALLBACK_PROFILE
     <...>
-    poe:
-      <...>
-    dot1x:
-      <...>
   - name: MY_SERVER_PROFILE
     <...>
+    poe:
+      <...>
+    dot1x:
+      <...>

servers:
  - name: MYSERVER1
    adapters:
      - <...>
        profile: MY_SERVER_PROFILE
        port_channel:
          <...>
          lacp_fallback:
            mode: individual
            individual:
              profile: MY_LACP_INDIVIDUAL_FALLBACK_PROFILE
```

No changes are needed if the LACP fallback individual profile is the same as the adapter profile

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing + new molecule coverage. Verified updated artifacts.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
