### PR TITLE
Fix(eos_designs)!: Correct Loopback prefixes in PL-LOOPBACKS-EVPN-OVERLAY prefix-list

### DIFF
--- a/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
+++ b/ansible_collections/arista/avd/docs/release-notes/5.x.x.md
@@ -42,7 +42,27 @@ AVD would wrongfully ignore the variables under the `node_groups[]` and `node_gr
           mgmt_ip: 192.168.200.10/24
 ```
 
-Starting with version 5.2 AVD follows the [documented behavior](https://avd.arista.com/5.0/roles/eos_designs/docs/input-variables.html#node-type-structure).
+Starting with version 5.2, AVD follows the [documented behavior](https://avd.arista.com/5.0/roles/eos_designs/docs/input-variables.html#node-type-structure).
+
+### Fix for incorrect output in prefix-list PL-LOOPBACKS-EVPN-OVERLAY when given incorrect prefixes for IPv4 Loopback pools
+
+When IPv4 Loopback pools contain IP prefixes with host bits set like `192.168.100.11/24` AVD previously relayed this wrong prefix directly:
+
+```eos
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.100.11/24 eq 32
+```
+
+This config is incorrect and EOS automatically changes it to the correct prefix `192.168.100.0/24` when the configuration is applied.
+
+Starting with version 5.2, AVD changes the prefix internally to output the correct prefix:
+
+```eos
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 192.168.100.0/24 eq 32
+```
+
+This may lead to updates in the generated configurations, but it will not affect the running configuration, since EOS already corrected this automatically.
 
 ## Release 5.1.0
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cvp-instance-ips-cvaas.cfg
@@ -34,7 +34,7 @@ ip routing
 no ip routing vrf MGMT
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 1.2.3.4/24 eq 32
+   seq 10 permit 1.2.3.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.0.1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/device.with.dots.in.hostname.cfg
@@ -30,7 +30,7 @@ ip routing
 no ip routing vrf MGMT
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 1.2.3.4/24 eq 32
+   seq 10 permit 1.2.3.0/24 eq 32
 !
 ip route vrf MGMT 0.0.0.0/0 192.168.0.1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_bgp.cfg
@@ -118,7 +118,7 @@ ip routing
 no ip routing vrf MGMT
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 1.2.3.4/24 eq 32
+   seq 10 permit 1.2.3.0/24 eq 32
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-interfaces.cfg
@@ -67,7 +67,7 @@ ip routing
 no ip routing vrf MGMT
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-   seq 10 permit 1.2.3.4/24 eq 32
+   seq 10 permit 1.2.3.0/24 eq 32
 !
 ip route 0.0.0.0/0 192.168.1.3
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -31,7 +31,7 @@ prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
   - sequence: 10
-    action: permit 1.2.3.4/24 eq 32
+    action: permit 1.2.3.0/24 eq 32
 route_maps:
 - name: RM-CONN-2-BGP
   sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
@@ -21,7 +21,7 @@ prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
   - sequence: 10
-    action: permit 1.2.3.4/24 eq 32
+    action: permit 1.2.3.0/24 eq 32
 route_maps:
 - name: RM-CONN-2-BGP
   sequence_numbers:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_bgp.yml
@@ -139,7 +139,7 @@ prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
   - sequence: 10
-    action: permit 1.2.3.4/24 eq 32
+    action: permit 1.2.3.0/24 eq 32
 ptp:
   mode: boundary
   clock_identity: 00:1C:73:14:00:01

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-interfaces.yml
@@ -71,7 +71,7 @@ prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
   - sequence: 10
-    action: permit 1.2.3.4/24 eq 32
+    action: permit 1.2.3.0/24 eq 32
 route_maps:
 - name: RM-CONN-2-BGP
   sequence_numbers:

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/prefix_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/prefix_lists.py
@@ -36,10 +36,10 @@ class PrefixListsMixin(UtilsMixin):
             return None
 
         # IPv4 - PL-LOOPBACKS-EVPN-OVERLAY
-        sequence_numbers = [{"sequence": 10, "action": f"permit {self.shared_utils.loopback_ipv4_pool} eq 32"}]
+        sequence_numbers = [{"sequence": 10, "action": f"permit {ipaddress.ip_network(self.shared_utils.loopback_ipv4_pool, strict=False)} eq 32"}]
 
         if self.shared_utils.overlay_vtep and self.shared_utils.vtep_loopback.lower() != "loopback0" and not self.shared_utils.is_wan_router:
-            sequence_numbers.append({"sequence": 20, "action": f"permit {self.shared_utils.vtep_loopback_ipv4_pool} eq 32"})
+            sequence_numbers.append({"sequence": 20, "action": f"permit {ipaddress.ip_network(self.shared_utils.vtep_loopback_ipv4_pool, strict=False)} eq 32"})
 
         if self.inputs.vtep_vvtep_ip is not None and self.shared_utils.network_services_l3 is True and not self.shared_utils.is_wan_router:
             sequence_numbers.append({"sequence": 30, "action": f"permit {self.inputs.vtep_vvtep_ip}"})


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix for incorrect output in prefix-list PL-LOOPBACKS-EVPN-OVERLAY when given incorrect prefixes for IPv4 Loopback pools

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

When IPv4 Loopback pools contain IP prefixes with host bits set like `192.168.100.11/24` AVD previously relayed this wrong prefix directly:

```eos
ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
   seq 10 permit 192.168.100.11/24 eq 32
```

This config is incorrect and EOS automatically changes it to the correct prefix `192.168.100.0/24` when the configuration is applied.

Starting with version 5.2, AVD changes the prefix internally to output the correct prefix:

```eos
ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
   seq 10 permit 192.168.100.0/24 eq 32
```

This may lead to updates in the generated configurations, but it will not affect the running configuration, since EOS already corrected this automatically.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Exposed by existing molecule tests.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.sh/en/latest/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
