### PR TITLE
Fix(eos_cli_config_gen): Fix wrong variable used in `eos\stun.j2`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -81,6 +81,9 @@
 - [IP NAT](#ip-nat)
   - [IP NAT Device Configuration](#ip-nat-device-configuration)
   - [Traffic Policies information](#traffic-policies-information)
+- [STUN](#stun)
+  - [STUN Server](#stun-server)
+  - [STUN Device Configuration](#stun-device-configuration)
 
 ## Management
 
@@ -1176,4 +1179,22 @@ traffic-policies
       11:22:33:44:55:66:77:88
    !
    field-set ipv6 prefix IPv6-DEMO-2
+```
+
+## STUN
+
+### STUN Server
+
+| Server Local Interfaces | Bindings Timeout (s) | SSL Profile | SSL Connection Lifetime | Port |
+| ----------------------- | -------------------- | ----------- | ----------------------- | ---- |
+| Ethernet1 | - | - | 3 hours | 3478 |
+
+### STUN Device Configuration
+
+```eos
+!
+stun
+   server
+      local-interface Ethernet1
+      ssl connection lifetime 3 hours
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
@@ -305,6 +305,11 @@ router pim sparse-mode
       ipv4
          make-before-break
 !
+stun
+   server
+      local-interface Ethernet1
+      ssl connection lifetime 3 hours
+!
 traffic-policies
    field-set ipv6 prefix IPv6-DEMO-1
       11:22:33:44:55:66:77:88

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/stun.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/stun.yml
@@ -1,0 +1,8 @@
+---
+### stun
+stun:
+  server:
+    local_interfaces:
+      - Ethernet1
+    ssl_connection_lifetime:
+      hours: 3

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/stun.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/stun.j2
@@ -39,7 +39,7 @@ stun
 {%         if stun.server.ssl_connection_lifetime.minutes is arista.avd.defined %}
       ssl connection lifetime {{ stun.server.ssl_connection_lifetime.minutes }} minutes
 {%         elif stun.server.ssl_connection_lifetime.hours is arista.avd.defined %}
-      ssl connection lifetime {{ stun.segitrver.ssl_connection_lifetime.hours }} hours
+      ssl connection lifetime {{ stun.server.ssl_connection_lifetime.hours }} hours
 {%         endif %}
 {%     endif %}
 {% endif %}


### PR DESCRIPTION
## Change Summary
Fix wrong variable used in `eos\stun.j2`.

Wrong variable in eos/stun.j2

```
{% elif stun.server.ssl_connection_lifetime.hours is arista.avd.defined %}
ssl connection lifetime {{ stun.segitrver.ssl_connection_lifetime.hours }} hours >>>
{% endif %}
```
The variable should be stun.server.ssl_connection_lifetime.hours instead of stun.segitrver.ssl_connection_lifetime.hours.

## Related Issue(s)

Fixes #4808 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Fix wrong variable used in `eos\stun.j2`.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
