### PR TITLE
Bump: arista.cvp Ansible collection requirement to latest version

### DIFF
--- a/ansible_collections/arista/avd/collections.yml
+++ b/ansible_collections/arista/avd/collections.yml
@@ -1,7 +1,7 @@
 # collection requirements leveraged by molecule etc
 collections:
   - name: arista.cvp
-    version: ">=3.10.1"
+    version: ">=3.11.0"
   - name: arista.eos
     version: ">=7.0.0"
   - name: ansible.utils

--- a/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
@@ -16,9 +16,12 @@ title: Release Notes for AVD 5.x.x
 
 ### Changes to requirements
 
-- AVD v.5.0.0 requires Python version 3.10 or newer.
-- AVD now requires the `cvprac` Python library to be version 1.4.0 or higher.<br>
-  The latest version can be installed with `pip install "cvprac>=1.4.0" --upgrade`. has been removed from the `arista.avd` Ansible collection in v5.0.0.
+- Python requirements:
+  - AVD v.5.0.0 requires Python version 3.10 or newer.
+  - AVD now requires the `cvprac` Python library to be version 1.4.0 or higher.<br>
+    The latest version can be installed with `pip install "cvprac>=1.4.0" --upgrade`.
+- Ansible collection requirements:
+  - Minimum `arista.cvp` version 3.11.0.
 
 ### Removal of Ansible components
 

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -36,7 +36,7 @@ tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-    "arista.cvp": ">=3.11.1"
+    "arista.cvp": ">=3.11.0"
     "arista.eos": ">=7.0.0"
     "ansible.utils": ">=3.0.0"
 

--- a/ansible_collections/arista/avd/galaxy.yml
+++ b/ansible_collections/arista/avd/galaxy.yml
@@ -36,7 +36,7 @@ tags: ['arista', 'network', 'networking', 'eos', 'avd', 'cloudvision', 'cvp']
 # L(specifiers,https://python-semanticversion.readthedocs.io/en/latest/#requirement-specification). Multiple version
 # range specifiers can be set and are separated by ','
 dependencies:
-    "arista.cvp": ">=3.10.1"
+    "arista.cvp": ">=3.11.1"
     "arista.eos": ">=7.0.0"
     "ansible.utils": ">=3.0.0"
 


### PR DESCRIPTION
## Change Summary

Bump Ansible collection requirements:
  - Minimum `arista.cvp` version 3.11.0.

