### PR TITLE
Feat(eos_designs): Enable evpn_gateway for pathfinder deployment

### DIFF
--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-border1.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-border1.md
@@ -229,7 +229,7 @@ daemon TerminAttr
 
 | Tracker Name | Record Export On Inactive Timeout | Record Export On Interval | MPLS | Number of Exporters | Applied On | Table Size |
 | ------------ | --------------------------------- | ------------------------- | ---- | ------------------- | ---------- | ---------- |
-| FLOW-TRACKER | 70000 | 5000 | - | 1 | Ethernet3<br>Ethernet3.100<br>Ethernet3.101<br>Ethernet4<br>Ethernet4.100<br>Ethernet4.101 | - |
+| FLOW-TRACKER | 70000 | 5000 | - | 1 | Ethernet3<br>Ethernet4<br>Ethernet8 | - |
 
 ##### Exporters Summary
 
@@ -362,25 +362,13 @@ vlan 4094
 
 *Inherited from Port-Channel Interface
 
-##### Encapsulation Dot1q Interfaces
-
-| Interface | Description | Vlan ID | Dot1q VLAN Tag | Dot1q Inner VLAN Tag |
-| --------- | ----------- | ------- | -------------- | -------------------- |
-| Ethernet3.100 | P2P_site1-wan1_Ethernet1.100_VRF_BLUE | - | 100 | - |
-| Ethernet3.101 | P2P_site1-wan1_Ethernet1.101_VRF_RED | - | 101 | - |
-| Ethernet4.100 | P2P_site1-wan2_Ethernet1.100_VRF_BLUE | - | 100 | - |
-| Ethernet4.101 | P2P_site1-wan2_Ethernet1.101_VRF_RED | - | 101 | - |
-
 ##### IPv4
 
 | Interface | Description | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet3 | P2P_site1-wan1_Ethernet1 | - | 10.0.1.8/31 | default | 9214 | False | - | - |
-| Ethernet3.100 | P2P_site1-wan1_Ethernet1.100_VRF_BLUE | - | 10.0.1.8/31 | BLUE | 9214 | False | - | - |
-| Ethernet3.101 | P2P_site1-wan1_Ethernet1.101_VRF_RED | - | 10.0.1.8/31 | RED | 9214 | False | - | - |
 | Ethernet4 | P2P_site1-wan2_Ethernet1 | - | 10.0.1.12/31 | default | 9214 | False | - | - |
-| Ethernet4.100 | P2P_site1-wan2_Ethernet1.100_VRF_BLUE | - | 10.0.1.12/31 | BLUE | 9214 | False | - | - |
-| Ethernet4.101 | P2P_site1-wan2_Ethernet1.101_VRF_RED | - | 10.0.1.12/31 | RED | 9214 | False | - | - |
+| Ethernet8 | P2P_site1-rs1_Ethernet1 | - | 10.0.5.9/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
@@ -394,48 +382,12 @@ interface Ethernet3
    flow tracker sampled FLOW-TRACKER
    ip address 10.0.1.8/31
 !
-interface Ethernet3.100
-   description P2P_site1-wan1_Ethernet1.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker sampled FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.8/31
-!
-interface Ethernet3.101
-   description P2P_site1-wan1_Ethernet1.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker sampled FLOW-TRACKER
-   vrf RED
-   ip address 10.0.1.8/31
-!
 interface Ethernet4
    description P2P_site1-wan2_Ethernet1
    no shutdown
    mtu 9214
    no switchport
    flow tracker sampled FLOW-TRACKER
-   ip address 10.0.1.12/31
-!
-interface Ethernet4.100
-   description P2P_site1-wan2_Ethernet1.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker sampled FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.12/31
-!
-interface Ethernet4.101
-   description P2P_site1-wan2_Ethernet1.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker sampled FLOW-TRACKER
-   vrf RED
    ip address 10.0.1.12/31
 !
 interface Ethernet5
@@ -447,6 +399,14 @@ interface Ethernet6
    description MLAG_site1-border2_Ethernet6
    no shutdown
    channel-group 5 mode active
+!
+interface Ethernet8
+   description P2P_site1-rs1_Ethernet1
+   no shutdown
+   mtu 9214
+   no switchport
+   flow tracker sampled FLOW-TRACKER
+   ip address 10.0.5.9/31
 ```
 
 ### Port-Channel Interfaces
@@ -721,12 +681,10 @@ ASN Notation: asplain
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- | ------------ |
 | 10.0.1.9 | 65000 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.0.1.13 | 65000 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
+| 10.0.5.8 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.251.9 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
-| 10.0.1.9 | 65000 | BLUE | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
-| 10.0.1.13 | 65000 | BLUE | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
+| 192.168.255.99 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
 | 10.255.251.9 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | BLUE | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
-| 10.0.1.9 | 65000 | RED | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
-| 10.0.1.13 | 65000 | RED | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
 | 10.255.251.9 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | RED | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
 
 #### Router BGP EVPN Address Family
@@ -781,8 +739,14 @@ router bgp 65101
    neighbor 10.0.1.13 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.0.1.13 remote-as 65000
    neighbor 10.0.1.13 description site1-wan2_Ethernet1
+   neighbor 10.0.5.8 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.0.5.8 remote-as 65101
+   neighbor 10.0.5.8 description site1-rs1_Ethernet1
    neighbor 10.255.251.9 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.255.251.9 description site1-border2_Vlan4093
+   neighbor 192.168.255.99 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.99 remote-as 65101
+   neighbor 192.168.255.99 description site1-rs1_Loopback0
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 42
@@ -808,12 +772,6 @@ router bgp 65101
       route-target import evpn 100:100
       route-target export evpn 100:100
       router-id 192.168.255.5
-      neighbor 10.0.1.9 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.9 remote-as 65000
-      neighbor 10.0.1.9 description site1-wan1_Ethernet1.100_vrf_BLUE
-      neighbor 10.0.1.13 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.13 remote-as 65000
-      neighbor 10.0.1.13 description site1-wan2_Ethernet1.100_vrf_BLUE
       neighbor 10.255.251.9 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.255.251.9 description site1-border2_Vlan3099
       redistribute connected route-map RM-CONN-2-BGP-VRFS
@@ -823,12 +781,6 @@ router bgp 65101
       route-target import evpn 101:101
       route-target export evpn 101:101
       router-id 192.168.255.5
-      neighbor 10.0.1.9 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.9 remote-as 65000
-      neighbor 10.0.1.9 description site1-wan1_Ethernet1.101_vrf_RED
-      neighbor 10.0.1.13 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.13 remote-as 65000
-      neighbor 10.0.1.13 description site1-wan2_Ethernet1.101_vrf_RED
       neighbor 10.255.251.9 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.255.251.9 description site1-border2_Vlan3100
       redistribute connected route-map RM-CONN-2-BGP-VRFS

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-rs1.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-rs1.md
@@ -1,4 +1,4 @@
-# site1-border2
+# site1-rs1
 
 ## Table of Contents
 
@@ -15,24 +15,15 @@
 - [Monitoring](#monitoring)
   - [TerminAttr Daemon](#terminattr-daemon)
   - [Flow Tracking](#flow-tracking)
-- [MLAG](#mlag)
-  - [MLAG Summary](#mlag-summary)
-  - [MLAG Device Configuration](#mlag-device-configuration)
 - [Spanning Tree](#spanning-tree)
   - [Spanning Tree Summary](#spanning-tree-summary)
   - [Spanning Tree Device Configuration](#spanning-tree-device-configuration)
 - [Internal VLAN Allocation Policy](#internal-vlan-allocation-policy)
   - [Internal VLAN Allocation Policy Summary](#internal-vlan-allocation-policy-summary)
   - [Internal VLAN Allocation Policy Device Configuration](#internal-vlan-allocation-policy-device-configuration)
-- [VLANs](#vlans)
-  - [VLANs Summary](#vlans-summary)
-  - [VLANs Device Configuration](#vlans-device-configuration)
 - [Interfaces](#interfaces)
   - [Ethernet Interfaces](#ethernet-interfaces)
-  - [Port-Channel Interfaces](#port-channel-interfaces)
   - [Loopback Interfaces](#loopback-interfaces)
-  - [VLAN Interfaces](#vlan-interfaces)
-  - [VXLAN Interface](#vxlan-interface)
 - [Routing](#routing)
   - [Service Routing Protocols Model](#service-routing-protocols-model)
   - [IP Routing](#ip-routing)
@@ -41,8 +32,6 @@
   - [Router BGP](#router-bgp)
 - [BFD](#bfd)
   - [Router BFD](#router-bfd)
-- [Multicast](#multicast)
-  - [IP IGMP Snooping](#ip-igmp-snooping)
 - [Filters](#filters)
   - [Prefix-lists](#prefix-lists)
   - [Route-maps](#route-maps)
@@ -60,7 +49,7 @@
 
 | Management Interface | Description | Type | VRF | IP Address | Gateway |
 | -------------------- | ----------- | ---- | --- | ---------- | ------- |
-| Management1 | OOB_MANAGEMENT | oob | MGMT | 192.168.17.15/24 | 192.168.17.1 |
+| Management1 | OOB_MANAGEMENT | oob | MGMT | 192.168.17.60/24 | 192.168.17.1 |
 
 ##### IPv6
 
@@ -76,7 +65,7 @@ interface Management1
    description OOB_MANAGEMENT
    no shutdown
    vrf MGMT
-   ip address 192.168.17.15/24
+   ip address 192.168.17.60/24
    no lldp transmit
    no lldp receive
 ```
@@ -229,7 +218,7 @@ daemon TerminAttr
 
 | Tracker Name | Record Export On Inactive Timeout | Record Export On Interval | MPLS | Number of Exporters | Applied On | Table Size |
 | ------------ | --------------------------------- | ------------------------- | ---- | ------------------- | ---------- | ---------- |
-| FLOW-TRACKER | 70000 | 5000 | - | 1 | Ethernet3<br>Ethernet4<br>Ethernet8 | - |
+| FLOW-TRACKER | 70000 | 5000 | - | 1 | Ethernet1<br>Ethernet2 | - |
 
 ##### Exporters Summary
 
@@ -252,44 +241,17 @@ flow tracking sampled
    no shutdown
 ```
 
-## MLAG
-
-### MLAG Summary
-
-| Domain-id | Local-interface | Peer-address | Peer-link |
-| --------- | --------------- | ------------ | --------- |
-| SITE1 | Vlan4094 | 10.255.252.8 | Port-Channel5 |
-
-Dual primary detection is disabled.
-
-### MLAG Device Configuration
-
-```eos
-!
-mlag configuration
-   domain-id SITE1
-   local-interface Vlan4094
-   peer-address 10.255.252.8
-   peer-link Port-Channel5
-   reload-delay mlag 300
-   reload-delay non-mlag 330
-```
-
 ## Spanning Tree
 
 ### Spanning Tree Summary
 
-STP mode: **mstp**
-
-#### Global Spanning-Tree Settings
-
-- Spanning Tree disabled for VLANs: **4093-4094**
+STP mode: **none**
 
 ### Spanning Tree Device Configuration
 
 ```eos
 !
-no spanning-tree vlan-id 4093-4094
+spanning-tree mode none
 ```
 
 ## Internal VLAN Allocation Policy
@@ -307,46 +269,6 @@ no spanning-tree vlan-id 4093-4094
 vlan internal order ascending range 1006 1199
 ```
 
-## VLANs
-
-### VLANs Summary
-
-| VLAN ID | Name | Trunk Groups |
-| ------- | ---- | ------------ |
-| 42 | RED-TEST | - |
-| 666 | BLUE-TEST | - |
-| 3099 | MLAG_L3_VRF_BLUE | MLAG |
-| 3100 | MLAG_L3_VRF_RED | MLAG |
-| 4093 | MLAG_L3 | MLAG |
-| 4094 | MLAG | MLAG |
-
-### VLANs Device Configuration
-
-```eos
-!
-vlan 42
-   name RED-TEST
-!
-vlan 666
-   name BLUE-TEST
-!
-vlan 3099
-   name MLAG_L3_VRF_BLUE
-   trunk group MLAG
-!
-vlan 3100
-   name MLAG_L3_VRF_RED
-   trunk group MLAG
-!
-vlan 4093
-   name MLAG_L3
-   trunk group MLAG
-!
-vlan 4094
-   name MLAG
-   trunk group MLAG
-```
-
 ## Interfaces
 
 ### Ethernet Interfaces
@@ -357,8 +279,6 @@ vlan 4094
 
 | Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | Channel-Group |
 | --------- | ----------- | ---- | ----- | ----------- | ----------- | ------------- |
-| Ethernet5 | MLAG_site1-border1_Ethernet5 | *trunk | *- | *- | *MLAG | 5 |
-| Ethernet6 | MLAG_site1-border1_Ethernet6 | *trunk | *- | *- | *MLAG | 5 |
 
 *Inherited from Port-Channel Interface
 
@@ -366,69 +286,28 @@ vlan 4094
 
 | Interface | Description | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
