### PR TITLE
CI: Fix issue in requirements

### DIFF
--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,7 +1,3 @@
-# Installing PyAVD as editable install.
-# Providing config-settings in a requirements file is only supported by very recent pip versions.
-# The editable_mode=compat is required for pylance to work correctly.
-# The path is relative to the root of the repo, so this only works when executed from there.
 ansible-core>=2.15.0,<2.18.0
 ansible-doc-extractor>=0.1.10
 ansible-lint>=24.6.0

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -2,7 +2,6 @@
 # Providing config-settings in a requirements file is only supported by very recent pip versions.
 # The editable_mode=compat is required for pylance to work correctly.
 # The path is relative to the root of the repo, so this only works when executed from there.
--e python-avd --config-settings editable_mode=compat
 ansible-core>=2.15.0,<2.18.0
 ansible-doc-extractor>=0.1.10
 ansible-lint>=24.6.0

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -1,3 +1,11 @@
+# pyavd minimal requirements when running from source
+anta>=1.1.0
+cvprac>=1.4.0
+netaddr>=0.7.19
+PyYAML>=6.0.0
+treelib>=1.5.5
+jsonschema>=3.2.0
+# dev requirements
 ansible-core>=2.15.0,<2.18.0
 ansible-doc-extractor>=0.1.10
 ansible-lint>=24.6.0


### PR DESCRIPTION
## Change Summary

* version checking is not working for pyavd installed from source so ignoring it
* removing from dev requirements the editable install of pyavd

## Related Issue(s)

From field

## Component(s) name

`ci`

## Proposed changes

cf summary

bonus it will fix 
<img width="962" alt="Screenshot 2024-11-04 at 17 29 04" src="https://github.com/user-attachments/assets/9ff2deb8-74f3-49c9-87e2-dd92879c913c">

## How to test

CI should pass
users should be able to run Ansible AVD without issue and see templates and schema auto update

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
