### PR TITLE
Feat(eos_cli_config_gen): Added support for Virtual Router MAC Address Advertisement Interval

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -6531,12 +6531,14 @@ service routing protocols model multi-agent
 #### Virtual Router MAC Address Summary
 
 Virtual Router MAC Address: 00:1c:73:00:dc:01
+Virtual Router MAC Address Advertisement Interval: 40
 
 #### Virtual Router MAC Address Device Configuration
 
 ```eos
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
+ip virtual-router mac-address advertisement-interval 40
 ```
 
 ### IP Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4149,6 +4149,7 @@ interface profile TEST-PROFILE-2
    command ptp enable
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
+ip virtual-router mac-address advertisement-interval 40
 !
 ip address virtual source-nat vrf TEST_01 address 1.1.1.1
 ip address virtual source-nat vrf TEST_02 address 1.1.1.2

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ip-virtual-router-mac-address-advertisement-interval.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ip-virtual-router-mac-address-advertisement-interval.yml
@@ -1,0 +1,3 @@
+---
+### IP Virtual Router MAC Address Advertisement Interval ###
+ip_virtual_router_mac_address_advertisement_interval: 40

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-virtual-router-mac-address-advertisement-interval.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-virtual-router-mac-address-advertisement-interval.md
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright (c) 2025 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>ip_virtual_router_mac_address_advertisement_interval</samp>](## "ip_virtual_router_mac_address_advertisement_interval") | Integer |  |  | Min: 0<br>Max: 86400 | Advertisement interval in seconds. |
+
+=== "YAML"
+
+    ```yaml
+    # Advertisement interval in seconds.
+    ip_virtual_router_mac_address_advertisement_interval: <int; 0-86400>
+    ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-virtual-router-mac-address.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-virtual-router-mac-address.j2
@@ -4,13 +4,18 @@
  that can be found in the LICENSE file.
 #}
 {# doc - ip virtual router mac address #}
-{% if ip_virtual_router_mac_address is arista.avd.defined %}
+{% if ip_virtual_router_mac_address is arista.avd.defined or ip_virtual_router_mac_address_advertisement_interval is arista.avd.defined %}
 
 ### Virtual Router MAC Address
 
 #### Virtual Router MAC Address Summary
 
+{%     if ip_virtual_router_mac_address is arista.avd.defined %}
 Virtual Router MAC Address: {{ ip_virtual_router_mac_address }}
+{%     endif %}
+{%     if ip_virtual_router_mac_address_advertisement_interval is arista.avd.defined %}
+Virtual Router MAC Address Advertisement Interval: {{ ip_virtual_router_mac_address_advertisement_interval }}
+{%     endif %}
 
 #### Virtual Router MAC Address Device Configuration
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-virtual-router-mac-address.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-virtual-router-mac-address.j2
@@ -4,7 +4,12 @@
  that can be found in the LICENSE file.
 #}
 {# eos - ip virtual router mac address #}
-{% if ip_virtual_router_mac_address is arista.avd.defined %}
+{% if ip_virtual_router_mac_address is arista.avd.defined or ip_virtual_router_mac_address_advertisement_interval is arista.avd.defined %}
 !
+{%     if ip_virtual_router_mac_address is arista.avd.defined %}
 ip virtual-router mac-address {{ ip_virtual_router_mac_address }}
+{%     endif %}
+{%     if ip_virtual_router_mac_address_advertisement_interval is arista.avd.defined %}
+ip virtual-router mac-address advertisement-interval {{ ip_virtual_router_mac_address_advertisement_interval }}
+{%     endif %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -70578,6 +70578,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         "ip_telnet_client_source_interfaces": {"type": IpTelnetClientSourceInterfaces},
         "ip_tftp_client_source_interfaces": {"type": IpTftpClientSourceInterfaces},
         "ip_virtual_router_mac_address": {"type": str},
+        "ip_virtual_router_mac_address_advertisement_interval": {"type": int},
         "ipv6_access_lists": {"type": Ipv6AccessLists},
         "ipv6_dhcp_relay": {"type": Ipv6DhcpRelay},
         "ipv6_hardware": {"type": Ipv6Hardware},
@@ -70957,6 +70958,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
     """Subclass of AvdList with `IpTftpClientSourceInterfacesItem` items."""
     ip_virtual_router_mac_address: str | None
     """MAC address (hh:hh:hh:hh:hh:hh)."""
+    ip_virtual_router_mac_address_advertisement_interval: int | None
+    """Advertisement interval in seconds."""
     ipv6_access_lists: Ipv6AccessLists
     """Subclass of AvdIndexedList with `Ipv6AccessListsItem` items. Primary key is `name` (`str`)."""
     ipv6_dhcp_relay: Ipv6DhcpRelay
@@ -71313,6 +71316,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             ip_telnet_client_source_interfaces: IpTelnetClientSourceInterfaces | UndefinedType = Undefined,
             ip_tftp_client_source_interfaces: IpTftpClientSourceInterfaces | UndefinedType = Undefined,
             ip_virtual_router_mac_address: str | None | UndefinedType = Undefined,
+            ip_virtual_router_mac_address_advertisement_interval: int | None | UndefinedType = Undefined,
             ipv6_access_lists: Ipv6AccessLists | UndefinedType = Undefined,
             ipv6_dhcp_relay: Ipv6DhcpRelay | UndefinedType = Undefined,
             ipv6_hardware: Ipv6Hardware | UndefinedType = Undefined,
@@ -71607,6 +71611,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 ip_telnet_client_source_interfaces: Subclass of AvdList with `IpTelnetClientSourceInterfacesItem` items.
                 ip_tftp_client_source_interfaces: Subclass of AvdList with `IpTftpClientSourceInterfacesItem` items.
                 ip_virtual_router_mac_address: MAC address (hh:hh:hh:hh:hh:hh).
+                ip_virtual_router_mac_address_advertisement_interval: Advertisement interval in seconds.
                 ipv6_access_lists: Subclass of AvdIndexedList with `Ipv6AccessListsItem` items. Primary key is `name` (`str`).
                 ipv6_dhcp_relay: Subclass of AvdModel.
                 ipv6_hardware: Subclass of AvdModel.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -6126,6 +6126,13 @@ keys:
   ip_virtual_router_mac_address:
     type: str
     description: MAC address (hh:hh:hh:hh:hh:hh).
+  ip_virtual_router_mac_address_advertisement_interval:
+    type: int
+    description: Advertisement interval in seconds.
+    convert_types:
+    - str
+    min: 0
+    max: 86400
   ipv6_access_lists:
     type: list
     primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_virtual_router_mac_address_advertisement_interval.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_virtual_router_mac_address_advertisement_interval.schema.yml
@@ -1,0 +1,15 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../_schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  ip_virtual_router_mac_address_advertisement_interval:
+    type: int
+    description: Advertisement interval in seconds.
+    convert_types:
+      - str
+    min: 0
+    max: 86400


### PR DESCRIPTION

## Change Summary

Added support for Virtual Router MAC Address Advertisement Interval.

## Related Issue(s)

Fixes #4772 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added support for Virtual Router MAC Address Advertisement Interval.>

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
