### PR TITLE
Fix(eos_designs): Always output interface access_vlan as int in structured_config

### DIFF
--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -73,7 +73,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -73,7 +73,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
@@ -73,7 +73,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
@@ -73,7 +73,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
@@ -146,7 +146,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '10'
+    access_vlan: 10
   spanning_tree_portfast: edge
 mlag_configuration:
   domain_id: RACK1

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
@@ -146,7 +146,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '20'
+    access_vlan: 20
   spanning_tree_portfast: edge
 mlag_configuration:
   domain_id: RACK1

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
@@ -146,7 +146,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '10'
+    access_vlan: 10
   spanning_tree_portfast: edge
 mlag_configuration:
   domain_id: RACK2

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
@@ -146,7 +146,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '30'
+    access_vlan: 30
   spanning_tree_portfast: edge
 mlag_configuration:
   domain_id: RACK2

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -94,7 +94,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -94,7 +94,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -268,7 +268,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 loopback_interfaces:
 - name: Loopback0
   description: ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
@@ -51,7 +51,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 - name: Ethernet11
   peer_type: network_port
   description: Endpoint
@@ -59,7 +59,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 - name: Ethernet12
   peer_type: network_port
   description: IP Phone

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
@@ -51,7 +51,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 - name: Ethernet11
   peer_type: network_port
   description: Endpoint
@@ -59,7 +59,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 port_channel_interfaces:
 - name: Port-Channel1
   description: L2_BGP_SPINES_Port-Channel2

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
@@ -52,7 +52,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 port_channel_interfaces:
 - name: Port-Channel1
   description: L2_ISIS-LEAF1_Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
@@ -51,7 +51,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 - name: Ethernet11
   peer_type: network_port
   description: Endpoint
@@ -59,7 +59,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 port_channel_interfaces:
 - name: Port-Channel1
   description: L2_L2ONLY_SPINES_Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
@@ -51,7 +51,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 - name: Ethernet11
   peer_type: network_port
   description: Endpoint
@@ -59,7 +59,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 port_channel_interfaces:
 - name: Port-Channel1
   description: L2_L2ONLY_SPINES_Port-Channel2

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
@@ -51,7 +51,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 - name: Ethernet11
   peer_type: network_port
   description: Endpoint
@@ -59,7 +59,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 port_channel_interfaces:
 - name: Port-Channel1
   description: L2_OSPF_SPINES_Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
@@ -51,7 +51,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 - name: Ethernet11
   peer_type: network_port
   description: Endpoint
@@ -59,7 +59,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
 port_channel_interfaces:
 - name: Port-Channel1
   description: L2_OSPF_SPINES_Port-Channel2

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -512,7 +512,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 16
 - name: Port-Channel17
   description: Set using structured_config on server adapter port-channel
@@ -521,7 +521,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 17
 - name: Port-Channel18
   description: PortChannel
@@ -537,7 +537,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 18
 - name: Port-Channel19
   description: PortChannel
@@ -553,7 +553,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 19
 ethernet_interfaces:
 - name: Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -472,7 +472,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 16
 - name: Port-Channel17
   description: Set using structured_config on server adapter port-channel
@@ -481,7 +481,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 17
 - name: Port-Channel18
   description: PortChannel
@@ -497,7 +497,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 18
 - name: Port-Channel19
   description: PortChannel
@@ -513,7 +513,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 19
 ethernet_interfaces:
 - name: Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-invalid-access-vlan-ethernet.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-invalid-access-vlan-ethernet.yml
