### PR TITLE
Doc(eos_cli_config_gen): Make the Radius Server documentation visible

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/input-variables.md
@@ -80,10 +80,10 @@ roles/eos_cli_config_gen/docs/tables/ip-tacacs-source-interfaces.md
 roles/eos_cli_config_gen/docs/tables/local-users.md
 --8<--
 
-### Radius servers
+### Radius server
 
 --8<--
-roles/eos_cli_config_gen/docs/tables/radius-servers.md
+roles/eos_cli_config_gen/docs/tables/radius-server.md
 --8<--
 
 ### Roles


### PR DESCRIPTION
## Change Summary

Radius Server documentation was not using the correct model

## Related Issue(s)

Reported from the field

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Fix the doc link

## How to test

Should pop up in rtd for the PR

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
