### PR TITLE
Feat(eos_cli_config_gen): Add support for mpls tunnel termination settings

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -9288,8 +9288,8 @@ router bfd
 | LDP Interface Disabled Default | True |
 | LDP Transport-Address Interface | Loopback0 |
 | ICMP Fragmentation-Needed Tunneling Enabled | True |
-| Tunnel Termination Model | ttl uniform dscp uniform |
-| Tunnel Termination PHP Model | ttl pipe dscp pipe |
+| Tunnel Termination Model | TTL: uniform, DSCP: uniform |
+| Tunnel Termination PHP Model | TTL: pipe, DSCP: pipe |
 
 ### MPLS Interfaces
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -9289,6 +9289,7 @@ router bfd
 | LDP Transport-Address Interface | Loopback0 |
 | ICMP Fragmentation-Needed Tunneling Enabled | True |
 | Tunnel Termination Model | ttl uniform dscp uniform |
+| Tunnel Termination PHP Model | ttl pipe dscp pipe |
 
 ### MPLS Interfaces
 
@@ -9355,6 +9356,7 @@ router bfd
 !
 mpls ip
 mpls tunnel termination model ttl uniform dscp uniform
+mpls tunnel termination php model ttl pipe dscp pipe
 !
 mpls ldp
    router-id 192.168.1.1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -9288,6 +9288,7 @@ router bfd
 | LDP Interface Disabled Default | True |
 | LDP Transport-Address Interface | Loopback0 |
 | ICMP Fragmentation-Needed Tunneling Enabled | True |
+| Tunnel Termination Model | ttl uniform dscp uniform |
 
 ### MPLS Interfaces
 
