### PR TITLE
Feat(eos_cli_config_gen): Add comment to ethernet and port-channel interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3832,6 +3832,8 @@ interface Dps1
 ```eos
 !
 interface Ethernet1
+   !! this is my interface do not touch
+   !! it connects to the super firewall
    traffic-policy input BLUE-C1-POLICY
    traffic-policy output BLUE-C2-POLICY
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
@@ -5088,6 +5090,8 @@ interface Port-Channel3
    isis authentication key 0 <removed>
 !
 interface Port-Channel5
+   !! this is my interface do not touch
+   !! it connects to the super firewall
    description DC1_L2LEAF1_Po1
    bgp session tracker ST2
    switchport trunk allowed vlan 110,201

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3834,8 +3834,8 @@ interface Dps1
 ```eos
 !
 interface Ethernet1
-   !! this is my interface do not touch
-   !! it connects to the super firewall
+   !! testing multi line comment with |-
+   !! connection to dc1-spine1
    traffic-policy input BLUE-C1-POLICY
    traffic-policy output BLUE-C2-POLICY
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
@@ -3915,6 +3915,8 @@ interface Ethernet1
 
 !
 interface Ethernet2
+   !! testing multi line comments with |
+   !! connection to server in pod02
    description SRV-POD02_Eth1
    switchport dot1q vlan tag disallowed
    switchport trunk allowed vlan 110-111,210-211
@@ -3941,6 +3943,7 @@ interface Ethernet2
    spanning-tree bpdufilter disable
 !
 interface Ethernet3
+   !! testing single line comment
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    switchport trunk native vlan 5
@@ -5092,8 +5095,8 @@ interface Port-Channel3
    isis authentication key 0 <removed>
 !
 interface Port-Channel5
-   !! this is my interface do not touch
-   !! it connects to the super firewall
+   !! testing multi line comments with | -
+   !! applied to port-channel 5
    description DC1_L2LEAF1_Po1
    bgp session tracker ST2
    switchport trunk allowed vlan 110,201
@@ -5214,6 +5217,8 @@ interface Port-Channel14
       route-target import 00:00:01:02:03:05
 !
 interface Port-Channel15
+   !! testing multi line comments with |
+   !! applied to port-channel 15
    traffic-policy input BLUE-C1-POLICY
    traffic-policy output BLUE-C2-POLICY
    description DC1_L2LEAF3_Po1
@@ -5231,6 +5236,7 @@ interface Port-Channel15
    link tracking group EVPN_MH_ES2 upstream
 !
 interface Port-Channel16
+   !! testing single line comment
    description DC1_L2LEAF4_Po1
    switchport trunk native vlan 10
    switchport dot1q vlan tag disallowed

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -5095,7 +5095,7 @@ interface Port-Channel3
    isis authentication key 0 <removed>
 !
 interface Port-Channel5
-   !! testing multi line comments with | -
+   !! testing multi line comments with |-
    !! applied to port-channel 5
    description DC1_L2LEAF1_Po1
    bgp session tracker ST2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1654,8 +1654,8 @@ interface Port-Channel3
    isis authentication key 0 password
 !
 interface Port-Channel5
-   !! this is my interface do not touch
-   !! it connects to the super firewall
+   !! testing multi line comments with | -
+   !! applied to port-channel 5
    description DC1_L2LEAF1_Po1
    bgp session tracker ST2
    switchport trunk allowed vlan 110,201
@@ -1776,6 +1776,8 @@ interface Port-Channel14
       route-target import 00:00:01:02:03:05
 !
 interface Port-Channel15
+   !! testing multi line comments with |
+   !! applied to port-channel 15
    traffic-policy input BLUE-C1-POLICY
    traffic-policy output BLUE-C2-POLICY
    description DC1_L2LEAF3_Po1
@@ -1793,6 +1795,7 @@ interface Port-Channel15
    link tracking group EVPN_MH_ES2 upstream
 !
 interface Port-Channel16
