### PR TITLE
Refactor(eos_cli_config_gen): Adding check for hosts key in TACACS server j2 file

### DIFF
--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/tacacs-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/tacacs-servers.j2
@@ -12,24 +12,26 @@ tacacs-server timeout {{ tacacs_servers.timeout }}
 {%     if tacacs_servers.policy_unknown_mandatory_attribute_ignore is arista.avd.defined(true) %}
 tacacs-server policy unknown-mandatory-attribute ignore
 {%     endif %}
-{%     for host in tacacs_servers.hosts %}
-{%         if host.host is arista.avd.defined %}
-{%             set host_cli = "tacacs-server host " ~ host.host %}
-{%         endif %}
-{%         if host.single_connection is arista.avd.defined(true) %}
-{%             set host_cli = host_cli ~ " single-connection" %}
-{%         endif %}
-{%         if host.vrf is arista.avd.defined %}
-{%             if host.vrf != 'default' %}
-{%                 set host_cli = host_cli ~ " vrf " ~ host.vrf %}
+{%     if tacacs_servers.hosts is arista.avd.defined %}
+{%         for host in tacacs_servers.hosts %}
+{%             if host.host is arista.avd.defined %}
+{%                 set host_cli = "tacacs-server host " ~ host.host %}
 {%             endif %}
-{%         endif %}
-{%         if host.timeout is arista.avd.defined %}
-{%             set host_cli = host_cli ~ " timeout " ~ host.timeout %}
-{%         endif %}
-{%         if host.key is arista.avd.defined %}
-{%             set host_cli = host_cli ~ " key " ~ host.key_type | arista.avd.default('7') ~ ' ' ~ host.key | arista.avd.hide_passwords(hide_passwords) %}
-{%         endif %}
+{%             if host.single_connection is arista.avd.defined(true) %}
+{%                 set host_cli = host_cli ~ " single-connection" %}
+{%             endif %}
+{%             if host.vrf is arista.avd.defined %}
+{%                 if host.vrf != 'default' %}
+{%                     set host_cli = host_cli ~ " vrf " ~ host.vrf %}
+{%                 endif %}
+{%             endif %}
+{%             if host.timeout is arista.avd.defined %}
+{%                 set host_cli = host_cli ~ " timeout " ~ host.timeout %}
+{%             endif %}
+{%             if host.key is arista.avd.defined %}
+{%                 set host_cli = host_cli ~ " key " ~ host.key_type | arista.avd.default('7') ~ ' ' ~ host.key | arista.avd.hide_passwords(hide_passwords) %}
+{%             endif %}
 {{ host_cli }}
-{%     endfor %}
+{%         endfor %}
+{%     endif %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/tacacs-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/tacacs-servers.j2
@@ -20,10 +20,8 @@ tacacs-server policy unknown-mandatory-attribute ignore
 {%             if host.single_connection is arista.avd.defined(true) %}
 {%                 set host_cli = host_cli ~ " single-connection" %}
 {%             endif %}
-{%             if host.vrf is arista.avd.defined %}
-{%                 if host.vrf != 'default' %}
-{%                     set host_cli = host_cli ~ " vrf " ~ host.vrf %}
-{%                 endif %}
+{%             if host.vrf is arista.avd.defined and host.vrf != 'default' %}
+{%                 set host_cli = host_cli ~ " vrf " ~ host.vrf %}
 {%             endif %}
 {%             if host.timeout is arista.avd.defined %}
 {%                 set host_cli = host_cli ~ " timeout " ~ host.timeout %}


### PR DESCRIPTION
## Change Summary

Adding check for hosts key in TACACS server j2 file

## Related Issue(s)

Fixes #4649 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