@@ -1,0 +1,20 @@
+loopback_ipv4_pool: 192.168.0.0/24
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    - name: connected-endpoints-invalid-access-vlan-ethernet
+
+servers:
+  # port-channel provide physical and individual port-channel descriptions
+  - name: OLD_SW-1/7
+    adapters:
+      - switches: [connected-endpoints-invalid-access-vlan-ethernet]
+        switch_ports: [Ethernet9]
+        mode: access
+        vlans: 1-2
+
+expected_error_message: >-
+  Adapter 'vlans' value must be a single vlan ID when mode is 'access' or 'dot1q-tunnel'.
+  Got 1-2 for interface Ethernet9.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-invalid-access-vlan-port-channel.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/connected-endpoints-invalid-access-vlan-port-channel.yml
@@ -1,0 +1,22 @@
+loopback_ipv4_pool: 192.168.0.0/24
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    - name: connected-endpoints-invalid-access-vlan-port-channel
+
+servers:
+  # port-channel provide physical and individual port-channel descriptions
+  - name: OLD_SW-1/7
+    adapters:
+      - switches: [connected-endpoints-invalid-access-vlan-port-channel]
+        switch_ports: [Ethernet9]
+        mode: access
+        vlans: 1-2
+        port_channel:
+          mode: "active"
+
+expected_error_message: >-
+  Adapter 'vlans' value must be a single vlan ID when mode is 'access' or 'dot1q-tunnel'.
+  Got 1-2 for interface Port-Channel9.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -73,6 +73,8 @@ all:
             connected-endpoints-monitor-session-connected-endpoint-acl:
             connected-endpoints-monitor-session-network-port-acl:
             connected-endpoints-monitor-sessions-mismatch-direction:
+            connected-endpoints-invalid-access-vlan-ethernet:
+            connected-endpoints-invalid-access-vlan-port-channel:
             duplicate-vlans-l2vlans:
             duplicate-vlans-svi-id:
             duplicate-vrfs-duplicate-svi-name-conflict:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -363,7 +363,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet8
   peer: PHONE01_untagged
   peer_interface: Eth0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -745,7 +745,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet26
   peer: PHONE03_port_channel
   peer_interface: Eth0
@@ -834,7 +834,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   spanning_tree_bpdufilter: enabled
   spanning_tree_bpduguard: enabled
 - name: Port-Channel12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -688,7 +688,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet26
   peer: PHONE03_port_channel
   peer_interface: Eth1
@@ -777,7 +777,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   spanning_tree_bpdufilter: enabled
   spanning_tree_bpduguard: enabled
 - name: Port-Channel12

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -1086,7 +1086,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 22
 - name: Port-Channel23
   description: server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
@@ -1094,7 +1094,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 23
 - name: Port-Channel24
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
@@ -1102,7 +1102,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 24
 - name: Port-Channel27
   description: server18_monitoring_session_source_po_server18_monitoring_session_source_po
@@ -1110,7 +1110,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 27
 - name: Port-Channel42
   description: server21_monitoring_session_destination_po_server21_monitoring_session_destination_po
@@ -1118,7 +1118,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 42
 - name: Port-Channel1291
   description: SERVER_server22_port_channel_with_custom_id_server22_port_channel_with_custom_id
@@ -1126,7 +1126,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 1291
 - name: Port-Channel31
   description: server24_port_channel_lacp_timer_profile_server24_port_channel_with_lacp_timer
@@ -1164,7 +1164,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 43
 ethernet_interfaces:
 - name: Ethernet53/1
@@ -1330,7 +1330,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: disabled
   spanning_tree_bpduguard: 'True'
@@ -1378,7 +1378,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: disabled
   spanning_tree_bpduguard: 'True'
@@ -1437,7 +1437,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet21
   peer: server14_explicitly_enabled_interfaces
   peer_interface: Eth1
@@ -1448,7 +1448,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet22
   peer: server15_port_channel_with_disabled_phy_interfaces
   peer_interface: Eth1
@@ -1489,7 +1489,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet27
   peer: server18_monitoring_session_source_po
   peer_interface: Eth3
@@ -1510,7 +1510,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet26
   peer: server19_monitoring_session_destination_phys
   peer_interface: Eth1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -1074,7 +1074,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 22
 - name: Port-Channel23
   description: server16_port_channel_with_disabled_port_channel_server16_port_channel_with_disabled_port_channel
