### PR TITLE
Feat(eos_cli_config_gen): Add is_hostname knob to router_isis

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/router-isis-new.md
@@ -192,6 +192,7 @@ interface Vlan4094
 | Settings | Value |
 | -------- | ----- |
 | Instance | EVPN_UNDERLAY |
+| Hostname | MYROUTER |
 | Log Adjacency Changes | False |
 | MPLS LDP Sync Default | True |
 | Advertise Passive-only | True |
@@ -276,6 +277,7 @@ interface Vlan4094
 ```eos
 !
 router isis EVPN_UNDERLAY
+   is-hostname MYROUTER
    no log-adjacency-changes
    mpls ldp sync default
    redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/router-isis-new.cfg
@@ -58,6 +58,7 @@ interface Vlan4094
    ip address 10.255.252.0/31
 !
 router isis EVPN_UNDERLAY
+   is-hostname MYROUTER
    no log-adjacency-changes
    mpls ldp sync default
    redistribute connected

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/router-isis-new.yml
@@ -1,6 +1,7 @@
 ### Routing - ISIS ###
 router_isis:
   instance: EVPN_UNDERLAY
+  is_hostname: MYROUTER
   log_adjacency_changes: false
   mpls_ldp_sync_default: true
   spf_interval:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-isis.md
@@ -11,6 +11,7 @@
     | [<samp>&nbsp;&nbsp;instance</samp>](## "router_isis.instance") | String | Required |  |  | ISIS Instance Name. |
     | [<samp>&nbsp;&nbsp;net</samp>](## "router_isis.net") | String |  |  |  | CLNS Address like "49.0001.0001.0000.0001.00". |
     | [<samp>&nbsp;&nbsp;router_id</samp>](## "router_isis.router_id") | String |  |  |  | IPv4 Address. |
+    | [<samp>&nbsp;&nbsp;is_hostname</samp>](## "router_isis.is_hostname") | String |  |  |  | Hostname of Intermediate System. |
     | [<samp>&nbsp;&nbsp;is_type</samp>](## "router_isis.is_type") | String |  |  | Valid Values:<br>- <code>level-1</code><br>- <code>level-1-2</code><br>- <code>level-2</code> |  |
     | [<samp>&nbsp;&nbsp;log_adjacency_changes</samp>](## "router_isis.log_adjacency_changes") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;mpls_ldp_sync_default</samp>](## "router_isis.mpls_ldp_sync_default") | Boolean |  |  |  |  |
@@ -150,6 +151,9 @@
 
       # IPv4 Address.
       router_id: <str>
+
+      # Hostname of Intermediate System.
+      is_hostname: <str>
       is_type: <str; "level-1" | "level-1-2" | "level-2">
       log_adjacency_changes: <bool>
       mpls_ldp_sync_default: <bool>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-isis.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/router-isis.j2
@@ -18,6 +18,9 @@
 {%     if router_isis.net is arista.avd.defined %}
 | Net-ID | {{ router_isis.net }} |
 {%     endif %}
+{%     if router_isis.is_hostname is arista.avd.defined %}
+| Hostname | {{ router_isis.is_hostname }} |
+{%     endif %}
 {%     if router_isis.is_type is arista.avd.defined %}
 | Type | {{ router_isis.is_type }} |
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-isis.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-isis.j2
@@ -10,6 +10,9 @@ router isis {{ router_isis.instance }}
 {%     if router_isis.net is arista.avd.defined %}
    net {{ router_isis.net }}
 {%     endif %}
+{%     if router_isis.is_hostname is arista.avd.defined %}
+   is-hostname {{ router_isis.is_hostname }}
+{%     endif %}
 {%     if router_isis.router_id is arista.avd.defined %}
    router-id ipv4 {{ router_isis.router_id }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -18046,6 +18046,9 @@ keys:
       router_id:
         type: str
         description: IPv4 Address.
+      is_hostname:
+        type: str
+        description: Hostname of Intermediate System.
       is_type:
         display_name: IS Type
         type: str

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
@@ -19,6 +19,9 @@ keys:
       router_id:
         type: str
         description: IPv4 Address.
+      is_hostname:
+        type: str
+        description: Hostname of Intermediate System.
       is_type:
         display_name: "IS Type"
         type: str


### PR DESCRIPTION
## Change Summary

Add knob to set "is_hostname" under "router_isis"

cli order tested under EOS 4.28.10.1M

## Related Issue(s)

Fixes #<N/A>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
```
keys:
  router_isis:
    type: dict
    keys:
    <snip>
      is_hostname:
        type: str
        description: Hostname of Intermediate System.
```

## How to test
added molecule test

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
