### PR TITLE
Feat(eos_cli_config_gen): Add interface traffic engineering and TE admin group for ethernet/port-channel

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3792,7 +3792,6 @@ interface Dps1
 | Interface | Enabled | Administrative Groups |
 | --------- | ------- | --------------------- |
 | Ethernet81/3 | True | 3,15-29,testgrp |
-| Ethernet81/4 | False | 4,7-100,testgrp |
 
 #### Ethernet Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3791,8 +3791,8 @@ interface Dps1
 
 | Interface | Enabled | Administrative Groups |
 | --------- | ------- | --------------------- |
-| Ethernet81/3 | True | 3,testgrp,15-29 |
-| Ethernet81/4 | False | 4,testgrp,7-100 |
+| Ethernet81/3 | True | 3,15-29,testgrp |
+| Ethernet81/4 | False | 4,7-100,testgrp |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -4770,14 +4770,14 @@ interface Ethernet81/3
    no switchport
    ip address 100.64.127.0/31
    traffic-engineering
-   traffic-engineering administrative-group 3,testgrp,15-29
+   traffic-engineering administrative-group 3,15-29,testgrp
 !
 interface Ethernet81/4
    description Traffic Engineering Interface
    no shutdown
    no switchport
    ip address 100.64.127.0/31
-   traffic-engineering administrative-group 4,testgrp,7-100
+   traffic-engineering administrative-group 4,7-100,testgrp
 !
 interface Ethernet81/10
    description isis_port_channel_member
@@ -4966,6 +4966,7 @@ interface Ethernet84
 | Port-Channel113 | interface_with_mpls_enabled | - | 172.31.128.9/31 | default | - | - | - | - |
 | Port-Channel114 | interface_with_mpls_disabled | - | 172.31.128.10/31 | default | - | - | - | - |
 | Port-Channel136 | Test_te_admin_groups | - | 100.64.127.2/31 | default | - | - | - | - |
+| Port-Channel137 | Traffic Engineering Interface | - | 100.64.127.4/31 | default | - | - | - | - |
 
 ##### IP NAT: Source Static
 
@@ -5624,6 +5625,12 @@ interface Port-Channel136
    ip address 100.64.127.2/31
    traffic-engineering
    traffic-engineering administrative-group 7