@@ -1082,7 +1082,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 23
 - name: Port-Channel24
   description: server17_port_channel_with_disabled_phy_and_po_interfaces_server17_port_channel_with_disabled_phy_and_po_interfaces
@@ -1090,7 +1090,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 24
 - name: Port-Channel27
   description: server18_monitoring_session_source_po_server18_monitoring_session_source_po
@@ -1098,7 +1098,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 27
 - name: Port-Channel42
   description: server21_monitoring_session_destination_po_server21_monitoring_session_destination_po
@@ -1106,7 +1106,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 42
 - name: Port-Channel1291
   description: SERVER_server22_port_channel_with_custom_id_server22_port_channel_with_custom_id
@@ -1114,7 +1114,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 1291
 - name: Port-Channel31
   description: server24_port_channel_lacp_timer_profile_server24_port_channel_with_lacp_timer
@@ -1152,7 +1152,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 43
 ethernet_interfaces:
 - name: Ethernet53/1
@@ -1308,7 +1308,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: disabled
   spanning_tree_bpduguard: 'True'
@@ -1356,7 +1356,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: disabled
   spanning_tree_bpduguard: 'True'
@@ -1415,7 +1415,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet21
   peer: server14_explicitly_enabled_interfaces
   peer_interface: Eth2
@@ -1426,7 +1426,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet22
   peer: server15_port_channel_with_disabled_phy_interfaces
   peer_interface: Eth2
@@ -1467,7 +1467,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet27
   peer: server18_monitoring_session_source_po
   peer_interface: Eth4

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -443,7 +443,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '310'
+    access_vlan: 310
   evpn_ethernet_segment:
     identifier: 0000:0000:0001:1010:1010
     route_target: 00:01:10:10:10:10
@@ -457,7 +457,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '310'
+    access_vlan: 310
   evpn_ethernet_segment:
     identifier: 0000:0000:fc87:ae24:2cb3
     route_target: fc:87:ae:24:2c:b3
@@ -471,7 +471,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '310'
+    access_vlan: 310
   evpn_ethernet_segment:
     identifier: 0000:0000:29cc:4043:0a29
     route_target: 29:cc:40:43:0a:29
@@ -485,7 +485,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '310'
+    access_vlan: 310
   evpn_ethernet_segment:
     identifier: 0000:0000:010a:010a:010a
     route_target: 01:0a:01:0a:01:0a

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -443,7 +443,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '310'
+    access_vlan: 310
   evpn_ethernet_segment:
     identifier: 0000:0000:0001:1010:1010
     route_target: 00:01:10:10:10:10
@@ -457,7 +457,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '310'
+    access_vlan: 310
   evpn_ethernet_segment:
     identifier: 0000:0000:fc87:ae24:2cb3
     route_target: fc:87:ae:24:2c:b3
@@ -471,7 +471,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '310'
+    access_vlan: 310
   evpn_ethernet_segment:
     identifier: 0000:0000:29cc:4043:0a29
     route_target: 29:cc:40:43:0a:29
@@ -485,7 +485,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '310'
+    access_vlan: 310
   evpn_ethernet_segment:
     identifier: 0000:0000:010a:010a:010a
     route_target: 01:0a:01:0a:01:0a

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -229,7 +229,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '310'
+    access_vlan: 310
   link_tracking_groups:
   - name: Eth-conn-to-router
     direction: downstream

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf1.yml
@@ -189,7 +189,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   flow_tracker:
     hardware: FLOW-TRACKER-3
 - name: Ethernet11
@@ -201,7 +201,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
 - name: Ethernet12
   peer: single-interface-no-definition
   peer_interface: eth12
@@ -211,7 +211,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   flow_tracker:
     hardware: FLOW-TRACKER
 - name: Ethernet13
@@ -223,7 +223,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   flow_tracker:
     hardware: FLOW-TRACKER
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf2.yml
@@ -183,7 +183,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
 - name: Ethernet11
   peer: single-interface-false
   peer_interface: eth12
