### PR TITLE
Fix(eos_cli_config_gen): Fix the invalid configuration of vpn-route in export direction for router bgp vrf

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -8568,7 +8568,7 @@ router bgp 65101
       route-target export evpn 1:30001
       route-target export evpn rcf RT_EXPORT_AF_RCF()
       route-target export vpn-ipv6 1:30011
-      route-target export vpn-ipv6 rcf RT_IMPORT_AF_RCF() vpn-route filter-rcf RT_IMPORT_AF_RCF_FILTER()
+      route-target export vpn-ipv6 rcf RT_IMPORT_AF_RCF() vrf-route filter-rcf RT_IMPORT_AF_RCF_FILTER()
       route-target export vpn-ipv6 route-map RT_IMPORT_AF_RM
       redistribute connected
       redistribute ospf match external include leaked

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -5391,7 +5391,7 @@ router bgp 65101
       route-target export evpn 1:30001
       route-target export evpn rcf RT_EXPORT_AF_RCF()
       route-target export vpn-ipv6 1:30011
-      route-target export vpn-ipv6 rcf RT_IMPORT_AF_RCF() vpn-route filter-rcf RT_IMPORT_AF_RCF_FILTER()
+      route-target export vpn-ipv6 rcf RT_IMPORT_AF_RCF() vrf-route filter-rcf RT_IMPORT_AF_RCF_FILTER()
       route-target export vpn-ipv6 route-map RT_IMPORT_AF_RM
       redistribute connected
       redistribute ospf match external include leaked

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/router-bgp.yml
@@ -1982,7 +1982,7 @@ router_bgp:
               - "1:30011"
             rcf: RT_IMPORT_AF_RCF()
             route_map: RT_IMPORT_AF_RM
-            vpn_route_filter_rcf: RT_IMPORT_AF_RCF_FILTER()
+            vrf_route_filter_rcf: RT_IMPORT_AF_RCF_FILTER()
       redistribute:
         ospf:
           match_external:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -1076,7 +1076,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "router_bgp.vrfs.[].route_targets.export.[].route_targets.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "router_bgp.vrfs.[].route_targets.export.[].route_map") | String |  |  |  | Only applicable if `address_family` is one of `evpn`, `vpn-ipv4` or `vpn-ipv6`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rcf</samp>](## "router_bgp.vrfs.[].route_targets.export.[].rcf") | String |  |  |  | RCF function name with parenthesis.<br>Example: MyFunction(myarg).<br>Only applicable if `address_family` is one of `evpn`, `vpn-ipv4` or `vpn-ipv6`. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vpn_route_filter_rcf</samp>](## "router_bgp.vrfs.[].route_targets.export.[].vpn_route_filter_rcf") | String |  |  |  | RCF function name with parenthesis for filtering VPN routes. Also requires `rcf` to be set.<br>Example: MyFunction(myarg).<br>Only applicable if `address_family` is one of `vpn-ipv4` or `vpn-ipv6`. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf_route_filter_rcf</samp>](## "router_bgp.vrfs.[].route_targets.export.[].vrf_route_filter_rcf") | String |  |  |  | RCF function name with parenthesis for filtering VRF routes. Also requires `rcf` to be set.<br>Example: MyFunction(myarg).<br>Only applicable if `address_family` is one of `vpn-ipv4` or `vpn-ipv6`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;router_id</samp>](## "router_bgp.vrfs.[].router_id") | String |  |  |  | in IP address format A.B.C.D. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;timers</samp>](## "router_bgp.vrfs.[].timers") | String |  |  |  | BGP Keepalive and Hold Timer values in seconds as string "<0-3600> <0-3600>". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;networks</samp>](## "router_bgp.vrfs.[].networks") | List, items: Dictionary |  |  |  |  |
@@ -3825,10 +3825,10 @@
                 # Only applicable if `address_family` is one of `evpn`, `vpn-ipv4` or `vpn-ipv6`.
                 rcf: <str>
 
-                # RCF function name with parenthesis for filtering VPN routes. Also requires `rcf` to be set.
+                # RCF function name with parenthesis for filtering VRF routes. Also requires `rcf` to be set.
                 # Example: MyFunction(myarg).
                 # Only applicable if `address_family` is one of `vpn-ipv4` or `vpn-ipv6`.
-                vpn_route_filter_rcf: <str>
+                vrf_route_filter_rcf: <str>
 
           # in IP address format A.B.C.D.
           router_id: <str>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -2678,7 +2678,7 @@ router bgp {{ router_bgp.as }}
 {%                 if address_family.address_family in ['evpn', 'vpn-ipv4', 'vpn-ipv6'] %}
 {%                     if address_family.rcf is arista.avd.defined %}
 {%                         if address_family.vpn_route_filter_rcf is arista.avd.defined and address_family.address_family in ['vpn-ipv4', 'vpn-ipv6'] %}