+   !! testing single line comment
    description DC1_L2LEAF4_Po1
    switchport trunk native vlan 10
    switchport dot1q vlan tag disallowed
@@ -2271,8 +2274,8 @@ interface Dps1
    load-interval 42
 !
 interface Ethernet1
-   !! this is my interface do not touch
-   !! it connects to the super firewall
+   !! testing multi line comment with |-
+   !! connection to dc1-spine1
    traffic-policy input BLUE-C1-POLICY
    traffic-policy output BLUE-C2-POLICY
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1
@@ -2352,6 +2355,8 @@ interface Ethernet1
 
 !
 interface Ethernet2
+   !! testing multi line comments with |
+   !! connection to server in pod02
    description SRV-POD02_Eth1
    switchport dot1q vlan tag disallowed
    switchport trunk allowed vlan 110-111,210-211
@@ -2378,6 +2383,7 @@ interface Ethernet2
    spanning-tree bpdufilter disable
 !
 interface Ethernet3
+   !! testing single line comment
    description P2P_LINK_TO_DC1-SPINE2_Ethernet2
    mtu 1500
    switchport trunk native vlan 5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1653,6 +1653,8 @@ interface Port-Channel3
    isis authentication key 0 password
 !
 interface Port-Channel5
+   !! this is my interface do not touch
+   !! it connects to the super firewall
    description DC1_L2LEAF1_Po1
    bgp session tracker ST2
    switchport trunk allowed vlan 110,201
@@ -2266,6 +2268,8 @@ interface Dps1
    load-interval 42
 !
 interface Ethernet1
+   !! this is my interface do not touch
+   !! it connects to the super firewall
    traffic-policy input BLUE-C1-POLICY
    traffic-policy output BLUE-C2-POLICY
    description P2P_LINK_TO_DC1-SPINE1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1654,7 +1654,7 @@ interface Port-Channel3
    isis authentication key 0 password
 !
 interface Port-Channel5
-   !! testing multi line comments with | -
+   !! testing multi line comments with |-
    !! applied to port-channel 5
    description DC1_L2LEAF1_Po1
    bgp session tracker ST2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -6,6 +6,9 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: spine
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet1
+    comment: |
+      this is my interface do not touch
+      it connects to the super firewall
     speed: forced 100gfull
     mtu: 1500
     l2_mtu: 8000

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -6,9 +6,9 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: spine
     description: P2P_LINK_TO_DC1-SPINE1_Ethernet1
-    comment: |
-      this is my interface do not touch
-      it connects to the super firewall
+    comment: |-
+      testing multi line comment with |-
+      connection to dc1-spine1
     speed: forced 100gfull
     mtu: 1500
     l2_mtu: 8000
@@ -164,6 +164,9 @@ ethernet_interfaces:
     peer_interface: Eth1
     peer_type: server
     description: SRV-POD02_Eth1
+    comment: |
+      testing multi line comments with |
+      connection to server in pod02
     tcp_mss_ceiling:
       ipv4_segment_size: 70
       direction: ingress
@@ -220,6 +223,7 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: spine
     description: P2P_LINK_TO_DC1-SPINE2_Ethernet2
+    comment: testing single line comment
     mtu: 1500
     ip_address: 172.31.128.1/31
     snmp_trap_link_change: false

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -3,9 +3,9 @@
 port_channel_interfaces:
   - name: Port-Channel5
     description: DC1_L2LEAF1_Po1
-    comment: |
-      this is my interface do not touch
-      it connects to the super firewall
+    comment: |-
+      testing multi line comments with | -
+      applied to port-channel 5
     link_tracking_groups:
       - name: EVPN_MH_ES1
         direction: downstream
@@ -73,6 +73,9 @@ port_channel_interfaces:
           destination_mac_address: forwardable
 
   - name: Port-Channel15
+    comment: |
+      testing multi line comments with |
+      applied to port-channel 15
     description: DC1_L2LEAF3_Po1
     link_tracking_groups:
       - name: EVPN_MH_ES2