-| Ethernet3 | P2P_site1-wan1_Ethernet2 | - | 10.0.1.10/31 | default | 9214 | False | - | - |
-| Ethernet4 | P2P_site1-wan2_Ethernet2 | - | 10.0.1.14/31 | default | 9214 | False | - | - |
-| Ethernet8 | P2P_site1-rs1_Ethernet2 | - | 10.0.5.11/31 | default | 9214 | False | - | - |
+| Ethernet1 | P2P_site1-border1_Ethernet8 | - | 10.0.5.8/31 | default | 9214 | False | - | - |
+| Ethernet2 | P2P_site1-border2_Ethernet8 | - | 10.0.5.10/31 | default | 9214 | False | - | - |
 
 #### Ethernet Interfaces Device Configuration
 
 ```eos
 !
-interface Ethernet3
-   description P2P_site1-wan1_Ethernet2
+interface Ethernet1
+   description P2P_site1-border1_Ethernet8
    no shutdown
    mtu 9214
    no switchport
    flow tracker sampled FLOW-TRACKER
-   ip address 10.0.1.10/31
+   ip address 10.0.5.8/31
 !
-interface Ethernet4
-   description P2P_site1-wan2_Ethernet2
+interface Ethernet2
+   description P2P_site1-border2_Ethernet8
    no shutdown
    mtu 9214
    no switchport
    flow tracker sampled FLOW-TRACKER
-   ip address 10.0.1.14/31
-!
-interface Ethernet5
-   description MLAG_site1-border1_Ethernet5
-   no shutdown
-   channel-group 5 mode active
-!
-interface Ethernet6
-   description MLAG_site1-border1_Ethernet6
-   no shutdown
-   channel-group 5 mode active
-!
-interface Ethernet8
-   description P2P_site1-rs1_Ethernet2
-   no shutdown
-   mtu 9214
-   no switchport
-   flow tracker sampled FLOW-TRACKER
-   ip address 10.0.5.11/31
-```
-
-### Port-Channel Interfaces
-
-#### Port-Channel Interfaces Summary
-
-##### L2
-
-| Interface | Description | Mode | VLANs | Native VLAN | Trunk Group | LACP Fallback Timeout | LACP Fallback Mode | MLAG ID | EVPN ESI |
-| --------- | ----------- | ---- | ----- | ----------- | ------------| --------------------- | ------------------ | ------- | -------- |
-| Port-Channel5 | MLAG_site1-border1_Port-Channel5 | trunk | - | - | MLAG | - | - | - | - |
-
-#### Port-Channel Interfaces Device Configuration
-
-```eos
-!
-interface Port-Channel5
-   description MLAG_site1-border1_Port-Channel5
-   no shutdown
-   switchport mode trunk
-   switchport trunk group MLAG
-   switchport
+   ip address 10.0.5.10/31
 ```
 
 ### Loopback Interfaces
@@ -439,15 +318,13 @@ interface Port-Channel5
 
 | Interface | Description | VRF | IP Address |
 | --------- | ----------- | --- | ---------- |
-| Loopback0 | ROUTER_ID | default | 192.168.255.6/32 |
-| Loopback1 | VXLAN_TUNNEL_SOURCE | default | 192.168.42.5/32 |
+| Loopback0 | ROUTER_ID | default | 192.168.255.99/32 |
 
 ##### IPv6
 
 | Interface | Description | VRF | IPv6 Address |
 | --------- | ----------- | --- | ------------ |
 | Loopback0 | ROUTER_ID | default | - |
-| Loopback1 | VXLAN_TUNNEL_SOURCE | default | - |
 
 #### Loopback Interfaces Device Configuration
 
@@ -456,119 +333,7 @@ interface Port-Channel5
 interface Loopback0
    description ROUTER_ID
    no shutdown
-   ip address 192.168.255.6/32
-!
-interface Loopback1
-   description VXLAN_TUNNEL_SOURCE
-   no shutdown
-   ip address 192.168.42.5/32
-```
-
-### VLAN Interfaces
-
-#### VLAN Interfaces Summary
-
-| Interface | Description | VRF |  MTU | Shutdown |
-| --------- | ----------- | --- | ---- | -------- |
-| Vlan42 | RED-TEST | RED | - | False |
-| Vlan666 | BLUE-TEST | BLUE | - | False |
-| Vlan3099 | MLAG_L3_VRF_BLUE | BLUE | 9214 | False |
-| Vlan3100 | MLAG_L3_VRF_RED | RED | 9214 | False |
-| Vlan4093 | MLAG_L3 | default | 9214 | False |
-| Vlan4094 | MLAG | default | 9214 | False |
-
-##### IPv4
-
-| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | ACL In | ACL Out |
-| --------- | --- | ---------- | ------------------ | ------------------------- | ------ | ------- |
-| Vlan42 |  RED  |  10.42.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan666 |  BLUE  |  10.66.11.1/24  |  -  |  -  |  -  |  -  |
-| Vlan3099 |  BLUE  |  10.255.251.9/31  |  -  |  -  |  -  |  -  |
-| Vlan3100 |  RED  |  10.255.251.9/31  |  -  |  -  |  -  |  -  |
-| Vlan4093 |  default  |  10.255.251.9/31  |  -  |  -  |  -  |  -  |
-| Vlan4094 |  default  |  10.255.252.9/31  |  -  |  -  |  -  |  -  |
-
-#### VLAN Interfaces Device Configuration
-
-```eos
-!
-interface Vlan42
-   description RED-TEST
-   no shutdown
-   vrf RED
-   ip address 10.42.11.1/24
-!
-interface Vlan666
-   description BLUE-TEST
-   no shutdown
-   vrf BLUE
-   ip address 10.66.11.1/24
-!
-interface Vlan3099
-   description MLAG_L3_VRF_BLUE
-   no shutdown
-   mtu 9214
-   vrf BLUE
-   ip address 10.255.251.9/31
-!
-interface Vlan3100
-   description MLAG_L3_VRF_RED
-   no shutdown
-   mtu 9214
-   vrf RED
-   ip address 10.255.251.9/31
-!
-interface Vlan4093
-   description MLAG_L3
-   no shutdown
-   mtu 9214
-   ip address 10.255.251.9/31
-!
-interface Vlan4094
-   description MLAG
-   no shutdown
-   mtu 9214
-   no autostate
-   ip address 10.255.252.9/31
-```
-
-### VXLAN Interface
-
-#### VXLAN Interface Summary
-
-| Setting | Value |
-| ------- | ----- |
-| Source Interface | Loopback1 |
-| UDP port | 4789 |
-| EVPN MLAG Shared Router MAC | mlag-system-id |
-
-##### VLAN to VNI, Flood List and Multicast Group Mappings
-
-| VLAN | VNI | Flood List | Multicast Group |
-| ---- | --- | ---------- | --------------- |
-| 42 | 10042 | - | - |
-| 666 | 10666 | - | - |
-
-##### VRF to VNI and Multicast Group Mappings
-
-| VRF | VNI | Multicast Group |
-| ---- | --- | --------------- |
-| BLUE | 100 | - |
-| RED | 101 | - |
-
-#### VXLAN Interface Device Configuration
-
-```eos
-!
-interface Vxlan1
-   description site1-border2_VTEP
-   vxlan source-interface Loopback1
-   vxlan virtual-router encapsulation mac-address mlag-system-id
-   vxlan udp-port 4789
-   vxlan vlan 42 vni 10042
-   vxlan vlan 666 vni 10666
-   vxlan vrf BLUE vni 100
-   vxlan vrf RED vni 101
+   ip address 192.168.255.99/32
 ```
 
 ## Routing
@@ -589,18 +354,14 @@ service routing protocols model multi-agent
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | True |
-| BLUE | True |
 | MGMT | False |
-| RED | True |
 
 #### IP Routing Device Configuration
 
 ```eos
 !
 ip routing
-ip routing vrf BLUE
 no ip routing vrf MGMT
-ip routing vrf RED
 ```
 
 ### IPv6 Routing
@@ -610,9 +371,7 @@ ip routing vrf RED
 | VRF | Routing Enabled |
 | --- | --------------- |
 | default | False |
-| BLUE | false |
 | MGMT | false |
-| RED | false |
 
 ### Static Routes
 
@@ -637,7 +396,7 @@ ASN Notation: asplain
 
 | BGP AS | Router ID |
 | ------ | --------- |
-| 65101 | 192.168.255.6 |
+| 65101 | 192.168.255.99 |
 
 | BGP Tuning |
 | ---------- |
@@ -651,6 +410,7 @@ ASN Notation: asplain
 | Settings | Value |
 | -------- | ----- |
 | Address Family | evpn |
+| Next-hop unchanged | True |
 | Source | Loopback0 |
 | BFD | True |
 | Ebgp multihop | 3 |
@@ -665,27 +425,15 @@ ASN Notation: asplain
 | Send community | all |
 | Maximum routes | 12000 |
 
-##### MLAG-IPv4-UNDERLAY-PEER
-
-| Settings | Value |
-| -------- | ----- |
-| Address Family | ipv4 |
-| Remote AS | 65101 |
-| Next-hop self | True |
-| Send community | all |
-| Maximum routes | 12000 |
-
 #### BGP Neighbors
 
 | Neighbor | Remote AS | VRF | Shutdown | Send-community | Maximum-routes | Allowas-in | BFD | RIB Pre-Policy Retain | Route-Reflector Client | Passive | TTL Max Hops |
 | -------- | --------- | --- | -------- | -------------- | -------------- | ---------- | --- | --------------------- | ---------------------- | ------- | ------------ |
-| 10.0.1.11 | 65000 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
-| 10.0.1.15 | 65000 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
-| 10.0.5.10 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
-| 10.255.251.8 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | default | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
-| 192.168.255.99 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
-| 10.255.251.8 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | BLUE | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
-| 10.255.251.8 | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | RED | - | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | Inherited from peer group MLAG-IPv4-UNDERLAY-PEER | - | - | - | - | - | - |
+| 10.0.5.9 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
+| 10.0.5.11 | 65101 | default | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - | - |
+| 192.168.255.3 | 65000 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
+| 192.168.255.5 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
+| 192.168.255.6 | 65101 | default | - | Inherited from peer group EVPN-OVERLAY-PEERS | Inherited from peer group EVPN-OVERLAY-PEERS | - | Inherited from peer group EVPN-OVERLAY-PEERS | - | - | - | - |
 
 #### Router BGP EVPN Address Family
 
@@ -695,29 +443,16 @@ ASN Notation: asplain
 | ---------- | -------- | ------------ | ------------- | ------------- |
 | EVPN-OVERLAY-PEERS | True |  - | - | default |
 
-#### Router BGP VLANs
-
-| VLAN | Route-Distinguisher | Both Route-Target | Import Route Target | Export Route-Target | Redistribute |
-| ---- | ------------------- | ----------------- | ------------------- | ------------------- | ------------ |
-| 42 | 192.168.255.6:10042 | 10042:10042 | - | - | learned |
-| 666 | 192.168.255.6:10666 | 10666:10666 | - | - | learned |
-
-#### Router BGP VRFs
-
-| VRF | Route-Distinguisher | Redistribute |
-| --- | ------------------- | ------------ |
-| BLUE | 192.168.255.6:100 | connected |
-| RED | 192.168.255.6:101 | connected |
-
 #### Router BGP Device Configuration
 
 ```eos
 !
 router bgp 65101
-   router-id 192.168.255.6
+   router-id 192.168.255.99
    no bgp default ipv4-unicast
    maximum-paths 4 ecmp 4
    neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
@@ -726,38 +461,22 @@ router bgp 65101
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
-   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65101
-   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
-   neighbor MLAG-IPv4-UNDERLAY-PEER description site1-border1
-   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
-   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
-   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
-   neighbor 10.0.1.11 peer group IPv4-UNDERLAY-PEERS
-   neighbor 10.0.1.11 remote-as 65000
-   neighbor 10.0.1.11 description site1-wan1_Ethernet2
-   neighbor 10.0.1.15 peer group IPv4-UNDERLAY-PEERS
-   neighbor 10.0.1.15 remote-as 65000
-   neighbor 10.0.1.15 description site1-wan2_Ethernet2
-   neighbor 10.0.5.10 peer group IPv4-UNDERLAY-PEERS
-   neighbor 10.0.5.10 remote-as 65101
-   neighbor 10.0.5.10 description site1-rs1_Ethernet2
-   neighbor 10.255.251.8 peer group MLAG-IPv4-UNDERLAY-PEER
-   neighbor 10.255.251.8 description site1-border1_Vlan4093
-   neighbor 192.168.255.99 peer group EVPN-OVERLAY-PEERS
-   neighbor 192.168.255.99 remote-as 65101
-   neighbor 192.168.255.99 description site1-rs1_Loopback0
+   neighbor 10.0.5.9 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.0.5.9 remote-as 65101
+   neighbor 10.0.5.9 description site1-border1_Ethernet8
+   neighbor 10.0.5.11 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.0.5.11 remote-as 65101
+   neighbor 10.0.5.11 description site1-border2_Ethernet8
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65000
+   neighbor 192.168.255.3 description site1-wan1_Loopback0
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description site1-border1_Loopback0
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65101
+   neighbor 192.168.255.6 description site1-border2_Loopback0
    redistribute connected route-map RM-CONN-2-BGP