+!
+interface Port-Channel137
+   description Traffic Engineering Interface
+   no switchport
+   ip address 100.64.127.4/31
+   traffic-engineering administrative-group 4,7-100,testgrp
 ```
 
 ### Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3630,6 +3630,7 @@ interface Dps1
 | Ethernet80 | LAG Member | 17 | *192.0.2.3/31 | **default | **- | **- | **- | **- |
 | Ethernet81/2 | LAG Member LACP fallback LLDP ZTP VLAN | 112 | *dhcp | **default | **- | **- | **- | **- |
 | Ethernet81/3 | Traffic Engineering Interface | - | 100.64.127.0/31 | default | - | False | - | - |
+| Ethernet81/4 | Traffic Engineering Interface | - | 100.64.127.0/31 | default | - | False | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -3788,9 +3789,10 @@ interface Dps1
 
 #### Traffic Engineering
 
-| Interface | Administrative Groups |
-| --------- | --------------------- |
-| Ethernet81/3 | 3,testgrp,15-29 |
+| Interface | Enabled | Administrative Groups |
+| --------- | ------- | --------------------- |
+| Ethernet81/3 | True | 3,testgrp,15-29 |
+| Ethernet81/4 | False | 4,testgrp,7-100 |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -4769,6 +4771,13 @@ interface Ethernet81/3
    ip address 100.64.127.0/31
    traffic-engineering
    traffic-engineering administrative-group 3,testgrp,15-29
+!
+interface Ethernet81/4
+   description Traffic Engineering Interface
+   no shutdown
+   no switchport
+   ip address 100.64.127.0/31
+   traffic-engineering administrative-group 4,testgrp,7-100
 !
 interface Ethernet81/10
    description isis_port_channel_member

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -4767,6 +4767,7 @@ interface Ethernet81/3
    no shutdown
    no switchport
    ip address 100.64.127.0/31
+   traffic-engineering
    traffic-engineering administrative-group 3,testgrp,15-29
 !
 interface Ethernet81/10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3629,6 +3629,7 @@ interface Dps1
 | Ethernet66 | Multiple VRIDs and tracking | - | 192.0.2.2/25 | default | - | False | - | - |
 | Ethernet80 | LAG Member | 17 | *192.0.2.3/31 | **default | **- | **- | **- | **- |
 | Ethernet81/2 | LAG Member LACP fallback LLDP ZTP VLAN | 112 | *dhcp | **default | **- | **- | **- | **- |
+| Ethernet81/3 | Traffic Engineering Interface | - | 100.64.127.0/31 | default | - | False | - | - |
 
 *Inherited from Port-Channel Interface
 
@@ -3784,6 +3785,12 @@ interface Dps1
 | Ethernet3 | 10 |
 | Ethernet5 | 127 |
 | Ethernet6 | disabled |
+
+#### Traffic Engineering
+
+| Interface | Administrative Groups |
+| --------- | --------------------- |
+| Ethernet81/3 | 3,testgrp,15-29 |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -4754,6 +4761,13 @@ interface Ethernet81/2
    channel-group 112 mode active
    lldp tlv transmit ztp vlan 112
    spanning-tree portfast
+!
+interface Ethernet81/3
+   description Traffic Engineering Interface
+   no shutdown
+   no switchport
+   ip address 100.64.127.0/31
+   traffic-engineering administrative-group 3,testgrp,15-29
 !
 interface Ethernet81/10
    description isis_port_channel_member

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -4956,6 +4956,7 @@ interface Ethernet84
 | Port-Channel112 | LACP fallback individual | - | dhcp | default | - | - | - | - |
 | Port-Channel113 | interface_with_mpls_enabled | - | 172.31.128.9/31 | default | - | - | - | - |
 | Port-Channel114 | interface_with_mpls_disabled | - | 172.31.128.10/31 | default | - | - | - | - |
+| Port-Channel136 | Test_te_admin_groups | - | 100.64.127.2/31 | default | - | - | - | - |
 
 ##### IP NAT: Source Static
 
@@ -4998,6 +4999,12 @@ interface Ethernet84
 | Port-Channel51 | EVPN_UNDERLAY | - | - | - | - | - | shared-secret |
 | Port-Channel100 | EVPN_UNDERLAY | - | - | - | - | - | Level-1: md5<br>Level-2: text |
 | Port-Channel110 | ISIS_TEST | True | 99 | point-to-point | level-2 | True | - |
+
+#### Traffic Engineering
+
+| Interface | Administrative Groups |
+| --------- | --------------------- |
+| Port-Channel136 | 7 |
 
 #### Port-Channel Interfaces Device Configuration
 
@@ -5601,6 +5608,13 @@ interface Port-Channel135
    switchport tap encapsulation gre protocol 0x2 feature header length 3 strip
    switchport tap encapsulation gre protocol 0x3 feature header length 2 strip re-encapsulation ethernet
    switchport tap encapsulation gre protocol 0x10 strip
+!
+interface Port-Channel136
+   description Test_te_admin_groups
+   no switchport
+   ip address 100.64.127.2/31
+   traffic-engineering
+   traffic-engineering administrative-group 7
 ```
 
 ### Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -5011,9 +5011,9 @@ interface Ethernet84
 
 #### Traffic Engineering
 
-| Interface | Administrative Groups |
-| --------- | --------------------- |
-| Port-Channel136 | 7 |
+| Interface | Enabled | Administrative Groups |
+| --------- | ------- | --------------------- |
+| Port-Channel136 | True | 7 |
 
 #### Port-Channel Interfaces Device Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -3192,6 +3192,13 @@ interface Ethernet81/2
    lldp tlv transmit ztp vlan 112
    spanning-tree portfast
 !
+interface Ethernet81/3
+   description Traffic Engineering Interface
+   no shutdown
+   no switchport
+   ip address 100.64.127.0/31
+   traffic-engineering administrative-group 3,testgrp,15-29
+!
 interface Ethernet81/10
    description isis_port_channel_member
    channel-group 110 mode active

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -2223,6 +2223,12 @@ interface Port-Channel136
    traffic-engineering
    traffic-engineering administrative-group 7
 !
+interface Port-Channel137
+   description Traffic Engineering Interface
+   no switchport
+   ip address 100.64.127.4/31
+   traffic-engineering administrative-group 4,7-100,testgrp
+!
 interface Dps1
    description Test DPS Interface
    shutdown
@@ -3205,14 +3211,14 @@ interface Ethernet81/3
    no switchport
    ip address 100.64.127.0/31
    traffic-engineering
-   traffic-engineering administrative-group 3,testgrp,15-29
+   traffic-engineering administrative-group 3,15-29,testgrp
 !
 interface Ethernet81/4
    description Traffic Engineering Interface
    no shutdown
    no switchport
    ip address 100.64.127.0/31
-   traffic-engineering administrative-group 4,testgrp,7-100
+   traffic-engineering administrative-group 4,7-100,testgrp
 !
 interface Ethernet81/10
    description isis_port_channel_member

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -3207,6 +3207,13 @@ interface Ethernet81/3
    traffic-engineering
    traffic-engineering administrative-group 3,testgrp,15-29
 !
+interface Ethernet81/4
+   description Traffic Engineering Interface
+   no shutdown
+   no switchport
+   ip address 100.64.127.0/31
+   traffic-engineering administrative-group 4,testgrp,7-100
+!
 interface Ethernet81/10
    description isis_port_channel_member
    channel-group 110 mode active

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -3197,6 +3197,7 @@ interface Ethernet81/3
    no shutdown
    no switchport
    ip address 100.64.127.0/31