@@ -193,7 +193,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
 - name: Ethernet12
   peer: single-interface-no-definition
   peer_interface: eth13
@@ -203,7 +203,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   flow_tracker:
     sampled: FLOW-TRACKER-3
 - name: Ethernet13
@@ -215,7 +215,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
 loopback_interfaces:
 - name: Loopback0
   description: ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf3.yml
@@ -238,7 +238,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 14
 - name: Port-Channel15
@@ -249,7 +249,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 15
 - name: Port-Channel16
@@ -258,7 +258,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 16
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf4.yml
@@ -238,7 +238,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 14
 - name: Port-Channel15
@@ -249,7 +249,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 15
 - name: Port-Channel16
@@ -258,7 +258,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 16
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -60,7 +60,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '101'
+    access_vlan: 101
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
   mlag: 1
@@ -70,7 +70,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '101'
+    access_vlan: 101
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
   mlag: 2
@@ -127,7 +127,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet4
@@ -139,7 +139,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/1
@@ -151,7 +151,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/2
@@ -163,7 +163,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/3
@@ -175,7 +175,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/4
@@ -187,7 +187,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/5
@@ -199,7 +199,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/6
@@ -211,7 +211,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/7
@@ -223,7 +223,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/8
@@ -235,7 +235,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/9
@@ -247,7 +247,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/10
@@ -259,7 +259,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/11
@@ -271,7 +271,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/12
@@ -283,7 +283,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/13
@@ -295,7 +295,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/14
@@ -307,7 +307,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/15
@@ -319,7 +319,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/16
@@ -331,7 +331,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/17
@@ -343,7 +343,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/18
@@ -355,7 +355,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/19
@@ -367,7 +367,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/20
@@ -379,7 +379,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/21
@@ -391,7 +391,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/22
@@ -403,7 +403,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/23
@@ -415,7 +415,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/24
@@ -427,7 +427,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/25
@@ -439,7 +439,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/26
@@ -451,7 +451,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/27
@@ -463,7 +463,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/28
@@ -475,7 +475,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/29
@@ -487,7 +487,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/30
@@ -499,7 +499,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/31
@@ -511,7 +511,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/32
@@ -523,7 +523,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/33
@@ -535,7 +535,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/34
@@ -547,7 +547,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/35
@@ -559,7 +559,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/36
@@ -571,7 +571,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/37
@@ -583,7 +583,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/38
@@ -595,7 +595,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/39
@@ -607,7 +607,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/40
@@ -619,7 +619,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/41
@@ -631,7 +631,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/42
@@ -643,7 +643,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/43
@@ -655,7 +655,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/44
@@ -667,7 +667,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/45
@@ -679,7 +679,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/46
@@ -691,7 +691,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/47
@@ -703,7 +703,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/48
@@ -715,7 +715,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -76,7 +76,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2
@@ -88,7 +88,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet3
@@ -100,7 +100,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet4
@@ -112,7 +112,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/1
@@ -124,7 +124,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/2
@@ -136,7 +136,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/3
@@ -148,7 +148,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/4
@@ -160,7 +160,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/5
@@ -172,7 +172,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/6
@@ -184,7 +184,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/7
@@ -196,7 +196,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/8
@@ -208,7 +208,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/9
@@ -220,7 +220,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/10
@@ -232,7 +232,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/11
@@ -244,7 +244,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/12
@@ -256,7 +256,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/13
@@ -268,7 +268,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/14
@@ -280,7 +280,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/15
@@ -292,7 +292,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/16
@@ -304,7 +304,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/17
@@ -316,7 +316,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/18
@@ -328,7 +328,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/19
@@ -340,7 +340,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/20
@@ -352,7 +352,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/21
@@ -364,7 +364,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/22
@@ -376,7 +376,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/23
@@ -388,7 +388,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/24
@@ -400,7 +400,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/25
@@ -412,7 +412,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/26
@@ -424,7 +424,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/27
@@ -436,7 +436,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/28
@@ -448,7 +448,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/29
@@ -460,7 +460,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/30
@@ -472,7 +472,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/31
@@ -484,7 +484,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/32
@@ -496,7 +496,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/33
@@ -508,7 +508,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/34
@@ -520,7 +520,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/35
@@ -532,7 +532,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/36
@@ -544,7 +544,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/37
@@ -556,7 +556,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/38
@@ -568,7 +568,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/39
@@ -580,7 +580,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/40
@@ -592,7 +592,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/41
@@ -604,7 +604,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/42
@@ -616,7 +616,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/43
@@ -628,7 +628,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/44
@@ -640,7 +640,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/45
@@ -652,7 +652,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/46
@@ -664,7 +664,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/47
@@ -676,7 +676,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet2/48
@@ -688,7 +688,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '100'
+    access_vlan: 100
   spanning_tree_portfast: edge
   spanning_tree_bpdufilter: enabled
 - name: Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -272,7 +272,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   mlag: 6
 ethernet_interfaces:
 - name: Ethernet9