-   !
-   vlan 42
-      rd 192.168.255.6:10042
-      route-target both 10042:10042
-      redistribute learned
-   !
-   vlan 666
-      rd 192.168.255.6:10666
-      route-target both 10666:10666
-      redistribute learned
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
@@ -765,25 +484,6 @@ router bgp 65101
    address-family ipv4
       no neighbor EVPN-OVERLAY-PEERS activate
       neighbor IPv4-UNDERLAY-PEERS activate
-      neighbor MLAG-IPv4-UNDERLAY-PEER activate
-   !
-   vrf BLUE
-      rd 192.168.255.6:100
-      route-target import evpn 100:100
-      route-target export evpn 100:100
-      router-id 192.168.255.6
-      neighbor 10.255.251.8 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.8 description site1-border1_Vlan3099
-      redistribute connected route-map RM-CONN-2-BGP-VRFS
-   !
-   vrf RED
-      rd 192.168.255.6:101
-      route-target import evpn 101:101
-      route-target export evpn 101:101
-      router-id 192.168.255.6
-      neighbor 10.255.251.8 peer group MLAG-IPv4-UNDERLAY-PEER
-      neighbor 10.255.251.8 description site1-border1_Vlan3100
-      redistribute connected route-map RM-CONN-2-BGP-VRFS
 ```
 
 ## BFD
@@ -804,21 +504,6 @@ router bfd
    multihop interval 300 min-rx 300 multiplier 3
 ```
 
-## Multicast
-
-### IP IGMP Snooping
-
-#### IP IGMP Snooping Summary
-
-| IGMP Snooping | Fast Leave | Interface Restart Query | Proxy | Restart Query Interval | Robustness Variable |
-| ------------- | ---------- | ----------------------- | ----- | ---------------------- | ------------------- |
-| Enabled | - | - | - | - | - |
-
-#### IP IGMP Snooping Device Configuration
-
-```eos
-```
-
 ## Filters
 
 ### Prefix-lists
@@ -830,13 +515,6 @@ router bfd
 | Sequence | Action |
 | -------- | ------ |
 | 10 | permit 192.168.255.0/24 eq 32 |
-| 20 | permit 192.168.42.0/24 eq 32 |
-
-##### PL-MLAG-PEER-VRFS
-
-| Sequence | Action |
-| -------- | ------ |
-| 10 | permit 10.255.251.8/31 |
 
 #### Prefix-lists Device Configuration
 
@@ -844,10 +522,6 @@ router bfd
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
-   seq 20 permit 192.168.42.0/24 eq 32
-!
-ip prefix-list PL-MLAG-PEER-VRFS
-   seq 10 permit 10.255.251.8/31
 ```
 
 ### Route-maps
@@ -860,34 +534,12 @@ ip prefix-list PL-MLAG-PEER-VRFS
 | -------- | ---- | ----- | --- | ------------- | -------- |
 | 10 | permit | ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY | - | - | - |
 
-##### RM-CONN-2-BGP-VRFS
-
-| Sequence | Type | Match | Set | Sub-Route-Map | Continue |
-| -------- | ---- | ----- | --- | ------------- | -------- |
-| 10 | deny | ip address prefix-list PL-MLAG-PEER-VRFS | - | - | - |
-| 20 | permit | - | - | - | - |
-
-##### RM-MLAG-PEER-IN
-
-| Sequence | Type | Match | Set | Sub-Route-Map | Continue |
-| -------- | ---- | ----- | --- | ------------- | -------- |
-| 10 | permit | - | origin incomplete | - | - |
-
 #### Route-maps Device Configuration
 
 ```eos
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-!
-route-map RM-CONN-2-BGP-VRFS deny 10
-   match ip address prefix-list PL-MLAG-PEER-VRFS
-!
-route-map RM-CONN-2-BGP-VRFS permit 20
-!
-route-map RM-MLAG-PEER-IN permit 10
-   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
-   set origin incomplete
 ```
 
 ## VRF Instances
@@ -896,17 +548,11 @@ route-map RM-MLAG-PEER-IN permit 10
 
 | VRF Name | IP Routing |
 | -------- | ---------- |
-| BLUE | enabled |
 | MGMT | disabled |
-| RED | enabled |
 
 ### VRF Instances Device Configuration
 
 ```eos
 !
-vrf instance BLUE
-!
 vrf instance MGMT
-!
-vrf instance RED
 ```

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-wan1.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-wan1.md
@@ -288,7 +288,7 @@ daemon TerminAttr
 
 | Tracker Name | Record Export On Inactive Timeout | Record Export On Interval | Number of Exporters | Applied On |
 | ------------ | --------------------------------- | ------------------------- | ------------------- | ---------- |
-| FLOW-TRACKER | 70000 | 5000 | 1 | Dps1<br>Ethernet1<br>Ethernet1.100<br>Ethernet1.101<br>Ethernet2<br>Ethernet2.100<br>Ethernet2.101<br>Ethernet3<br>Ethernet4 |
+| FLOW-TRACKER | 70000 | 5000 | 1 | Dps1<br>Ethernet1<br>Ethernet2<br>Ethernet3<br>Ethernet4 |
 
 ##### Exporters Summary
 
@@ -423,25 +423,12 @@ interface Dps1
 
 *Inherited from Port-Channel Interface
 
-##### Encapsulation Dot1q Interfaces
-
-| Interface | Description | Vlan ID | Dot1q VLAN Tag | Dot1q Inner VLAN Tag |
-| --------- | ----------- | ------- | -------------- | -------------------- |
-| Ethernet1.100 | P2P_site1-border1_Ethernet3.100_VRF_BLUE | - | 100 | - |
-| Ethernet1.101 | P2P_site1-border1_Ethernet3.101_VRF_RED | - | 101 | - |
-| Ethernet2.100 | P2P_site1-border2_Ethernet3.100_VRF_BLUE | - | 100 | - |
-| Ethernet2.101 | P2P_site1-border2_Ethernet3.101_VRF_RED | - | 101 | - |
-
 ##### IPv4
 
 | Interface | Description | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 | P2P_site1-border1_Ethernet3 | - | 10.0.1.9/31 | default | 9214 | False | - | - |
-| Ethernet1.100 | P2P_site1-border1_Ethernet3.100_VRF_BLUE | - | 10.0.1.9/31 | BLUE | 9214 | False | - | - |
-| Ethernet1.101 | P2P_site1-border1_Ethernet3.101_VRF_RED | - | 10.0.1.9/31 | RED | 9214 | False | - | - |
 | Ethernet2 | P2P_site1-border2_Ethernet3 | - | 10.0.1.11/31 | default | 9214 | False | - | - |
-| Ethernet2.100 | P2P_site1-border2_Ethernet3.100_VRF_BLUE | - | 10.0.1.11/31 | BLUE | 9214 | False | - | - |
-| Ethernet2.101 | P2P_site1-border2_Ethernet3.101_VRF_RED | - | 10.0.1.11/31 | RED | 9214 | False | - | - |
 | Ethernet3 | ACME-MPLS-INC_mpls-site1-wan1_mpls-cloud_Ethernet5 | - | 172.18.10.2/24 | default | - | False | - | - |
 | Ethernet4 | REGION1-INTERNET-CORP_inet-site1-wan1_inet-cloud_Ethernet5 | - | 100.64.10.2/24 | default | - | False | ACL-INTERNET-IN_Ethernet4 | - |
 
@@ -457,48 +444,12 @@ interface Ethernet1
    flow tracker hardware FLOW-TRACKER
    ip address 10.0.1.9/31
 !
-interface Ethernet1.100
-   description P2P_site1-border1_Ethernet3.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.9/31
-!
-interface Ethernet1.101
-   description P2P_site1-border1_Ethernet3.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker hardware FLOW-TRACKER
-   vrf RED
-   ip address 10.0.1.9/31
-!
 interface Ethernet2
    description P2P_site1-border2_Ethernet3
    no shutdown
    mtu 9214
    no switchport
    flow tracker hardware FLOW-TRACKER
-   ip address 10.0.1.11/31
-!
-interface Ethernet2.100
-   description P2P_site1-border2_Ethernet3.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.11/31
-!
-interface Ethernet2.101
-   description P2P_site1-border2_Ethernet3.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker hardware FLOW-TRACKER
-   vrf RED
    ip address 10.0.1.11/31
 !
 interface Ethernet3
@@ -639,6 +590,8 @@ ip route vrf MGMT 0.0.0.0/0 192.168.17.1
 
 Topology role: transit region
 
+VXLAN gateway: Enabled
+
 | Hierarchy | Name | ID |
 | --------- | ---- | -- |
 | Region | REGION1 | 1 |
@@ -725,7 +678,7 @@ Topology role: transit region
 ```eos
 !
 router adaptive-virtual-topology
-   topology role transit region
+   topology role transit region gateway vxlan
    region REGION1 id 1
    zone REGION1-ZONE id 1
    site SITE1 id 101
@@ -831,6 +784,17 @@ ASN Notation: asplain
 
 #### Router BGP Peer Groups
 
+##### EVPN-OVERLAY-CORE
+
+| Settings | Value |
+| -------- | ----- |
+| Address Family | evpn |
+| Source | Loopback0 |
+| BFD | True |
+| Ebgp multihop | 15 |
+| Send community | all |
+| Maximum routes | 0 (no limit) |
+
 ##### IPv4-UNDERLAY-PEERS
 
 | Settings | Value |
@@ -862,10 +826,7 @@ ASN Notation: asplain
 | 192.168.42.1 | Inherited from peer group WAN-OVERLAY-PEERS | default | - | Inherited from peer group WAN-OVERLAY-PEERS | Inherited from peer group WAN-OVERLAY-PEERS | - | Inherited from peer group WAN-OVERLAY-PEERS(interval: 1000, min_rx: 1000, multiplier: 10) | - | - | - | Inherited from peer group WAN-OVERLAY-PEERS |
 | 192.168.42.2 | Inherited from peer group WAN-OVERLAY-PEERS | default | - | Inherited from peer group WAN-OVERLAY-PEERS | Inherited from peer group WAN-OVERLAY-PEERS | - | Inherited from peer group WAN-OVERLAY-PEERS(interval: 1000, min_rx: 1000, multiplier: 10) | - | - | - | Inherited from peer group WAN-OVERLAY-PEERS |
 | 192.168.42.4 | 65000 | default | - | all | - | - | - | - | True | - | - |
-| 10.0.1.8 | 65101 | BLUE | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
-| 10.0.1.10 | 65101 | BLUE | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
-| 10.0.1.8 | 65101 | RED | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
-| 10.0.1.10 | 65101 | RED | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
+| 192.168.255.99 | - | default | - | Inherited from peer group EVPN-OVERLAY-CORE | Inherited from peer group EVPN-OVERLAY-CORE | - | Inherited from peer group EVPN-OVERLAY-CORE | - | - | - | - |
 
 #### Router BGP EVPN Address Family
 
@@ -873,6 +834,7 @@ ASN Notation: asplain
 
 | Peer Group | Activate | Route-map In | Route-map Out | Encapsulation |
 | ---------- | -------- | ------------ | ------------- | ------------- |
+| EVPN-OVERLAY-CORE | True |  - | - | default |
 | WAN-OVERLAY-PEERS | True |  RM-EVPN-SOO-IN | RM-EVPN-SOO-OUT | path-selection |
 
 ##### EVPN Neighbors
@@ -885,6 +847,7 @@ ASN Notation: asplain
 
 | Settings | Value |
 | -------- | ----- |
+| Remote Domain Peer Groups | EVPN-OVERLAY-CORE |
 | L3 Gateway Configured | True |
 
 #### Router BGP IPv4 SR-TE Address Family
@@ -933,6 +896,12 @@ router bgp 65000
    router-id 192.168.255.3
    no bgp default ipv4-unicast
    maximum-paths 16
+   neighbor EVPN-OVERLAY-CORE peer group
+   neighbor EVPN-OVERLAY-CORE update-source Loopback0
+   neighbor EVPN-OVERLAY-CORE bfd
+   neighbor EVPN-OVERLAY-CORE ebgp-multihop 15
+   neighbor EVPN-OVERLAY-CORE send-community
+   neighbor EVPN-OVERLAY-CORE maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS allowas-in 1
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
@@ -965,9 +934,13 @@ router bgp 65000
    neighbor 192.168.42.4 route-map RM-WAN-HA-PEER-IN in
    neighbor 192.168.42.4 route-map RM-WAN-HA-PEER-OUT out
    neighbor 192.168.42.4 send-community
+   neighbor 192.168.255.99 peer group EVPN-OVERLAY-CORE
+   neighbor 192.168.255.99 description site1-rs1_Loopback0
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-CORE activate
+      neighbor EVPN-OVERLAY-CORE domain remote
       neighbor WAN-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
       neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
@@ -977,6 +950,7 @@ router bgp 65000
       neighbor default next-hop-self received-evpn-routes route-type ip-prefix
    !
    address-family ipv4
+      no neighbor EVPN-OVERLAY-CORE activate
       neighbor IPv4-UNDERLAY-PEERS activate
       no neighbor WAN-OVERLAY-PEERS activate
    !
@@ -997,12 +971,6 @@ router bgp 65000
       route-target import evpn 100:100
       route-target export evpn 100:100
       router-id 192.168.255.3
