### PR TITLE
Refactor(plugins): Add support for default_value to natural_sort

### DIFF
--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -5,40 +5,23 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterable, Mapping
+from functools import partial
 from typing import Any
 
 from jinja2.runtime import Undefined
 from jinja2.utils import Namespace
 
 
-def convert(text: str, ignore_case: bool) -> int | str:
-    """Converts the input string to be sorted.
-
-    Converts the string to an integer if it is a digit, otherwise converts
-    it to lower case if ignore_case is True.
-
-    Args:
-    -----
-        text (str): Input string.
-        ignore_case (bool): If ignore_case is True, strings are applied lower() function.
-
-    Returns:
-    -------
-        int | str: Converted string.
+def natural_sort(iterable: Iterable | None, sort_key: str | None = None, *, strict: bool = True, ignore_case: bool = True, default_value: Any = None) -> list:
     """
-    if text.isdigit():
-        return int(text)
-    return text.lower() if ignore_case else text
-
-
-def natural_sort(iterable: Iterable | None, sort_key: str | None = None, *, strict: bool = True, ignore_case: bool = True) -> list:
-    """Sorts an iterable in a natural (alphanumeric) order.
+    Sorts an iterable in a natural (alphanumeric) order.
 
     Args:
         iterable: Input iterable.
         sort_key: Key to sort by, defaults to None.
-        strict: If strict is True, raise an error is the sort_key is missing.
+        strict: If strict is True, raise an error is the sort_key is missing and no default value is given.
         ignore_case: If ignore_case is True, strings are applied lower() function.
+        default_value: Default value to use if the sort_key is missing.
 
     Returns:
         list: Sorted iterable.
@@ -49,18 +32,45 @@ def natural_sort(iterable: Iterable | None, sort_key: str | None = None, *, stri
     if isinstance(iterable, Undefined) or iterable is None:
         return []
 
-    def alphanum_key(key: Any) -> list:
-        pattern = r"(\d+)"
-        if sort_key is not None and isinstance(key, Mapping):
-            if strict and sort_key not in key:
-                msg = f"Missing key '{sort_key}' in item to sort {key}."
-                raise KeyError(msg)
-            return [convert(c, ignore_case) for c in re.split(pattern, str(key.get(sort_key, key)))]
-        if sort_key is not None and isinstance(key, Namespace):
-            if strict and not hasattr(key, sort_key):
-                msg = f"Missing attribute '{sort_key}' in item to sort {key}."
-                raise AttributeError(msg)
-            return [convert(c, ignore_case) for c in re.split(pattern, str(getattr(key, sort_key)))]
-        return [convert(c, ignore_case) for c in re.split(pattern, str(key))]
+    alphanum_key = partial(_alphanum_key, sort_key=sort_key, strict=strict, ignore_case=ignore_case, default_value=default_value)
 
     return sorted(iterable, key=alphanum_key)
+
+
+def _alphanum_key(item: Any, sort_key: str | None = None, *, strict: bool = True, ignore_case: bool = True, default_value: Any = None) -> list:
+    """Get the key to natural sort by. Falling back to the item itself."""
+    pattern = r"(\d+)"
+    if sort_key is not None and isinstance(item, Mapping):
+        if strict and sort_key not in item and default_value is None:
+            msg = f"Missing key '{sort_key}' in item to sort {item}."
+            raise KeyError(msg)
+        if default_value is None:
+            default_value = item
+        return [_convert(c, ignore_case) for c in re.split(pattern, str(item.get(sort_key, default_value)))]
+    if sort_key is not None and isinstance(item, Namespace):
+        if strict and not hasattr(item, sort_key) and default_value is None:
+            msg = f"Missing attribute '{sort_key}' in item to sort {item}."
+            raise AttributeError(msg)
+        if default_value is None:
+            default_value = item
+        return [_convert(c, ignore_case) for c in re.split(pattern, str(getattr(item, sort_key, default_value)))]
+    return [_convert(c, ignore_case) for c in re.split(pattern, str(item))]
+
+
+def _convert(text: str, ignore_case: bool) -> int | str:
+    """
+    Converts the input string to be sorted.
+
+    Converts the string to an integer if it is a digit, otherwise converts
+    it to lower case if ignore_case is True.
+
+    Args:
+        text: Input string.
+        ignore_case: If ignore_case is True, strings are applied lower() function.
+
+    Returns:
+        Converted string.
+    """
+    if text.isdigit():
+        return int(text)
+    return text.lower() if ignore_case else text

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -11,6 +11,8 @@ from typing import Any
 from jinja2.runtime import Undefined
 from jinja2.utils import Namespace
 
+SPLIT_PATTERN = re.compile(r"(\d+)")
+
 
 def natural_sort(iterable: Iterable | None, sort_key: str | None = None, *, strict: bool = True, ignore_case: bool = True, default_value: Any = None) -> list:
     """