@@ -368,7 +368,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   ptp:
     announce:
       interval: 0
@@ -387,7 +387,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   ptp:
     announce:
@@ -417,7 +417,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   ptp:
     announce:
       interval: -2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -283,7 +283,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   mlag: 6
 ethernet_interfaces:
 - name: Ethernet9
@@ -378,7 +378,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   ptp:
     announce:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf1.yml
@@ -150,7 +150,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   sflow:
     enable: true
 - name: Ethernet12
@@ -162,7 +162,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   sflow:
     enable: false
 - name: Ethernet14
@@ -174,7 +174,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   sflow:
     enable: true
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf3.yml
@@ -204,7 +204,7 @@ port_channel_interfaces:
     trunk:
       groups:
       - MLAG
-    access_vlan: '11'
+    access_vlan: 11
   shutdown: false
   sflow:
     enable: true
@@ -240,7 +240,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 13
 - name: Port-Channel15
@@ -251,7 +251,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 15
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf4.yml
@@ -204,7 +204,7 @@ port_channel_interfaces:
     trunk:
       groups:
       - MLAG
-    access_vlan: '11'
+    access_vlan: 11
   shutdown: false
   sflow:
     enable: true
@@ -240,7 +240,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 13
 - name: Port-Channel15
@@ -251,7 +251,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
   mlag: 15
 ethernet_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1a.yml
@@ -454,7 +454,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 - name: Ethernet32
   peer: dc1-leaf1-workstation2
@@ -467,7 +467,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 mlag_configuration:
   domain_id: DC1_L3_LEAF1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1b.yml
@@ -439,7 +439,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '50'
+    access_vlan: 50
   spanning_tree_portfast: edge
 - name: Ethernet42
   peer_type: network_port
@@ -449,7 +449,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '50'
+    access_vlan: 50
   spanning_tree_portfast: edge
 - name: Ethernet43
   peer_type: network_port
@@ -459,7 +459,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '50'
+    access_vlan: 50
   spanning_tree_portfast: edge
 - name: Ethernet44
   peer_type: network_port
@@ -469,7 +469,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '50'
+    access_vlan: 50
   spanning_tree_portfast: edge
 - name: Ethernet45
   peer_type: network_port
@@ -479,7 +479,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '50'
+    access_vlan: 50
   spanning_tree_portfast: edge
 - name: Ethernet46
   peer_type: network_port
@@ -489,7 +489,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '50'
+    access_vlan: 50
   spanning_tree_portfast: edge
 - name: Ethernet47
   peer_type: network_port
@@ -499,7 +499,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '50'
+    access_vlan: 50
   spanning_tree_portfast: edge
 - name: Ethernet48
   peer_type: network_port
@@ -509,7 +509,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '50'
+    access_vlan: 50
   spanning_tree_portfast: edge
 - name: Ethernet49
   peer_type: network_port
@@ -519,7 +519,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '50'
+    access_vlan: 50
   spanning_tree_portfast: edge
 - name: Ethernet5
   peer: dc1-leaf1-server1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1c.yml