-      neighbor 10.0.1.8 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.8 remote-as 65101
-      neighbor 10.0.1.8 description site1-border1_Ethernet3.100_vrf_BLUE
-      neighbor 10.0.1.10 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.10 remote-as 65101
-      neighbor 10.0.1.10 description site1-border2_Ethernet3.100_vrf_BLUE
       redistribute connected
    !
    vrf default
@@ -1016,12 +984,6 @@ router bgp 65000
       route-target import evpn 101:101
       route-target export evpn 101:101
       router-id 192.168.255.3
-      neighbor 10.0.1.8 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.8 remote-as 65101
-      neighbor 10.0.1.8 description site1-border1_Ethernet3.101_vrf_RED
-      neighbor 10.0.1.10 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.10 remote-as 65101
-      neighbor 10.0.1.10 description site1-border2_Ethernet3.101_vrf_RED
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-wan2.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site1-wan2.md
@@ -288,7 +288,7 @@ daemon TerminAttr
 
 | Tracker Name | Record Export On Inactive Timeout | Record Export On Interval | Number of Exporters | Applied On |
 | ------------ | --------------------------------- | ------------------------- | ------------------- | ---------- |
-| FLOW-TRACKER | 70000 | 5000 | 1 | Dps1<br>Ethernet1<br>Ethernet1.100<br>Ethernet1.101<br>Ethernet2<br>Ethernet2.100<br>Ethernet2.101<br>Ethernet3<br>Ethernet4 |
+| FLOW-TRACKER | 70000 | 5000 | 1 | Dps1<br>Ethernet1<br>Ethernet2<br>Ethernet3<br>Ethernet4 |
 
 ##### Exporters Summary
 
@@ -423,25 +423,12 @@ interface Dps1
 
 *Inherited from Port-Channel Interface
 
-##### Encapsulation Dot1q Interfaces
-
-| Interface | Description | Vlan ID | Dot1q VLAN Tag | Dot1q Inner VLAN Tag |
-| --------- | ----------- | ------- | -------------- | -------------------- |
-| Ethernet1.100 | P2P_site1-border1_Ethernet4.100_VRF_BLUE | - | 100 | - |
-| Ethernet1.101 | P2P_site1-border1_Ethernet4.101_VRF_RED | - | 101 | - |
-| Ethernet2.100 | P2P_site1-border2_Ethernet4.100_VRF_BLUE | - | 100 | - |
-| Ethernet2.101 | P2P_site1-border2_Ethernet4.101_VRF_RED | - | 101 | - |
-
 ##### IPv4
 
 | Interface | Description | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1 | P2P_site1-border1_Ethernet4 | - | 10.0.1.13/31 | default | 9214 | False | - | - |
-| Ethernet1.100 | P2P_site1-border1_Ethernet4.100_VRF_BLUE | - | 10.0.1.13/31 | BLUE | 9214 | False | - | - |
-| Ethernet1.101 | P2P_site1-border1_Ethernet4.101_VRF_RED | - | 10.0.1.13/31 | RED | 9214 | False | - | - |
 | Ethernet2 | P2P_site1-border2_Ethernet4 | - | 10.0.1.15/31 | default | 9214 | False | - | - |
-| Ethernet2.100 | P2P_site1-border2_Ethernet4.100_VRF_BLUE | - | 10.0.1.15/31 | BLUE | 9214 | False | - | - |
-| Ethernet2.101 | P2P_site1-border2_Ethernet4.101_VRF_RED | - | 10.0.1.15/31 | RED | 9214 | False | - | - |
 | Ethernet3 | ACME-MPLS-INC_mpls-site1-wan2_mpls-cloud_Ethernet6 | - | 172.18.11.2/24 | default | - | False | - | - |
 | Ethernet4 | REGION1-INTERNET-CORP_inet-site1-wan2_inet-cloud_Ethernet6 | - | dhcp | default | - | False | ACL-INTERNET-IN_Ethernet4 | - |
 
@@ -457,48 +444,12 @@ interface Ethernet1
    flow tracker hardware FLOW-TRACKER
    ip address 10.0.1.13/31
 !
-interface Ethernet1.100
-   description P2P_site1-border1_Ethernet4.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.13/31
-!
-interface Ethernet1.101
-   description P2P_site1-border1_Ethernet4.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker hardware FLOW-TRACKER
-   vrf RED
-   ip address 10.0.1.13/31
-!
 interface Ethernet2
    description P2P_site1-border2_Ethernet4
    no shutdown
    mtu 9214
    no switchport
    flow tracker hardware FLOW-TRACKER
-   ip address 10.0.1.15/31
-!
-interface Ethernet2.100
-   description P2P_site1-border2_Ethernet4.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.15/31
-!
-interface Ethernet2.101
-   description P2P_site1-border2_Ethernet4.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker hardware FLOW-TRACKER
-   vrf RED
    ip address 10.0.1.15/31
 !
 interface Ethernet3
@@ -863,10 +814,6 @@ ASN Notation: asplain
 | 192.168.42.1 | Inherited from peer group WAN-OVERLAY-PEERS | default | - | Inherited from peer group WAN-OVERLAY-PEERS | Inherited from peer group WAN-OVERLAY-PEERS | - | Inherited from peer group WAN-OVERLAY-PEERS(interval: 1000, min_rx: 1000, multiplier: 10) | - | - | - | Inherited from peer group WAN-OVERLAY-PEERS |
 | 192.168.42.2 | Inherited from peer group WAN-OVERLAY-PEERS | default | - | Inherited from peer group WAN-OVERLAY-PEERS | Inherited from peer group WAN-OVERLAY-PEERS | - | Inherited from peer group WAN-OVERLAY-PEERS(interval: 1000, min_rx: 1000, multiplier: 10) | - | - | - | Inherited from peer group WAN-OVERLAY-PEERS |
 | 192.168.42.3 | 65000 | default | - | all | - | - | - | - | True | - | - |
-| 10.0.1.12 | 65101 | BLUE | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
-| 10.0.1.14 | 65101 | BLUE | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
-| 10.0.1.12 | 65101 | RED | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
-| 10.0.1.14 | 65101 | RED | - | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | Inherited from peer group IPv4-UNDERLAY-PEERS | - | - | - | - | - |
 
 #### Router BGP EVPN Address Family
 
@@ -998,12 +945,6 @@ router bgp 65000
       route-target import evpn 100:100
       route-target export evpn 100:100
       router-id 192.168.255.4
-      neighbor 10.0.1.12 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.12 remote-as 65101
-      neighbor 10.0.1.12 description site1-border1_Ethernet4.100_vrf_BLUE
-      neighbor 10.0.1.14 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.14 remote-as 65101
-      neighbor 10.0.1.14 description site1-border2_Ethernet4.100_vrf_BLUE
       redistribute connected
    !
    vrf default
@@ -1017,12 +958,6 @@ router bgp 65000
       route-target import evpn 101:101
       route-target export evpn 101:101
       router-id 192.168.255.4