-      route-target export {{ address_family.address_family }} rcf {{ address_family.rcf }} vpn-route filter-rcf {{ address_family.vpn_route_filter_rcf }}
+      route-target export {{ address_family.address_family }} rcf {{ address_family.rcf }} vrf-route filter-rcf {{ address_family.vpn_route_filter_rcf }}
 {%                         else %}
       route-target export {{ address_family.address_family }} rcf {{ address_family.rcf }}
 {%                         endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -2677,8 +2677,8 @@ router bgp {{ router_bgp.as }}
 {%                 endfor %}
 {%                 if address_family.address_family in ['evpn', 'vpn-ipv4', 'vpn-ipv6'] %}
 {%                     if address_family.rcf is arista.avd.defined %}
-{%                         if address_family.vpn_route_filter_rcf is arista.avd.defined and address_family.address_family in ['vpn-ipv4', 'vpn-ipv6'] %}
-      route-target export {{ address_family.address_family }} rcf {{ address_family.rcf }} vrf-route filter-rcf {{ address_family.vpn_route_filter_rcf }}
+{%                         if address_family.vrf_route_filter_rcf is arista.avd.defined and address_family.address_family in ['vpn-ipv4', 'vpn-ipv6'] %}
+      route-target export {{ address_family.address_family }} rcf {{ address_family.rcf }} vrf-route filter-rcf {{ address_family.vrf_route_filter_rcf }}
 {%                         else %}
       route-target export {{ address_family.address_family }} rcf {{ address_family.rcf }}
 {%                         endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -47051,7 +47051,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         "route_targets": {"type": RouteTargets},
                         "route_map": {"type": str},
                         "rcf": {"type": str},
-                        "vpn_route_filter_rcf": {"type": str},
+                        "vrf_route_filter_rcf": {"type": str},
                         "_custom_data": {"type": dict},
                     }
                     address_family: str
@@ -47066,9 +47066,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Only applicable if `address_family`
                     is one of `evpn`, `vpn-ipv4` or `vpn-ipv6`.
                     """
-                    vpn_route_filter_rcf: str | None
+                    vrf_route_filter_rcf: str | None
                     """
-                    RCF function name with parenthesis for filtering VPN routes. Also requires `rcf` to be set.
+                    RCF function name with parenthesis for filtering VRF routes. Also requires `rcf` to be set.
                     Example:
                     MyFunction(myarg).
                     Only applicable if `address_family` is one of `vpn-ipv4` or `vpn-ipv6`.
@@ -47084,7 +47084,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             route_targets: RouteTargets | UndefinedType = Undefined,
                             route_map: str | None | UndefinedType = Undefined,
                             rcf: str | None | UndefinedType = Undefined,
-                            vpn_route_filter_rcf: str | None | UndefinedType = Undefined,
+                            vrf_route_filter_rcf: str | None | UndefinedType = Undefined,
                             _custom_data: dict[str, Any] | UndefinedType = Undefined,
                         ) -> None:
                             """
@@ -47102,8 +47102,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                                    Example: MyFunction(myarg).
                                    Only applicable if `address_family`
                                    is one of `evpn`, `vpn-ipv4` or `vpn-ipv6`.
-                                vpn_route_filter_rcf:
-                                   RCF function name with parenthesis for filtering VPN routes. Also requires `rcf` to be set.
+                                vrf_route_filter_rcf:
+                                   RCF function name with parenthesis for filtering VRF routes. Also requires `rcf` to be set.
                                    Example:  # fmt: skip
                                    MyFunction(myarg).
                                    Only applicable if `address_family` is one of `vpn-ipv4` or `vpn-ipv6`.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -15945,10 +15945,10 @@ keys:
 
                           Only applicable if `address_family` is one of `evpn`, `vpn-ipv4`
                           or `vpn-ipv6`.'
-                      vpn_route_filter_rcf:
+                      vrf_route_filter_rcf:
                         type: str
                         description: 'RCF function name with parenthesis for filtering
-                          VPN routes. Also requires `rcf` to be set.
+                          VRF routes. Also requires `rcf` to be set.
 
                           Example: MyFunction(myarg).
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
@@ -3762,10 +3762,10 @@ keys:
                           RCF function name with parenthesis.
                           Example: MyFunction(myarg).
                           Only applicable if `address_family` is one of `evpn`, `vpn-ipv4` or `vpn-ipv6`.
-                      vpn_route_filter_rcf:
+                      vrf_route_filter_rcf:
                         type: str
                         description: |-
-                          RCF function name with parenthesis for filtering VPN routes. Also requires `rcf` to be set.
+                          RCF function name with parenthesis for filtering VRF routes. Also requires `rcf` to be set.
                           Example: MyFunction(myarg).
                           Only applicable if `address_family` is one of `vpn-ipv4` or `vpn-ipv6`.
             router_id:


### PR DESCRIPTION
## Change Summary

Fix the vrf-route for route-target export in router bgp vrf.

Router BGP VRF configuration for route-target should have vrf-route in one direction(export) and vpn-route in the other direction(import) but right now both have vpn-route. 

Hence it renders the below configuration.
route-target export vpn-ipv6 rcf RT_IMPORT_AF_RCF() vpn-route filter-rcf RT_IMPORT_AF_RCF_FILTER().

Expected configuration
route-target export vpn-ipv6 rcf RT_IMPORT_AF_RCF() vrf-route filter-rcf RT_IMPORT_AF_RCF_FILTER()

## Related Issue(s)

Fixes #4731 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Updated the j2 template to render the vrf-route instead of vpn-route for export direction in router bgp vrf.

## How to test
Run molecule and deploy the config on lab.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
