### PR TITLE
Refactor(eos_designs): Use new isis_authentication data models

### DIFF
--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p1.yml
@@ -85,8 +85,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -107,8 +110,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -129,8 +135,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -151,8 +160,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p2.yml
@@ -85,8 +85,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -107,8 +110,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -129,8 +135,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -151,8 +160,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p3.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p3.yml
@@ -85,8 +85,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -107,8 +110,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -129,8 +135,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p4.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p4.yml
@@ -85,8 +85,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -107,8 +110,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -129,8 +135,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe1.yml
@@ -180,8 +180,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -202,8 +205,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe2.yml
@@ -180,8 +180,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -202,8 +205,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe3.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe3.yml
@@ -180,8 +180,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -202,8 +205,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr1.yml
@@ -151,8 +151,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -173,8 +176,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -195,8 +201,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr2.yml
@@ -151,8 +151,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -173,8 +176,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -195,8 +201,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -227,8 +227,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -254,8 +257,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -272,8 +272,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-1-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -299,8 +302,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR1.yml
@@ -102,8 +102,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -129,8 +132,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -156,8 +162,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR2.yml
@@ -102,8 +102,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-1-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -129,8 +132,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
@@ -183,8 +183,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -281,8 +281,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -417,8 +420,11 @@ port_channel_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -443,8 +449,11 @@ port_channel_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR1.yml
@@ -102,8 +102,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -129,8 +132,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -156,8 +162,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
@@ -102,8 +102,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -170,8 +173,11 @@ port_channel_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -196,8 +202,11 @@ port_channel_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
@@ -183,8 +183,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: asdadjiwtelogkkdng
+  isis_authentication:
+    both:
+      mode: md5
+      key: asdadjiwtelogkkdng
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-1-isis-sr-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-1-isis-sr-ldp.yml
@@ -92,8 +92,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -138,8 +141,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -162,8 +168,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   description: P2P_LINK_TO_CORE-2-OSPF-LDP_Ethernet4
   speed: forced 1000full
 - name: Ethernet5
@@ -181,8 +190,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
   description: P2P_LINK_TO_CORE-2-OSPF-LDP_Ethernet5
@@ -203,8 +215,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: true
   isis_circuit_type: level-1-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -372,8 +387,11 @@ port_channel_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -395,8 +413,11 @@ port_channel_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:
@@ -418,8 +439,11 @@ port_channel_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   mpls:
     ip: true
     ldp:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_isis.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_isis.yml
@@ -70,8 +70,11 @@ ethernet_interfaces:
   isis_network_point_to_point: true
   isis_hello_padding: false
   isis_circuit_type: level-2
-  isis_authentication_mode: md5
-  isis_authentication_key: $1c$sTNAlR6rKSw=
+  isis_authentication:
+    both:
+      mode: md5
+      key: $1c$sTNAlR6rKSw=
+      key_type: '7'
   description: P2P_peer2_ethernet2
 - name: ethernet3
   peer: peer3

--- a/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/utils.py
@@ -251,10 +251,18 @@ class UtilsMixin:
                         "isis_network_point_to_point": p2p_link.get("isis_network_type", "point-to-point") == "point-to-point",
                         "isis_hello_padding": p2p_link.get("isis_hello_padding", True),
                         "isis_circuit_type": default(p2p_link.get("isis_circuit_type"), self.shared_utils.isis_default_circuit_type),
-                        "isis_authentication_mode": p2p_link.get("isis_authentication_mode"),
-                        "isis_authentication_key": p2p_link.get("isis_authentication_key"),
                     },
                 )
+                if (isis_authentication_mode := p2p_link.get("isis_authentication_mode")) is not None:
+                    interface_cfg.setdefault("isis_authentication", {}).setdefault("both", {})["mode"] = isis_authentication_mode
+
+                if (isis_authentication_key := p2p_link.get("isis_authentication_key")) is not None:
+                    interface_cfg.setdefault("isis_authentication", {}).setdefault("both", {}).update(
+                        {
+                            "key": isis_authentication_key,
+                            "key_type": "7",
+                        }
+                    )
 
         if p2p_link.get("macsec_profile"):
             interface_cfg["mac_security"] = {


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Use new isis_authentication data models to avoid the deprecated `isis_authentication_mode` and `isis_authentication_key`.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- [x] Update eos_designs to use the new models.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Existing molecule tests no longer produce deprecation warnings
- structured config is updated.
- Configurations are not changing.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
