### PR TITLE
Refactor(pyavd): Adding `path` attribute to the validation error for removed keys

### DIFF
--- a/python-avd/pyavd/_errors/__init__.py
+++ b/python-avd/pyavd/_errors/__init__.py
@@ -89,6 +89,9 @@ class AvdDeprecationWarning(AristaAvdError):  # noqa: N818
         self.message = " ".join(messages)
         super().__init__(self.message)
 
+    def to_validation_error(self) -> AvdValidationError:
+        return AvdValidationError(self.message, self.path.split("."))
+
 
 class AristaAvdDuplicateDataError(AristaAvdError):
     def __init__(self, context: str, context_item_a: str, context_item_b: str) -> None:

--- a/python-avd/pyavd/_errors/__init__.py
+++ b/python-avd/pyavd/_errors/__init__.py
@@ -90,6 +90,7 @@ class AvdDeprecationWarning(AristaAvdError):  # noqa: N818
         super().__init__(self.message)
 
     def to_validation_error(self) -> AvdValidationError:
+        """Converting AvdDeprecationWarning to AvdValidationError."""
         return AvdValidationError(self.message, self.path.split("."))
 
 

--- a/python-avd/pyavd/_errors/__init__.py
+++ b/python-avd/pyavd/_errors/__init__.py
@@ -89,7 +89,7 @@ class AvdDeprecationWarning(AristaAvdError):  # noqa: N818
         self.message = " ".join(messages)
         super().__init__(self.message)
 
-    def to_validation_error(self) -> AvdValidationError:
+    def _as_validation_error(self) -> AvdValidationError:
         """Converting AvdDeprecationWarning to AvdValidationError."""
         return AvdValidationError(self.message, self.path.split("."))
 

--- a/python-avd/pyavd/_errors/__init__.py
+++ b/python-avd/pyavd/_errors/__init__.py
@@ -78,7 +78,7 @@ class AvdDeprecationWarning(AristaAvdError):  # noqa: N818
             if not url:
                 url = "the porting guide on https://avd.arista.com"
         else:
-            messages.append(f"{conflict} The input data model '{self.path}' is deprecated.")
+            messages.append(f"The input data model '{self.path}' is deprecated.")
 
         if new_key and not conflict:
             messages.append(f"Use '{new_key}' instead.")

--- a/python-avd/pyavd/_errors/__init__.py
+++ b/python-avd/pyavd/_errors/__init__.py
@@ -91,7 +91,7 @@ class AvdDeprecationWarning(AristaAvdError):  # noqa: N818
 
     def _as_validation_error(self) -> AvdValidationError:
         """Converting AvdDeprecationWarning to AvdValidationError."""
-        return AvdValidationError(self.message, self.path.split("."))
+        return AvdValidationError(message=self.message, path=self.path.split("."))
 
 
 class AristaAvdDuplicateDataError(AristaAvdError):

--- a/python-avd/pyavd/avd_schema_tools.py
+++ b/python-avd/pyavd/avd_schema_tools.py
@@ -64,7 +64,7 @@ class AvdSchemaTools:
             # Store but continue for deprecations
             if isinstance(exception, AvdDeprecationWarning):
                 if exception.removed or exception.conflict:
-                    result.validation_errors.append(exception.to_validation_error())
+                    result.validation_errors.append(exception._as_validation_error())
                     result.failed = True
                     continue
 

--- a/python-avd/pyavd/avd_schema_tools.py
+++ b/python-avd/pyavd/avd_schema_tools.py
@@ -51,7 +51,7 @@ class AvdSchemaTools:
             ValidationResult object with any validation errors or deprecation warnings.
         """
         # pylint: disable=import-outside-toplevel
-        from ._errors import AvdDeprecationWarning, AvdValidationError
+        from ._errors import AvdDeprecationWarning
         from .validation_result import ValidationResult
 
         # pylint: enable=import-outside-toplevel
@@ -64,7 +64,7 @@ class AvdSchemaTools:
             # Store but continue for deprecations
             if isinstance(exception, AvdDeprecationWarning):
                 if exception.removed or exception.conflict:
-                    result.validation_errors.append(AvdValidationError(exception.message))
+                    result.validation_errors.append(exception.to_validation_error())
                     result.failed = True
                     continue
 


### PR DESCRIPTION
## Change Summary

In https://github.com/aristanetworks/avd/blob/devel/python-avd/pyavd/avd_schema_tools.py#L67,
the AvdDeprecationWarning is converted to AvdValidationError for the removed keys. 
It does not have path attribute which is needed for highlighting errors in AVD VSCode extension.

Updating the conversion to get the path attribute.


## Related Issue(s)

Fixes #https://github.com/aristanetworks/vscode-avd/issues/5

## Component(s) name

`pyavd`

## Proposed changes
Adding `to_validation_error` method to AvdDeprecationWarning for error conversion along with getting the path attribute.
Using this method in schema tools for getting validation error.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
