### PR TITLE
Feat(eos_cli_config_gen): Added support for DHCP client accept default route feature in port-channel interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3412,6 +3412,7 @@ interface Dps1
 | Ethernet65 | Multiple VRIDs | - | 192.0.2.2/25 | default | - | False | - | - |
 | Ethernet66 | Multiple VRIDs and tracking | - | 192.0.2.2/25 | default | - | False | - | - |
 | Ethernet80 | LAG Member | 17 | *192.0.2.3/31 | **default | **- | **- | **- | **- |
+| Ethernet81/2 | LAG Member LACP fallback LLDP ZTP VLAN | 112 | *dhcp | **default | **- | **- | **- | **- |
 
 *Inherited from Port-Channel Interface
 
@@ -4674,6 +4675,8 @@ interface Ethernet81/10
 | Port-Channel99 | MCAST | - | 192.0.2.10/31 | default | - | - | - | - |
 | Port-Channel100.101 | IFL for TENANT01 | - | 10.1.1.3/31 | default | 1500 | - | - | - |
 | Port-Channel100.102 | IFL for TENANT02 | - | 10.1.2.3/31 | C2 | 1500 | - | - | - |
+| Port-Channel111.400 | TENANT_A pseudowire 3 interface | - | dhcp | default | - | - | - | - |
+| Port-Channel112 | LACP fallback individual | - | dhcp | default | - | - | - | - |
 | Port-Channel113 | interface_with_mpls_enabled | - | 172.31.128.9/31 | default | - | - | - | - |
 | Port-Channel114 | interface_with_mpls_disabled | - | 172.31.128.10/31 | default | - | - | - | - |
 
@@ -5112,6 +5115,7 @@ interface Port-Channel111.400
    !
    encapsulation vlan
       client dot1q outer 400 inner 20 network dot1q outer 401 inner 21
+   ip address dhcp
 !
 interface Port-Channel111.1000
    description L2 Subinterface
@@ -5130,6 +5134,8 @@ interface Port-Channel112
    switchport trunk allowed vlan 112
    switchport mode trunk
    switchport
+   ip address dhcp
+   dhcp client accept default-route
    port-channel lacp fallback individual
    port-channel lacp fallback timeout 5
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1930,6 +1930,7 @@ interface Port-Channel111.400
    !
    encapsulation vlan
       client dot1q outer 400 inner 20 network dot1q outer 401 inner 21
+   ip address dhcp
 !
 interface Port-Channel111.1000
    description L2 Subinterface
@@ -1948,6 +1949,8 @@ interface Port-Channel112
    switchport trunk allowed vlan 112
    switchport mode trunk
    switchport
+   ip address dhcp
+   dhcp client accept default-route
    port-channel lacp fallback individual
    port-channel lacp fallback timeout 5
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -714,6 +714,7 @@ port_channel_interfaces:
     switchport:
       enabled: false
     ip_address: 172.31.128.9/31
+    # This won't be rendered because IP address is not DHCP
     dhcp_client_accept_default_route: true
     mpls:
       ip: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -673,7 +673,6 @@ port_channel_interfaces:
   - name: Port-Channel111.400
     description: TENANT_A pseudowire 3 interface
     ip_address: dhcp
-    dhcp_client_accept_default_route: false
     encapsulation_vlan:
       client:
         encapsulation: dot1q
@@ -727,7 +726,6 @@ port_channel_interfaces:
     switchport:
       enabled: false
     ip_address: 172.31.128.10/31
-    dhcp_client_accept_default_route: false
     mpls:
       ip: false
       ldp:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -672,6 +672,8 @@ port_channel_interfaces:
 
   - name: Port-Channel111.400
     description: TENANT_A pseudowire 3 interface
+    ip_address: dhcp
+    dhcp_client_accept_default_route: false
     encapsulation_vlan:
       client:
         encapsulation: dot1q
@@ -705,12 +707,15 @@ port_channel_interfaces:
         allowed_vlan: 112
     lacp_fallback_timeout: 5
     lacp_fallback_mode: individual
+    ip_address: dhcp
+    dhcp_client_accept_default_route: true
 
   - name: Port-Channel113
     description: interface_with_mpls_enabled
     switchport:
       enabled: false
     ip_address: 172.31.128.9/31
+    dhcp_client_accept_default_route: true
     mpls:
       ip: true
       ldp:
@@ -722,6 +727,7 @@ port_channel_interfaces:
     switchport:
       enabled: false
     ip_address: 172.31.128.10/31
