### PR TITLE
CI: Fix ansible-lint failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ __pycache__/
 # ansible_collections/arista/avd/tests ignores
 ansible_collections/arista/avd/tests/.mypy_cache/
 
+# ansible-lint ignores
+ansible_collections/arista/avd/.ansible
+
 # Development
 ## pyenv
 .python-version

--- a/ansible_collections/arista/avd/.ansible-lint
+++ b/ansible_collections/arista/avd/.ansible-lint
@@ -8,3 +8,6 @@ skip_list:
   - var-naming[no-role-prefix] # TODO: Fix internal variable names as a breaking change for AVD 5.0.0
 kinds:
   - yaml: "**/molecule/**/inventory/host_vars/host1/roles.yml"
+exclude_paths:
+  - .cache/
+  - .ansible/


### PR DESCRIPTION
## Change Summary

Upgrade to ansible-compat (25.0.0) released yesterday broke our ignore config for ansible-lint.

## Related Issue(s)

CI is failing everywhere

## Component(s) name

`ci`

## Proposed changes

Ignore the new location of the ansible-compat cache folder

## How to test

ci is 🟢 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