@@ -114,6 +117,7 @@ port_channel_interfaces:
       output: BLUE-C2-POLICY
 
   - name: Port-Channel16
+    comment: testing single line comment
     description: DC1_L2LEAF4_Po1
     snmp_trap_link_change: true
     mlag: 16

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -4,7 +4,7 @@ port_channel_interfaces:
   - name: Port-Channel5
     description: DC1_L2LEAF1_Po1
     comment: |-
-      testing multi line comments with | -
+      testing multi line comments with |-
       applied to port-channel 5
     link_tracking_groups:
       - name: EVPN_MH_ES1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -3,6 +3,9 @@
 port_channel_interfaces:
   - name: Port-Channel5
     description: DC1_L2LEAF1_Po1
+    comment: |
+      this is my interface do not touch
+      it connects to the super firewall
     link_tracking_groups:
       - name: EVPN_MH_ES1
         direction: downstream

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -9,6 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>ethernet_interfaces</samp>](## "ethernet_interfaces") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "ethernet_interfaces.[].name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;comment</samp>](## "ethernet_interfaces.[].comment") | String |  |  |  | Text comment added under ethernet interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "ethernet_interfaces.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "ethernet_interfaces.[].shutdown") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;load_interval</samp>](## "ethernet_interfaces.[].load_interval") | Integer |  |  | Min: 0<br>Max: 600 | Interval in seconds for updating interface counters. |
@@ -622,6 +623,9 @@
     ```yaml
     ethernet_interfaces:
       - name: <str; required; unique>
+
+        # Text comment added under ethernet interface.
+        comment: <str>
         description: <str>
         shutdown: <bool>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -9,7 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>port_channel_interfaces</samp>](## "port_channel_interfaces") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "port_channel_interfaces.[].name") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;comment</samp>](## "port_channel_interfaces.[].comment") | String |  |  |  | Text comment added under port channel interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;comment</samp>](## "port_channel_interfaces.[].comment") | String |  |  |  | Text comment added under port-channel interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "port_channel_interfaces.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "port_channel_interfaces.[].profile") | String |  |  |  | Interface profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "port_channel_interfaces.[].logging") | Dictionary |  |  |  |  |
@@ -453,7 +453,7 @@
     port_channel_interfaces:
       - name: <str; required; unique>
 
-        # Text comment added under port channel interface.
+        # Text comment added under port-channel interface.
         comment: <str>
         description: <str>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -9,6 +9,7 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>port_channel_interfaces</samp>](## "port_channel_interfaces") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;name</samp>](## "port_channel_interfaces.[].name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;comment</samp>](## "port_channel_interfaces.[].comment") | String |  |  |  | Text comment added under port channel interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "port_channel_interfaces.[].description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "port_channel_interfaces.[].profile") | String |  |  |  | Interface profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "port_channel_interfaces.[].logging") | Dictionary |  |  |  |  |
@@ -449,6 +450,9 @@
     ```yaml
     port_channel_interfaces:
       - name: <str; required; unique>
+
+        # Text comment added under port channel interface.
+        comment: <str>
         description: <str>
 
         # Interface profile.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -8,6 +8,11 @@
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 !
 interface {{ ethernet_interface.name }}
+{%     if ethernet_interface.comment is arista.avd.defined %}
+{%         for comment_line in ethernet_interface.comment.splitlines() | arista.avd.default([]) %}
+   !! {{ comment_line }}
+{%         endfor %}
+{%     endif %}
 {%     if ethernet_interface.profile is arista.avd.defined %}
    profile {{ ethernet_interface.profile }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -7,6 +7,11 @@
 {% for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort('name') %}
 !
 interface {{ port_channel_interface.name }}
+{%     if port_channel_interface.comment is arista.avd.defined %}
+{%         for comment_line in port_channel_interface.comment.splitlines() | arista.avd.default([]) %}
+   !! {{ comment_line }}
+{%         endfor %}
+{%     endif %}
 {%     if port_channel_interface.profile is arista.avd.defined %}
    profile {{ port_channel_interface.profile }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -33148,7 +33148,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         }
         name: str
         comment: str | None
-        """Text comment added under port channel interface."""
+        """Text comment added under port-channel interface."""
         description: str | None
         profile: str | None
         """Interface profile."""
@@ -33457,7 +33457,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 Args:
                     name: name
-                    comment: Text comment added under port channel interface.
+                    comment: Text comment added under port-channel interface.
                     description: description
                     profile: Interface profile.
                     logging: Subclass of AvdModel.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -12414,6 +12414,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
         _fields: ClassVar[dict] = {
             "name": {"type": str},
+            "comment": {"type": str},
             "description": {"type": str},
             "shutdown": {"type": bool},
             "load_interval": {"type": int},
@@ -12531,6 +12532,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "_custom_data": {"type": dict},
         }
         name: str
+        comment: str | None
+        """Text comment added under ethernet interface."""
         description: str | None
         shutdown: bool | None
         load_interval: int | None
@@ -12804,6 +12807,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 self,
                 *,
                 name: str | UndefinedType = Undefined,
+                comment: str | None | UndefinedType = Undefined,
                 description: str | None | UndefinedType = Undefined,
                 shutdown: bool | None | UndefinedType = Undefined,
                 load_interval: int | None | UndefinedType = Undefined,
@@ -12928,6 +12932,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 Args:
                     name: name
+                    comment: Text comment added under ethernet interface.
                     description: description
                     shutdown: shutdown
                     load_interval: Interval in seconds for updating interface counters.
@@ -33044,6 +33049,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
         _fields: ClassVar[dict] = {
             "name": {"type": str},
+            "comment": {"type": str},
             "description": {"type": str},
             "profile": {"type": str},
             "logging": {"type": Logging},
@@ -33139,6 +33145,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "_custom_data": {"type": dict},
         }
         name: str
+        comment: str | None
+        """Text comment added under port channel interface."""
         description: str | None
         profile: str | None
         """Interface profile."""
@@ -33338,6 +33346,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 self,
                 *,
                 name: str | UndefinedType = Undefined,
+                comment: str | None | UndefinedType = Undefined,
                 description: str | None | UndefinedType = Undefined,
                 profile: str | None | UndefinedType = Undefined,
                 logging: Logging | UndefinedType = Undefined,
@@ -33440,6 +33449,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 Args:
                     name: name
+                    comment: Text comment added under port channel interface.
                     description: description
                     profile: Interface profile.
                     logging: Subclass of AvdModel.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -9905,7 +9905,7 @@ keys:
           type: str
         comment:
           type: str
-          description: Text comment added under port channel interface.
+          description: Text comment added under port-channel interface.
         description:
           type: str
         profile:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -2029,6 +2029,9 @@ keys:
       keys:
         name:
           type: str
+        comment:
+          type: str
+          description: Text comment added under ethernet interface.
         description:
           type: str
         shutdown:
@@ -9900,6 +9903,9 @@ keys:
       keys:
         name:
           type: str
+        comment:
+          type: str
+          description: Text comment added under port channel interface.
         description:
           type: str
         profile:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -14,6 +14,9 @@ keys:
       keys:
         name:
           type: str
+        comment:
+          type: str
+          description: Text comment added under ethernet interface.
         description:
           type: str
         shutdown:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -16,7 +16,7 @@ keys:
           type: str
         comment:
           type: str
-          description: Text comment added under port channel interface.
+          description: Text comment added under port-channel interface.
         description:
           type: str
         profile:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -14,6 +14,9 @@ keys:
       keys:
         name:
           type: str
+        comment:
+          type: str
+          description: Text comment added under port channel interface.
         description:
           type: str
         profile:


### PR DESCRIPTION
## Change Summary

Add comment to ethernet and port-channel interfaces

## Related Issue(s)

Fixes #4864

## Component(s) name

`arista.avd.eos_cli_config_gen`

## How to test
see molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
