### PR TITLE
Refactor(eos_cli_config_gen): Updated `hash_algorithm ` and `authentication key` as required key in ntp schema

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -5,6 +5,7 @@
 - [Management](#management)
   - [Banner](#banner)
   - [Management Interfaces](#management-interfaces)
+  - [NTP](#ntp)
   - [Management SSH](#management-ssh)
   - [Management API gNMI](#management-api-gnmi)
   - [Management CVX Summary](#management-cvx-summary)
@@ -133,6 +134,21 @@ interface Management1
    description OOB_MANAGEMENT
    vrf MGMT
    ip address 10.73.255.122/24
+```
+
+### NTP
+
+#### NTP Summary
+
+##### NTP Authentication
+
+- Authentication enabled
+
+#### NTP Device Configuration
+
+```eos
+!
+ntp authenticate
 ```
 
 ### Management SSH

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
@@ -194,6 +194,8 @@ mpls rsvp
 !
 ip nat synchronization
 !
+ntp authenticate
+!
 policy-map type pbr POLICY_DROP_THEN_NEXTHOP
    10 class CLASS_DROP
       drop

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ntp.yml
@@ -19,7 +19,6 @@ ntp:
       local_interface: lo0
   authenticate_servers_only: true
   trusted_keys: "1-2"
-  authenticate: true
   authentication_keys:
     - id: 1
       hash_algorithm: "md5"

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/ntp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/ntp.yml
@@ -1,0 +1,4 @@
+---
+### NTP tests for authenticate
+ntp:
+  authenticate: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ntp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ntp.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "ntp.local_interface.name") | String |  |  |  | Source interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.local_interface.vrf") | String |  |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;servers</samp>](## "ntp.servers") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp.servers.[].name") | String | Required |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp.servers.[].name") | String | Required, Unique |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;burst</samp>](## "ntp.servers.[].burst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;iburst</samp>](## "ntp.servers.[].iburst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.servers.[].key") | Integer |  |  | Min: 1<br>Max: 65535 |  |
@@ -45,7 +45,7 @@
       servers:
 
           # IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org.
-        - name: <str; required>
+        - name: <str; required; unique>
           burst: <bool>
           iburst: <bool>
           key: <int; 1-65535>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ntp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ntp.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "ntp.local_interface.name") | String |  |  |  | Source interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "ntp.local_interface.vrf") | String |  |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;servers</samp>](## "ntp.servers") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp.servers.[].name") | String |  |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp.servers.[].name") | String | Required |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;burst</samp>](## "ntp.servers.[].burst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;iburst</samp>](## "ntp.servers.[].iburst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.servers.[].key") | Integer |  |  | Min: 1<br>Max: 65535 |  |
@@ -26,8 +26,8 @@
     | [<samp>&nbsp;&nbsp;authenticate_servers_only</samp>](## "ntp.authenticate_servers_only") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;authentication_keys</samp>](## "ntp.authentication_keys") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "ntp.authentication_keys.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65534 | Key identifier. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ntp.authentication_keys.[].hash_algorithm") | String |  |  | Valid Values:<br>- <code>md5</code><br>- <code>sha1</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.authentication_keys.[].key") | String |  |  |  | Obfuscated key. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ntp.authentication_keys.[].hash_algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha1</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp.authentication_keys.[].key") | String | Required |  |  | Obfuscated key. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "ntp.authentication_keys.[].key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> |  |
     | [<samp>&nbsp;&nbsp;trusted_keys</samp>](## "ntp.trusted_keys") | String |  |  |  | List of trusted-keys as string ex. 10-12,15. |
 
@@ -45,7 +45,7 @@
       servers:
 
           # IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org.
-        - name: <str>
+        - name: <str; required>
           burst: <bool>
           iburst: <bool>
           key: <int; 1-65535>
@@ -69,10 +69,10 @@
 
           # Key identifier.
         - id: <int; 1-65534; required; unique>
-          hash_algorithm: <str; "md5" | "sha1">
+          hash_algorithm: <str; "md5" | "sha1"; required>
 
           # Obfuscated key.
-          key: <str>
+          key: <str; required>
           key_type: <str; "0" | "7" | "8a">
 
       # List of trusted-keys as string ex. 10-12,15.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -61,7 +61,7 @@
     | [<samp>ntp_settings</samp>](## "ntp_settings") | Dictionary |  |  |  | NTP settings |
     | [<samp>&nbsp;&nbsp;server_vrf</samp>](## "ntp_settings.server_vrf") | String |  |  |  | EOS only supports NTP servers in one VRF, so this VRF is used for all NTP servers and one local-interface.<br>- `use_mgmt_interface_vrf` will configure the NTP server(s) under the VRF set with `mgmt_interface_vrf` and set the `mgmt_interface` as NTP local-interface.<br>  An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.<br>- `use_inband_mgmt_vrf` will configure the NTP server(s) under the VRF set with `inband_mgmt_vrf` and set the `inband_mgmt_interface` as NTP local-interface.<br>  An error will be raised if inband management is not configured for the device.<br>- Any other string will be used directly as the VRF name but local interface must be set with `custom_structured_configuration_ntp` if needed.<br>If not set, the VRF is automatically picked up from the global setting `default_mgmt_method`. |
     | [<samp>&nbsp;&nbsp;servers</samp>](## "ntp_settings.servers") | List, items: Dictionary |  |  |  | The first server is always set as "preferred". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp_settings.servers.[].name") | String |  |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp_settings.servers.[].name") | String | Required |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;burst</samp>](## "ntp_settings.servers.[].burst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;iburst</samp>](## "ntp_settings.servers.[].iburst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp_settings.servers.[].key") | Integer |  |  | Min: 1<br>Max: 65535 |  |
@@ -72,8 +72,8 @@
     | [<samp>&nbsp;&nbsp;authenticate_servers_only</samp>](## "ntp_settings.authenticate_servers_only") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;authentication_keys</samp>](## "ntp_settings.authentication_keys") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "ntp_settings.authentication_keys.[].id") | Integer | Required, Unique |  | Min: 1<br>Max: 65534 | Key identifier. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ntp_settings.authentication_keys.[].hash_algorithm") | String |  |  | Valid Values:<br>- <code>md5</code><br>- <code>sha1</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp_settings.authentication_keys.[].key") | String |  |  |  | Obfuscated key. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ntp_settings.authentication_keys.[].hash_algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha1</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp_settings.authentication_keys.[].key") | String | Required |  |  | Obfuscated key. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key_type</samp>](## "ntp_settings.authentication_keys.[].key_type") | String |  |  | Valid Values:<br>- <code>0</code><br>- <code>7</code><br>- <code>8a</code> |  |
     | [<samp>&nbsp;&nbsp;trusted_keys</samp>](## "ntp_settings.trusted_keys") | String |  |  |  | List of trusted-keys as string ex. 10-12,15. |
     | [<samp>timezone</samp>](## "timezone") | String |  |  |  | Clock timezone like "CET" or "US/Pacific". |
@@ -238,7 +238,7 @@
       servers:
 
           # IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org.
-        - name: <str>
+        - name: <str; required>
           burst: <bool>
           iburst: <bool>
           key: <int; 1-65535>
@@ -255,10 +255,10 @@
 
           # Key identifier.
         - id: <int; 1-65534; required; unique>
-          hash_algorithm: <str; "md5" | "sha1">
+          hash_algorithm: <str; "md5" | "sha1"; required>
 
           # Obfuscated key.
-          key: <str>
+          key: <str; required>
           key_type: <str; "0" | "7" | "8a">
 
       # List of trusted-keys as string ex. 10-12,15.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -61,7 +61,7 @@
     | [<samp>ntp_settings</samp>](## "ntp_settings") | Dictionary |  |  |  | NTP settings |
     | [<samp>&nbsp;&nbsp;server_vrf</samp>](## "ntp_settings.server_vrf") | String |  |  |  | EOS only supports NTP servers in one VRF, so this VRF is used for all NTP servers and one local-interface.<br>- `use_mgmt_interface_vrf` will configure the NTP server(s) under the VRF set with `mgmt_interface_vrf` and set the `mgmt_interface` as NTP local-interface.<br>  An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.<br>- `use_inband_mgmt_vrf` will configure the NTP server(s) under the VRF set with `inband_mgmt_vrf` and set the `inband_mgmt_interface` as NTP local-interface.<br>  An error will be raised if inband management is not configured for the device.<br>- Any other string will be used directly as the VRF name but local interface must be set with `custom_structured_configuration_ntp` if needed.<br>If not set, the VRF is automatically picked up from the global setting `default_mgmt_method`. |
     | [<samp>&nbsp;&nbsp;servers</samp>](## "ntp_settings.servers") | List, items: Dictionary |  |  |  | The first server is always set as "preferred". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp_settings.servers.[].name") | String | Required |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ntp_settings.servers.[].name") | String |  |  |  | IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;burst</samp>](## "ntp_settings.servers.[].burst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;iburst</samp>](## "ntp_settings.servers.[].iburst") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;key</samp>](## "ntp_settings.servers.[].key") | Integer |  |  | Min: 1<br>Max: 65535 |  |
@@ -238,7 +238,7 @@
       servers:
 
           # IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org.
-        - name: <str; required>
+        - name: <str>
           burst: <bool>
           iburst: <bool>
           key: <int; 1-65535>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ntp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ntp.j2
@@ -24,20 +24,18 @@
 | Server | VRF | Preferred | Burst | iBurst | Version | Min Poll | Max Poll | Local-interface | Key |
 | ------ | --- | --------- | ----- | ------ | ------- | -------- | -------- | --------------- | --- |
 {%         for server in ntp.servers | arista.avd.natural_sort('name') %}
-{%             if server.name is arista.avd.defined %}
-{%                 set r = namespace() %}
-{%                 set r.s = server.name %}
-{%                 set r.v = server.vrf | arista.avd.default('-') %}
-{%                 set r.p = server.preferred | arista.avd.default('-') %}
-{%                 set r.b = server.burst | arista.avd.default('-') %}
-{%                 set r.i = server.iburst | arista.avd.default('-') %}
-{%                 set r.vv = server.version | arista.avd.default('-') %}
-{%                 set r.mi = server.minpoll | arista.avd.default('-') %}
-{%                 set r.ma = server.maxpoll | arista.avd.default('-') %}
-{%                 set r.l = server.local_interface | arista.avd.default('-') %}
-{%                 set r.k = server.key | arista.avd.default('-') %}
+{%             set r = namespace() %}
+{%             set r.s = server.name %}
+{%             set r.v = server.vrf | arista.avd.default('-') %}
+{%             set r.p = server.preferred | arista.avd.default('-') %}
+{%             set r.b = server.burst | arista.avd.default('-') %}
+{%             set r.i = server.iburst | arista.avd.default('-') %}
+{%             set r.vv = server.version | arista.avd.default('-') %}
+{%             set r.mi = server.minpoll | arista.avd.default('-') %}
+{%             set r.ma = server.maxpoll | arista.avd.default('-') %}
+{%             set r.l = server.local_interface | arista.avd.default('-') %}
+{%             set r.k = server.key | arista.avd.default('-') %}
 | {{ r.s }} | {{ r.v }} | {{ r.p }} | {{ r.b }} | {{ r.i }} | {{ r.vv }} | {{ r.mi }} | {{ r.ma }} | {{ r.l }} | {{ r.k }} |
-{%             endif %}
 {%         endfor %}
 {%     endif %}
 {%     if ntp.authenticate is arista.avd.defined
@@ -64,11 +62,7 @@
 | ID | Algorithm |
 | -- | -------- |
 {%         for authentication_key in ntp.authentication_keys | arista.avd.natural_sort('id') %}
-{%             if authentication_key.id is arista.avd.defined and
-                  authentication_key.key is arista.avd.defined and
-                  authentication_key.hash_algorithm is arista.avd.defined %}
 | {{ authentication_key.id }} | {{ authentication_key.hash_algorithm }} |
-{%             endif %}
 {%         endfor %}
 {%     endif %}
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ntp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ntp.j2
@@ -7,16 +7,12 @@
 {% if ntp is arista.avd.defined %}
 !
 {%     for authentication_key in ntp.authentication_keys | arista.avd.natural_sort('id') %}
-{%         if authentication_key.id is arista.avd.defined and
-              authentication_key.key is arista.avd.defined and
-              authentication_key.hash_algorithm is arista.avd.defined %}
-{%             set ntp_auth_key_cli = "ntp authentication-key " ~ authentication_key.id ~ " " ~ authentication_key.hash_algorithm %}
-{%             if authentication_key.key_type is arista.avd.defined %}
-{%                 set ntp_auth_key_cli = ntp_auth_key_cli ~ " " ~ authentication_key.key_type %}
-{%             endif %}
-{%             set ntp_auth_key_cli = ntp_auth_key_cli ~ " " ~ authentication_key.key | arista.avd.hide_passwords(hide_passwords) %}
-{{ ntp_auth_key_cli }}
+{%         set ntp_auth_key_cli = "ntp authentication-key " ~ authentication_key.id ~ " " ~ authentication_key.hash_algorithm %}
+{%         if authentication_key.key_type is arista.avd.defined %}
+{%             set ntp_auth_key_cli = ntp_auth_key_cli ~ " " ~ authentication_key.key_type %}
 {%         endif %}
+{%         set ntp_auth_key_cli = ntp_auth_key_cli ~ " " ~ authentication_key.key | arista.avd.hide_passwords(hide_passwords) %}
+{{ ntp_auth_key_cli }}
 {%     endfor %}
 {%     if ntp.trusted_keys is arista.avd.defined %}
 ntp trusted-key {{ ntp.trusted_keys }}
@@ -35,37 +31,35 @@ ntp authenticate
 {{ ntp_int_cli }}
 {%     endif %}
 {%     for server in ntp.servers | arista.avd.natural_sort('name') %}
-{%         if server.name is arista.avd.defined %}
-{%             set ntp_server_cli = "ntp server" %}
-{%             if server.vrf is arista.avd.defined and server.vrf != 'default' %}
-{%                 set ntp_server_cli = ntp_server_cli ~ " vrf " ~ server.vrf %}
-{%             endif %}
-{%             set ntp_server_cli = ntp_server_cli ~ " " ~ server.name %}
-{%             if server.preferred is arista.avd.defined(true) %}
-{%                 set ntp_server_cli = ntp_server_cli ~ " prefer" %}
-{%             endif %}
-{%             if server.burst is arista.avd.defined(true) %}
-{%                 set ntp_server_cli = ntp_server_cli ~ " burst" %}
-{%             endif %}
-{%             if server.iburst is arista.avd.defined(true) %}
-{%                 set ntp_server_cli = ntp_server_cli ~ " iburst" %}
-{%             endif %}
-{%             if server.version is arista.avd.defined %}
-{%                 set ntp_server_cli = ntp_server_cli ~ " version " ~ server.version %}
-{%             endif %}
-{%             if server.minpoll is arista.avd.defined %}
-{%                 set ntp_server_cli = ntp_server_cli ~ " minpoll " ~ server.minpoll %}
-{%             endif %}
-{%             if server.maxpoll is arista.avd.defined %}
-{%                 set ntp_server_cli = ntp_server_cli ~ " maxpoll " ~ server.maxpoll %}
-{%             endif %}
-{%             if server.local_interface is arista.avd.defined %}
-{%                 set ntp_server_cli = ntp_server_cli ~ " local-interface " ~ server.local_interface %}
-{%             endif %}
-{%             if server.key is arista.avd.defined %}
-{%                 set ntp_server_cli = ntp_server_cli ~ " key " ~ server.key | arista.avd.hide_passwords(hide_passwords) %}
-{%             endif %}
-{{ ntp_server_cli }}
+{%         set ntp_server_cli = "ntp server" %}
+{%         if server.vrf is arista.avd.defined and server.vrf != 'default' %}
+{%             set ntp_server_cli = ntp_server_cli ~ " vrf " ~ server.vrf %}
 {%         endif %}
+{%         set ntp_server_cli = ntp_server_cli ~ " " ~ server.name %}
+{%         if server.preferred is arista.avd.defined(true) %}
+{%             set ntp_server_cli = ntp_server_cli ~ " prefer" %}
+{%         endif %}
+{%         if server.burst is arista.avd.defined(true) %}
+{%             set ntp_server_cli = ntp_server_cli ~ " burst" %}
+{%         endif %}
+{%         if server.iburst is arista.avd.defined(true) %}
+{%             set ntp_server_cli = ntp_server_cli ~ " iburst" %}
+{%         endif %}
+{%         if server.version is arista.avd.defined %}
+{%             set ntp_server_cli = ntp_server_cli ~ " version " ~ server.version %}
+{%         endif %}
+{%         if server.minpoll is arista.avd.defined %}
+{%             set ntp_server_cli = ntp_server_cli ~ " minpoll " ~ server.minpoll %}
+{%         endif %}
+{%         if server.maxpoll is arista.avd.defined %}
+{%             set ntp_server_cli = ntp_server_cli ~ " maxpoll " ~ server.maxpoll %}
+{%         endif %}
+{%         if server.local_interface is arista.avd.defined %}
+{%             set ntp_server_cli = ntp_server_cli ~ " local-interface " ~ server.local_interface %}
+{%         endif %}
+{%         if server.key is arista.avd.defined %}
+{%             set ntp_server_cli = ntp_server_cli ~ " key " ~ server.key | arista.avd.hide_passwords(hide_passwords) %}
+{%         endif %}
+{{ ntp_server_cli }}
 {%     endfor %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -26838,8 +26838,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
-        class Servers(AvdList[ServersItem]):
-            """Subclass of AvdList with `ServersItem` items."""
+        class Servers(AvdIndexedList[str, ServersItem]):
+            """Subclass of AvdIndexedList with `ServersItem` items. Primary key is `name` (`str`)."""
+
+            _primary_key: ClassVar[str] = "name"
 
         Servers._item_type = ServersItem
 
@@ -26906,7 +26908,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         local_interface: LocalInterface
         """Subclass of AvdModel."""
         servers: Servers
-        """Subclass of AvdList with `ServersItem` items."""
+        """Subclass of AvdIndexedList with `ServersItem` items. Primary key is `name` (`str`)."""
         authenticate: bool | None
         authenticate_servers_only: bool | None
         authentication_keys: AuthenticationKeys
@@ -26936,7 +26938,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 Args:
                     local_interface: Subclass of AvdModel.
-                    servers: Subclass of AvdList with `ServersItem` items.
+                    servers: Subclass of AvdIndexedList with `ServersItem` items. Primary key is `name` (`str`).
                     authenticate: authenticate
                     authenticate_servers_only: authenticate_servers_only
                     authentication_keys: Subclass of AvdIndexedList with `AuthenticationKeysItem` items. Primary key is `id` (`int`).

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -26688,7 +26688,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 "vrf": {"type": str},
                 "_custom_data": {"type": dict},
             }
-            name: str | None
+            name: str
             """IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org."""
             burst: bool | None
             iburst: bool | None
@@ -26710,7 +26710,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 def __init__(
                     self,
                     *,
-                    name: str | None | UndefinedType = Undefined,
+                    name: str | UndefinedType = Undefined,
                     burst: bool | None | UndefinedType = Undefined,
                     iburst: bool | None | UndefinedType = Undefined,
                     key: int | None | UndefinedType = Undefined,
@@ -26760,8 +26760,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             }
             id: int
             """Key identifier."""
-            hash_algorithm: Literal["md5", "sha1"] | None
-            key: str | None
+            hash_algorithm: Literal["md5", "sha1"]
+            key: str
             """Obfuscated key."""
             key_type: Literal["0", "7", "8a"] | None
             _custom_data: dict[str, Any]
@@ -26772,8 +26772,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     self,
                     *,
                     id: int | UndefinedType = Undefined,
-                    hash_algorithm: Literal["md5", "sha1"] | None | UndefinedType = Undefined,
-                    key: str | None | UndefinedType = Undefined,
+                    hash_algorithm: Literal["md5", "sha1"] | UndefinedType = Undefined,
+                    key: str | UndefinedType = Undefined,
                     key_type: Literal["0", "7", "8a"] | None | UndefinedType = Undefined,
                     _custom_data: dict[str, Any] | UndefinedType = Undefined,
                 ) -> None:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -9265,13 +9265,13 @@ keys:
             - int
       servers:
         type: list
+        primary_key: name
         items:
           type: dict
           keys:
             name:
               type: str
               description: IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org.
-              required: true
             burst:
               type: bool
             iburst:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -9223,6 +9223,7 @@ keys:
             name:
               type: str
               description: IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org.
+              required: true
             burst:
               type: bool
             iburst:
@@ -9285,9 +9286,11 @@ keys:
               valid_values:
               - md5
               - sha1
+              required: true
             key:
               type: str
               description: Obfuscated key.
+              required: true
             key_type:
               type: str
               convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ntp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ntp.schema.yml
@@ -66,6 +66,7 @@ keys:
                 - str
             vrf:
               type: str
+              # TODO(AVD 6.0.0): Move the vrf key outside to servers list as all the server should be configured in single vrf.
               description: VRF name.
               convert_types:
                 - int

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ntp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ntp.schema.yml
@@ -28,6 +28,7 @@ keys:
             name:
               type: str
               description: IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org.
+              required: true
             burst:
               type: bool
             iburst:
@@ -88,9 +89,11 @@ keys:
             hash_algorithm:
               type: str
               valid_values: ["md5", "sha1"]
+              required: true
             key:
               type: str
               description: Obfuscated key.
+              required: true
             key_type:
               type: str
               convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ntp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ntp.schema.yml
@@ -22,13 +22,13 @@ keys:
               - int
       servers:
         type: list
+        primary_key: name
         items:
           type: dict
           keys:
             name:
               type: str
               description: IP or hostname e.g., 2.2.2.55, 2001:db8::55, ie.pool.ntp.org.
-              required: true
             burst:
               type: bool
             iburst:

--- a/python-avd/tests/pyavd/schema/data_merging_schema_class.py
+++ b/python-avd/tests/pyavd/schema/data_merging_schema_class.py
@@ -3,8 +3,8 @@
 # that can be found in the LICENSE file.
 
 from __future__ import annotations
-from typing import ClassVar
 from pyavd._schema.models.eos_cli_config_gen_root_model import EosCliConfigGenRootModel
+from typing import ClassVar
 from typing import Any
 from typing import TYPE_CHECKING
 

--- a/python-avd/tests/pyavd/schema/data_merging_schema_class.py
+++ b/python-avd/tests/pyavd/schema/data_merging_schema_class.py
@@ -3,8 +3,8 @@
 # that can be found in the LICENSE file.
 
 from __future__ import annotations
-from pyavd._schema.models.eos_cli_config_gen_root_model import EosCliConfigGenRootModel
 from typing import ClassVar
+from pyavd._schema.models.eos_cli_config_gen_root_model import EosCliConfigGenRootModel
 from typing import Any
 from typing import TYPE_CHECKING
 


### PR DESCRIPTION
## Change Summary

Updated `hash_algorithm ` and `authentication key` as required key in ntp schema. Updated the j2 module.

## Related Issue(s)

Fixes #4732

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Updated `hash_algorithm ` and `authentication key` as required key in ntp schema. Updated the j2 module.

## How to test
Run molecule to check the config and tox to check the coverage
```
molecule converge -s eos_cli_config_gen
tox
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