+    dhcp_client_accept_default_route: false
     mpls:
       ip: false
       ldp:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -214,7 +214,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].ptp.vlan") | String |  |  |  | VLAN can be 'all' or list of vlans as string. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transport</samp>](## "port_channel_interfaces.[].ptp.transport") | String |  |  | Valid Values:<br>- <code>ipv4</code><br>- <code>ipv6</code><br>- <code>layer2</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mpass</samp>](## "port_channel_interfaces.[].ptp.mpass") | Boolean |  |  |  | When MPASS is enabled on an MLAG port-channel, MLAG peers coordinate to function as a single PTP logical device.<br>Arista PTP enabled devices always place PTP messages on the same physical link within the port-channel.<br>Hence, MPASS is needed only on MLAG port-channels connected to non-Arista devices. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "port_channel_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "port_channel_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask or "dhcp". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "port_channel_interfaces.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Install default-route obtained via DHCP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify_unicast_source_reachable_via</samp>](## "port_channel_interfaces.[].ip_verify_unicast_source_reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_nat</samp>](## "port_channel_interfaces.[].ip_nat") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "port_channel_interfaces.[].ip_nat.destination") | Dictionary |  |  |  |  |
@@ -852,8 +853,11 @@
           # Hence, MPASS is needed only on MLAG port-channels connected to non-Arista devices.
           mpass: <bool>
 
-        # IPv4 address/mask.
+        # IPv4 address/mask or "dhcp".
         ip_address: <str>
+
+        # Install default-route obtained via DHCP.
+        dhcp_client_accept_default_route: <bool>
         ip_verify_unicast_source_reachable_via: <str; "any" | "rx">
         ip_nat:
           destination:

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -330,6 +330,9 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.ip_address is arista.avd.defined %}
    ip address {{ port_channel_interface.ip_address }}
 {%     endif %}
+{%     if port_channel_interface.ip_address is arista.avd.defined("dhcp") and port_channel_interface.dhcp_client_accept_default_route is arista.avd.defined(true) %}
+   dhcp client accept default-route
+{%     endif %}
 {%     if port_channel_interface.ip_verify_unicast_source_reachable_via is arista.avd.defined %}
    ip verify unicast source reachable-via {{ port_channel_interface.ip_verify_unicast_source_reachable_via }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -30486,6 +30486,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "vmtracer": {"type": bool},
             "ptp": {"type": Ptp},
             "ip_address": {"type": str},
+            "dhcp_client_accept_default_route": {"type": bool},
             "ip_verify_unicast_source_reachable_via": {"type": str},
             "ip_nat": {"type": IpNat},
             "ipv6_enable": {"type": bool},
@@ -30641,7 +30642,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         ptp: Ptp
         """Subclass of AvdModel."""
         ip_address: str | None
-        """IPv4 address/mask."""
+        """IPv4 address/mask or "dhcp"."""
+        dhcp_client_accept_default_route: bool | None
+        """Install default-route obtained via DHCP."""
         ip_verify_unicast_source_reachable_via: Literal["any", "rx"] | None
         ip_nat: IpNat
         """Subclass of AvdModel."""
@@ -30767,6 +30770,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 vmtracer: bool | None | UndefinedType = Undefined,
                 ptp: Ptp | UndefinedType = Undefined,
                 ip_address: str | None | UndefinedType = Undefined,
+                dhcp_client_accept_default_route: bool | None | UndefinedType = Undefined,
                 ip_verify_unicast_source_reachable_via: Literal["any", "rx"] | None | UndefinedType = Undefined,
                 ip_nat: IpNat | UndefinedType = Undefined,
                 ipv6_enable: bool | None | UndefinedType = Undefined,
@@ -30886,7 +30890,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     spanning_tree_portfast: spanning_tree_portfast
                     vmtracer: vmtracer
                     ptp: Subclass of AvdModel.
-                    ip_address: IPv4 address/mask.
+                    ip_address: IPv4 address/mask or "dhcp".
+                    dhcp_client_accept_default_route: Install default-route obtained via DHCP.
                     ip_verify_unicast_source_reachable_via: ip_verify_unicast_source_reachable_via
                     ip_nat: Subclass of AvdModel.
                     ipv6_enable: ipv6_enable

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -10087,7 +10087,10 @@ keys:
                 devices.'
         ip_address:
           type: str
-          description: IPv4 address/mask.
+          description: IPv4 address/mask or "dhcp".
+        dhcp_client_accept_default_route:
+          type: bool
+          description: Install default-route obtained via DHCP.
         ip_verify_unicast_source_reachable_via:
           type: str
           valid_values:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -801,7 +801,10 @@ keys:
                 Hence, MPASS is needed only on MLAG port-channels connected to non-Arista devices.
         ip_address:
           type: str
-          description: IPv4 address/mask.
+          description: IPv4 address/mask or "dhcp".
+        dhcp_client_accept_default_route:
+          type: bool
+          description: Install default-route obtained via DHCP.
         ip_verify_unicast_source_reachable_via:
           type: str
           valid_values:


### PR DESCRIPTION

## Change Summary

Added support for DHCP client accept default route feature in port-channel interfaces.

## Related Issue(s)

Fixes #4766 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added support for DHCP client accept default route feature in port-channel interfaces.

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