@@ -9353,6 +9354,7 @@ router bfd
 ```eos
 !
 mpls ip
+mpls tunnel termination model ttl uniform dscp uniform
 !
 mpls ldp
    router-id 192.168.1.1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4524,6 +4524,7 @@ ipv6 route vrf TENANT_A_PROJECT01 2b01:cb04:4e6:a400::/64 Vlan102 2a01:cb04:4e6:
 ipv6 route vrf TENANT_A_PROJECT01 2c01:cb04:4e6:a400::/64 Vlan102 201 tag 102 name No-Track-BFD
 !
 mpls ip
+mpls tunnel termination model ttl uniform dscp uniform
 !
 mpls ldp
    router-id 192.168.1.1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4525,6 +4525,7 @@ ipv6 route vrf TENANT_A_PROJECT01 2c01:cb04:4e6:a400::/64 Vlan102 201 tag 102 na
 !
 mpls ip
 mpls tunnel termination model ttl uniform dscp uniform
+mpls tunnel termination php model ttl pipe dscp pipe
 !
 mpls ldp
    router-id 192.168.1.1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/mpls.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/mpls.yml
@@ -6,6 +6,8 @@ mpls:
     router_id: 192.168.1.1
     shutdown: false
     transport_address_interface: Loopback0
+  tunnel:
+    termination_model: "ttl uniform dscp uniform"
   icmp:
     fragmentation_needed_tunneling: true
   rsvp:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/mpls.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/mpls.yml
@@ -7,7 +7,8 @@ mpls:
     shutdown: false
     transport_address_interface: Loopback0
   tunnel:
-    termination_model: "ttl uniform dscp uniform"
+    termination_model: ttl uniform dscp uniform
+    termination_php_model: ttl pipe dscp pipe
   icmp:
     fragmentation_needed_tunneling: true
   rsvp:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/mpls.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/mpls.yml
@@ -7,8 +7,13 @@ mpls:
     shutdown: false
     transport_address_interface: Loopback0
   tunnel:
-    termination_model: ttl uniform dscp uniform
-    termination_php_model: ttl pipe dscp pipe
+    termination:
+      model:
+        ttl: uniform
+        dscp: uniform
+      php_model:
+        ttl: pipe
+        dscp: pipe
   icmp:
     fragmentation_needed_tunneling: true
   rsvp:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mpls.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mpls.md
@@ -67,9 +67,14 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;p2mp</samp>](## "mpls.rsvp.p2mp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "mpls.rsvp.p2mp.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "mpls.rsvp.shutdown") | Boolean |  |  |  | Make `shutdown` key false for `no shutdown` cli. |
-    | [<samp>&nbsp;&nbsp;tunnel</samp>](## "mpls.tunnel") | Dictionary |  |  |  | Configure tunnel termination model. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination_model</samp>](## "mpls.tunnel.termination_model") | String |  |  | Valid Values:<br>- <code>ttl pipe dscp pipe</code><br>- <code>ttl pipe dscp uniform</code><br>- <code>ttl uniform dscp pipe</code><br>- <code>ttl uniform dscp uniform</code> | TTL and DSCP configuration as a string.<br>Make sure to check for compatibility with your Platform.<br>Example:<br>- "ttl pipe dscp pipe"<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination_php_model</samp>](## "mpls.tunnel.termination_php_model") | String |  |  | Valid Values:<br>- <code>ttl pipe dscp pipe</code><br>- <code>ttl pipe dscp uniform</code><br>- <code>ttl uniform dscp pipe</code><br>- <code>ttl uniform dscp uniform</code> | TTL and DSCP configuration as a string.<br>Make sure to check for compatibility with your Platform.<br>Example:<br>- "ttl pipe dscp pipe"<br> |
+    | [<samp>&nbsp;&nbsp;tunnel</samp>](## "mpls.tunnel") | Dictionary |  |  |  | Configure MPLS tunnel. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination</samp>](## "mpls.tunnel.termination") | Dictionary |  |  |  | Controls selection of the TTL/DSCP values by LER when decapsulating MPLS packets. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;model</samp>](## "mpls.tunnel.termination.model") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ttl</samp>](## "mpls.tunnel.termination.model.ttl") | String | Required |  | Valid Values:<br>- <code>pipe</code><br>- <code>uniform</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "mpls.tunnel.termination.model.dscp") | String | Required |  | Valid Values:<br>- <code>pipe</code><br>- <code>uniform</code> | DSCP model `uniform` supported with ttl model `uniform` on some platforms. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;php_model</samp>](## "mpls.tunnel.termination.php_model") | Dictionary |  |  |  | Used on PHP router in the absence of any VPN routes and explicit null VRF labels. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ttl</samp>](## "mpls.tunnel.termination.php_model.ttl") | String | Required |  | Valid Values:<br>- <code>pipe</code><br>- <code>uniform</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "mpls.tunnel.termination.php_model.dscp") | String | Required |  | Valid Values:<br>- <code>pipe</code> |  |
 
 === "YAML"
 
@@ -220,18 +225,19 @@
         # Make `shutdown` key false for `no shutdown` cli.
         shutdown: <bool>
 
-      # Configure tunnel termination model.
+      # Configure MPLS tunnel.
       tunnel:
 
-        # TTL and DSCP configuration as a string.
-        # Make sure to check for compatibility with your Platform.
-        # Example:
-        # - "ttl pipe dscp pipe"
-        termination_model: <str; "ttl pipe dscp pipe" | "ttl pipe dscp uniform" | "ttl uniform dscp pipe" | "ttl uniform dscp uniform">
+        # Controls selection of the TTL/DSCP values by LER when decapsulating MPLS packets.
+        termination:
+          model:
+            ttl: <str; "pipe" | "uniform"; required>
 
-        # TTL and DSCP configuration as a string.
-        # Make sure to check for compatibility with your Platform.
-        # Example:
-        # - "ttl pipe dscp pipe"
-        termination_php_model: <str; "ttl pipe dscp pipe" | "ttl pipe dscp uniform" | "ttl uniform dscp pipe" | "ttl uniform dscp uniform">
+            # DSCP model `uniform` supported with ttl model `uniform` on some platforms.
+            dscp: <str; "pipe" | "uniform"; required>
+
+          # Used on PHP router in the absence of any VPN routes and explicit null VRF labels.
+          php_model:
+            ttl: <str; "pipe" | "uniform"; required>
+            dscp: <str; "pipe"; required>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mpls.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mpls.md
@@ -67,6 +67,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;p2mp</samp>](## "mpls.rsvp.p2mp") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "mpls.rsvp.p2mp.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "mpls.rsvp.shutdown") | Boolean |  |  |  | Make `shutdown` key false for `no shutdown` cli. |
+    | [<samp>&nbsp;&nbsp;tunnel</samp>](## "mpls.tunnel") | Dictionary |  |  |  | Configure tunnel termination model. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination_model</samp>](## "mpls.tunnel.termination_model") | String |  |  | Valid Values:<br>- <code>ttl pipe dscp pipe</code><br>- <code>ttl uniform dscp pipe</code><br>- <code>ttl uniform dscp uniform</code> | TTL and DSCP configuration as a string.<br>Example:<br>- "ttl pipe dscp pipe"<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination_php_model</samp>](## "mpls.tunnel.termination_php_model") | String |  |  | Valid Values:<br>- <code>ttl pipe dscp pipe</code><br>- <code>ttl uniform dscp pipe</code> | TTL and DSCP configuration as a string.<br>Example:<br>- "ttl pipe dscp pipe"<br> |
 
 === "YAML"
 
@@ -216,4 +219,17 @@
 
         # Make `shutdown` key false for `no shutdown` cli.
         shutdown: <bool>
+
+      # Configure tunnel termination model.
+      tunnel:
+
+        # TTL and DSCP configuration as a string.
+        # Example:
+        # - "ttl pipe dscp pipe"
+        termination_model: <str; "ttl pipe dscp pipe" | "ttl uniform dscp pipe" | "ttl uniform dscp uniform">
+
+        # TTL and DSCP configuration as a string.
+        # Example:
+        # - "ttl pipe dscp pipe"
+        termination_php_model: <str; "ttl pipe dscp pipe" | "ttl uniform dscp pipe">
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mpls.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mpls.md
@@ -68,8 +68,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "mpls.rsvp.p2mp.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "mpls.rsvp.shutdown") | Boolean |  |  |  | Make `shutdown` key false for `no shutdown` cli. |
     | [<samp>&nbsp;&nbsp;tunnel</samp>](## "mpls.tunnel") | Dictionary |  |  |  | Configure tunnel termination model. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination_model</samp>](## "mpls.tunnel.termination_model") | String |  |  | Valid Values:<br>- <code>ttl pipe dscp pipe</code><br>- <code>ttl uniform dscp pipe</code><br>- <code>ttl uniform dscp uniform</code> | TTL and DSCP configuration as a string.<br>Example:<br>- "ttl pipe dscp pipe"<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination_php_model</samp>](## "mpls.tunnel.termination_php_model") | String |  |  | Valid Values:<br>- <code>ttl pipe dscp pipe</code><br>- <code>ttl uniform dscp pipe</code> | TTL and DSCP configuration as a string.<br>Example:<br>- "ttl pipe dscp pipe"<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination_model</samp>](## "mpls.tunnel.termination_model") | String |  |  | Valid Values:<br>- <code>ttl pipe dscp pipe</code><br>- <code>ttl pipe dscp uniform</code><br>- <code>ttl uniform dscp pipe</code><br>- <code>ttl uniform dscp uniform</code> | TTL and DSCP configuration as a string.<br>Make sure to check for compatibility with your Platform.<br>Example:<br>- "ttl pipe dscp pipe"<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination_php_model</samp>](## "mpls.tunnel.termination_php_model") | String |  |  | Valid Values:<br>- <code>ttl pipe dscp pipe</code><br>- <code>ttl pipe dscp uniform</code><br>- <code>ttl uniform dscp pipe</code><br>- <code>ttl uniform dscp uniform</code> | TTL and DSCP configuration as a string.<br>Make sure to check for compatibility with your Platform.<br>Example:<br>- "ttl pipe dscp pipe"<br> |
 
 === "YAML"
 
@@ -224,12 +224,14 @@
       tunnel:
 
         # TTL and DSCP configuration as a string.
+        # Make sure to check for compatibility with your Platform.
         # Example:
         # - "ttl pipe dscp pipe"
-        termination_model: <str; "ttl pipe dscp pipe" | "ttl uniform dscp pipe" | "ttl uniform dscp uniform">
+        termination_model: <str; "ttl pipe dscp pipe" | "ttl pipe dscp uniform" | "ttl uniform dscp pipe" | "ttl uniform dscp uniform">
 
         # TTL and DSCP configuration as a string.
+        # Make sure to check for compatibility with your Platform.
         # Example:
         # - "ttl pipe dscp pipe"
-        termination_php_model: <str; "ttl pipe dscp pipe" | "ttl uniform dscp pipe">
+        termination_php_model: <str; "ttl pipe dscp pipe" | "ttl pipe dscp uniform" | "ttl uniform dscp pipe" | "ttl uniform dscp uniform">
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mpls.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mpls.md
@@ -71,10 +71,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;termination</samp>](## "mpls.tunnel.termination") | Dictionary |  |  |  | Controls selection of the TTL/DSCP values by LER when decapsulating MPLS packets. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;model</samp>](## "mpls.tunnel.termination.model") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ttl</samp>](## "mpls.tunnel.termination.model.ttl") | String | Required |  | Valid Values:<br>- <code>pipe</code><br>- <code>uniform</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "mpls.tunnel.termination.model.dscp") | String | Required |  | Valid Values:<br>- <code>pipe</code><br>- <code>uniform</code> | DSCP model `uniform` supported with ttl model `uniform` on some platforms. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "mpls.tunnel.termination.model.dscp") | String | Required |  | Valid Values:<br>- <code>pipe</code><br>- <code>uniform</code> | The DSCP model `uniform` is supported only on specific hardware platforms. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;php_model</samp>](## "mpls.tunnel.termination.php_model") | Dictionary |  |  |  | Used on PHP router in the absence of any VPN routes and explicit null VRF labels. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ttl</samp>](## "mpls.tunnel.termination.php_model.ttl") | String | Required |  | Valid Values:<br>- <code>pipe</code><br>- <code>uniform</code> |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "mpls.tunnel.termination.php_model.dscp") | String | Required |  | Valid Values:<br>- <code>pipe</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dscp</samp>](## "mpls.tunnel.termination.php_model.dscp") | String | Required |  | Valid Values:<br>- <code>pipe</code><br>- <code>uniform</code> | The DSCP model `uniform` is supported only on specific hardware platforms. |
 
 === "YAML"
 
@@ -233,11 +233,13 @@
           model:
             ttl: <str; "pipe" | "uniform"; required>
 
-            # DSCP model `uniform` supported with ttl model `uniform` on some platforms.
+            # The DSCP model `uniform` is supported only on specific hardware platforms.
             dscp: <str; "pipe" | "uniform"; required>
 
           # Used on PHP router in the absence of any VPN routes and explicit null VRF labels.
           php_model:
             ttl: <str; "pipe" | "uniform"; required>
-            dscp: <str; "pipe"; required>
+
+            # The DSCP model `uniform` is supported only on specific hardware platforms.
+            dscp: <str; "pipe" | "uniform"; required>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mpls-and-ldp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mpls-and-ldp.j2
@@ -23,10 +23,10 @@
 {%     if mpls.icmp.ttl_exceeded_tunneling is arista.avd.defined %}
 | ICMP TTL-Exceeded Tunneling Enabled | {{ mpls.icmp.ttl_exceeded_tunneling }} |
 {%     endif %}
-{%     if mpls.tunnel.termination_model is arista.avd.defined %}
-| Tunnel Termination Model | {{ mpls.tunnel.termination_model }} |
+{%     if mpls.tunnel.termination.model.ttl is arista.avd.defined and mpls.tunnel.termination.model.dscp is arista.avd.defined %}
+| Tunnel Termination Model | TTL: {{ mpls.tunnel.termination.model.ttl }}, DSCP: {{ mpls.tunnel.termination.model.ttl }} |
 {%     endif %}
-{%     if mpls.tunnel.termination_php_model is arista.avd.defined %}
-| Tunnel Termination PHP Model | {{ mpls.tunnel.termination_php_model }} |
+{%     if mpls.tunnel.termination.php_model.ttl is arista.avd.defined and mpls.tunnel.termination.php_model.dscp is arista.avd.defined %}
+| Tunnel Termination PHP Model | TTL: {{ mpls.tunnel.termination.php_model.ttl }}, DSCP: {{ mpls.tunnel.termination.php_model.ttl }} |
 {%     endif %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mpls-and-ldp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mpls-and-ldp.j2
@@ -23,4 +23,10 @@
 {%     if mpls.icmp.ttl_exceeded_tunneling is arista.avd.defined %}
 | ICMP TTL-Exceeded Tunneling Enabled | {{ mpls.icmp.ttl_exceeded_tunneling }} |
 {%     endif %}
+{%     if mpls.tunnel.termination_model is arista.avd.defined %}
+| Tunnel Termination Model | {{ mpls.tunnel.termination_model }} |
+{%     endif %}
+{%     if mpls.tunnel.termination_php_model is arista.avd.defined %}
+| Tunnel Termination PHP Model | {{ mpls.tunnel.termination_php_model }} |
+{%     endif %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/mpls.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/mpls.j2
@@ -8,11 +8,11 @@
 !
 mpls ip
 {% endif %}
-{% if mpls.tunnel.termination_model is arista.avd.defined %}
-mpls tunnel termination model {{ mpls.tunnel.termination_model }}
+{% if mpls.tunnel.termination.model.ttl is arista.avd.defined and mpls.tunnel.termination.model.dscp is arista.avd.defined %}
+mpls tunnel termination model ttl {{ mpls.tunnel.termination.model.ttl }} dscp {{ mpls.tunnel.termination.model.dscp }}
 {% endif %}
-{% if mpls.tunnel.termination_php_model is arista.avd.defined %}
-mpls tunnel termination php model {{ mpls.tunnel.termination_php_model }}
+{% if mpls.tunnel.termination.php_model.ttl is arista.avd.defined and mpls.tunnel.termination.php_model.dscp is arista.avd.defined %}
+mpls tunnel termination php model ttl {{ mpls.tunnel.termination.php_model.ttl }} dscp {{ mpls.tunnel.termination.php_model.dscp }}
 {% endif %}
 {% if mpls.ldp is arista.avd.defined %}
 !

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/mpls.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/mpls.j2
@@ -8,6 +8,12 @@
 !
 mpls ip
 {% endif %}
+{% if mpls.tunnel.termination_model is arista.avd.defined %}
+mpls tunnel termination model {{ mpls.tunnel.termination_model }}
+{% endif %}
+{% if mpls.tunnel.termination_php_model is arista.avd.defined %}
+mpls tunnel termination php model {{ mpls.tunnel.termination_php_model }}
+{% endif %}
 {% if mpls.ldp is arista.avd.defined %}
 !
 mpls ldp

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -26863,7 +26863,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     _fields: ClassVar[dict] = {"ttl": {"type": str}, "dscp": {"type": str}, "_custom_data": {"type": dict}}
                     ttl: Literal["pipe", "uniform"]
                     dscp: Literal["pipe", "uniform"]
-                    """DSCP model `uniform` supported with ttl model `uniform` on some platforms."""
+                    """The DSCP model `uniform` is supported only on specific hardware platforms."""
                     _custom_data: dict[str, Any]
 
                     if TYPE_CHECKING:
@@ -26883,7 +26883,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                             Args:
                                 ttl: ttl
-                                dscp: DSCP model `uniform` supported with ttl model `uniform` on some platforms.
+                                dscp: The DSCP model `uniform` is supported only on specific hardware platforms.
                                 _custom_data: _custom_data
 
                             """
@@ -26893,7 +26893,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     _fields: ClassVar[dict] = {"ttl": {"type": str}, "dscp": {"type": str}, "_custom_data": {"type": dict}}
                     ttl: Literal["pipe", "uniform"]
-                    dscp: Literal["pipe"]
+                    dscp: Literal["pipe", "uniform"]
+                    """The DSCP model `uniform` is supported only on specific hardware platforms."""
                     _custom_data: dict[str, Any]
 
                     if TYPE_CHECKING:
@@ -26902,7 +26903,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             self,
                             *,
                             ttl: Literal["pipe", "uniform"] | UndefinedType = Undefined,
-                            dscp: Literal["pipe"] | UndefinedType = Undefined,
+                            dscp: Literal["pipe", "uniform"] | UndefinedType = Undefined,
                             _custom_data: dict[str, Any] | UndefinedType = Undefined,
                         ) -> None:
                             """
@@ -26913,7 +26914,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                             Args:
                                 ttl: ttl
-                                dscp: dscp
+                                dscp: The DSCP model `uniform` is supported only on specific hardware platforms.
                                 _custom_data: _custom_data
 
                             """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -26855,15 +26855,17 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             """Subclass of AvdModel."""
 
             _fields: ClassVar[dict] = {"termination_model": {"type": str}, "termination_php_model": {"type": str}, "_custom_data": {"type": dict}}
-            termination_model: Literal["ttl pipe dscp pipe", "ttl uniform dscp pipe", "ttl uniform dscp uniform"] | None
+            termination_model: Literal["ttl pipe dscp pipe", "ttl pipe dscp uniform", "ttl uniform dscp pipe", "ttl uniform dscp uniform"] | None
             """
             TTL and DSCP configuration as a string.
+            Make sure to check for compatibility with your Platform.
             Example:
             - "ttl pipe dscp pipe"
             """
-            termination_php_model: Literal["ttl pipe dscp pipe", "ttl uniform dscp pipe"] | None
+            termination_php_model: Literal["ttl pipe dscp pipe", "ttl pipe dscp uniform", "ttl uniform dscp pipe", "ttl uniform dscp uniform"] | None
             """
             TTL and DSCP configuration as a string.
+            Make sure to check for compatibility with your Platform.
             Example:
             - "ttl pipe dscp pipe"
             """
@@ -26874,8 +26876,12 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 def __init__(
                     self,
                     *,
-                    termination_model: Literal["ttl pipe dscp pipe", "ttl uniform dscp pipe", "ttl uniform dscp uniform"] | None | UndefinedType = Undefined,
-                    termination_php_model: Literal["ttl pipe dscp pipe", "ttl uniform dscp pipe"] | None | UndefinedType = Undefined,
+                    termination_model: Literal["ttl pipe dscp pipe", "ttl pipe dscp uniform", "ttl uniform dscp pipe", "ttl uniform dscp uniform"]
+                    | None
+                    | UndefinedType = Undefined,
+                    termination_php_model: Literal["ttl pipe dscp pipe", "ttl pipe dscp uniform", "ttl uniform dscp pipe", "ttl uniform dscp uniform"]
+                    | None
+                    | UndefinedType = Undefined,
                     _custom_data: dict[str, Any] | UndefinedType = Undefined,
                 ) -> None:
                     """
@@ -26887,10 +26893,12 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Args:
                         termination_model:
                            TTL and DSCP configuration as a string.
+                           Make sure to check for compatibility with your Platform.
                            Example:  # fmt: skip
                            - "ttl pipe dscp pipe"
                         termination_php_model:
                            TTL and DSCP configuration as a string.
+                           Make sure to check for compatibility with your Platform.
                            Example:  # fmt: skip
                            - "ttl pipe dscp pipe"
                         _custom_data: _custom_data

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -26854,36 +26854,121 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         class Tunnel(AvdModel):
             """Subclass of AvdModel."""
 
-            _fields: ClassVar[dict] = {"termination_model": {"type": str}, "termination_php_model": {"type": str}, "_custom_data": {"type": dict}}
-            termination_model: Literal["ttl pipe dscp pipe", "ttl pipe dscp uniform", "ttl uniform dscp pipe", "ttl uniform dscp uniform"] | None
+            class Termination(AvdModel):
+                """Subclass of AvdModel."""
+
+                class Model(AvdModel):
+                    """Subclass of AvdModel."""
+
+                    _fields: ClassVar[dict] = {"ttl": {"type": str}, "dscp": {"type": str}, "_custom_data": {"type": dict}}
+                    ttl: Literal["pipe", "uniform"]
+                    dscp: Literal["pipe", "uniform"]
+                    """DSCP model `uniform` supported with ttl model `uniform` on some platforms."""
+                    _custom_data: dict[str, Any]
+
+                    if TYPE_CHECKING:
+
+                        def __init__(
+                            self,
+                            *,
+                            ttl: Literal["pipe", "uniform"] | UndefinedType = Undefined,
+                            dscp: Literal["pipe", "uniform"] | UndefinedType = Undefined,
+                            _custom_data: dict[str, Any] | UndefinedType = Undefined,
+                        ) -> None:
+                            """
+                            Model.
+
+
+                            Subclass of AvdModel.
+
+                            Args:
+                                ttl: ttl
+                                dscp: DSCP model `uniform` supported with ttl model `uniform` on some platforms.
+                                _custom_data: _custom_data
+
+                            """
+
+                class PhpModel(AvdModel):
+                    """Subclass of AvdModel."""
+
+                    _fields: ClassVar[dict] = {"ttl": {"type": str}, "dscp": {"type": str}, "_custom_data": {"type": dict}}
+                    ttl: Literal["pipe", "uniform"]
+                    dscp: Literal["pipe"]
+                    _custom_data: dict[str, Any]
+
+                    if TYPE_CHECKING:
+
+                        def __init__(
+                            self,
+                            *,
+                            ttl: Literal["pipe", "uniform"] | UndefinedType = Undefined,
+                            dscp: Literal["pipe"] | UndefinedType = Undefined,
+                            _custom_data: dict[str, Any] | UndefinedType = Undefined,
+                        ) -> None:
+                            """
+                            PhpModel.
+
+
+                            Subclass of AvdModel.
+
+                            Args:
+                                ttl: ttl
+                                dscp: dscp
+                                _custom_data: _custom_data
+
+                            """
+
+                _fields: ClassVar[dict] = {"model": {"type": Model}, "php_model": {"type": PhpModel}, "_custom_data": {"type": dict}}
+                model: Model
+                """Subclass of AvdModel."""
+                php_model: PhpModel
+                """
+                Used on PHP router in the absence of any VPN routes and explicit null VRF labels.
+
+                Subclass of
+                AvdModel.
+                """
+                _custom_data: dict[str, Any]
+
+                if TYPE_CHECKING:
+
+                    def __init__(
+                        self,
+                        *,
+                        model: Model | UndefinedType = Undefined,
+                        php_model: PhpModel | UndefinedType = Undefined,
+                        _custom_data: dict[str, Any] | UndefinedType = Undefined,
+                    ) -> None:
+                        """
+                        Termination.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            model: Subclass of AvdModel.
+                            php_model:
+                               Used on PHP router in the absence of any VPN routes and explicit null VRF labels.
+
+                               Subclass of
+                               AvdModel.
+                            _custom_data: _custom_data
+
+                        """
+
+            _fields: ClassVar[dict] = {"termination": {"type": Termination}, "_custom_data": {"type": dict}}
+            termination: Termination
             """
-            TTL and DSCP configuration as a string.
-            Make sure to check for compatibility with your Platform.
-            Example:
-            - "ttl pipe dscp pipe"
-            """
-            termination_php_model: Literal["ttl pipe dscp pipe", "ttl pipe dscp uniform", "ttl uniform dscp pipe", "ttl uniform dscp uniform"] | None
-            """
-            TTL and DSCP configuration as a string.
-            Make sure to check for compatibility with your Platform.
-            Example:
-            - "ttl pipe dscp pipe"
+            Controls selection of the TTL/DSCP values by LER when decapsulating MPLS packets.
+
+            Subclass of
+            AvdModel.
             """
             _custom_data: dict[str, Any]
 
             if TYPE_CHECKING:
 
-                def __init__(
-                    self,
-                    *,
-                    termination_model: Literal["ttl pipe dscp pipe", "ttl pipe dscp uniform", "ttl uniform dscp pipe", "ttl uniform dscp uniform"]
-                    | None
-                    | UndefinedType = Undefined,
-                    termination_php_model: Literal["ttl pipe dscp pipe", "ttl pipe dscp uniform", "ttl uniform dscp pipe", "ttl uniform dscp uniform"]
-                    | None
-                    | UndefinedType = Undefined,
-                    _custom_data: dict[str, Any] | UndefinedType = Undefined,
-                ) -> None:
+                def __init__(self, *, termination: Termination | UndefinedType = Undefined, _custom_data: dict[str, Any] | UndefinedType = Undefined) -> None:
                     """
                     Tunnel.
 
@@ -26891,16 +26976,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Subclass of AvdModel.
 
                     Args:
-                        termination_model:
-                           TTL and DSCP configuration as a string.
-                           Make sure to check for compatibility with your Platform.
-                           Example:  # fmt: skip
-                           - "ttl pipe dscp pipe"
-                        termination_php_model:
-                           TTL and DSCP configuration as a string.
-                           Make sure to check for compatibility with your Platform.
-                           Example:  # fmt: skip
-                           - "ttl pipe dscp pipe"
+                        termination:
+                           Controls selection of the TTL/DSCP values by LER when decapsulating MPLS packets.
+
+                           Subclass of
+                           AvdModel.
                         _custom_data: _custom_data
 
                     """
@@ -26927,7 +27007,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Subclass of AvdModel."""
         tunnel: Tunnel
         """
-        Configure tunnel termination model.
+        Configure MPLS tunnel.
 
         Subclass of AvdModel.
         """
@@ -26961,7 +27041,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        of AvdModel.
                     rsvp: Subclass of AvdModel.
                     tunnel:
-                       Configure tunnel termination model.
+                       Configure MPLS tunnel.
 
                        Subclass of AvdModel.
                     _custom_data: _custom_data

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -26851,7 +26851,60 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
-        _fields: ClassVar[dict] = {"ip": {"type": bool}, "ldp": {"type": Ldp}, "icmp": {"type": Icmp}, "rsvp": {"type": Rsvp}, "_custom_data": {"type": dict}}
+        class Tunnel(AvdModel):
+            """Subclass of AvdModel."""
+
+            _fields: ClassVar[dict] = {"termination_model": {"type": str}, "termination_php_model": {"type": str}, "_custom_data": {"type": dict}}
+            termination_model: Literal["ttl pipe dscp pipe", "ttl uniform dscp pipe", "ttl uniform dscp uniform"] | None
+            """
+            TTL and DSCP configuration as a string.
+            Example:
+            - "ttl pipe dscp pipe"
+            """
+            termination_php_model: Literal["ttl pipe dscp pipe", "ttl uniform dscp pipe"] | None
+            """
+            TTL and DSCP configuration as a string.
+            Example:
+            - "ttl pipe dscp pipe"
+            """
+            _custom_data: dict[str, Any]
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self,
+                    *,
+                    termination_model: Literal["ttl pipe dscp pipe", "ttl uniform dscp pipe", "ttl uniform dscp uniform"] | None | UndefinedType = Undefined,
+                    termination_php_model: Literal["ttl pipe dscp pipe", "ttl uniform dscp pipe"] | None | UndefinedType = Undefined,
+                    _custom_data: dict[str, Any] | UndefinedType = Undefined,
+                ) -> None:
+                    """
+                    Tunnel.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        termination_model:
+                           TTL and DSCP configuration as a string.
+                           Example:  # fmt: skip
+                           - "ttl pipe dscp pipe"
+                        termination_php_model:
+                           TTL and DSCP configuration as a string.
+                           Example:  # fmt: skip
+                           - "ttl pipe dscp pipe"
+                        _custom_data: _custom_data
+
+                    """
+
+        _fields: ClassVar[dict] = {
+            "ip": {"type": bool},
+            "ldp": {"type": Ldp},
+            "icmp": {"type": Icmp},
+            "rsvp": {"type": Rsvp},
+            "tunnel": {"type": Tunnel},
+            "_custom_data": {"type": dict},
+        }
         ip: bool | None
         ldp: Ldp
         """Subclass of AvdModel."""
@@ -26864,6 +26917,12 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """
         rsvp: Rsvp
         """Subclass of AvdModel."""
+        tunnel: Tunnel
+        """
+        Configure tunnel termination model.
+
+        Subclass of AvdModel.
+        """
         _custom_data: dict[str, Any]
 
         if TYPE_CHECKING:
@@ -26875,6 +26934,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 ldp: Ldp | UndefinedType = Undefined,
                 icmp: Icmp | UndefinedType = Undefined,
                 rsvp: Rsvp | UndefinedType = Undefined,
+                tunnel: Tunnel | UndefinedType = Undefined,
                 _custom_data: dict[str, Any] | UndefinedType = Undefined,
             ) -> None:
                 """
@@ -26892,6 +26952,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        Subclass
                        of AvdModel.
                     rsvp: Subclass of AvdModel.
+                    tunnel:
+                       Configure tunnel termination model.
+
+                       Subclass of AvdModel.
                     _custom_data: _custom_data
 
                 """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -9339,8 +9339,8 @@ keys:
                     - pipe
                     - uniform
                   dscp:
-                    description: DSCP model `uniform` supported with ttl model `uniform`
-                      on some platforms.
+                    description: The DSCP model `uniform` is supported only on specific
+                      hardware platforms.
                     type: str
                     required: true
                     valid_values:
@@ -9358,10 +9358,13 @@ keys:
                     - pipe
                     - uniform
                   dscp:
+                    description: The DSCP model `uniform` is supported only on specific
+                      hardware platforms.
                     type: str
                     required: true
                     valid_values:
                     - pipe
+                    - uniform
   name_server:
     documentation_options:
       table: ip-name-servers

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -9320,6 +9320,35 @@ keys:
           shutdown:
             type: bool
             description: Make `shutdown` key false for `no shutdown` cli.
+      tunnel:
+        description: Configure tunnel termination model.
+        type: dict
+        keys:
+          termination_model:
+            type: str
+            description: 'TTL and DSCP configuration as a string.
+
+              Example:
+
+              - "ttl pipe dscp pipe"
+
+              '
+            valid_values:
+            - ttl pipe dscp pipe
+            - ttl uniform dscp pipe
+            - ttl uniform dscp uniform
+          termination_php_model:
+            type: str
+            description: 'TTL and DSCP configuration as a string.
+
+              Example:
+
+              - "ttl pipe dscp pipe"
+
+              '
+            valid_values:
+            - ttl pipe dscp pipe
+            - ttl uniform dscp pipe
   name_server:
     documentation_options:
       table: ip-name-servers

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -9328,6 +9328,8 @@ keys:
             type: str
             description: 'TTL and DSCP configuration as a string.
 
+              Make sure to check for compatibility with your Platform.
+
               Example:
 
               - "ttl pipe dscp pipe"
@@ -9335,12 +9337,15 @@ keys:
               '
             valid_values:
             - ttl pipe dscp pipe
+            - ttl pipe dscp uniform
             - ttl uniform dscp pipe
             - ttl uniform dscp uniform
           termination_php_model:
             type: str
             description: 'TTL and DSCP configuration as a string.
 
+              Make sure to check for compatibility with your Platform.
+
               Example:
 
               - "ttl pipe dscp pipe"
@@ -9348,7 +9353,9 @@ keys:
               '
             valid_values:
             - ttl pipe dscp pipe
+            - ttl pipe dscp uniform
             - ttl uniform dscp pipe
+            - ttl uniform dscp uniform
   name_server:
     documentation_options:
       table: ip-name-servers

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -9321,41 +9321,47 @@ keys:
             type: bool
             description: Make `shutdown` key false for `no shutdown` cli.
       tunnel:
-        description: Configure tunnel termination model.
+        description: Configure MPLS tunnel.
         type: dict
         keys:
-          termination_model:
-            type: str
-            description: 'TTL and DSCP configuration as a string.
-
-              Make sure to check for compatibility with your Platform.
-
-              Example:
-
-              - "ttl pipe dscp pipe"
-
-              '
-            valid_values:
-            - ttl pipe dscp pipe
-            - ttl pipe dscp uniform
-            - ttl uniform dscp pipe
-            - ttl uniform dscp uniform
-          termination_php_model:
-            type: str
-            description: 'TTL and DSCP configuration as a string.
-
-              Make sure to check for compatibility with your Platform.
-
-              Example:
-
-              - "ttl pipe dscp pipe"
-
-              '
-            valid_values:
-            - ttl pipe dscp pipe
-            - ttl pipe dscp uniform
-            - ttl uniform dscp pipe
-            - ttl uniform dscp uniform
+          termination:
+            description: Controls selection of the TTL/DSCP values by LER when decapsulating
+              MPLS packets.
+            type: dict
+            keys:
+              model:
+                type: dict
+                keys:
+                  ttl:
+                    type: str
+                    required: true
+                    valid_values:
+                    - pipe
+                    - uniform
+                  dscp:
+                    description: DSCP model `uniform` supported with ttl model `uniform`
+                      on some platforms.
+                    type: str
+                    required: true
+                    valid_values:
+                    - pipe
+                    - uniform
+              php_model:
+                description: Used on PHP router in the absence of any VPN routes and
+                  explicit null VRF labels.
+                type: dict
+                keys:
+                  ttl:
+                    type: str
+                    required: true
+                    valid_values:
+                    - pipe
+                    - uniform
+                  dscp:
+                    type: str
+                    required: true
+                    valid_values:
+                    - pipe
   name_server:
     documentation_options:
       table: ip-name-servers

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
@@ -300,7 +300,7 @@ keys:
                       - pipe
                       - uniform
                   dscp:
-                    description: DSCP model `uniform` supported with ttl model `uniform` on some platforms.
+                    description: The DSCP model `uniform` is supported only on specific hardware platforms.
                     type: str
                     required: true
                     valid_values:
@@ -317,7 +317,9 @@ keys:
                       - pipe
                       - uniform
                   dscp:
+                    description: The DSCP model `uniform` is supported only on specific hardware platforms.
                     type: str
                     required: true
                     valid_values:
                       - pipe
+                      - uniform

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
@@ -290,18 +290,23 @@ keys:
             type: str
             description: |
               TTL and DSCP configuration as a string.
+              Make sure to check for compatibility with your Platform.
               Example:
               - "ttl pipe dscp pipe"
             valid_values:
               - "ttl pipe dscp pipe"
+              - "ttl pipe dscp uniform"
               - "ttl uniform dscp pipe"
               - "ttl uniform dscp uniform"
           termination_php_model:
             type: str
             description: |
               TTL and DSCP configuration as a string.
+              Make sure to check for compatibility with your Platform.
               Example:
               - "ttl pipe dscp pipe"
             valid_values:
               - "ttl pipe dscp pipe"
+              - "ttl pipe dscp uniform"
               - "ttl uniform dscp pipe"
+              - "ttl uniform dscp uniform"

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
@@ -282,3 +282,26 @@ keys:
           shutdown:
             type: bool
             description: Make `shutdown` key false for `no shutdown` cli.
+      tunnel:
+        description: Configure tunnel termination model.
+        type: dict
+        keys:
+          termination_model:
+            type: str
+            description: |
+              TTL and DSCP configuration as a string.
+              Example:
+              - "ttl pipe dscp pipe"
+            valid_values:
+              - "ttl pipe dscp pipe"
+              - "ttl uniform dscp pipe"
+              - "ttl uniform dscp uniform"
+          termination_php_model:
+            type: str
+            description: |
+              TTL and DSCP configuration as a string.
+              Example:
+              - "ttl pipe dscp pipe"
+            valid_values:
+              - "ttl pipe dscp pipe"
+              - "ttl uniform dscp pipe"

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
@@ -283,30 +283,41 @@ keys:
             type: bool
             description: Make `shutdown` key false for `no shutdown` cli.
       tunnel:
-        description: Configure tunnel termination model.
+        description: Configure MPLS tunnel.
         type: dict
         keys:
-          termination_model:
-            type: str
-            description: |
-              TTL and DSCP configuration as a string.
-              Make sure to check for compatibility with your Platform.
-              Example:
-              - "ttl pipe dscp pipe"
-            valid_values:
-              - "ttl pipe dscp pipe"
-              - "ttl pipe dscp uniform"
-              - "ttl uniform dscp pipe"
-              - "ttl uniform dscp uniform"
-          termination_php_model:
-            type: str
-            description: |
-              TTL and DSCP configuration as a string.
-              Make sure to check for compatibility with your Platform.
-              Example:
-              - "ttl pipe dscp pipe"
-            valid_values:
-              - "ttl pipe dscp pipe"
-              - "ttl pipe dscp uniform"
-              - "ttl uniform dscp pipe"
-              - "ttl uniform dscp uniform"
+          termination:
+            description: Controls selection of the TTL/DSCP values by LER when decapsulating MPLS packets.
+            type: dict
+            keys:
+              model:
+                type: dict
+                keys:
+                  ttl:
+                    type: str
+                    required: true
+                    valid_values:
+                      - pipe
+                      - uniform
+                  dscp:
+                    description: DSCP model `uniform` supported with ttl model `uniform` on some platforms.
+                    type: str
+                    required: true
+                    valid_values:
+                      - pipe
+                      - uniform
+              php_model:
+                description: Used on PHP router in the absence of any VPN routes and explicit null VRF labels.
+                type: dict
+                keys:
+                  ttl:
+                    type: str
+                    required: true
+                    valid_values:
+                      - pipe
+                      - uniform
+                  dscp:
+                    type: str
+                    required: true
+                    valid_values:
+                      - pipe


### PR DESCRIPTION
## Change Summary

Add knobs to configure tunnel termination settings for MPLS

## Related Issue(s)

Fixes #<N/A>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
      tunnel:
        description: Configure tunnel termination model.
        type: dict
        keys:
          termination_model:
            type: str
            description: |
              TTL and DSCP configuration as a string.
              Example:
              - "ttl pipe dscp pipe"
            valid_values:
              - "ttl pipe dscp pipe"
              - "ttl uniform dscp pipe"
              - "ttl uniform dscp uniform"
          termination_php_model:
            type: str
            description: |
              TTL and DSCP configuration as a string.
              Example:
              - "ttl pipe dscp pipe"
            valid_values:
              - "ttl pipe dscp pipe"
              - "ttl uniform dscp pipe"

## How to test
added molecule test
cli command order was tested on EOS 4.30.5 - **Please let me know if newer version sort differently**

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
