### PR TITLE
Feat(eos_cli_config_gen): Add support for configuring  `dhcp server ipv4` and `dhcp server ipv6` for Port-Channel interfaces

### DIFF
--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/inet-cloud.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/inet-cloud.md
@@ -233,9 +233,9 @@ dhcp server
 
 | Interface name | DHCP IPv4 | DHCP IPv6 |
 | -------------- | --------- | --------- |
-| Ethernet5 | True | False |
-| Ethernet6 | True | False |
-| Ethernet8 | True | False |
+| Ethernet5 | True | - |
+| Ethernet6 | True | - |
+| Ethernet8 | True | - |
 
 ## Monitoring
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -5495,6 +5495,7 @@ interface Port-Channel112
    ip address dhcp
    dhcp client accept default-route
    dhcp server ipv4
+   dhcp server ipv6
    port-channel lacp fallback individual
    port-channel lacp fallback timeout 5
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -1794,6 +1794,7 @@ dhcp server vrf VRF01
 | Interface name | DHCP IPv4 | DHCP IPv6 |
 | -------------- | --------- | --------- |
 | Ethernet64 | True | True |
+| Port-Channel112 | True | True |
 
 ## System Boot Settings
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -5494,6 +5494,7 @@ interface Port-Channel112
    switchport
    ip address dhcp
    dhcp client accept default-route
+   dhcp server ipv4
    port-channel lacp fallback individual
    port-channel lacp fallback timeout 5
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -2060,6 +2060,7 @@ interface Port-Channel112
    ip address dhcp
    dhcp client accept default-route
    dhcp server ipv4
+   dhcp server ipv6
    port-channel lacp fallback individual
    port-channel lacp fallback timeout 5
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -2059,6 +2059,7 @@ interface Port-Channel112
    switchport
    ip address dhcp
    dhcp client accept default-route
+   dhcp server ipv4
    port-channel lacp fallback individual
    port-channel lacp fallback timeout 5
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -721,6 +721,7 @@ port_channel_interfaces:
     lacp_fallback_mode: individual
     ip_address: dhcp
     dhcp_client_accept_default_route: true
+    dhcp_server_ipv4: true
 
   - name: Port-Channel113
     description: interface_with_mpls_enabled
@@ -729,6 +730,7 @@ port_channel_interfaces:
     ip_address: 172.31.128.9/31
     # This won't be rendered because IP address is not DHCP
     dhcp_client_accept_default_route: true
+    dhcp_server_ipv4: false
     mpls:
       ip: true
       ldp:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -722,6 +722,7 @@ port_channel_interfaces:
     ip_address: dhcp
     dhcp_client_accept_default_route: true
     dhcp_server_ipv4: true
+    dhcp_server_ipv6: true
 
   - name: Port-Channel113
     description: interface_with_mpls_enabled
@@ -731,6 +732,7 @@ port_channel_interfaces:
     # This won't be rendered because IP address is not DHCP
     dhcp_client_accept_default_route: true
     dhcp_server_ipv4: false