@@ -39,22 +41,21 @@ def natural_sort(iterable: Iterable | None, sort_key: str | None = None, *, stri
 
 def _alphanum_key(item: Any, sort_key: str | None = None, *, strict: bool = True, ignore_case: bool = True, default_value: Any = None) -> list:
     """Get the key to natural sort by. Falling back to the item itself."""
-    pattern = r"(\d+)"
     if sort_key is not None and isinstance(item, Mapping):
         if strict and sort_key not in item and default_value is None:
             msg = f"Missing key '{sort_key}' in item to sort {item}."
             raise KeyError(msg)
         if default_value is None:
             default_value = item
-        return [_convert(c, ignore_case) for c in re.split(pattern, str(item.get(sort_key, default_value)))]
+        return [_convert(c, ignore_case) for c in re.split(SPLIT_PATTERN, str(item.get(sort_key, default_value)))]
     if sort_key is not None and isinstance(item, Namespace):
         if strict and not hasattr(item, sort_key) and default_value is None:
             msg = f"Missing attribute '{sort_key}' in item to sort {item}."
             raise AttributeError(msg)
         if default_value is None:
             default_value = item
-        return [_convert(c, ignore_case) for c in re.split(pattern, str(getattr(item, sort_key, default_value)))]
-    return [_convert(c, ignore_case) for c in re.split(pattern, str(item))]
+        return [_convert(c, ignore_case) for c in re.split(SPLIT_PATTERN, str(getattr(item, sort_key, default_value)))]
+    return [_convert(c, ignore_case) for c in re.split(SPLIT_PATTERN, str(item))]
 
 
 def _convert(text: str, ignore_case: bool) -> int | str:

--- a/python-avd/pyavd/j2filters/natural_sort.py
+++ b/python-avd/pyavd/j2filters/natural_sort.py
@@ -19,7 +19,7 @@ def natural_sort(iterable: Iterable | None, sort_key: str | None = None, *, stri
     Args:
         iterable: Input iterable.
         sort_key: Key to sort by, defaults to None.
-        strict: If strict is True, raise an error is the sort_key is missing and no default value is given.
+        strict: If strict is True, raise an error if the sort_key is missing and no default value is given.
         ignore_case: If ignore_case is True, strings are applied lower() function.
         default_value: Default value to use if the sort_key is missing.
 

--- a/python-avd/tests/pyavd/j2filters/test_natural_sort.py
+++ b/python-avd/tests/pyavd/j2filters/test_natural_sort.py
@@ -8,41 +8,42 @@ from typing import Any
 
 import pytest
 
-from pyavd.j2filters.natural_sort import convert, natural_sort
+from pyavd.j2filters.natural_sort import _convert, natural_sort
 
 
 class TestNaturalSortFilter:
     @pytest.mark.parametrize(
         ("item_to_convert", "converted_item", "ignore_case"),
         [
-            ("100", 100, True),
-            ("200", 200, True),
-            ("ABC", "abc", True),
-            ("ABC", "ABC", False),
+            pytest.param("100", 100, True),
+            pytest.param("200", 200, True),
+            pytest.param("ABC", "abc", True),
+            pytest.param("ABC", "ABC", False),
         ],
     )
     def test_convert(self, item_to_convert: str, converted_item: int | str, ignore_case: bool) -> None:
-        resp = convert(item_to_convert, ignore_case)
+        resp = _convert(item_to_convert, ignore_case)
         assert resp == converted_item
 
     @pytest.mark.parametrize(
-        ("item_to_natural_sort", "sort_key", "strict", "ignore_case", "sorted_list", "expected_raise"),
+        ("item_to_natural_sort", "sort_key", "strict", "ignore_case", "default_value", "sorted_list", "expected_raise"),
         [
-            pytest.param(None, None, False, True, [], does_not_raise(), id="None"),
-            pytest.param([], None, False, True, [], does_not_raise(), id="empty-list"),
-            pytest.param({}, "", False, True, [], does_not_raise(), id="empty-dict"),
-            pytest.param("", "", False, True, [], does_not_raise(), id="empty-string"),
-            pytest.param("access_list", None, False, True, ["_", "a", "c", "c", "e", "i", "l", "s", "s", "s", "t"], does_not_raise(), id="string-input"),
+            pytest.param(None, None, False, True, None, [], does_not_raise(), id="None"),
+            pytest.param([], None, False, True, None, [], does_not_raise(), id="empty-list"),
+            pytest.param({}, "", False, True, None, [], does_not_raise(), id="empty-dict"),
+            pytest.param("", "", False, True, None, [], does_not_raise(), id="empty-string"),
+            pytest.param("access_list", None, False, True, None, ["_", "a", "c", "c", "e", "i", "l", "s", "s", "s", "t"], does_not_raise(), id="string-input"),
             pytest.param(
                 ["1,2,3,4", "11,2,3,4", "5.6.7.8"],  # NOSONAR, IP is just test data
                 None,
                 False,
                 True,
+                None,
                 ["1,2,3,4", "5.6.7.8", "11,2,3,4"],  # NOSONAR, IP is just test data
                 does_not_raise(),
                 id="list-of-integers",
             ),
-            pytest.param({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, None, False, True, ["a1", "a2", "a10", "a11"], does_not_raise(), id="dict"),
+            pytest.param({"a1": 123, "a10": 333, "a2": 2, "a11": 4456}, None, False, True, None, ["a1", "a2", "a10", "a11"], does_not_raise(), id="dict"),
             pytest.param(
                 [
                     {"name": "ACL-10", "counters_per_entry": True},
@@ -52,6 +53,7 @@ class TestNaturalSortFilter:
                 "name",
                 False,
                 True,
+                None,
                 [
                     {"name": "ACL-01", "counters_per_entry": True},
                     {"name": "ACL-05", "counters_per_entry": False},
@@ -70,6 +72,7 @@ class TestNaturalSortFilter:
                 "name",
                 False,
                 True,
+                None,
                 [
                     {"name": "ACL-05", "counters_per_entry": False},
                     {"name": "ACL-10", "counters_per_entry": True},
@@ -88,6 +91,7 @@ class TestNaturalSortFilter:
                 "name",
                 False,
                 True,
+                None,
                 [
                     {"action": "action_command"},
                     {"counters_per_entry": False},
@@ -105,6 +109,7 @@ class TestNaturalSortFilter:
                 "name",
                 False,
                 True,
+                None,
                 [
                     {"name": "D"},
                     {"name": "default"},
@@ -122,6 +127,7 @@ class TestNaturalSortFilter:
                 "name",
                 False,
                 False,
+                None,
                 [
                     {"name": "D"},
                     {"name": "E"},
@@ -140,8 +146,27 @@ class TestNaturalSortFilter:
                 True,
                 True,
                 None,
+                None,
                 pytest.raises(Exception, match="Missing key 'name' in item to sort "),
                 id="list-of-dict-with-sort-key-strict-mode",
+            ),
+            pytest.param(
+                [
+                    {"name": "ACL-10", "counters_per_entry": True},
+                    {"counters_per_entry": False},
+                    {"name": "ACL-05", "counters_per_entry": False},
+                ],
+                "name",
+                True,
+                True,
+                "ACL-00",
+                [
+                    {"counters_per_entry": False},
+                    {"name": "ACL-05", "counters_per_entry": False},
+                    {"name": "ACL-10", "counters_per_entry": True},
+                ],
+                does_not_raise(),
+                id="list-of-dict-with-sort-key-strict-mode-and-default-value",
             ),
         ],
     )
@@ -151,9 +176,10 @@ class TestNaturalSortFilter:
         sort_key: str | None,
         strict: bool,
         ignore_case: bool,
+        default_value: Any,
         sorted_list: list | None,
         expected_raise: AbstractContextManager,
     ) -> None:
         with expected_raise:
-            resp = natural_sort(item_to_natural_sort, sort_key, strict=strict, ignore_case=ignore_case)
+            resp = natural_sort(item_to_natural_sort, sort_key, strict=strict, ignore_case=ignore_case, default_value=default_value)
             assert resp == sorted_list


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add support for default_value to natural_sort

## Component(s) name

`arista.avd.natural_sort` J2 filter and python util.

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Adding `default_value` kwarg to natural_sort, so if missing the key, we will use this value instead for sorting.
- Useful in eos_cli_config_gen templates to enforce same sorting as on EOS without requiring default values.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added pytest coverage

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
