### PR TITLE
Fix(eos_cli_config_gen): Fix the invalid comand `no neighbor PATH-SELECTION-PG-1 send` for BGP address-family path-selection

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -8609,7 +8609,7 @@ router bgp 65101
       bgp additional-paths send ecmp limit 42
       neighbor PATH-SELECTION-PG-1 activate
       neighbor PATH-SELECTION-PG-1 additional-paths receive
-      no neighbor PATH-SELECTION-PG-1 send
+      no neighbor PATH-SELECTION-PG-1 additional-paths send
       neighbor PATH-SELECTION-PG-2 activate
       neighbor PATH-SELECTION-PG-2 additional-paths send backup
       neighbor PATH-SELECTION-PG-3 activate

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -5464,7 +5464,7 @@ router bgp 65101
       bgp additional-paths send ecmp limit 42
       neighbor PATH-SELECTION-PG-1 activate
       neighbor PATH-SELECTION-PG-1 additional-paths receive
-      no neighbor PATH-SELECTION-PG-1 send
+      no neighbor PATH-SELECTION-PG-1 additional-paths send
       neighbor PATH-SELECTION-PG-2 activate
       neighbor PATH-SELECTION-PG-2 additional-paths send backup
       neighbor PATH-SELECTION-PG-3 activate

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -2432,7 +2432,7 @@ router bgp {{ router_bgp.as }}
 {%             endif %}
 {%             if peer_group.additional_paths.send is arista.avd.defined %}
 {%                 if peer_group.additional_paths.send == 'disabled' %}
-      no neighbor {{ peer_group.name }} send
+      no neighbor {{ peer_group.name }} additional-paths send
 {%                 elif peer_group.additional_paths.send_limit is arista.avd.defined and peer_group.additional_paths.send == 'ecmp' %}
       neighbor {{ peer_group.name }} additional-paths send ecmp limit {{ peer_group.additional_paths.send_limit }}
 {%                 elif peer_group.additional_paths.send == 'limit' %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-bgp.j2
@@ -2433,10 +2433,10 @@ router bgp {{ router_bgp.as }}
 {%             if peer_group.additional_paths.send is arista.avd.defined %}
 {%                 if peer_group.additional_paths.send == 'disabled' %}
       no neighbor {{ peer_group.name }} additional-paths send
-{%                 elif peer_group.additional_paths.send_limit is arista.avd.defined and peer_group.additional_paths.send == 'ecmp' %}
+{%                 elif peer_group.additional_paths.send_limit is arista.avd.defined %}
+{%                     if peer_group.additional_paths.send == 'ecmp' %}
       neighbor {{ peer_group.name }} additional-paths send ecmp limit {{ peer_group.additional_paths.send_limit }}
-{%                 elif peer_group.additional_paths.send == 'limit' %}
-{%                     if peer_group.additional_paths.send_limit is arista.avd.defined %}
+{%                     elif peer_group.additional_paths.send == 'limit' %}
       neighbor {{ peer_group.name }} additional-paths send limit {{ peer_group.additional_paths.send_limit }}
 {%                     endif %}
 {%                 else %}


### PR DESCRIPTION
## Change Summary

Fix the invalid comand `no neighbor PATH-SELECTION-PG-1 send` for BGP address-family path-selection. It should be `no neighbor PATH-SELECTION-PG-1 additional-paths send`.

## Related Issue(s)

Fixes #4787 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Fix the invalid comand `no neighbor PATH-SELECTION-PG-1 send` for BGP address-family path-selection. It should be `no neighbor PATH-SELECTION-PG-1 additional-paths send`.

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
