### PR TITLE
Doc(eos_cli_config_gen): Improve snmp server documention

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
@@ -60,7 +60,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;host</samp>](## "snmp_server.hosts.[].host") | String |  |  |  | Host IP address or name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.hosts.[].vrf") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.hosts.[].version") | String |  |  | Valid Values:<br>- <code>1</code><br>- <code>2c</code><br>- <code>3</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  | Community name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  | Community name. Required when version "1" or "2c". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users</samp>](## "snmp_server.hosts.[].users") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;username</samp>](## "snmp_server.hosts.[].users.[].username") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_level</samp>](## "snmp_server.hosts.[].users.[].authentication_level") | String |  |  | Valid Values:<br>- <code>auth</code><br>- <code>noauth</code><br>- <code>priv</code> |  |
@@ -184,7 +184,7 @@
           vrf: <str>
           version: <str; "1" | "2c" | "3">
 
-          # Community name.
+          # Community name. Required when version "1" or "2c".
           community: <str>
           users:
             - username: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
@@ -60,7 +60,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;host</samp>](## "snmp_server.hosts.[].host") | String |  |  |  | Host IP address or name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_server.hosts.[].vrf") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.hosts.[].version") | String |  |  | Valid Values:<br>- <code>1</code><br>- <code>2c</code><br>- <code>3</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  | Community name. Required when version "1" or "2c". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_server.hosts.[].community") | String |  |  |  | Community name. Required with version "1" or "2c". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users</samp>](## "snmp_server.hosts.[].users") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;username</samp>](## "snmp_server.hosts.[].users.[].username") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_level</samp>](## "snmp_server.hosts.[].users.[].authentication_level") | String |  |  | Valid Values:<br>- <code>auth</code><br>- <code>noauth</code><br>- <code>priv</code> |  |
@@ -184,7 +184,7 @@
           vrf: <str>
           version: <str; "1" | "2c" | "3">
 
-          # Community name. Required when version "1" or "2c".
+          # Community name. Required with version "1" or "2c".
           community: <str>
           users:
             - username: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
@@ -32,7 +32,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_mgmt_interface_vrf</samp>](## "snmp_settings.hosts.[].use_mgmt_interface_vrf") | Boolean |  |  |  | Configure the SNMP host under the VRF set with "mgmt_interface_vrf". Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_inband_mgmt_vrf" to configure the SNMP host under multiple VRFs. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_inband_mgmt_vrf</samp>](## "snmp_settings.hosts.[].use_inband_mgmt_vrf") | Boolean |  |  |  | Configure the SNMP host under the VRF set with "inband_mgmt_vrf". Ignored if inband management is not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_mgmt_interface_vrf" to configure the SNMP host under multiple VRFs. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_settings.hosts.[].version") | String |  |  | Valid Values:<br>- <code>1</code><br>- <code>2c</code><br>- <code>3</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_settings.hosts.[].community") | String |  |  |  | Community name. Required when version "1" or "2c". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_settings.hosts.[].community") | String |  |  |  | Community name. Required with version "1" or "2c". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users</samp>](## "snmp_settings.hosts.[].users") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;username</samp>](## "snmp_settings.hosts.[].users.[].username") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_level</samp>](## "snmp_settings.hosts.[].users.[].authentication_level") | String |  |  | Valid Values:<br>- <code>auth</code><br>- <code>noauth</code><br>- <code>priv</code> |  |
@@ -151,7 +151,7 @@
           use_inband_mgmt_vrf: <bool>
           version: <str; "1" | "2c" | "3">
 
-          # Community name. Required when version "1" or "2c".
+          # Community name. Required with version "1" or "2c".
           community: <str>
           users:
             - username: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
@@ -32,7 +32,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_mgmt_interface_vrf</samp>](## "snmp_settings.hosts.[].use_mgmt_interface_vrf") | Boolean |  |  |  | Configure the SNMP host under the VRF set with "mgmt_interface_vrf". Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_inband_mgmt_vrf" to configure the SNMP host under multiple VRFs. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_inband_mgmt_vrf</samp>](## "snmp_settings.hosts.[].use_inband_mgmt_vrf") | Boolean |  |  |  | Configure the SNMP host under the VRF set with "inband_mgmt_vrf". Ignored if inband management is not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_mgmt_interface_vrf" to configure the SNMP host under multiple VRFs. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_settings.hosts.[].version") | String |  |  | Valid Values:<br>- <code>1</code><br>- <code>2c</code><br>- <code>3</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_settings.hosts.[].community") | String |  |  |  | Community name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_settings.hosts.[].community") | String |  |  |  | Community name. Required when version "1" or "2c". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users</samp>](## "snmp_settings.hosts.[].users") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;username</samp>](## "snmp_settings.hosts.[].users.[].username") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_level</samp>](## "snmp_settings.hosts.[].users.[].authentication_level") | String |  |  | Valid Values:<br>- <code>auth</code><br>- <code>noauth</code><br>- <code>priv</code> |  |
@@ -151,7 +151,7 @@
           use_inband_mgmt_vrf: <bool>
           version: <str; "1" | "2c" | "3">
 
-          # Community name.
+          # Community name. Required when version "1" or "2c".
           community: <str>
           users:
             - username: <str>

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -60950,7 +60950,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             vrf: str | None
             version: Literal["1", "2c", "3"] | None
             community: str | None
-            """Community name."""
+            """Community name. Required when version "1" or "2c"."""
             users: Users
             """Subclass of AvdList with `UsersItem` items."""
             _custom_data: dict[str, Any]
@@ -60977,7 +60977,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         host: Host IP address or name.
                         vrf: vrf
                         version: version
-                        community: Community name.
+                        community: Community name. Required when version "1" or "2c".
                         users: Subclass of AvdList with `UsersItem` items.
                         _custom_data: _custom_data
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -60950,7 +60950,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             vrf: str | None
             version: Literal["1", "2c", "3"] | None
             community: str | None
-            """Community name. Required when version "1" or "2c"."""
+            """Community name. Required with version "1" or "2c"."""
             users: Users
             """Subclass of AvdList with `UsersItem` items."""
             _custom_data: dict[str, Any]
@@ -60977,7 +60977,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         host: Host IP address or name.
                         vrf: vrf
                         version: version
-                        community: Community name. Required when version "1" or "2c".
+                        community: Community name. Required with version "1" or "2c".
                         users: Subclass of AvdList with `UsersItem` items.
                         _custom_data: _custom_data
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -20194,7 +20194,7 @@ keys:
               - '3'
             community:
               type: str
-              description: Community name.
+              description: Community name. Required when version "1" or "2c".
             users:
               type: list
               items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -20194,7 +20194,7 @@ keys:
               - '3'
             community:
               type: str
-              description: Community name. Required when version "1" or "2c".
+              description: Community name. Required with version "1" or "2c".
             users:
               type: list
               items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
@@ -215,7 +215,7 @@ keys:
               valid_values: ["1", "2c", "3"]
             community:
               type: str
-              description: Community name.
+              description: Community name. Required when version "1" or "2c".
             users:
               type: list
               items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
@@ -215,7 +215,7 @@ keys:
               valid_values: ["1", "2c", "3"]
             community:
               type: str
-              description: Community name. Required when version "1" or "2c".
+              description: Community name. Required with version "1" or "2c".
             users:
               type: list
               items:

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -12836,7 +12836,7 @@ class EosDesigns(EosDesignsRootModel):
             """
             version: Literal["1", "2c", "3"] | None
             community: str | None
-            """Community name. Required when version "1" or "2c"."""
+            """Community name. Required with version "1" or "2c"."""
             users: Users
             """Subclass of AvdList with `UsersItem` items."""
             _custom_data: dict[str, Any]
@@ -12878,7 +12878,7 @@ class EosDesigns(EosDesignsRootModel):
                            configured at all. Can be used in combination with "vrf" and "use_mgmt_interface_vrf" to configure
                            the SNMP host under multiple VRFs.
                         version: version
-                        community: Community name. Required when version "1" or "2c".
+                        community: Community name. Required with version "1" or "2c".
                         users: Subclass of AvdList with `UsersItem` items.
                         _custom_data: _custom_data
 

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -12836,7 +12836,7 @@ class EosDesigns(EosDesignsRootModel):
             """
             version: Literal["1", "2c", "3"] | None
             community: str | None
-            """Community name."""
+            """Community name. Required when version "1" or "2c"."""
             users: Users
             """Subclass of AvdList with `UsersItem` items."""
             _custom_data: dict[str, Any]
@@ -12878,7 +12878,7 @@ class EosDesigns(EosDesignsRootModel):
                            configured at all. Can be used in combination with "vrf" and "use_mgmt_interface_vrf" to configure
                            the SNMP host under multiple VRFs.
                         version: version
-                        community: Community name.
+                        community: Community name. Required when version "1" or "2c".
                         users: Subclass of AvdList with `UsersItem` items.
                         _custom_data: _custom_data
 


### PR DESCRIPTION
## Change Summary

When configuring snmp_server.hosts, the community is required to be defined when a version is 1 or 2c but not version 3. 
Improving the documentation to make this more clear.


See template:
```jinja
{%     if snmp_server.hosts is arista.avd.defined %}
{%         for host in snmp_server.hosts | arista.avd.natural_sort('host') %}
{%             if host.host is arista.avd.defined %}
{%                 set host_cli = "snmp-server host " ~ host.host %}
{%                 if host.vrf is arista.avd.defined %}
{%                     set host_cli = host_cli ~ " vrf " ~ host.vrf %}
{%                 endif %}
{%                 if host.users is arista.avd.defined
                      and host.version | arista.avd.default('3') | string == '3' %}
{%                     for user in host.users %}
{%                         if user.username is arista.avd.defined
                              and user.authentication_level is arista.avd.defined %}
{{ host_cli }} version 3 {{ user.authentication_level }} {{ user.username }}
{%                         endif %}
{%                     endfor %}
{%                 elif host.community is arista.avd.defined
                        and host.version | arista.avd.default('2c') | string in ['1', '2c'] %}
{{ host_cli }} version {{ host.version | arista.avd.default('2c') }} {{ host.community | arista.avd.hide_passwords(hide_passwords) }}
{%                 endif %}
```

## Related Issue(s)

Fixes #4802 

## Component(s) name

`arista.avd.eos_cli_config_gen`


