### PR TITLE
CI: Revert "Fix ansible-lint failures"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,9 +31,6 @@ __pycache__/
 # ansible_collections/arista/avd/tests ignores
 ansible_collections/arista/avd/tests/.mypy_cache/
 
-# ansible-lint ignores
-ansible_collections/arista/avd/.ansible
-
 # Development
 ## pyenv
 .python-version

--- a/ansible_collections/arista/avd/.ansible-lint
+++ b/ansible_collections/arista/avd/.ansible-lint
@@ -8,6 +8,3 @@ skip_list:
   - var-naming[no-role-prefix] # TODO: Fix internal variable names as a breaking change for AVD 5.0.0
 kinds:
   - yaml: "**/molecule/**/inventory/host_vars/host1/roles.yml"
-exclude_paths:
-  - .cache/
-  - .ansible/


### PR DESCRIPTION
Reverts aristanetworks/avd#4882

ansible-compat version 25.0.0 has been yanked so we don't need this no more