### PR TITLE
Fix(eos_cli_config_gen): Change `lldp.receive_packet_tagged_drop` from `str` to `bool`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -2996,7 +2996,7 @@ mlag configuration
 
 | Enabled | Management Address | Management VRF | Timer | Hold-Time | Re-initialization Timer | Drop Received Tagged Packets |
 | ------- | ------------------ | -------------- | ----- | --------- | ----------------------- | ---------------------------- |
-| False | 192.168.1.1/24 | Management | 30 | 90 | 2 | - |
+| False | 192.168.1.1/24 | Management | 30 | 90 | 2 | True |
 
 #### LLDP Explicit TLV Transmit Settings
 
@@ -3029,6 +3029,7 @@ lldp tlv transmit system-description
 no lldp run
 lldp management-address 192.168.1.1/24
 lldp management-address vrf Management
+lldp receive packet tagged drop
 ```
 
 ## L2 Protocol Forwarding

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -358,6 +358,7 @@ lldp tlv transmit system-description
 no lldp run
 lldp management-address 192.168.1.1/24
 lldp management-address vrf Management
+lldp receive packet tagged drop
 !
 logging repeat-messages
 logging buffered 1000000 warnings

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/lldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/lldp.yml
@@ -5,6 +5,7 @@ lldp:
   timer: 30
   holdtime: 90
   management_address: 192.168.1.1/24
+  receive_packet_tagged_drop: true
   vrf: Management
   tlvs:
     - name: system-capabilities

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/lldp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/lldp.md
@@ -13,7 +13,7 @@
     | [<samp>&nbsp;&nbsp;holdtime</samp>](## "lldp.holdtime") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;management_address</samp>](## "lldp.management_address") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;vrf</samp>](## "lldp.vrf") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;receive_packet_tagged_drop</samp>](## "lldp.receive_packet_tagged_drop") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;receive_packet_tagged_drop</samp>](## "lldp.receive_packet_tagged_drop") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;tlvs</samp>](## "lldp.tlvs") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "lldp.tlvs.[].name") | String | Required, Unique |  | Valid Values:<br>- <code>link-aggregation</code><br>- <code>management-address</code><br>- <code>max-frame-size</code><br>- <code>med</code><br>- <code>port-description</code><br>- <code>port-vlan</code><br>- <code>power-via-mdi</code><br>- <code>system-capabilities</code><br>- <code>system-description</code><br>- <code>system-name</code><br>- <code>vlan-name</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;transmit</samp>](## "lldp.tlvs.[].transmit") | Boolean |  |  |  |  |
@@ -28,7 +28,7 @@
       holdtime: <int>
       management_address: <str>
       vrf: <str>
-      receive_packet_tagged_drop: <str>
+      receive_packet_tagged_drop: <bool>
       tlvs:
         - name: <str; "link-aggregation" | "management-address" | "max-frame-size" | "med" | "port-description" | "port-vlan" | "power-via-mdi" | "system-capabilities" | "system-description" | "system-name" | "vlan-name"; required; unique>
           transmit: <bool>

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -18424,7 +18424,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "holdtime": {"type": int},
             "management_address": {"type": str},
             "vrf": {"type": str},
-            "receive_packet_tagged_drop": {"type": str},
+            "receive_packet_tagged_drop": {"type": bool},
             "tlvs": {"type": Tlvs},
             "run": {"type": bool},
             "_custom_data": {"type": dict},
@@ -18434,7 +18434,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         holdtime: int | None
         management_address: str | None
         vrf: str | None
-        receive_packet_tagged_drop: str | None
+        receive_packet_tagged_drop: bool | None
         tlvs: Tlvs
         """Subclass of AvdIndexedList with `TlvsItem` items. Primary key is `name` (`str`)."""
         run: bool | None
@@ -18450,7 +18450,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 holdtime: int | None | UndefinedType = Undefined,
                 management_address: str | None | UndefinedType = Undefined,
                 vrf: str | None | UndefinedType = Undefined,
-                receive_packet_tagged_drop: str | None | UndefinedType = Undefined,
+                receive_packet_tagged_drop: bool | None | UndefinedType = Undefined,
                 tlvs: Tlvs | UndefinedType = Undefined,
                 run: bool | None | UndefinedType = Undefined,
                 _custom_data: dict[str, Any] | UndefinedType = Undefined,

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -6449,7 +6449,7 @@ keys:
         convert_types:
         - int
       receive_packet_tagged_drop:
-        type: str
+        type: bool
       tlvs:
         type: list
         primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/lldp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/lldp.schema.yml
@@ -22,7 +22,7 @@ keys:
         convert_types:
           - int
       receive_packet_tagged_drop:
-        type: str
+        type: bool
       tlvs:
         type: list
         primary_key: name


### PR DESCRIPTION
## Change Summary

Change `lldp.receive_packet_tagged_drop` from `str` to `bool`

## Related Issue(s)

Fixes #4794 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Change `lldp.receive_packet_tagged_drop` from `str` to `bool`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