@@ -69,7 +69,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2c.yml
@@ -69,7 +69,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1c.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1c.yml
@@ -74,7 +74,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2c.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2c.yml
@@ -74,7 +74,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '11'
+    access_vlan: 11
   spanning_tree_portfast: edge
 port_channel_interfaces:
 - name: Port-Channel1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -300,7 +300,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 loopback_interfaces:
 - name: Loopback0
   description: CUSTOM_EVPN_Overlay_Peering_L3LEAF

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -494,7 +494,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 port_channel_interfaces:
 - name: Port-Channel7
   description: CUSTOM_DC1-L2LEAF1A_Po1
@@ -535,7 +535,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Port-Channel12
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1
   shutdown: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -494,7 +494,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 port_channel_interfaces:
 - name: Port-Channel7
   description: CUSTOM_DC1-L2LEAF1A_Po1
@@ -535,7 +535,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Port-Channel12
   description: CUSTOM_server01_MTU_ADAPTOR_MLAG_PortChanne1
   shutdown: false

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -1033,7 +1033,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 22
 ethernet_interfaces:
 - name: Ethernet5
@@ -1193,7 +1193,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: 'False'
   spanning_tree_bpduguard: 'True'
@@ -1240,7 +1240,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: 'False'
   spanning_tree_bpduguard: 'True'
@@ -1299,7 +1299,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet21
   peer: server14_explicitly_enabled_interfaces
   peer_interface: Eth1
@@ -1310,7 +1310,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet22
   peer: server15_port_channel_disabled_interfaces
   peer_interface: Eth1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -1033,7 +1033,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 22
 ethernet_interfaces:
 - name: Ethernet5
@@ -1193,7 +1193,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: 'False'
   spanning_tree_bpduguard: 'True'
@@ -1240,7 +1240,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: 'False'
   spanning_tree_bpduguard: 'True'
@@ -1299,7 +1299,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet21
   peer: server14_explicitly_enabled_interfaces
   peer_interface: Eth2
@@ -1310,7 +1310,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 - name: Ethernet22
   peer: server15_port_channel_disabled_interfaces
   peer_interface: Eth2

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -300,7 +300,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
 loopback_interfaces:
 - name: Loopback0
   description: ROUTER_ID

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -728,7 +728,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 11
 - name: Port-Channel12
   description: PortChanne1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -728,7 +728,7 @@ port_channel_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '110'
+    access_vlan: 110
   mlag: 11
 - name: Port-Channel12
   description: PortChanne1

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -1061,7 +1061,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: 'False'
   spanning_tree_bpduguard: 'True'
@@ -1107,7 +1107,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: 'False'
   spanning_tree_bpduguard: 'True'

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -1039,7 +1039,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: 'False'
   spanning_tree_bpduguard: 'True'
@@ -1085,7 +1085,7 @@ ethernet_interfaces:
   switchport:
     enabled: true
     mode: access
-    access_vlan: '210'
+    access_vlan: 210
   spanning_tree_portfast: network
   spanning_tree_bpdufilter: 'False'
   spanning_tree_bpduguard: 'True'

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -22,7 +22,7 @@ pylint>=3.2.6
 pre-commit>=3.2.0
 pre-commit-hooks>=3.3.0
 referencing>=0.35.0
-ruff==0.7.3
+ruff==0.7.4
 tox
 treelib>=1.5.5
 twine


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Always output interface access_vlan as int in structured_config

## Related Issue(s)

Recent changes caused `switchport.access_vlan` to be written as a string in the outputs of `eos_designs`.
This did not have an impact on most users, since validation in `eos_cli_config_gen` automatically converted the values.
For some users using PyAVD without running validation, the string values triggered template errors in `get_device_doc` which were very hard to decipher.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Convert `adapter.vlans` value to `int` when mode is `access` or `dot1q-tunnel`
- Catch errors on conversion and raise a more clear error message.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added negative testing.
Reran all molecule since structured config has changed.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