-      neighbor 10.0.1.12 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.12 remote-as 65101
-      neighbor 10.0.1.12 description site1-border1_Ethernet4.101_vrf_RED
-      neighbor 10.0.1.14 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.14 remote-as 65101
-      neighbor 10.0.1.14 description site1-border2_Ethernet4.101_vrf_RED
       redistribute connected
 ```
 

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/fabric/WAN-documentation.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/fabric/WAN-documentation.md
@@ -23,6 +23,7 @@
 | WAN | wan_rr | pf2 | 192.168.17.11/24 | - | Provisioned | - |
 | WAN | l3leaf | site1-border1 | 192.168.17.14/24 | - | Provisioned | - |
 | WAN | l3leaf | site1-border2 | 192.168.17.15/24 | - | Provisioned | - |
+| WAN | overlay-controller | site1-rs1 | 192.168.17.60/24 | vEOS-LAB | Provisioned | - |
 | WAN | wan_router | site1-wan1 | 192.168.17.12/24 | - | Provisioned | - |
 | WAN | wan_router | site1-wan2 | 192.168.17.13/24 | - | Provisioned | - |
 | WAN | l3leaf | site2-leaf1 | 192.168.17.18/24 | - | Provisioned | - |
@@ -44,19 +45,13 @@
 | Type | Node | Node Interface | Peer Type | Peer Node | Peer Interface |
 | ---- | ---- | -------------- | --------- | ----------| -------------- |
 | l3leaf | site1-border1 | Ethernet3 | wan_router | site1-wan1 | Ethernet1 |
-| l3leaf | site1-border1 | Ethernet3.100 | wan_router | site1-wan1 | Ethernet1.100 |
-| l3leaf | site1-border1 | Ethernet3.101 | wan_router | site1-wan1 | Ethernet1.101 |
 | l3leaf | site1-border1 | Ethernet4 | wan_router | site1-wan2 | Ethernet1 |
-| l3leaf | site1-border1 | Ethernet4.100 | wan_router | site1-wan2 | Ethernet1.100 |
-| l3leaf | site1-border1 | Ethernet4.101 | wan_router | site1-wan2 | Ethernet1.101 |
 | l3leaf | site1-border1 | Ethernet5 | mlag_peer | site1-border2 | Ethernet5 |
 | l3leaf | site1-border1 | Ethernet6 | mlag_peer | site1-border2 | Ethernet6 |
+| l3leaf | site1-border1 | Ethernet8 | overlay-controller | site1-rs1 | Ethernet1 |
 | l3leaf | site1-border2 | Ethernet3 | wan_router | site1-wan1 | Ethernet2 |
-| l3leaf | site1-border2 | Ethernet3.100 | wan_router | site1-wan1 | Ethernet2.100 |
-| l3leaf | site1-border2 | Ethernet3.101 | wan_router | site1-wan1 | Ethernet2.101 |
 | l3leaf | site1-border2 | Ethernet4 | wan_router | site1-wan2 | Ethernet2 |
-| l3leaf | site1-border2 | Ethernet4.100 | wan_router | site1-wan2 | Ethernet2.100 |
-| l3leaf | site1-border2 | Ethernet4.101 | wan_router | site1-wan2 | Ethernet2.101 |
+| l3leaf | site1-border2 | Ethernet8 | overlay-controller | site1-rs1 | Ethernet2 |
 | l3leaf | site2-leaf1 | Ethernet3 | wan_router | site2-wan1 | Ethernet1 |
 | l3leaf | site2-leaf1 | Ethernet3.100 | wan_router | site2-wan1 | Ethernet1.100 |
 | l3leaf | site2-leaf1 | Ethernet3.101 | wan_router | site2-wan1 | Ethernet1.101 |
@@ -76,26 +71,21 @@
 
 | Uplink IPv4 Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | ---------------- | ------------------- | ------------------ | ------------------ |
-| 10.0.1.0/24 | 256 | 24 | 9.38 % |
+| 10.0.1.0/24 | 256 | 8 | 3.13 % |
 | 10.0.2.0/24 | 256 | 12 | 4.69 % |
 | 10.0.3.0/24 | 256 | 0 | 0.0 % |
+| 10.0.5.0/24 | 256 | 4 | 1.57 % |
 
 ### Point-To-Point Links Node Allocation
 
 | Node | Node Interface | Node IP Address | Peer Node | Peer Interface | Peer IP Address |
 | ---- | -------------- | --------------- | --------- | -------------- | --------------- |
 | site1-border1 | Ethernet3 | 10.0.1.8/31 | site1-wan1 | Ethernet1 | 10.0.1.9/31 |
-| site1-border1 | Ethernet3.100 | 10.0.1.8/31 | site1-wan1 | Ethernet1.100 | 10.0.1.9/31 |
-| site1-border1 | Ethernet3.101 | 10.0.1.8/31 | site1-wan1 | Ethernet1.101 | 10.0.1.9/31 |
 | site1-border1 | Ethernet4 | 10.0.1.12/31 | site1-wan2 | Ethernet1 | 10.0.1.13/31 |
-| site1-border1 | Ethernet4.100 | 10.0.1.12/31 | site1-wan2 | Ethernet1.100 | 10.0.1.13/31 |
-| site1-border1 | Ethernet4.101 | 10.0.1.12/31 | site1-wan2 | Ethernet1.101 | 10.0.1.13/31 |
+| site1-border1 | Ethernet8 | 10.0.5.9/31 | site1-rs1 | Ethernet1 | 10.0.5.8/31 |
 | site1-border2 | Ethernet3 | 10.0.1.10/31 | site1-wan1 | Ethernet2 | 10.0.1.11/31 |
-| site1-border2 | Ethernet3.100 | 10.0.1.10/31 | site1-wan1 | Ethernet2.100 | 10.0.1.11/31 |
-| site1-border2 | Ethernet3.101 | 10.0.1.10/31 | site1-wan1 | Ethernet2.101 | 10.0.1.11/31 |
 | site1-border2 | Ethernet4 | 10.0.1.14/31 | site1-wan2 | Ethernet2 | 10.0.1.15/31 |
-| site1-border2 | Ethernet4.100 | 10.0.1.14/31 | site1-wan2 | Ethernet2.100 | 10.0.1.15/31 |
-| site1-border2 | Ethernet4.101 | 10.0.1.14/31 | site1-wan2 | Ethernet2.101 | 10.0.1.15/31 |
+| site1-border2 | Ethernet8 | 10.0.5.11/31 | site1-rs1 | Ethernet2 | 10.0.5.10/31 |
 | site2-leaf1 | Ethernet3 | 10.0.2.12/31 | site2-wan1 | Ethernet1 | 10.0.2.13/31 |
 | site2-leaf1 | Ethernet3.100 | 10.0.2.12/31 | site2-wan1 | Ethernet1.100 | 10.0.2.13/31 |
 | site2-leaf1 | Ethernet3.101 | 10.0.2.12/31 | site2-wan1 | Ethernet1.101 | 10.0.2.13/31 |
@@ -108,7 +98,7 @@
 | Loopback Pool | Available Addresses | Assigned addresses | Assigned Address % |
 | ------------- | ------------------- | ------------------ | ------------------ |
 | 172.31.255.0/24 | 256 | 2 | 0.79 % |
-| 192.168.255.0/24 | 256 | 11 | 4.3 % |
+| 192.168.255.0/24 | 256 | 12 | 4.69 % |
 
 ### Loopback0 Interfaces Node Allocation
 
@@ -120,6 +110,7 @@
 | WAN | pf2 | 192.168.255.2/32 |
 | WAN | site1-border1 | 192.168.255.5/32 |
 | WAN | site1-border2 | 192.168.255.6/32 |
+| WAN | site1-rs1 | 192.168.255.99/32 |
 | WAN | site1-wan1 | 192.168.255.3/32 |
 | WAN | site1-wan2 | 192.168.255.4/32 |
 | WAN | site2-leaf1 | 192.168.255.9/32 |

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/group_vars/SITE1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/group_vars/SITE1.yml
@@ -12,16 +12,33 @@ l3leaf:
     mlag_interfaces: [Ethernet5, Ethernet6]
     mlag_peer_l3_ipv4_pool: 10.255.251.0/24
     mlag_peer_ipv4_pool: 10.255.252.0/24
+    uplink_switches: [site1-rs1]
+    uplink_interfaces: [Ethernet8]
+    uplink_ipv4_pool: 10.0.5.0/24
   node_groups:
     - group: SITE1
       bgp_as: 65101
       nodes:
         - name: site1-border1
           mgmt_ip: 192.168.17.14/24
+          uplink_switch_interfaces: [Ethernet1]
           id: 5
         - name: site1-border2
           mgmt_ip: 192.168.17.15/24
+          uplink_switch_interfaces: [Ethernet2]
           id: 6
+
+overlay_controller:
+  defaults:
+    platform: vEOS-LAB
+    loopback_ipv4_pool: 192.168.255.0/24
+    uplink_bfd: False
+    bgp_as: 65101
+  nodes:
+    - name: site1-rs1
+      id: 99
+      mgmt_ip: 192.168.17.60/24
+      evpn_role: server
 
 wan_router:
   defaults:
@@ -32,7 +49,7 @@ wan_router:
       always_include_vrfs_in_tenants: [all]
     uplink_interfaces: [Ethernet1, Ethernet2]
     uplink_switches: [site1-border1, site1-border2]
-    uplink_type: p2p-vrfs # (1)!
+    uplink_type: p2p # (1)!
     bgp_as: 65000
   node_groups:
     - group: SITE1
@@ -49,6 +66,11 @@ wan_router:
           id: 3
           mgmt_ip: 192.168.17.12/24
           uplink_switch_interfaces: [Ethernet3, Ethernet3]
+          evpn_gateway:
+            remote_peers:
+              - hostname: site1-rs1
+            evpn_l3:
+              enabled: true
           l3_interfaces:
             - name: Ethernet3
               profile: MPLS-WAN-INTERFACE

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-border1.cfg
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-border1.cfg
@@ -84,48 +84,12 @@ interface Ethernet3
    flow tracker sampled FLOW-TRACKER
    ip address 10.0.1.8/31
 !
-interface Ethernet3.100
-   description P2P_site1-wan1_Ethernet1.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker sampled FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.8/31
-!
-interface Ethernet3.101
-   description P2P_site1-wan1_Ethernet1.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker sampled FLOW-TRACKER
-   vrf RED
-   ip address 10.0.1.8/31
-!
 interface Ethernet4
    description P2P_site1-wan2_Ethernet1
    no shutdown
    mtu 9214
    no switchport
    flow tracker sampled FLOW-TRACKER
-   ip address 10.0.1.12/31
-!
-interface Ethernet4.100
-   description P2P_site1-wan2_Ethernet1.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker sampled FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.12/31
-!
-interface Ethernet4.101
-   description P2P_site1-wan2_Ethernet1.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker sampled FLOW-TRACKER
-   vrf RED
    ip address 10.0.1.12/31
 !
 interface Ethernet5
@@ -137,6 +101,14 @@ interface Ethernet6
    description MLAG_site1-border2_Ethernet6
    no shutdown
    channel-group 5 mode active
+!
+interface Ethernet8
+   description P2P_site1-rs1_Ethernet1
+   no shutdown
+   mtu 9214
+   no switchport
+   flow tracker sampled FLOW-TRACKER
+   ip address 10.0.5.9/31
 !
 interface Loopback0
    description ROUTER_ID
@@ -271,8 +243,14 @@ router bgp 65101
    neighbor 10.0.1.13 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.0.1.13 remote-as 65000
    neighbor 10.0.1.13 description site1-wan2_Ethernet1
+   neighbor 10.0.5.8 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.0.5.8 remote-as 65101
+   neighbor 10.0.5.8 description site1-rs1_Ethernet1
    neighbor 10.255.251.9 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.255.251.9 description site1-border2_Vlan4093
+   neighbor 192.168.255.99 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.99 remote-as 65101
+   neighbor 192.168.255.99 description site1-rs1_Loopback0
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 42
@@ -298,12 +276,6 @@ router bgp 65101
       route-target import evpn 100:100
       route-target export evpn 100:100
       router-id 192.168.255.5
-      neighbor 10.0.1.9 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.9 remote-as 65000
-      neighbor 10.0.1.9 description site1-wan1_Ethernet1.100_vrf_BLUE
-      neighbor 10.0.1.13 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.13 remote-as 65000
-      neighbor 10.0.1.13 description site1-wan2_Ethernet1.100_vrf_BLUE
       neighbor 10.255.251.9 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.255.251.9 description site1-border2_Vlan3099
       redistribute connected route-map RM-CONN-2-BGP-VRFS
@@ -313,12 +285,6 @@ router bgp 65101
       route-target import evpn 101:101
       route-target export evpn 101:101
       router-id 192.168.255.5
-      neighbor 10.0.1.9 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.9 remote-as 65000
-      neighbor 10.0.1.9 description site1-wan1_Ethernet1.101_vrf_RED
-      neighbor 10.0.1.13 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.13 remote-as 65000
-      neighbor 10.0.1.13 description site1-wan2_Ethernet1.101_vrf_RED
       neighbor 10.255.251.9 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.255.251.9 description site1-border2_Vlan3100
       redistribute connected route-map RM-CONN-2-BGP-VRFS

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-border2.cfg
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-border2.cfg
@@ -84,48 +84,12 @@ interface Ethernet3
    flow tracker sampled FLOW-TRACKER
    ip address 10.0.1.10/31
 !
-interface Ethernet3.100
-   description P2P_site1-wan1_Ethernet2.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker sampled FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.10/31
-!
-interface Ethernet3.101
-   description P2P_site1-wan1_Ethernet2.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker sampled FLOW-TRACKER
-   vrf RED
-   ip address 10.0.1.10/31
-!
 interface Ethernet4
    description P2P_site1-wan2_Ethernet2
    no shutdown
    mtu 9214
    no switchport
    flow tracker sampled FLOW-TRACKER
-   ip address 10.0.1.14/31
-!
-interface Ethernet4.100
-   description P2P_site1-wan2_Ethernet2.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker sampled FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.14/31
-!
-interface Ethernet4.101
-   description P2P_site1-wan2_Ethernet2.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker sampled FLOW-TRACKER
-   vrf RED
    ip address 10.0.1.14/31
 !
 interface Ethernet5
@@ -137,6 +101,14 @@ interface Ethernet6
    description MLAG_site1-border1_Ethernet6
    no shutdown
    channel-group 5 mode active
+!
+interface Ethernet8
+   description P2P_site1-rs1_Ethernet2
+   no shutdown
+   mtu 9214
+   no switchport
+   flow tracker sampled FLOW-TRACKER
+   ip address 10.0.5.11/31
 !
 interface Loopback0
    description ROUTER_ID
@@ -271,8 +243,14 @@ router bgp 65101
    neighbor 10.0.1.15 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.0.1.15 remote-as 65000
    neighbor 10.0.1.15 description site1-wan2_Ethernet2
+   neighbor 10.0.5.10 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.0.5.10 remote-as 65101
+   neighbor 10.0.5.10 description site1-rs1_Ethernet2
    neighbor 10.255.251.8 peer group MLAG-IPv4-UNDERLAY-PEER
    neighbor 10.255.251.8 description site1-border1_Vlan4093
+   neighbor 192.168.255.99 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.99 remote-as 65101
+   neighbor 192.168.255.99 description site1-rs1_Loopback0
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan 42
@@ -298,12 +276,6 @@ router bgp 65101
       route-target import evpn 100:100
       route-target export evpn 100:100
       router-id 192.168.255.6
-      neighbor 10.0.1.11 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.11 remote-as 65000
-      neighbor 10.0.1.11 description site1-wan1_Ethernet2.100_vrf_BLUE
-      neighbor 10.0.1.15 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.15 remote-as 65000
-      neighbor 10.0.1.15 description site1-wan2_Ethernet2.100_vrf_BLUE
       neighbor 10.255.251.8 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.255.251.8 description site1-border1_Vlan3099
       redistribute connected route-map RM-CONN-2-BGP-VRFS
@@ -313,12 +285,6 @@ router bgp 65101
       route-target import evpn 101:101
       route-target export evpn 101:101
       router-id 192.168.255.6
-      neighbor 10.0.1.11 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.11 remote-as 65000
-      neighbor 10.0.1.11 description site1-wan1_Ethernet2.101_vrf_RED
-      neighbor 10.0.1.15 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.15 remote-as 65000
-      neighbor 10.0.1.15 description site1-wan2_Ethernet2.101_vrf_RED
       neighbor 10.255.251.8 peer group MLAG-IPv4-UNDERLAY-PEER
       neighbor 10.255.251.8 description site1-border1_Vlan3100
       redistribute connected route-map RM-CONN-2-BGP-VRFS

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-rs1.cfg
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-rs1.cfg
@@ -1,0 +1,130 @@
+!
+no enable password
+no aaa root
+!
+username ansible privilege 15 role network-admin secret sha512 $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
+username arista privilege 15 role network-admin secret sha512 $6$Enl0WfE32FthwyiJ$yTyGaEJ2uPKLU.F7314YtB7J1jrzrMi7ogXIRTEHQfLdLgKWWmr1UvNlZLN6AyuxET7G5aH3AI9OYRzxVTkB1.
+username cvpadmin privilege 15 role network-admin secret sha512 $6$a7LdQWHxWzYHpvVt$n62q.1mbm4kzQ5oBr0lhXCE9ntnTn.SNa16DovZHahFQLH.iPcPMZa5JUSFtncrDW4EDQ3oSWgP8G0S4FtOFx1
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=www.cv-staging.corp.arista.io:443 -cvauth=token-secure,/tmp/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+flow tracking sampled
+   sample 10000
+   tracker FLOW-TRACKER
+      record export on inactive timeout 70000
+      record export on interval 5000
+      exporter CV-TELEMETRY
+         collector 127.0.0.1
+         local interface Loopback0
+   no shutdown
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname site1-rs1
+ip name-server vrf MGMT 192.168.17.1
+dns domain wan.example.local
+!
+spanning-tree mode none
+!
+vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+aaa authorization exec default local
+!
+interface Ethernet1
+   description P2P_site1-border1_Ethernet8
+   no shutdown
+   mtu 9214
+   no switchport
+   flow tracker sampled FLOW-TRACKER
+   ip address 10.0.5.8/31
+!
+interface Ethernet2
+   description P2P_site1-border2_Ethernet8
+   no shutdown
+   mtu 9214
+   no switchport
+   flow tracker sampled FLOW-TRACKER
+   ip address 10.0.5.10/31
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 192.168.255.99/32
+!
+interface Management1
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 192.168.17.60/24
+   no lldp transmit
+   no lldp receive
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.255.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.17.1
+!
+ntp local-interface vrf MGMT Management1
+ntp server vrf MGMT 0.pool.ntp.org prefer
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65101
+   router-id 192.168.255.99
+   no bgp default ipv4-unicast
+   maximum-paths 4 ecmp 4
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.0.5.9 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.0.5.9 remote-as 65101
+   neighbor 10.0.5.9 description site1-border1_Ethernet8
+   neighbor 10.0.5.11 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.0.5.11 remote-as 65101
+   neighbor 10.0.5.11 description site1-border2_Ethernet8
+   neighbor 192.168.255.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.3 remote-as 65000
+   neighbor 192.168.255.3 description site1-wan1_Loopback0
+   neighbor 192.168.255.5 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.5 remote-as 65101
+   neighbor 192.168.255.5 description site1-border1_Loopback0
+   neighbor 192.168.255.6 peer group EVPN-OVERLAY-PEERS
+   neighbor 192.168.255.6 remote-as 65101
+   neighbor 192.168.255.6 description site1-border2_Loopback0
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+end

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-wan1.cfg
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-wan1.cfg
@@ -28,7 +28,7 @@ ip name-server vrf MGMT 192.168.17.1
 dns domain wan.example.local
 !
 router adaptive-virtual-topology
-   topology role transit region
+   topology role transit region gateway vxlan
    region REGION1 id 1
    zone REGION1-ZONE id 1
    site SITE1 id 101
@@ -267,48 +267,12 @@ interface Ethernet1
    flow tracker hardware FLOW-TRACKER
    ip address 10.0.1.9/31
 !
-interface Ethernet1.100
-   description P2P_site1-border1_Ethernet3.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.9/31
-!
-interface Ethernet1.101
-   description P2P_site1-border1_Ethernet3.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker hardware FLOW-TRACKER
-   vrf RED
-   ip address 10.0.1.9/31
-!
 interface Ethernet2
    description P2P_site1-border2_Ethernet3
    no shutdown
    mtu 9214
    no switchport
    flow tracker hardware FLOW-TRACKER
-   ip address 10.0.1.11/31
-!
-interface Ethernet2.100
-   description P2P_site1-border2_Ethernet3.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.11/31
-!
-interface Ethernet2.101
-   description P2P_site1-border2_Ethernet3.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker hardware FLOW-TRACKER
-   vrf RED
    ip address 10.0.1.11/31
 !
 interface Ethernet3
@@ -485,6 +449,12 @@ router bgp 65000
    router-id 192.168.255.3
    no bgp default ipv4-unicast
    maximum-paths 16
+   neighbor EVPN-OVERLAY-CORE peer group
+   neighbor EVPN-OVERLAY-CORE update-source Loopback0
+   neighbor EVPN-OVERLAY-CORE bfd
+   neighbor EVPN-OVERLAY-CORE ebgp-multihop 15
+   neighbor EVPN-OVERLAY-CORE send-community
+   neighbor EVPN-OVERLAY-CORE maximum-routes 0
    neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS allowas-in 1
    neighbor IPv4-UNDERLAY-PEERS route-map RM-BGP-UNDERLAY-PEERS-IN in
@@ -517,9 +487,13 @@ router bgp 65000
    neighbor 192.168.42.4 route-map RM-WAN-HA-PEER-IN in
    neighbor 192.168.42.4 route-map RM-WAN-HA-PEER-OUT out
    neighbor 192.168.42.4 send-community
+   neighbor 192.168.255.99 peer group EVPN-OVERLAY-CORE
+   neighbor 192.168.255.99 description site1-rs1_Loopback0
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
+      neighbor EVPN-OVERLAY-CORE activate
+      neighbor EVPN-OVERLAY-CORE domain remote
       neighbor WAN-OVERLAY-PEERS activate
       neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-IN in
       neighbor WAN-OVERLAY-PEERS route-map RM-EVPN-SOO-OUT out
@@ -529,6 +503,7 @@ router bgp 65000
       neighbor default next-hop-self received-evpn-routes route-type ip-prefix
    !
    address-family ipv4
+      no neighbor EVPN-OVERLAY-CORE activate
       neighbor IPv4-UNDERLAY-PEERS activate
       no neighbor WAN-OVERLAY-PEERS activate
    !
@@ -549,12 +524,6 @@ router bgp 65000
       route-target import evpn 100:100
       route-target export evpn 100:100
       router-id 192.168.255.3
-      neighbor 10.0.1.8 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.8 remote-as 65101
-      neighbor 10.0.1.8 description site1-border1_Ethernet3.100_vrf_BLUE
-      neighbor 10.0.1.10 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.10 remote-as 65101
-      neighbor 10.0.1.10 description site1-border2_Ethernet3.100_vrf_BLUE
       redistribute connected
    !
    vrf default
@@ -568,12 +537,6 @@ router bgp 65000
       route-target import evpn 101:101
       route-target export evpn 101:101
       router-id 192.168.255.3
-      neighbor 10.0.1.8 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.8 remote-as 65101
-      neighbor 10.0.1.8 description site1-border1_Ethernet3.101_vrf_RED
-      neighbor 10.0.1.10 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.10 remote-as 65101
-      neighbor 10.0.1.10 description site1-border2_Ethernet3.101_vrf_RED
       redistribute connected
 !
 router traffic-engineering

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-wan2.cfg
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/configs/site1-wan2.cfg
@@ -267,48 +267,12 @@ interface Ethernet1
    flow tracker hardware FLOW-TRACKER
    ip address 10.0.1.13/31
 !
-interface Ethernet1.100
-   description P2P_site1-border1_Ethernet4.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.13/31
-!
-interface Ethernet1.101
-   description P2P_site1-border1_Ethernet4.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker hardware FLOW-TRACKER
-   vrf RED
-   ip address 10.0.1.13/31
-!
 interface Ethernet2
    description P2P_site1-border2_Ethernet4
    no shutdown
    mtu 9214
    no switchport
    flow tracker hardware FLOW-TRACKER
-   ip address 10.0.1.15/31
-!
-interface Ethernet2.100
-   description P2P_site1-border2_Ethernet4.100_VRF_BLUE
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 100
-   flow tracker hardware FLOW-TRACKER
-   vrf BLUE
-   ip address 10.0.1.15/31
-!
-interface Ethernet2.101
-   description P2P_site1-border2_Ethernet4.101_VRF_RED
-   no shutdown
-   mtu 9214
-   encapsulation dot1q vlan 101
-   flow tracker hardware FLOW-TRACKER
-   vrf RED
    ip address 10.0.1.15/31
 !
 interface Ethernet3
@@ -550,12 +514,6 @@ router bgp 65000
       route-target import evpn 100:100
       route-target export evpn 100:100
       router-id 192.168.255.4
-      neighbor 10.0.1.12 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.12 remote-as 65101
-      neighbor 10.0.1.12 description site1-border1_Ethernet4.100_vrf_BLUE
-      neighbor 10.0.1.14 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.14 remote-as 65101
-      neighbor 10.0.1.14 description site1-border2_Ethernet4.100_vrf_BLUE
       redistribute connected
    !
    vrf default
@@ -569,12 +527,6 @@ router bgp 65000
       route-target import evpn 101:101
       route-target export evpn 101:101
       router-id 192.168.255.4
-      neighbor 10.0.1.12 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.12 remote-as 65101
-      neighbor 10.0.1.12 description site1-border1_Ethernet4.101_vrf_RED
-      neighbor 10.0.1.14 peer group IPv4-UNDERLAY-PEERS
-      neighbor 10.0.1.14 remote-as 65101
-      neighbor 10.0.1.14 description site1-border2_Ethernet4.101_vrf_RED
       redistribute connected
 !
 router traffic-engineering

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border1.yml
@@ -56,21 +56,22 @@ router_bgp:
     remote_as: '65000'
     peer: site1-wan2
     description: site1-wan2_Ethernet1
+  - ip_address: 10.0.5.8
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    peer: site1-rs1
+    description: site1-rs1_Ethernet1
+  - ip_address: 192.168.255.99
+    peer_group: EVPN-OVERLAY-PEERS
+    peer: site1-rs1
+    description: site1-rs1_Loopback0
+    remote_as: '65101'
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
   vrfs:
   - name: BLUE
-    router_id: 192.168.255.5
-    neighbors:
-    - ip_address: 10.0.1.9
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65000'
-      description: site1-wan1_Ethernet1.100_vrf_BLUE
-    - ip_address: 10.0.1.13
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65000'
-      description: site1-wan2_Ethernet1.100_vrf_BLUE
-    - ip_address: 10.255.251.9
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
-      description: site1-border2_Vlan3099
     rd: 192.168.255.5:100
     route_targets:
       import:
@@ -81,24 +82,16 @@ router_bgp:
       - address_family: evpn
         route_targets:
         - 100:100
+    router_id: 192.168.255.5
     redistribute:
       connected:
         enabled: true
         route_map: RM-CONN-2-BGP-VRFS
-  - name: RED
-    router_id: 192.168.255.5
     neighbors:
-    - ip_address: 10.0.1.9
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65000'
-      description: site1-wan1_Ethernet1.101_vrf_RED
-    - ip_address: 10.0.1.13
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65000'
-      description: site1-wan2_Ethernet1.101_vrf_RED
     - ip_address: 10.255.251.9
       peer_group: MLAG-IPv4-UNDERLAY-PEER
-      description: site1-border2_Vlan3100
+      description: site1-border2_Vlan3099
+  - name: RED
     rd: 192.168.255.5:101
     route_targets:
       import:
@@ -109,14 +102,15 @@ router_bgp:
       - address_family: evpn
         route_targets:
         - 101:101
+    router_id: 192.168.255.5
     redistribute:
       connected:
         enabled: true
         route_map: RM-CONN-2-BGP-VRFS
-  address_family_evpn:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: true
+    neighbors:
+    - ip_address: 10.255.251.9
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: site1-border2_Vlan3100
   vlans:
   - id: 666
     tenant: WAN-EXAMPLE-TENANT
@@ -319,32 +313,6 @@ ethernet_interfaces:
   flow_tracker:
     sampled: FLOW-TRACKER
   ip_address: 10.0.1.8/31
-- name: Ethernet3.100
-  peer: site1-wan1
-  peer_interface: Ethernet1.100
-  peer_type: wan_router
-  vrf: BLUE
-  description: P2P_site1-wan1_Ethernet1.100_VRF_BLUE
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 100
-  flow_tracker:
-    sampled: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.8/31
-- name: Ethernet3.101
-  peer: site1-wan1
-  peer_interface: Ethernet1.101
-  peer_type: wan_router
-  vrf: RED
-  description: P2P_site1-wan1_Ethernet1.101_VRF_RED
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 101
-  flow_tracker:
-    sampled: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.8/31
 - name: Ethernet4
   peer: site1-wan2
   peer_interface: Ethernet1
@@ -357,32 +325,18 @@ ethernet_interfaces:
   flow_tracker:
     sampled: FLOW-TRACKER
   ip_address: 10.0.1.12/31
-- name: Ethernet4.100
-  peer: site1-wan2
-  peer_interface: Ethernet1.100
-  peer_type: wan_router
-  vrf: BLUE
-  description: P2P_site1-wan2_Ethernet1.100_VRF_BLUE
+- name: Ethernet8
+  peer: site1-rs1
+  peer_interface: Ethernet1
+  peer_type: overlay-controller
+  description: P2P_site1-rs1_Ethernet1
   shutdown: false
-  encapsulation_dot1q:
-    vlan: 100
+  mtu: 9214
+  switchport:
+    enabled: false
   flow_tracker:
     sampled: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.12/31
-- name: Ethernet4.101
-  peer: site1-wan2
-  peer_interface: Ethernet1.101
-  peer_type: wan_router
-  vrf: RED
-  description: P2P_site1-wan2_Ethernet1.101_VRF_RED
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 101
-  flow_tracker:
-    sampled: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.12/31
+  ip_address: 10.0.5.9/31
 mlag_configuration:
   domain_id: SITE1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border2.yml
@@ -56,21 +56,22 @@ router_bgp:
     remote_as: '65000'
     peer: site1-wan2
     description: site1-wan2_Ethernet2
+  - ip_address: 10.0.5.10
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    peer: site1-rs1
+    description: site1-rs1_Ethernet2
+  - ip_address: 192.168.255.99
+    peer_group: EVPN-OVERLAY-PEERS
+    peer: site1-rs1
+    description: site1-rs1_Loopback0
+    remote_as: '65101'
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
   vrfs:
   - name: BLUE
-    router_id: 192.168.255.6
-    neighbors:
-    - ip_address: 10.0.1.11
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65000'
-      description: site1-wan1_Ethernet2.100_vrf_BLUE
-    - ip_address: 10.0.1.15
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65000'
-      description: site1-wan2_Ethernet2.100_vrf_BLUE
-    - ip_address: 10.255.251.8
-      peer_group: MLAG-IPv4-UNDERLAY-PEER
-      description: site1-border1_Vlan3099
     rd: 192.168.255.6:100
     route_targets:
       import:
@@ -81,24 +82,16 @@ router_bgp:
       - address_family: evpn
         route_targets:
         - 100:100
+    router_id: 192.168.255.6
     redistribute:
       connected:
         enabled: true
         route_map: RM-CONN-2-BGP-VRFS
-  - name: RED
-    router_id: 192.168.255.6
     neighbors:
-    - ip_address: 10.0.1.11
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65000'
-      description: site1-wan1_Ethernet2.101_vrf_RED
-    - ip_address: 10.0.1.15
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65000'
-      description: site1-wan2_Ethernet2.101_vrf_RED
     - ip_address: 10.255.251.8
       peer_group: MLAG-IPv4-UNDERLAY-PEER
-      description: site1-border1_Vlan3100
+      description: site1-border1_Vlan3099
+  - name: RED
     rd: 192.168.255.6:101
     route_targets:
       import:
@@ -109,14 +102,15 @@ router_bgp:
       - address_family: evpn
         route_targets:
         - 101:101
+    router_id: 192.168.255.6
     redistribute:
       connected:
         enabled: true
         route_map: RM-CONN-2-BGP-VRFS
-  address_family_evpn:
-    peer_groups:
-    - name: EVPN-OVERLAY-PEERS
-      activate: true
+    neighbors:
+    - ip_address: 10.255.251.8
+      peer_group: MLAG-IPv4-UNDERLAY-PEER
+      description: site1-border1_Vlan3100
   vlans:
   - id: 666
     tenant: WAN-EXAMPLE-TENANT
@@ -319,32 +313,6 @@ ethernet_interfaces:
   flow_tracker:
     sampled: FLOW-TRACKER
   ip_address: 10.0.1.10/31
-- name: Ethernet3.100
-  peer: site1-wan1
-  peer_interface: Ethernet2.100
-  peer_type: wan_router
-  vrf: BLUE
-  description: P2P_site1-wan1_Ethernet2.100_VRF_BLUE
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 100
-  flow_tracker:
-    sampled: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.10/31
-- name: Ethernet3.101
-  peer: site1-wan1
-  peer_interface: Ethernet2.101
-  peer_type: wan_router
-  vrf: RED
-  description: P2P_site1-wan1_Ethernet2.101_VRF_RED
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 101
-  flow_tracker:
-    sampled: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.10/31
 - name: Ethernet4
   peer: site1-wan2
   peer_interface: Ethernet2
@@ -357,32 +325,18 @@ ethernet_interfaces:
   flow_tracker:
     sampled: FLOW-TRACKER
   ip_address: 10.0.1.14/31
-- name: Ethernet4.100
-  peer: site1-wan2
-  peer_interface: Ethernet2.100
-  peer_type: wan_router
-  vrf: BLUE
-  description: P2P_site1-wan2_Ethernet2.100_VRF_BLUE
+- name: Ethernet8
+  peer: site1-rs1
+  peer_interface: Ethernet2
+  peer_type: overlay-controller
+  description: P2P_site1-rs1_Ethernet2
   shutdown: false
-  encapsulation_dot1q:
-    vlan: 100
+  mtu: 9214
+  switchport:
+    enabled: false
   flow_tracker:
     sampled: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.14/31
-- name: Ethernet4.101
-  peer: site1-wan2
-  peer_interface: Ethernet2.101
-  peer_type: wan_router
-  vrf: RED
-  description: P2P_site1-wan2_Ethernet2.101_VRF_RED
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 101
-  flow_tracker:
-    sampled: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.14/31
+  ip_address: 10.0.5.11/31
 mlag_configuration:
   domain_id: SITE1
   local_interface: Vlan4094

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-rs1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-rs1.yml
@@ -1,0 +1,202 @@
+hostname: site1-rs1
+is_deployed: true
+router_bgp:
+  as: '65101'
+  router_id: 192.168.255.99
+  bgp:
+    default:
+      ipv4_unicast: false
+  maximum_paths:
+    paths: 4
+    ecmp: 4
+  redistribute:
+    connected:
+      enabled: true
+      route_map: RM-CONN-2-BGP
+  peer_groups:
+  - name: IPv4-UNDERLAY-PEERS
+    type: ipv4
+    maximum_routes: 12000
+    send_community: all
+  - name: EVPN-OVERLAY-PEERS
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 3
+    next_hop_unchanged: true
+  address_family_ipv4:
+    peer_groups:
+    - name: IPv4-UNDERLAY-PEERS
+      activate: true
+    - name: EVPN-OVERLAY-PEERS
+      activate: false
+  neighbors:
+  - ip_address: 10.0.5.9
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    peer: site1-border1
+    description: site1-border1_Ethernet8
+  - ip_address: 10.0.5.11
+    peer_group: IPv4-UNDERLAY-PEERS
+    remote_as: '65101'
+    peer: site1-border2
+    description: site1-border2_Ethernet8
+  - ip_address: 192.168.255.5
+    peer_group: EVPN-OVERLAY-PEERS
+    peer: site1-border1
+    description: site1-border1_Loopback0
+    remote_as: '65101'
+  - ip_address: 192.168.255.6
+    peer_group: EVPN-OVERLAY-PEERS
+    peer: site1-border2
+    description: site1-border2_Loopback0
+    remote_as: '65101'
+  - ip_address: 192.168.255.3
+    peer_group: EVPN-OVERLAY-PEERS
+    peer: site1-wan1
+    description: site1-wan1_Loopback0
+    remote_as: '65000'
+  address_family_evpn:
+    peer_groups:
+    - name: EVPN-OVERLAY-PEERS
+      activate: true
+static_routes:
+- vrf: MGMT
+  destination_address_prefix: 0.0.0.0/0
+  gateway: 192.168.17.1
+service_routing_protocols_model: multi-agent
+ip_routing: true
+daemon_terminattr:
+  cvaddrs:
+  - www.cv-staging.corp.arista.io:443
+  cvauth:
+    method: token-secure
+    token_file: /tmp/cv-onboarding-token
+  cvvrf: MGMT
+  smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
+  ingestexclude: /Sysdb/cell/1/agent,/Sysdb/cell/2/agent
+  disable_aaa: false
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+aaa_root:
+  disabled: true
+config_end: true
+enable_password:
+  disabled: true
+transceiver_qsfp_default_mode_4x10: true
+ip_name_servers:
+- ip_address: 192.168.17.1
+  vrf: MGMT
+spanning_tree:
+  mode: none
+local_users:
+- name: ansible
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$7u4j1rkb3VELgcZE$EJt2Qff8kd/TapRoci0XaIZsL4tFzgq1YZBLD9c6f/knXzvcYY0NcMKndZeCv0T268knGKhOEwZAxqKjlMm920
+- name: arista
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$Enl0WfE32FthwyiJ$yTyGaEJ2uPKLU.F7314YtB7J1jrzrMi7ogXIRTEHQfLdLgKWWmr1UvNlZLN6AyuxET7G5aH3AI9OYRzxVTkB1.
+- name: cvpadmin
+  privilege: 15
+  role: network-admin
+  sha512_password: $6$a7LdQWHxWzYHpvVt$n62q.1mbm4kzQ5oBr0lhXCE9ntnTn.SNa16DovZHahFQLH.iPcPMZa5JUSFtncrDW4EDQ3oSWgP8G0S4FtOFx1
+vrfs:
+- name: MGMT
+  ip_routing: false
+management_interfaces:
+- name: Management1
+  description: OOB_MANAGEMENT
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.17.60/24
+  gateway: 192.168.17.1
+  type: oob
+  lldp:
+    transmit: false
+    receive: false
+management_api_http:
+  enable_vrfs:
+  - name: MGMT
+  enable_https: true
+ntp:
+  local_interface:
+    name: Management1
+    vrf: MGMT
+  servers:
+  - name: 0.pool.ntp.org
+    vrf: MGMT
+    preferred: true
+ethernet_interfaces:
+- name: Ethernet1
+  peer: site1-border1
+  peer_interface: Ethernet8
+  peer_type: l3leaf
+  description: P2P_site1-border1_Ethernet8
+  shutdown: false
+  mtu: 9214
+  switchport:
+    enabled: false
+  flow_tracker:
+    sampled: FLOW-TRACKER
+  ip_address: 10.0.5.8/31
+- name: Ethernet2
+  peer: site1-border2
+  peer_interface: Ethernet8
+  peer_type: l3leaf
+  description: P2P_site1-border2_Ethernet8
+  shutdown: false
+  mtu: 9214
+  switchport:
+    enabled: false
+  flow_tracker:
+    sampled: FLOW-TRACKER
+  ip_address: 10.0.5.10/31
+loopback_interfaces:
+- name: Loopback0
+  description: ROUTER_ID
+  shutdown: false
+  ip_address: 192.168.255.99/32
+prefix_lists:
+- name: PL-LOOPBACKS-EVPN-OVERLAY
+  sequence_numbers:
+  - sequence: 10
+    action: permit 192.168.255.0/24 eq 32
+route_maps:
+- name: RM-CONN-2-BGP
+  sequence_numbers:
+  - sequence: 10
+    type: permit
+    match:
+    - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+flow_tracking:
+  sampled:
+    sample: 10000
+    trackers:
+    - name: FLOW-TRACKER
+      record_export:
+        on_inactive_timeout: 70000
+        on_interval: 5000
+      exporters:
+      - name: CV-TELEMETRY
+        collector:
+          host: 127.0.0.1
+        local_interface: Loopback0
+    shutdown: false
+metadata:
+  platform: vEOS-LAB
+dns_domain: wan.example.local
+aaa_authorization:
+  exec:
+    default: local

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan1.yml
@@ -35,11 +35,20 @@ router_bgp:
       interval: 1000
       min_rx: 1000
       multiplier: 10
+  - name: EVPN-OVERLAY-CORE
+    type: evpn
+    update_source: Loopback0
+    bfd: true
+    send_community: all
+    maximum_routes: 0
+    ebgp_multihop: 15
   address_family_ipv4:
     peer_groups:
     - name: IPv4-UNDERLAY-PEERS
       activate: true
     - name: WAN-OVERLAY-PEERS
+      activate: false
+    - name: EVPN-OVERLAY-CORE
       activate: false
   neighbors:
   - ip_address: 10.0.1.8
@@ -52,6 +61,10 @@ router_bgp:
     remote_as: '65101'
     peer: site1-border2
     description: site1-border2_Ethernet3
+  - ip_address: 192.168.255.99
+    peer_group: EVPN-OVERLAY-CORE
+    peer: site1-rs1
+    description: site1-rs1_Loopback0
   - ip_address: 192.168.42.1
     peer_group: WAN-OVERLAY-PEERS
     peer: pf1
@@ -69,77 +82,19 @@ router_bgp:
     send_community: all
     route_map_in: RM-WAN-HA-PEER-IN
     route_map_out: RM-WAN-HA-PEER-OUT
-  vrfs:
-  - name: BLUE
-    router_id: 192.168.255.3
-    neighbors:
-    - ip_address: 10.0.1.8
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: site1-border1_Ethernet3.100_vrf_BLUE
-    - ip_address: 10.0.1.10
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: site1-border2_Ethernet3.100_vrf_BLUE
-    rd: 192.168.255.3:100
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - 100:100
-      export:
-      - address_family: evpn
-        route_targets:
-        - 100:100
-    redistribute:
-      connected:
-        enabled: true
-  - name: RED
-    router_id: 192.168.255.3
-    neighbors:
-    - ip_address: 10.0.1.8
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: site1-border1_Ethernet3.101_vrf_RED
-    - ip_address: 10.0.1.10
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: site1-border2_Ethernet3.101_vrf_RED
-    rd: 192.168.255.3:101
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - 101:101
-      export:
-      - address_family: evpn
-        route_targets:
-        - 101:101
-    redistribute:
-      connected:
-        enabled: true
-  - name: default
-    rd: 192.168.255.3:1
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - '1:1'
-      export:
-      - address_family: evpn
-        route_targets:
-        - '1:1'
-        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
   address_family_evpn:
+    neighbor_default:
+      next_hop_self_received_evpn_routes:
+        enable: true
     peer_groups:
+    - name: EVPN-OVERLAY-CORE
+      domain_remote: true
+      activate: true
     - name: WAN-OVERLAY-PEERS
       activate: true
       encapsulation: path-selection
       route_map_in: RM-EVPN-SOO-IN
       route_map_out: RM-EVPN-SOO-OUT
-    neighbor_default:
-      next_hop_self_received_evpn_routes:
-        enable: true
     neighbors:
     - ip_address: 192.168.42.4
       activate: true
@@ -163,6 +118,49 @@ router_bgp:
       additional_paths:
         receive: true
         send: any
+  vrfs:
+  - name: BLUE
+    rd: 192.168.255.3:100
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 100:100
+      export:
+      - address_family: evpn
+        route_targets:
+        - 100:100
+    router_id: 192.168.255.3
+    redistribute:
+      connected:
+        enabled: true
+  - name: RED
+    rd: 192.168.255.3:101
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 101:101
+      export:
+      - address_family: evpn
+        route_targets:
+        - 101:101
+    router_id: 192.168.255.3
+    redistribute:
+      connected:
+        enabled: true
+  - name: default
+    rd: 192.168.255.3:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -250,32 +248,6 @@ ethernet_interfaces:
   flow_tracker:
     hardware: FLOW-TRACKER
   ip_address: 10.0.1.9/31
-- name: Ethernet1.100
-  peer: site1-border1
-  peer_interface: Ethernet3.100
-  peer_type: l3leaf
-  vrf: BLUE
-  description: P2P_site1-border1_Ethernet3.100_VRF_BLUE
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 100
-  flow_tracker:
-    hardware: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.9/31
-- name: Ethernet1.101
-  peer: site1-border1
-  peer_interface: Ethernet3.101
-  peer_type: l3leaf
-  vrf: RED
-  description: P2P_site1-border1_Ethernet3.101_VRF_RED
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 101
-  flow_tracker:
-    hardware: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.9/31
 - name: Ethernet2
   peer: site1-border2
   peer_interface: Ethernet3
@@ -287,32 +259,6 @@ ethernet_interfaces:
     enabled: false
   flow_tracker:
     hardware: FLOW-TRACKER
-  ip_address: 10.0.1.11/31
-- name: Ethernet2.100
-  peer: site1-border2
-  peer_interface: Ethernet3.100
-  peer_type: l3leaf
-  vrf: BLUE
-  description: P2P_site1-border2_Ethernet3.100_VRF_BLUE
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 100
-  flow_tracker:
-    hardware: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.11/31
-- name: Ethernet2.101
-  peer: site1-border2
-  peer_interface: Ethernet3.101
-  peer_type: l3leaf
-  vrf: RED
-  description: P2P_site1-border2_Ethernet3.101_VRF_RED
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 101
-  flow_tracker:
-    hardware: FLOW-TRACKER
-  mtu: 9214
   ip_address: 10.0.1.11/31
 - name: Ethernet3
   peer_type: l3_interface
@@ -540,6 +486,7 @@ router_adaptive_virtual_topology:
   site:
     name: SITE1
     id: 101
+  gateway_vxlan: true
   profiles:
   - name: BLUE-POLICY-VIDEO
     load_balance_policy: LB-BLUE-POLICY-VIDEO
@@ -837,23 +784,7 @@ metadata:
       tags:
       - name: Type
         value: lan
-    - interface: Ethernet1.100
-      tags:
-      - name: Type
-        value: lan
-    - interface: Ethernet1.101
-      tags:
-      - name: Type
-        value: lan
     - interface: Ethernet2
-      tags:
-      - name: Type
-        value: lan
-    - interface: Ethernet2.100
-      tags:
-      - name: Type
-        value: lan
-    - interface: Ethernet2.101
       tags:
       - name: Type
         value: lan

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan2.yml
@@ -69,67 +69,6 @@ router_bgp:
     send_community: all
     route_map_in: RM-WAN-HA-PEER-IN
     route_map_out: RM-WAN-HA-PEER-OUT
-  vrfs:
-  - name: BLUE
-    router_id: 192.168.255.4
-    neighbors:
-    - ip_address: 10.0.1.12
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: site1-border1_Ethernet4.100_vrf_BLUE
-    - ip_address: 10.0.1.14
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: site1-border2_Ethernet4.100_vrf_BLUE
-    rd: 192.168.255.4:100
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - 100:100
-      export:
-      - address_family: evpn
-        route_targets:
-        - 100:100
-    redistribute:
-      connected:
-        enabled: true
-  - name: RED
-    router_id: 192.168.255.4
-    neighbors:
-    - ip_address: 10.0.1.12
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: site1-border1_Ethernet4.101_vrf_RED
-    - ip_address: 10.0.1.14
-      peer_group: IPv4-UNDERLAY-PEERS
-      remote_as: '65101'
-      description: site1-border2_Ethernet4.101_vrf_RED
-    rd: 192.168.255.4:101
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - 101:101
-      export:
-      - address_family: evpn
-        route_targets:
-        - 101:101
-    redistribute:
-      connected:
-        enabled: true
-  - name: default
-    rd: 192.168.255.4:1
-    route_targets:
-      import:
-      - address_family: evpn
-        route_targets:
-        - '1:1'
-      export:
-      - address_family: evpn
-        route_targets:
-        - '1:1'
-        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
   address_family_evpn:
     peer_groups:
     - name: WAN-OVERLAY-PEERS
@@ -163,6 +102,49 @@ router_bgp:
       additional_paths:
         receive: true
         send: any
+  vrfs:
+  - name: BLUE
+    rd: 192.168.255.4:100
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 100:100
+      export:
+      - address_family: evpn
+        route_targets:
+        - 100:100
+    router_id: 192.168.255.4
+    redistribute:
+      connected:
+        enabled: true
+  - name: RED
+    rd: 192.168.255.4:101
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - 101:101
+      export:
+      - address_family: evpn
+        route_targets:
+        - 101:101
+    router_id: 192.168.255.4
+    redistribute:
+      connected:
+        enabled: true
+  - name: default
+    rd: 192.168.255.4:1
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '1:1'
+        - route-map RM-EVPN-EXPORT-VRF-DEFAULT
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -250,32 +232,6 @@ ethernet_interfaces:
   flow_tracker:
     hardware: FLOW-TRACKER
   ip_address: 10.0.1.13/31
-- name: Ethernet1.100
-  peer: site1-border1
-  peer_interface: Ethernet4.100
-  peer_type: l3leaf
-  vrf: BLUE
-  description: P2P_site1-border1_Ethernet4.100_VRF_BLUE
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 100
-  flow_tracker:
-    hardware: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.13/31
-- name: Ethernet1.101
-  peer: site1-border1
-  peer_interface: Ethernet4.101
-  peer_type: l3leaf
-  vrf: RED
-  description: P2P_site1-border1_Ethernet4.101_VRF_RED
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 101
-  flow_tracker:
-    hardware: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.13/31
 - name: Ethernet2
   peer: site1-border2
   peer_interface: Ethernet4
@@ -287,32 +243,6 @@ ethernet_interfaces:
     enabled: false
   flow_tracker:
     hardware: FLOW-TRACKER
-  ip_address: 10.0.1.15/31
-- name: Ethernet2.100
-  peer: site1-border2
-  peer_interface: Ethernet4.100
-  peer_type: l3leaf
-  vrf: BLUE
-  description: P2P_site1-border2_Ethernet4.100_VRF_BLUE
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 100
-  flow_tracker:
-    hardware: FLOW-TRACKER
-  mtu: 9214
-  ip_address: 10.0.1.15/31
-- name: Ethernet2.101
-  peer: site1-border2
-  peer_interface: Ethernet4.101
-  peer_type: l3leaf
-  vrf: RED
-  description: P2P_site1-border2_Ethernet4.101_VRF_RED
-  shutdown: false
-  encapsulation_dot1q:
-    vlan: 101
-  flow_tracker:
-    hardware: FLOW-TRACKER
-  mtu: 9214
   ip_address: 10.0.1.15/31
 - name: Ethernet3
   peer_type: l3_interface
@@ -838,23 +768,7 @@ metadata:
       tags:
       - name: Type
         value: lan
-    - interface: Ethernet1.100
-      tags:
-      - name: Type
-        value: lan
-    - interface: Ethernet1.101
-      tags:
-      - name: Type
-        value: lan
     - interface: Ethernet2
-      tags:
-      - name: Type
-        value: lan
-    - interface: Ethernet2.100
-      tags:
-      - name: Type
-        value: lan
-    - interface: Ethernet2.101
       tags:
       - name: Type
         value: lan

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan1.yml
@@ -276,6 +276,7 @@ ethernet_interfaces:
     enabled: false
   peer_type: l3_interface
   peer: site2-wan2
+  peer_interface: Ethernet5
   shutdown: false
   description: WAN_HA_site2-wan2_Ethernet5
   ip_address: 10.42.0.0/31

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan2.yml
@@ -373,6 +373,7 @@ ethernet_interfaces:
     enabled: false
   peer_type: l3_interface
   peer: site2-wan1
+  peer_interface: Ethernet5
   shutdown: false
   description: WAN_HA_site2-wan1_Ethernet5
   ip_address: 10.42.0.1/31

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/inventory.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/inventory.yml
@@ -24,6 +24,9 @@ all:
               ansible_host: 192.168.17.14
             site1-border2:
               ansible_host: 192.168.17.15
+            site1-rs1:
+              ansible_host: 192.168.17.60
+              type: overlay-controller
         SITE2:
           hosts:
             site2-wan1:

--- a/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_designs_facts.py
@@ -85,6 +85,11 @@ class ActionModule(ActionBase):
             for peer in host_mpls_route_reflectors:
                 avd_overlay_peers.setdefault(peer, []).append(host)
 
+            evpn_gateways = avd_switch_facts[host]["switch"].get("evpn_gateways", [])
+
+            for peer in evpn_gateways:
+                avd_overlay_peers.setdefault(peer, []).append(host)
+
             host_topology_peers = avd_switch_facts[host]["switch"].get("uplink_peers", [])
 
             for peer in host_topology_peers:

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/overlay.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/overlay.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING
 
+from pyavd._utils import get
+
 if TYPE_CHECKING:
     from . import EosDesignsFacts
 
@@ -27,6 +29,22 @@ class OverlayMixin:
     def mpls_overlay_role(self: EosDesignsFacts) -> str | None:
         """Exposed in avd_switch_facts."""
         return self.shared_utils.mpls_overlay_role
+
+    @cached_property
+    def evpn_gateways(self: EosDesignsFacts) -> list:
+        """
+        Exposed in avd_switch_facts.
+        For evpn clients the default value for EVPN Route Servers is the content of the uplink_switches variable set elsewhere.
+        For all other evpn roles there is no default.
+        """
+        hostnames = []
+        if evpn_gateway := self.shared_utils.node_config.evpn_gateway:
+            if evpn_gateway.remote_peers:
+                for peer in evpn_gateway.remote_peers:
+                    if peer.hostname:
+                        hostnames.append(peer.hostname)
+
+        return hostnames
 
     @cached_property
     def evpn_route_servers(self: EosDesignsFacts) -> list:

--- a/python-avd/pyavd/_eos_designs/shared_utils/overlay.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/overlay.py
@@ -9,7 +9,7 @@ from re import fullmatch
 from typing import TYPE_CHECKING
 
 from pyavd._errors import AristaAvdError, AristaAvdInvalidInputsError
-from pyavd._utils import default
+from pyavd._utils import default, get
 
 if TYPE_CHECKING:
     from . import SharedUtils
@@ -80,6 +80,15 @@ class OverlayMixin:
             return self.router_id
 
         return admin_subfield
+
+    @cached_property
+    def evpn_gateway_enabled(self: SharedUtils) -> bool:
+        if self.overlay_routing_protocol == "ebgp" or self.is_cv_pathfinder_client:
+            # Enable gateway when evpn_gateway is enabled
+            # - for ebgp
+            # - for ibgp, currently supported only for pathfinder deployment.
+            return self.node_config.evpn_gateway.evpn_l2.enabled or self.node_config.evpn_gateway.evpn_l3.enabled
+        return False
 
     @cached_property
     def overlay_routing_protocol_address_family(self: SharedUtils) -> str:

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/router_adaptive_virtual_topology.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/router_adaptive_virtual_topology.py
@@ -42,7 +42,7 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
             raise AristaAvdInvalidInputsError(msg)
 
         # Edge or Transit
-        return {
+        avt = {
             "topology_role": self.shared_utils.cv_pathfinder_role,
             "region": {
                 "name": self.shared_utils.wan_region.name,
@@ -54,3 +54,8 @@ class RouterAdaptiveVirtualTopologyMixin(UtilsMixin):
                 "id": self.shared_utils.wan_site.id,
             },
         }
+
+        if self.shared_utils.node_config.evpn_gateway.evpn_l3.enabled:
+            avt["gateway_vxlan"] = True
+
+        return avt

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/utils.py
@@ -67,6 +67,26 @@ class UtilsMixin:
         return evpn_gateway_remote_peers
 
     @cached_property
+    def _evpn_gateway_servers(self: AvdStructuredConfigOverlay) -> dict:
+        # TODO: Ayush A better name
+        # For pathfinder topology we are using one sided gateway, we want leaf to act as a server
+        if not self.shared_utils.overlay_evpn:
+            return {}
+
+
+        evpn_gateway_servers = {}
+        for avd_peer in self._avd_overlay_peers:
+            peer_facts = self.shared_utils.get_peer_facts(avd_peer, required=True)
+            remote_peers = peer_facts.get("evpn_gateways", [])
+
+            for peer in remote_peers:
+                if peer == self.shared_utils.hostname:
+                    if avd_peer not in self._evpn_route_servers and avd_peer not in self._evpn_gateway_remote_peers:
+                        self._append_peer(evpn_gateway_servers, avd_peer, peer_facts)
+
+        return evpn_gateway_servers
+
+    @cached_property
     def _evpn_route_clients(self: AvdStructuredConfigOverlay) -> dict:
         if not self.shared_utils.overlay_evpn:
             return {}
@@ -74,8 +94,7 @@ class UtilsMixin:
         if self.shared_utils.evpn_role != "server":
             return {}
 
-        evpn_route_clients = {}
-
+        evpn_route_clients = self._evpn_gateway_servers
         for avd_peer in self._avd_overlay_peers:
             peer_facts = self.shared_utils.get_peer_facts(avd_peer, required=True)
             if (

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/ethernet_interfaces.py
@@ -359,6 +359,7 @@ class EthernetInterfacesMixin(UtilsMixin):
                         "switchport": {"enabled": False},
                         "peer_type": "l3_interface",
                         "peer": self.shared_utils.wan_ha_peer,
+                        "peer_interface": interface,
                         "shutdown": False,
                         "description": description,
                         "ip_address": self.shared_utils.wan_ha_ip_addresses[index],


### PR DESCRIPTION
## Change Summary
Allow configuring evpn_gateway on wan_router 

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
No changes to data model.
Code Changes:
- Currently evpn_gw is only used if overlay routing protocol is ebgp
- We also add a case if router is wan_router client 

We also additionally generate config on peer side of remote gateway.

## How to test
molecule


## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