+    dhcp_server_ipv6: false
     mpls:
       ip: true
       ldp:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -218,6 +218,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "port_channel_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask or "dhcp". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "port_channel_interfaces.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Install default-route obtained via DHCP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv4</samp>](## "port_channel_interfaces.[].dhcp_server_ipv4") | Boolean |  |  |  | Enable IPv4 DHCP server. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv6</samp>](## "port_channel_interfaces.[].dhcp_server_ipv6") | Boolean |  |  |  | Enable IPv6 DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify_unicast_source_reachable_via</samp>](## "port_channel_interfaces.[].ip_verify_unicast_source_reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_nat</samp>](## "port_channel_interfaces.[].ip_nat") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "port_channel_interfaces.[].ip_nat.destination") | Dictionary |  |  |  |  |
@@ -930,6 +931,9 @@
 
         # Enable IPv4 DHCP server.
         dhcp_server_ipv4: <bool>
+
+        # Enable IPv6 DHCP server.
+        dhcp_server_ipv6: <bool>
         ip_verify_unicast_source_reachable_via: <str; "any" | "rx">
         ip_nat:
           destination:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -217,6 +217,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mpass</samp>](## "port_channel_interfaces.[].ptp.mpass") | Boolean |  |  |  | When MPASS is enabled on an MLAG port-channel, MLAG peers coordinate to function as a single PTP logical device.<br>Arista PTP enabled devices always place PTP messages on the same physical link within the port-channel.<br>Hence, MPASS is needed only on MLAG port-channels connected to non-Arista devices. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_address</samp>](## "port_channel_interfaces.[].ip_address") | String |  |  |  | IPv4 address/mask or "dhcp". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_client_accept_default_route</samp>](## "port_channel_interfaces.[].dhcp_client_accept_default_route") | Boolean |  |  |  | Install default-route obtained via DHCP. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv4</samp>](## "port_channel_interfaces.[].dhcp_server_ipv4") | Boolean |  |  |  | Enable IPv4 DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_verify_unicast_source_reachable_via</samp>](## "port_channel_interfaces.[].ip_verify_unicast_source_reachable_via") | String |  |  | Valid Values:<br>- <code>any</code><br>- <code>rx</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_nat</samp>](## "port_channel_interfaces.[].ip_nat") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination</samp>](## "port_channel_interfaces.[].ip_nat.destination") | Dictionary |  |  |  |  |
@@ -926,6 +927,9 @@
 
         # Install default-route obtained via DHCP.
         dhcp_client_accept_default_route: <bool>
+
+        # Enable IPv4 DHCP server.
+        dhcp_server_ipv4: <bool>
         ip_verify_unicast_source_reachable_via: <str; "any" | "rx">
         ip_nat:
           destination:

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -5,12 +5,18 @@
 #}
 {# doc - dhcp server #}
 {% set ethernet_interfaces_dhcp_server = [] %}
+{% set port_channel_interfaces_dhcp_server = [] %}
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
-{%     if ethernet_interface.dhcp_server_ipv4 is arista.avd.defined(true) or ethernet_interface.dhcp_server_ipv4 is arista.avd.defined(true) %}
+{%     if ethernet_interface.dhcp_server_ipv4 is arista.avd.defined(true) or ethernet_interface.dhcp_server_ipv6 is arista.avd.defined(true) %}
 {%         do ethernet_interfaces_dhcp_server.append(ethernet_interface) %}
 {%     endif %}
 {% endfor %}
-{% if (ethernet_interfaces_dhcp_server | length > 0 or dhcp_servers is arista.avd.defined) %}
+{% for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort('name') %}
+{%     if port_channel_interface.dhcp_server_ipv4 is arista.avd.defined(true) or port_channel_interfaces.dhcp_server_ipv6 is arista.avd.defined(true) %}
+{%         do port_channel_interfaces_dhcp_server.append(port_channel_interface) %}
+{%     endif %}
+{% endfor %}
+{% if (ethernet_interfaces_dhcp_server | length > 0 or port_channel_interfaces_dhcp_server | length > 0 or dhcp_servers is arista.avd.defined) %}
 
 ## DHCP Server
 {%     if dhcp_servers is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -138,5 +138,8 @@
 {%         for ethernet_interface in ethernet_interfaces_dhcp_server | arista.avd.natural_sort %}
 | {{ ethernet_interface.name }} | {{ ethernet_interface.dhcp_server_ipv4 | arista.avd.default(false) }} | {{ ethernet_interface.dhcp_server_ipv6 | arista.avd.default(false) }} |
 {%         endfor %}
+{%         for port_channel_interface in port_channel_interfaces_dhcp_server | arista.avd.natural_sort %}
+| {{ port_channel_interface.name }} | {{ port_channel_interface.dhcp_server_ipv4 | arista.avd.default(false) }} | {{ port_channel_interface.dhcp_server_ipv6 | arista.avd.default(false) }} |
+{%         endfor %}
 {%     endif %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -129,17 +129,21 @@
 {%         include 'eos/dhcp-servers.j2' %}
 ```
 {%     endif %}
-{%     if ethernet_interfaces_dhcp_server | length > 0 %}
+{%     if ethernet_interfaces_dhcp_server | length > 0 or port_channel_interfaces_dhcp_server | length > 0 %}
 
 ### DHCP Server Interfaces
 
 | Interface name | DHCP IPv4 | DHCP IPv6 |
 | -------------- | --------- | --------- |
-{%         for ethernet_interface in ethernet_interfaces_dhcp_server | arista.avd.natural_sort %}
-| {{ ethernet_interface.name }} | {{ ethernet_interface.dhcp_server_ipv4 | arista.avd.default(false) }} | {{ ethernet_interface.dhcp_server_ipv6 | arista.avd.default(false) }} |
-{%         endfor %}
-{%         for port_channel_interface in port_channel_interfaces_dhcp_server | arista.avd.natural_sort %}
-| {{ port_channel_interface.name }} | {{ port_channel_interface.dhcp_server_ipv4 | arista.avd.default(false) }} | {{ port_channel_interface.dhcp_server_ipv6 | arista.avd.default(false) }} |
-{%         endfor %}
+{%         if ethernet_interfaces_dhcp_server | length > 0 %}
+{%             for ethernet_interface in ethernet_interfaces_dhcp_server | arista.avd.natural_sort %}
+| {{ ethernet_interface.name }} | {{ ethernet_interface.dhcp_server_ipv4 | arista.avd.default("-") }} | {{ ethernet_interface.dhcp_server_ipv6 | arista.avd.default("-") }} |
+{%             endfor %}
+{%         endif %}
+{%         if port_channel_interfaces_dhcp_server | length > 0 %}
+{%             for port_channel_interface in port_channel_interfaces_dhcp_server | arista.avd.natural_sort %}
+| {{ port_channel_interface.name }} | {{ port_channel_interface.dhcp_server_ipv4 | arista.avd.default("-") }} | {{ port_channel_interface.dhcp_server_ipv6 | arista.avd.default("-") }} |
+{%             endfor %}
+{%         endif %}
 {%     endif %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -356,6 +356,9 @@ interface {{ port_channel_interface.name }}
    bfd per-link
 {%         endif %}
 {%     endif %}
+{%     if port_channel_interface.dhcp_server_ipv4 is arista.avd.defined(true) %}
+   dhcp server ipv4
+{%     endif %}
 {%     if port_channel_interface.ip_igmp_host_proxy.enabled is arista.avd.defined(true) %}
 {%         set host_proxy_cli =  "ip igmp host-proxy" %}
    {{ host_proxy_cli }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -359,6 +359,9 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.dhcp_server_ipv4 is arista.avd.defined(true) %}
    dhcp server ipv4
 {%     endif %}
+{%     if port_channel_interface.dhcp_server_ipv6 is arista.avd.defined(true) %}
+   dhcp server ipv6
+{%     endif %}
 {%     if port_channel_interface.ip_igmp_host_proxy.enabled is arista.avd.defined(true) %}
 {%         set host_proxy_cli =  "ip igmp host-proxy" %}
    {{ host_proxy_cli }}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -33103,6 +33103,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "ip_address": {"type": str},
             "dhcp_client_accept_default_route": {"type": bool},
             "dhcp_server_ipv4": {"type": bool},
+            "dhcp_server_ipv6": {"type": bool},
             "ip_verify_unicast_source_reachable_via": {"type": str},
             "ip_nat": {"type": IpNat},
             "ipv6_enable": {"type": bool},
@@ -33270,6 +33271,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Install default-route obtained via DHCP."""
         dhcp_server_ipv4: bool | None
         """Enable IPv4 DHCP server."""
+        dhcp_server_ipv6: bool | None
+        """Enable IPv6 DHCP server."""
         ip_verify_unicast_source_reachable_via: Literal["any", "rx"] | None
         ip_nat: IpNat
         """Subclass of AvdModel."""
@@ -33400,6 +33403,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 ip_address: str | None | UndefinedType = Undefined,
                 dhcp_client_accept_default_route: bool | None | UndefinedType = Undefined,
                 dhcp_server_ipv4: bool | None | UndefinedType = Undefined,
+                dhcp_server_ipv6: bool | None | UndefinedType = Undefined,
                 ip_verify_unicast_source_reachable_via: Literal["any", "rx"] | None | UndefinedType = Undefined,
                 ip_nat: IpNat | UndefinedType = Undefined,
                 ipv6_enable: bool | None | UndefinedType = Undefined,
@@ -33527,6 +33531,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     ip_address: IPv4 address/mask or "dhcp".
                     dhcp_client_accept_default_route: Install default-route obtained via DHCP.
                     dhcp_server_ipv4: Enable IPv4 DHCP server.
+                    dhcp_server_ipv6: Enable IPv6 DHCP server.
                     ip_verify_unicast_source_reachable_via: ip_verify_unicast_source_reachable_via
                     ip_nat: Subclass of AvdModel.
                     ipv6_enable: ipv6_enable

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -33102,6 +33102,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "ptp": {"type": Ptp},
             "ip_address": {"type": str},
             "dhcp_client_accept_default_route": {"type": bool},
+            "dhcp_server_ipv4": {"type": bool},
             "ip_verify_unicast_source_reachable_via": {"type": str},
             "ip_nat": {"type": IpNat},
             "ipv6_enable": {"type": bool},
@@ -33267,6 +33268,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """IPv4 address/mask or "dhcp"."""
         dhcp_client_accept_default_route: bool | None
         """Install default-route obtained via DHCP."""
+        dhcp_server_ipv4: bool | None
+        """Enable IPv4 DHCP server."""
         ip_verify_unicast_source_reachable_via: Literal["any", "rx"] | None
         ip_nat: IpNat
         """Subclass of AvdModel."""
@@ -33396,6 +33399,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 ptp: Ptp | UndefinedType = Undefined,
                 ip_address: str | None | UndefinedType = Undefined,
                 dhcp_client_accept_default_route: bool | None | UndefinedType = Undefined,
+                dhcp_server_ipv4: bool | None | UndefinedType = Undefined,
                 ip_verify_unicast_source_reachable_via: Literal["any", "rx"] | None | UndefinedType = Undefined,
                 ip_nat: IpNat | UndefinedType = Undefined,
                 ipv6_enable: bool | None | UndefinedType = Undefined,
@@ -33522,6 +33526,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     ptp: Subclass of AvdModel.
                     ip_address: IPv4 address/mask or "dhcp".
                     dhcp_client_accept_default_route: Install default-route obtained via DHCP.
+                    dhcp_server_ipv4: Enable IPv4 DHCP server.
                     ip_verify_unicast_source_reachable_via: ip_verify_unicast_source_reachable_via
                     ip_nat: Subclass of AvdModel.
                     ipv6_enable: ipv6_enable

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -10748,6 +10748,9 @@ keys:
         dhcp_server_ipv4:
           type: bool
           description: Enable IPv4 DHCP server.
+        dhcp_server_ipv6:
+          type: bool
+          description: Enable IPv6 DHCP server.
         ip_verify_unicast_source_reachable_via:
           type: str
           valid_values:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -10745,6 +10745,9 @@ keys:
         dhcp_client_accept_default_route:
           type: bool
           description: Install default-route obtained via DHCP.
+        dhcp_server_ipv4:
+          type: bool
+          description: Enable IPv4 DHCP server.
         ip_verify_unicast_source_reachable_via:
           type: str
           valid_values:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -817,6 +817,9 @@ keys:
         dhcp_server_ipv4:
           type: bool
           description: Enable IPv4 DHCP server.
+        dhcp_server_ipv6:
+          type: bool
+          description: Enable IPv6 DHCP server.
         ip_verify_unicast_source_reachable_via:
           type: str
           valid_values:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -814,6 +814,9 @@ keys:
         dhcp_client_accept_default_route:
           type: bool
           description: Install default-route obtained via DHCP.
+        dhcp_server_ipv4:
+          type: bool
+          description: Enable IPv4 DHCP server.
         ip_verify_unicast_source_reachable_via:
           type: str
           valid_values:


### PR DESCRIPTION
## Change Summary

Add support for configuring `dhcp server ipv4` and `dhcp server ipv6` for Port-Channel interfaces

## Related Issue(s)

Fixes #4875 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Adding new key `dhcp_server_ipv4` under port-channel-interfaces.
```
port_channel_interfaces:
     - dhcp_server_ipv4: <bool>
```

## How to test
Test added in molecule, verify the EOS CLI

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