+   traffic-engineering
    traffic-engineering administrative-group 3,testgrp,15-29
 !
 interface Ethernet81/10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -2216,6 +2216,13 @@ interface Port-Channel135
    switchport tap encapsulation gre protocol 0x3 feature header length 2 strip re-encapsulation ethernet
    switchport tap encapsulation gre protocol 0x10 strip
 !
+interface Port-Channel136
+   description Test_te_admin_groups
+   no switchport
+   ip address 100.64.127.2/31
+   traffic-engineering
+   traffic-engineering administrative-group 7
+!
 interface Dps1
    description Test DPS Interface
    shutdown

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -1862,6 +1862,19 @@ ethernet_interfaces:
         - testgrp
         - 15-29
 
+  - name: Ethernet81/4
+    description: Traffic Engineering Interface
+    shutdown: false
+    switchport:
+      enabled: false
+    ip_address: 100.64.127.0/31
+    traffic_engineering:
+      enabled: false
+      administrative_groups:
+        - 4
+        - testgrp
+        - 7-100
+
   - name: Ethernet82
     description: Switchport_tap_tool
     switchport:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -1856,6 +1856,7 @@ ethernet_interfaces:
       enabled: false
     ip_address: 100.64.127.0/31
     traffic_engineering:
+      enabled: true
       administrative_groups:
         - 3
         - testgrp

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -1849,6 +1849,18 @@ ethernet_interfaces:
     lldp:
       ztp_vlan: 112
 
+  - name: Ethernet81/3
+    description: Traffic Engineering Interface
+    shutdown: false
+    switchport:
+      enabled: false
+    ip_address: 100.64.127.0/31
+    traffic_engineering:
+      administrative_groups:
+        - 3
+        - testgrp
+        - 15-29
+
   - name: Ethernet82
     description: Switchport_tap_tool
     switchport:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -1859,8 +1859,8 @@ ethernet_interfaces:
       enabled: true
       administrative_groups:
         - 3
-        - testgrp
         - 15-29
+        - testgrp
 
   - name: Ethernet81/4
     description: Traffic Engineering Interface
@@ -1872,8 +1872,8 @@ ethernet_interfaces:
       enabled: false
       administrative_groups:
         - 4
-        - testgrp
         - 7-100
+        - testgrp
 
   - name: Ethernet82
     description: Switchport_tap_tool

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -1056,3 +1056,16 @@ port_channel_interfaces:
       enabled: true
       administrative_groups:
         - 7
+
+  - name: Port-Channel137
+    description: Traffic Engineering Interface
+    switchport:
+      enabled: false
+    ip_address: 100.64.127.4/31
+    traffic_engineering:
+      enabled: false
+      administrative_groups:
+        - 4
+        - 7-100
+        - testgrp
+

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -1046,3 +1046,13 @@ port_channel_interfaces:
                 feature_header_length: 2
                 re_encapsulation_ethernet_header: true
                 strip: true
+
+  - name: Port-Channel136
+    description: Test_te_admin_groups
+    switchport:
+      enabled: false
+    ip_address: 100.64.127.2/31
+    traffic_engineering:
+      enabled: true
+      administrative_groups:
+        - 7

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -1068,4 +1068,3 @@ port_channel_interfaces:
         - 4
         - 7-100
         - testgrp
-

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -599,6 +599,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "ethernet_interfaces.[].switchport.tool.groups") | List, items: String |  |  |  | Tool groups for the interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "ethernet_interfaces.[].switchport.tool.groups.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q_remove_outer_vlan_tag</samp>](## "ethernet_interfaces.[].switchport.tool.dot1q_remove_outer_vlan_tag") | String |  |  |  | Indices of vlan tags to be removed.<br>Range: 1-2 |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_engineering</samp>](## "ethernet_interfaces.[].traffic_engineering") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;administrative_groups</samp>](## "ethernet_interfaces.[].traffic_engineering.administrative_groups") | List, items: String |  |  |  | List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "ethernet_interfaces.[].traffic_engineering.administrative_groups.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration. |
 
 === "YAML"
@@ -1913,6 +1916,11 @@
             # Indices of vlan tags to be removed.
             # Range: 1-2
             dot1q_remove_outer_vlan_tag: <str>
