### PR TITLE
CI: Revert the Revert "Fix ansible-lint failures"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ __pycache__/
 # ansible_collections/arista/avd/tests ignores
 ansible_collections/arista/avd/tests/.mypy_cache/
 
+# ansible-lint ignores
+ansible_collections/arista/avd/.ansible
+
 # Development
 ## pyenv
 .python-version

--- a/ansible_collections/arista/avd/.ansible-lint
+++ b/ansible_collections/arista/avd/.ansible-lint
@@ -8,3 +8,6 @@ skip_list:
   - var-naming[no-role-prefix] # TODO: Fix internal variable names as a breaking change for AVD 5.0.0
 kinds:
   - yaml: "**/molecule/**/inventory/host_vars/host1/roles.yml"
+exclude_paths:
+  - .cache/
+  - .ansible/


### PR DESCRIPTION
Reverts aristanetworks/avd#4895

 - ansible-compat 25.1.0 was released