+        traffic_engineering:
+
+          # List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+          administrative_groups:
+            - <str>
 
         # Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration.
         eos_cli: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -600,7 +600,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "ethernet_interfaces.[].switchport.tool.groups.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q_remove_outer_vlan_tag</samp>](## "ethernet_interfaces.[].switchport.tool.dot1q_remove_outer_vlan_tag") | String |  |  |  | Indices of vlan tags to be removed.<br>Range: 1-2 |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_engineering</samp>](## "ethernet_interfaces.[].traffic_engineering") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;administrative_groups</samp>](## "ethernet_interfaces.[].traffic_engineering.administrative_groups") | List, items: String |  |  |  | List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].traffic_engineering.enabled") | Boolean |  |  |  | Whether to enable traffic-engineering on this interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;administrative_groups</samp>](## "ethernet_interfaces.[].traffic_engineering.administrative_groups") | List, items: String |  |  |  | List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single integers 0-127. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "ethernet_interfaces.[].traffic_engineering.administrative_groups.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "ethernet_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration. |
 
@@ -1918,7 +1919,10 @@
             dot1q_remove_outer_vlan_tag: <str>
         traffic_engineering:
 
-          # List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+          # Whether to enable traffic-engineering on this interface.
+          enabled: <bool>
+
+          # List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
           administrative_groups:
             - <str>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -426,6 +426,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;groups</samp>](## "port_channel_interfaces.[].switchport.tool.groups") | List, items: String |  |  |  | Tool groups for the interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "port_channel_interfaces.[].switchport.tool.groups.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dot1q_remove_outer_vlan_tag</samp>](## "port_channel_interfaces.[].switchport.tool.dot1q_remove_outer_vlan_tag") | String |  |  |  | Indices of vlan tags to be removed.<br>Range: 1-2 |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;traffic_engineering</samp>](## "port_channel_interfaces.[].traffic_engineering") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "port_channel_interfaces.[].traffic_engineering.enabled") | Boolean |  |  |  | Whether to enable traffic-engineering on this interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;administrative_groups</samp>](## "port_channel_interfaces.[].traffic_engineering.administrative_groups") | List, items: String |  |  |  | List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single integers 0-127. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "port_channel_interfaces.[].traffic_engineering.administrative_groups.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;validate_state</samp>](## "port_channel_interfaces.[].validate_state") | Boolean |  |  |  | Set to false to disable interface state and LLDP topology validation performed by the `eos_validate_state` role. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;validate_lldp</samp>](## "port_channel_interfaces.[].validate_lldp") | Boolean |  |  |  | Set to false to disable the LLDP topology validation performed by the `eos_validate_state` role. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "port_channel_interfaces.[].eos_cli") | String |  |  |  | Multiline EOS CLI rendered directly on the port-channel interface in the final EOS configuration. |
@@ -1407,6 +1411,14 @@
             # Indices of vlan tags to be removed.
             # Range: 1-2
             dot1q_remove_outer_vlan_tag: <str>
+        traffic_engineering:
+
+          # Whether to enable traffic-engineering on this interface.
+          enabled: <bool>
+
+          # List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+          administrative_groups:
+            - <str>
 
         # Set to false to disable interface state and LLDP topology validation performed by the `eos_validate_state` role.
         validate_state: <bool>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -797,7 +797,7 @@
 {%     endif %}
 {%     set te_interfaces = [] %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
-{%         if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) or ethernet_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
+{%         if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
 {%             do te_interfaces.append(ethernet_interface) %}
 {%         endif %}
 {%     endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -795,6 +795,23 @@
 | {{ sync_e_interface.name }} | {{ sync_e_interface.sync_e.priority | arista.avd.default('127') }} |
 {%         endfor %}
 {%     endif %}
+{%     set te_interfaces = [] %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
+{%         if ethernet_interface.traffic_engineering is arista.avd.defined %}
+{%             do te_interfaces.append(ethernet_interface) %}
+{%         endif %}
+{%     endfor %}
+{%     if te_interfaces | length > 0 %}
+
+#### Traffic Engineering
+
+| Interface | Administrative Groups |
+| --------- | --------------------- |
+{%         for te_interface in te_interfaces %}
+{%             set admin_groups = te_interface.traffic_engineering.administrative_groups | arista.avd.default (["-"]) | join(",") %}
+| {{ te_interface.name }} | {{ admin_groups }} |
+{%         endfor %}
+{%     endif %}
 
 #### Ethernet Interfaces Device Configuration
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -797,7 +797,7 @@
 {%     endif %}
 {%     set te_interfaces = [] %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
-{%         if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) or traffic_engineering.administrative_groups is arista.avd.defined %}
+{%         if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) or ethernet_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
 {%             do te_interfaces.append(ethernet_interface) %}
 {%         endif %}
 {%     endfor %}
@@ -805,11 +805,12 @@
 
 #### Traffic Engineering
 
-| Interface | Administrative Groups |
-| --------- | --------------------- |
+| Interface | Enabled | Administrative Groups |
+| --------- | ------- | --------------------- |
 {%         for te_interface in te_interfaces %}
 {%             set admin_groups = te_interface.traffic_engineering.administrative_groups | arista.avd.default (["-"]) | join(",") %}
-| {{ te_interface.name }} | {{ admin_groups }} |
+{%             set te_enabled = te_interface.traffic_engineering.enabled | arista.avd.default (["false"]) %}
+| {{ te_interface.name }} | {{ te_enabled }} | {{ admin_groups }} |
 {%         endfor %}
 {%     endif %}
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -797,7 +797,7 @@
 {%     endif %}
 {%     set te_interfaces = [] %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
-{%         if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
+{%         if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) or traffic_engineering.administrative_groups is arista.avd.defined %}
 {%             do te_interfaces.append(ethernet_interface) %}
 {%         endif %}
 {%     endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -797,7 +797,7 @@
 {%     endif %}
 {%     set te_interfaces = [] %}
 {%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
-{%         if ethernet_interface.traffic_engineering is arista.avd.defined %}
+{%         if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
 {%             do te_interfaces.append(ethernet_interface) %}
 {%         endif %}
 {%     endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -809,7 +809,7 @@
 | --------- | ------- | --------------------- |
 {%         for te_interface in te_interfaces %}
 {%             set admin_groups = te_interface.traffic_engineering.administrative_groups | arista.avd.default (["-"]) | join(",") %}
-{%             set te_enabled = te_interface.traffic_engineering.enabled | arista.avd.default (["false"]) %}
+{%             set te_enabled = te_interface.traffic_engineering.enabled | arista.avd.default ("-") %}
 | {{ te_interface.name }} | {{ te_enabled }} | {{ admin_groups }} |
 {%         endfor %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/port-channel-interfaces.j2
@@ -411,6 +411,23 @@
 | {{ port_channel_interface.name }} | {{ isis_instance }} | {{ isis_bfd }} | {{ isis_metric }} | {{ mode }} | {{ isis_circuit_type }} | {{ isis_hello_padding }} | {{ isis_authentication_mode }} |
 {%         endfor %}
 {%     endif %}
+{%     set port_channel_te_interfaces = [] %}
+{%     for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort('name') %}
+{%         if port_channel_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
+{%             do port_channel_te_interfaces.append(port_channel_interface) %}
+{%         endif %}
+{%     endfor %}
+{%     if port_channel_te_interfaces | length > 0 %}
+
+#### Traffic Engineering
+
+| Interface | Administrative Groups |
+| --------- | --------------------- |
+{%         for po_te_interface in port_channel_te_interfaces %}
+{%             set admin_groups = po_te_interface.traffic_engineering.administrative_groups | arista.avd.default (["-"]) | join(",") %}
+| {{ po_te_interface.name }} | {{ admin_groups }} |
+{%         endfor %}
+{%     endif %}
 
 #### Port-Channel Interfaces Device Configuration
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/port-channel-interfaces.j2
@@ -421,11 +421,12 @@
 
 #### Traffic Engineering
 
-| Interface | Administrative Groups |
-| --------- | --------------------- |
+| Interface | Enabled | Administrative Groups |
+| --------- | ------- | --------------------- |
 {%         for po_te_interface in port_channel_te_interfaces %}
-{%             set admin_groups = po_te_interface.traffic_engineering.administrative_groups | arista.avd.default (["-"]) | join(",") %}
-| {{ po_te_interface.name }} | {{ admin_groups }} |
+{%             set admin_groups = po_te_interface.traffic_engineering.administrative_groups | arista.avd.default(["-"]) | join(",") %}
+{%             set te_enabled = po_te_interface.traffic_engineering.enabled | arista.avd.default("-") %}
+| {{ po_te_interface.name }} | {{ te_enabled }} | {{ admin_groups }} |
 {%         endfor %}
 {%     endif %}
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -1102,6 +1102,7 @@ interface {{ ethernet_interface.name }}
 {%         if ethernet_interface.switchport.tool.dzgre_preserve is arista.avd.defined(true) %}
    switchport tool dzgre preserve
 {%         endif %}
+{%     endif %}
 {%     if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
    traffic-engineering
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -1102,6 +1102,11 @@ interface {{ ethernet_interface.name }}
 {%         if ethernet_interface.switchport.tool.dzgre_preserve is arista.avd.defined(true) %}
    switchport tool dzgre preserve
 {%         endif %}
+{%     if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
+   traffic-engineering
+{%     endif %}
+{%     if ethernet_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
+   traffic-engineering administrative-group {{ ethernet_interface.traffic_engineering.administrative_groups | join(",") }}
 {%     endif %}
 {%     for link_tracking_group in ethernet_interface.link_tracking_groups | arista.avd.natural_sort %}
 {%         if link_tracking_group.name is arista.avd.defined and link_tracking_group.direction is arista.avd.defined %}
@@ -1313,12 +1318,6 @@ interface {{ ethernet_interface.name }}
 {%             endif %}
    {{ auth_failure_fallback_mba }}
 {%         endif %}
-{%     endif %}
-{%     if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
-   traffic-engineering
-{%     if ethernet_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
-   traffic-engineering administrative-group {{ ethernet_interface.traffic_engineering.administrative_groups | join(",") }}
-{%     endif %}
 {%     endif %}
 {%     if ethernet_interface.eos_cli is arista.avd.defined %}
    {{ ethernet_interface.eos_cli | indent(3, false) }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -1314,8 +1314,11 @@ interface {{ ethernet_interface.name }}
    {{ auth_failure_fallback_mba }}
 {%         endif %}
 {%     endif %}
-{%     if ethernet_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
+{%     if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
+   traffic-engineering
+{%         if ethernet_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
    traffic-engineering administrative-group {{ ethernet_interface.traffic_engineering.administrative_groups | join(",") }}
+{%         endif %}
 {%     endif %}
 {%     if ethernet_interface.eos_cli is arista.avd.defined %}
    {{ ethernet_interface.eos_cli | indent(3, false) }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -1316,9 +1316,9 @@ interface {{ ethernet_interface.name }}
 {%     endif %}
 {%     if ethernet_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
    traffic-engineering
-{%         if ethernet_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
+{%     if ethernet_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
    traffic-engineering administrative-group {{ ethernet_interface.traffic_engineering.administrative_groups | join(",") }}
-{%         endif %}
+{%     endif %}
 {%     endif %}
 {%     if ethernet_interface.eos_cli is arista.avd.defined %}
    {{ ethernet_interface.eos_cli | indent(3, false) }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -1314,6 +1314,9 @@ interface {{ ethernet_interface.name }}
    {{ auth_failure_fallback_mba }}
 {%         endif %}
 {%     endif %}
+{%     if ethernet_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
+   traffic-engineering administrative-group {{ ethernet_interface.traffic_engineering.administrative_groups | join(",") }}
+{%     endif %}
 {%     if ethernet_interface.eos_cli is arista.avd.defined %}
    {{ ethernet_interface.eos_cli | indent(3, false) }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -922,6 +922,7 @@ interface {{ port_channel_interface.name }}
 {%         if port_channel_interface.switchport.tool.dot1q_remove_outer_vlan_tag is arista.avd.defined %}
    switchport tool dot1q remove outer {{ port_channel_interface.switchport.tool.dot1q_remove_outer_vlan_tag }}
 {%         endif %}
+{%     endif %}
 {%     if port_channel_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
    traffic-engineering
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -936,6 +936,12 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.vmtracer is arista.avd.defined(true) %}
    vmtracer vmware-esx
 {%     endif %}
+{%     if port_channel_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
+   traffic-engineering
+{%         if port_channel_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
+   traffic-engineering administrative-group {{ port_channel_interface.traffic_engineering.administrative_groups | join(",") }}
+{%         endif %}
+{%     endif %}
 {%     if port_channel_interface.eos_cli is arista.avd.defined %}
    {{ port_channel_interface.eos_cli | indent(3, false) }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -922,6 +922,11 @@ interface {{ port_channel_interface.name }}
 {%         if port_channel_interface.switchport.tool.dot1q_remove_outer_vlan_tag is arista.avd.defined %}
    switchport tool dot1q remove outer {{ port_channel_interface.switchport.tool.dot1q_remove_outer_vlan_tag }}
 {%         endif %}
+{%     if port_channel_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
+   traffic-engineering
+{%     endif %}
+{%     if port_channel_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
+   traffic-engineering administrative-group {{ port_channel_interface.traffic_engineering.administrative_groups | join(",") }}
 {%     endif %}
 {%     for link_tracking_group in port_channel_interface.link_tracking_groups | arista.avd.natural_sort('name') %}
 {%         if link_tracking_group.name is arista.avd.defined and link_tracking_group.direction is arista.avd.defined %}
@@ -935,12 +940,6 @@ interface {{ port_channel_interface.name }}
 {%     endif %}
 {%     if port_channel_interface.vmtracer is arista.avd.defined(true) %}
    vmtracer vmware-esx
-{%     endif %}
-{%     if port_channel_interface.traffic_engineering.enabled is arista.avd.defined(true) %}
-   traffic-engineering
-{%         if port_channel_interface.traffic_engineering.administrative_groups is arista.avd.defined %}
-   traffic-engineering administrative-group {{ port_channel_interface.traffic_engineering.administrative_groups | join(",") }}
-{%         endif %}
 {%     endif %}
 {%     if port_channel_interface.eos_cli is arista.avd.defined %}
    {{ port_channel_interface.eos_cli | indent(3, false) }}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -12194,10 +12194,14 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
             AdministrativeGroups._item_type = str
 
-            _fields: ClassVar[dict] = {"administrative_groups": {"type": AdministrativeGroups}, "_custom_data": {"type": dict}}
+            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "administrative_groups": {"type": AdministrativeGroups}, "_custom_data": {"type": dict}}
+            enabled: bool | None
+            """Whether to enable traffic-engineering on this interface."""
             administrative_groups: AdministrativeGroups
             """
-            List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+            List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single
+            integers 0-127.
+
             Subclass of AvdList with `str` items.
             """
             _custom_data: dict[str, Any]
@@ -12205,7 +12209,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             if TYPE_CHECKING:
 
                 def __init__(
-                    self, *, administrative_groups: AdministrativeGroups | UndefinedType = Undefined, _custom_data: dict[str, Any] | UndefinedType = Undefined
+                    self,
+                    *,
+                    enabled: bool | None | UndefinedType = Undefined,
+                    administrative_groups: AdministrativeGroups | UndefinedType = Undefined,
+                    _custom_data: dict[str, Any] | UndefinedType = Undefined,
                 ) -> None:
                     """
                     TrafficEngineering.
@@ -12214,8 +12222,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Subclass of AvdModel.
 
                     Args:
+                        enabled: Whether to enable traffic-engineering on this interface.
                         administrative_groups:
-                           List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+                           List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single
+                           integers 0-127.
+
                            Subclass of AvdList with `str` items.
                         _custom_data: _custom_data
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -32690,6 +32690,52 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
+        class TrafficEngineering(AvdModel):
+            """Subclass of AvdModel."""
+
+            class AdministrativeGroups(AvdList[str]):
+                """Subclass of AvdList with `str` items."""
+
+            AdministrativeGroups._item_type = str
+
+            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "administrative_groups": {"type": AdministrativeGroups}, "_custom_data": {"type": dict}}
+            enabled: bool | None
+            """Whether to enable traffic-engineering on this interface."""
+            administrative_groups: AdministrativeGroups
+            """
+            List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single
+            integers 0-127.
+
+            Subclass of AvdList with `str` items.
+            """
+            _custom_data: dict[str, Any]
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self,
+                    *,
+                    enabled: bool | None | UndefinedType = Undefined,
+                    administrative_groups: AdministrativeGroups | UndefinedType = Undefined,
+                    _custom_data: dict[str, Any] | UndefinedType = Undefined,
+                ) -> None:
+                    """
+                    TrafficEngineering.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        enabled: Whether to enable traffic-engineering on this interface.
+                        administrative_groups:
+                           List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single
+                           integers 0-127.
+
+                           Subclass of AvdList with `str` items.
+                        _custom_data: _custom_data
+
+                    """
+
         _fields: ClassVar[dict] = {
             "name": {"type": str},
             "description": {"type": str},
@@ -32780,6 +32826,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "peer_type": {"type": str},
             "sflow": {"type": Sflow},
             "switchport": {"type": Switchport},
+            "traffic_engineering": {"type": TrafficEngineering},
             "validate_state": {"type": bool},
             "validate_lldp": {"type": bool},
             "eos_cli": {"type": str},
@@ -32966,6 +33013,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Subclass of AvdModel."""
         switchport: Switchport
         """Subclass of AvdModel."""
+        traffic_engineering: TrafficEngineering
+        """Subclass of AvdModel."""
         validate_state: bool | None
         """
         Set to false to disable interface state and LLDP topology validation performed by the
@@ -33071,6 +33120,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 peer_type: str | None | UndefinedType = Undefined,
                 sflow: Sflow | UndefinedType = Undefined,
                 switchport: Switchport | UndefinedType = Undefined,
+                traffic_engineering: TrafficEngineering | UndefinedType = Undefined,
                 validate_state: bool | None | UndefinedType = Undefined,
                 validate_lldp: bool | None | UndefinedType = Undefined,
                 eos_cli: str | None | UndefinedType = Undefined,
@@ -33196,6 +33246,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     peer_type: Key only used for documentation or validation purposes.
                     sflow: Subclass of AvdModel.
                     switchport: Subclass of AvdModel.
+                    traffic_engineering: Subclass of AvdModel.
                     validate_state:
                        Set to false to disable interface state and LLDP topology validation performed by the
                        `eos_validate_state` role.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -12186,6 +12186,41 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
+        class TrafficEngineering(AvdModel):
+            """Subclass of AvdModel."""
+
+            class AdministrativeGroups(AvdList[str]):
+                """Subclass of AvdList with `str` items."""
+
+            AdministrativeGroups._item_type = str
+
+            _fields: ClassVar[dict] = {"administrative_groups": {"type": AdministrativeGroups}, "_custom_data": {"type": dict}}
+            administrative_groups: AdministrativeGroups
+            """
+            List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+            Subclass of AvdList with `str` items.
+            """
+            _custom_data: dict[str, Any]
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self, *, administrative_groups: AdministrativeGroups | UndefinedType = Undefined, _custom_data: dict[str, Any] | UndefinedType = Undefined
+                ) -> None:
+                    """
+                    TrafficEngineering.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        administrative_groups:
+                           List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+                           Subclass of AvdList with `str` items.
+                        _custom_data: _custom_data
+
+                    """
+
         _fields: ClassVar[dict] = {
             "name": {"type": str},
             "description": {"type": str},
@@ -12300,6 +12335,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "validate_state": {"type": bool},
             "validate_lldp": {"type": bool},
             "switchport": {"type": Switchport},
+            "traffic_engineering": {"type": TrafficEngineering},
             "eos_cli": {"type": str},
             "_custom_data": {"type": dict},
         }
@@ -12565,6 +12601,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         Subclass of
         AvdModel.
         """
+        traffic_engineering: TrafficEngineering
+        """Subclass of AvdModel."""
         eos_cli: str | None
         """Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration."""
         _custom_data: dict[str, Any]
@@ -12687,6 +12725,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 validate_state: bool | None | UndefinedType = Undefined,
                 validate_lldp: bool | None | UndefinedType = Undefined,
                 switchport: Switchport | UndefinedType = Undefined,
+                traffic_engineering: TrafficEngineering | UndefinedType = Undefined,
                 eos_cli: str | None | UndefinedType = Undefined,
                 _custom_data: dict[str, Any] | UndefinedType = Undefined,
             ) -> None:
@@ -12861,6 +12900,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                        Subclass of
                        AvdModel.
+                    traffic_engineering: Subclass of AvdModel.
                     eos_cli: Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration.
                     _custom_data: _custom_data
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -11225,6 +11225,20 @@ keys:
             tool:
               type: dict
               $ref: eos_cli_config_gen#/keys/ethernet_interfaces/items/keys/switchport/keys/tool
+        traffic_engineering:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+              description: Whether to enable traffic-engineering on this interface.
+            administrative_groups:
+              type: list
+              description: List of traffic-engineering administrative groups, valid
+                values are names, ranges 0-127, or single integers 0-127.
+              items:
+                type: str
+                convert_types:
+                - int
         validate_state:
           type: bool
           description: Set to false to disable interface state and LLDP topology validation

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -4394,10 +4394,13 @@ keys:
         traffic_engineering:
           type: dict
           keys:
+            enabled:
+              type: bool
+              description: Whether to enable traffic-engineering on this interface.
             administrative_groups:
               type: list
-              description: List of administrative groups, valid values are names,
-                ranges 0-127, or single integers 0-127.
+              description: List of traffic-engineering administrative groups, valid
+                values are names, ranges 0-127, or single integers 0-127.
               items:
                 type: str
                 convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -4391,6 +4391,17 @@ keys:
                   description: 'Indices of vlan tags to be removed.
 
                     Range: 1-2'
+        traffic_engineering:
+          type: dict
+          keys:
+            administrative_groups:
+              type: list
+              description: List of administrative groups, valid values are names,
+                ranges 0-127, or single integers 0-127.
+              items:
+                type: str
+                convert_types:
+                - int
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the ethernet interface

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -2183,6 +2183,16 @@ keys:
                   description: |-
                     Indices of vlan tags to be removed.
                     Range: 1-2
+        traffic_engineering:
+          type: dict
+          keys:
+            administrative_groups:
+              type: list
+              description: List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+              items:
+                type: str
+                convert_types:
+                  - int
         eos_cli:
           type: str
           description: Multiline EOS CLI rendered directly on the ethernet interface in the final EOS configuration.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -2186,9 +2186,12 @@ keys:
         traffic_engineering:
           type: dict
           keys:
+            enabled:
+              type: bool
+              description: Whether to enable traffic-engineering on this interface.
             administrative_groups:
               type: list
-              description: List of administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+              description: List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
               items:
                 type: str
                 convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -1385,6 +1385,19 @@ keys:
             tool:
               type: dict
               $ref: "eos_cli_config_gen#/keys/ethernet_interfaces/items/keys/switchport/keys/tool"
+        traffic_engineering:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+              description: Whether to enable traffic-engineering on this interface.
+            administrative_groups:
+              type: list
+              description: List of traffic-engineering administrative groups, valid values are names, ranges 0-127, or single integers 0-127.
+              items:
+                type: str
+                convert_types:
+                  - int
         validate_state:
           type: bool
           description: Set to false to disable interface state and LLDP topology validation performed by the `eos_validate_state` role.


### PR DESCRIPTION
## Change Summary

Adds data model for interface traffic engineering and te admin groups for ethernet and port-channel interfaces.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Issues

Fixes part of #https://github.com/aristanetworks/avd-internal/issues/149

## Proposed changes

Adds the following data model to ethernet and port-channel interfaces:

```yaml
    traffic_engineering:
      enabled: <bool>
      administrative_groups: <list>
```

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
