### PR TITLE
Feat(eos_cli_config_gen): Add support for Receive Side Scaling (RSS) interface profile

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -10701,6 +10701,66 @@ ipv6 address virtual source-nat vrf TEST_04 address 2001:db8:85a3::8a2e:370:7335
 | -------- | ----- |
 | Maximum CPU Allocation | 42 |
 
+##### Platform Software Forwarding Engine Interface Summary
+
+###### RSS Profile to apply
+
+####### TestProfile1
+
+###### RSS Profiles
+
+####### TestProfile1
+
+| Interface | Rx-Queue Count | Rx-Queue Worker | Rx-Queue Mode |
+| --------- | -------------- | --------------- | ------------- |
+| Ethernet1/1 | 4 | 0-2,5 | - |
+| Ethernet1/2 | 2 | - | shared |
+| Ethernet1/4 | 1 | - | - |
+| Ethernet1/5 | 2 | 3,4 | exclusive |
+
+####### TestProfile2
+
+| Interface | Rx-Queue Count | Rx-Queue Worker | Rx-Queue Mode |
+| --------- | -------------- | --------------- | ------------- |
+| Ethernet1 | 3 | 2 | - |
+| Ethernet9 | - | - | - |
+
+####### TestProfile3
+
+##### Platform Software Forwarding Engine Interface Device Configuration
+
+```eos
+!
+platform sfe interface
+   interface profile TestProfile1
+   !
+   profile TestProfile1
+      interface Ethernet1/1
+         rx-queue count 4
+         rx-queue worker 0-2,5
+      !
+      interface Ethernet1/2
+         rx-queue count 2
+         rx-queue mode shared
+      !
+      interface Ethernet1/4
+         rx-queue count 1
+      !
+      interface Ethernet1/5
+         rx-queue count 2
+         rx-queue worker 3,4
+         rx-queue mode exclusive
+   !
+   profile TestProfile2
+      interface Ethernet1
+         rx-queue count 3
+         rx-queue worker 2
+      !
+      interface Ethernet9
+   !
+   profile TestProfile3
+```
+
 ### Platform Device Configuration
 
 ```eos

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -10703,9 +10703,7 @@ ipv6 address virtual source-nat vrf TEST_04 address 2001:db8:85a3::8a2e:370:7335
 
 ##### Platform Software Forwarding Engine Interface Summary
 
-###### RSS Profile to apply
-
-####### TestProfile1
+Applied profile: TestProfile1
 
 ###### RSS Profiles
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -10700,14 +10700,11 @@ ipv6 address virtual source-nat vrf TEST_04 address 2001:db8:85a3::8a2e:370:7335
 | Settings | Value |
 | -------- | ----- |
 | Maximum CPU Allocation | 42 |
+| Interface profile | TestProfile1 |
 
-##### Platform Software Forwarding Engine Interface Summary
+#### Platform Software Forwarding Engine Interface Profiles
 
-Applied profile: TestProfile1
-
-###### RSS Profiles
-
-####### TestProfile1
+##### TestProfile1
 
 | Interface | Rx-Queue Count | Rx-Queue Worker | Rx-Queue Mode |
 | --------- | -------------- | --------------- | ------------- |
@@ -10716,18 +10713,30 @@ Applied profile: TestProfile1
 | Ethernet1/4 | 1 | - | - |
 | Ethernet1/5 | 2 | 3,4 | exclusive |
 
-####### TestProfile2
+##### TestProfile2
 
 | Interface | Rx-Queue Count | Rx-Queue Worker | Rx-Queue Mode |
 | --------- | -------------- | --------------- | ------------- |
 | Ethernet1 | 3 | 2 | - |
 | Ethernet9 | - | - | - |
 
-####### TestProfile3
+##### TestProfile3
 
-##### Platform Software Forwarding Engine Interface Device Configuration
+### Platform Device Configuration
 
 ```eos
+!
+platform trident l3 routing mac-address per-vlan
+platform trident forwarding-table partition 2
+platform sand forwarding mode arad
+platform sand lag mode 512x32
+platform sand lag hardware-only
+platform sand qos map traffic-class 0 to network-qos 0
+platform sand qos map traffic-class 1 to network-qos 7
+platform sand qos map traffic-class 2 to network-qos 15
+platform sand multicast replication default ingress
+platform sand mdb profile l3-xxl
+platform sfe data-plane cpu allocation maximum 42
 !
 platform sfe interface
    interface profile TestProfile1
@@ -10757,23 +10766,6 @@ platform sfe interface
       interface Ethernet9
    !
    profile TestProfile3
-```
-
-### Platform Device Configuration
-
-```eos
-!
-platform trident l3 routing mac-address per-vlan
-platform trident forwarding-table partition 2
-platform sand forwarding mode arad
-platform sand lag mode 512x32
-platform sand lag hardware-only
-platform sand qos map traffic-class 0 to network-qos 0
-platform sand qos map traffic-class 1 to network-qos 7
-platform sand qos map traffic-class 2 to network-qos 15
-platform sand multicast replication default ingress
-platform sand mdb profile l3-xxl
-platform sfe data-plane cpu allocation maximum 42
 ```
 
 ## System L1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -284,6 +284,35 @@ logging event congestion-drops interval 10
 !
 load-interval default 25
 !
+platform sfe interface
+   interface profile TestProfile1
+   !
+   profile TestProfile1
+      interface Ethernet1/1
+         rx-queue count 4
+         rx-queue worker 0-2,5
+      !
+      interface Ethernet1/2
+         rx-queue count 2
+         rx-queue mode shared
+      !
+      interface Ethernet1/4
+         rx-queue count 1
+      !
+      interface Ethernet1/5
+         rx-queue count 2
+         rx-queue worker 3,4
+         rx-queue mode exclusive
+   !
+   profile TestProfile2
+      interface Ethernet1
+         rx-queue count 3
+         rx-queue worker 2
+      !
+      interface Ethernet9
+   !
+   profile TestProfile3
+!
 interface defaults
    mtu 9000
    ethernet

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/platform.yml
@@ -71,3 +71,32 @@ platform:
     mdb_profile: "l3-xxl"
   sfe:
     data_plane_cpu_allocation_max: 42
+    interface:
+      profiles:
+        - name: TestProfile1
+          interfaces:
+            - name: Ethernet1/1
+              rx_queue:
+                count: 4
+                worker: "0-2,5"
+            - name: Ethernet1/5
+              rx_queue:
+                count: 2
+                worker: "3,4"
+                mode: exclusive
+            - name: Ethernet1/2
+              rx_queue:
+                count: 2
+                mode: shared
+            - name: Ethernet1/4
+              rx_queue:
+                count: 1
+        - name: TestProfile2
+          interfaces:
+            - name: Ethernet1
+              rx_queue:
+                count: 3
+                worker: "2"
+            - name: Ethernet9
+        - name: TestProfile3
+      interface_profile: TestProfile1

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/platform.md
@@ -45,6 +45,16 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mdb_profile</samp>](## "platform.sand.mdb_profile") | String |  |  | Valid Values:<br>- <code>balanced</code><br>- <code>balanced-xl</code><br>- <code>l3</code><br>- <code>l3-xl</code><br>- <code>l3-xxl</code><br>- <code>l3-xxxl</code> | Sand platforms MDB Profile configuration. Note: l3-xxxl does not support MLAG. |
     | [<samp>&nbsp;&nbsp;sfe</samp>](## "platform.sfe") | Dictionary |  |  |  | Sfe (Software Forwarding Engine) settings. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;data_plane_cpu_allocation_max</samp>](## "platform.sfe.data_plane_cpu_allocation_max") | Integer |  |  | Min: 1<br>Max: 128 | Maximum number of CPUs used for data plane traffic forwarding. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "platform.sfe.interface") | Dictionary |  |  |  | Configure interface related settings for Sfe platform. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profiles</samp>](## "platform.sfe.interface.profiles") | List, items: Dictionary |  |  |  | Configure one or more Receive Side Scaling (RSS) interface profiles.<br>This is supported on specific platforms. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "platform.sfe.interface.profiles.[].name") | String | Required, Unique |  |  | RSS interface profile name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interfaces</samp>](## "platform.sfe.interface.profiles.[].interfaces") | List, items: Dictionary |  |  |  | Interfaces within RSS profile. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "platform.sfe.interface.profiles.[].interfaces.[].name") | String | Required, Unique |  |  | Interface name such as 'Ethernet2'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;rx_queue</samp>](## "platform.sfe.interface.profiles.[].interfaces.[].rx_queue") | Dictionary |  |  |  | Receive queue parameters for the selected interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;count</samp>](## "platform.sfe.interface.profiles.[].interfaces.[].rx_queue.count") | Integer |  |  | Min: 1 | Number of receive queues.<br>The maximum value is platform dependent. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;worker</samp>](## "platform.sfe.interface.profiles.[].interfaces.[].rx_queue.worker") | String |  |  |  | Worker ids specified as combination of range and/or comma separated values<br>such as 0-4,7. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mode</samp>](## "platform.sfe.interface.profiles.[].interfaces.[].rx_queue.mode") | String |  |  | Valid Values:<br>- <code>shared</code><br>- <code>exclusive</code> | Mode applicable to the workers. Default mode is 'shared'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface_profile</samp>](## "platform.sfe.interface.interface_profile") | String |  |  |  | RSS interface profile name to apply for the platform.<br>Needs system reload or Sfe agent restart for change to take effect. |
 
 === "YAML"
 
@@ -122,4 +132,38 @@
 
         # Maximum number of CPUs used for data plane traffic forwarding.
         data_plane_cpu_allocation_max: <int; 1-128>
+
+        # Configure interface related settings for Sfe platform.
+        interface:
+
+          # Configure one or more Receive Side Scaling (RSS) interface profiles.
+          # This is supported on specific platforms.
+          profiles:
+
+              # RSS interface profile name.
+            - name: <str; required; unique>
+
+              # Interfaces within RSS profile.
+              interfaces:
+
+                  # Interface name such as 'Ethernet2'.
+                - name: <str; required; unique>
+
+                  # Receive queue parameters for the selected interface.
+                  rx_queue:
+
+                    # Number of receive queues.
+                    # The maximum value is platform dependent.
+                    count: <int; >=1>
+
+                    # Worker ids specified as combination of range and/or comma separated values
+                    # such as 0-4,7.
+                    worker: <str>
+
+                    # Mode applicable to the workers. Default mode is 'shared'.
+                    mode: <str; "shared" | "exclusive">
+
+          # RSS interface profile name to apply for the platform.
+          # Needs system reload or Sfe agent restart for change to take effect.
+          interface_profile: <str>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/platform.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/platform.j2
@@ -85,18 +85,15 @@
 {%             endif %}
 {## Platform Sfe Interface #}
 {%             if platform.sfe.interface is arista.avd.defined %}
-
-##### Platform Software Forwarding Engine Interface Summary
 {%                 if platform.sfe.interface.interface_profile is arista.avd.defined %}
-
-Applied profile: {{ platform.sfe.interface.interface_profile }}
+| Interface profile | {{ platform.sfe.interface.interface_profile }} |
 {%                 endif %}
 {%                 if platform.sfe.interface.profiles is arista.avd.defined %}
 
-###### RSS Profiles
+#### Platform Software Forwarding Engine Interface Profiles
 {%                     for profile_data in platform.sfe.interface.profiles | arista.avd.natural_sort('name') %}
 
-####### {{ profile_data.name }}
+##### {{ profile_data.name }}
 {%                         if profile_data.interfaces is arista.avd.defined %}
 
 | Interface | Rx-Queue Count | Rx-Queue Worker | Rx-Queue Mode |
@@ -105,18 +102,11 @@ Applied profile: {{ platform.sfe.interface.interface_profile }}
 {%                                 set rx_queue_count = interface_data.rx_queue.count | arista.avd.default('-') %}
 {%                                 set rx_queue_worker = interface_data.rx_queue.worker | arista.avd.default('-') %}
 {%                                 set rx_queue_mode = interface_data.rx_queue.mode | arista.avd.default('-') %}
-{%                                     endif %}
 | {{ interface_data.name }} | {{ rx_queue_count }} | {{ rx_queue_worker }} | {{ rx_queue_mode }} |
 {%                             endfor %}
 {%                         endif %}
 {%                     endfor %}
 {%                 endif %}
-
-##### Platform Software Forwarding Engine Interface Device Configuration
-
-```eos
-{%                 include 'eos/platform-sfe-interface.j2' %}
-```
 {%             endif %}
 {%         endif %}
 {%     endif %}
@@ -125,5 +115,6 @@ Applied profile: {{ platform.sfe.interface.interface_profile }}
 
 ```eos
 {%     include 'eos/platform.j2' %}
+{%     include 'eos/platform-sfe-interface.j2' %}
 ```
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/platform.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/platform.j2
@@ -87,14 +87,12 @@
 {%             if platform.sfe.interface is arista.avd.defined %}
 
 ##### Platform Software Forwarding Engine Interface Summary
-
 {%                 if platform.sfe.interface.interface_profile is arista.avd.defined %}
-###### RSS Profile to apply
 
-####### {{ platform.sfe.interface.interface_profile }}
+Applied profile: {{ platform.sfe.interface.interface_profile }}
 {%                 endif %}
-
 {%                 if platform.sfe.interface.profiles is arista.avd.defined %}
+
 ###### RSS Profiles
 {%                     for profile_data in platform.sfe.interface.profiles | arista.avd.natural_sort('name') %}
 
@@ -104,21 +102,11 @@
 | Interface | Rx-Queue Count | Rx-Queue Worker | Rx-Queue Mode |
 | --------- | -------------- | --------------- | ------------- |
 {%                             for interface_data in profile_data.interfaces | arista.avd.natural_sort('name') %}
-{%                                 if interface_data.rx_queue is arista.avd.defined %}
-{%                                     if interface_data.rx_queue.count is arista.avd.defined %}
-{%                                         set rx_queue_count = interface_data.rx_queue.count %}
+{%                                 set rx_queue_count = interface_data.rx_queue.count | arista.avd.default('-') %}
+{%                                 set rx_queue_worker = interface_data.rx_queue.worker | arista.avd.default('-') %}
+{%                                 set rx_queue_mode = interface_data.rx_queue.mode | arista.avd.default('-') %}
 {%                                     endif %}
-{%                                     if interface_data.rx_queue.worker is arista.avd.defined %}
-{%                                         set rx_queue_worker = interface_data.rx_queue.worker %}
-{%                                     endif %}
-{%                                     if interface_data.rx_queue.mode is arista.avd.defined %}
-{%                                         set rx_queue_mode = interface_data.rx_queue.mode %}
-{%                                     endif %}
-| {{ interface_data.name }} | {{ rx_queue_count | arista.avd.default('-') }} | {{ rx_queue_worker | arista.avd.default('-') }} | {{ rx_queue_mode | arista.avd.default('-') }} |
-{%                                 else %}
-{# Rx_queue parameters were not specified for interface #}
-| {{ interface_data.name }} | - | - | - |
-{%                                 endif %}
+| {{ interface_data.name }} | {{ rx_queue_count }} | {{ rx_queue_worker }} | {{ rx_queue_mode }} |
 {%                             endfor %}
 {%                         endif %}
 {%                     endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/platform.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/platform.j2
@@ -83,6 +83,53 @@
 {%             if platform.sfe.data_plane_cpu_allocation_max is arista.avd.defined %}
 | Maximum CPU Allocation | {{ platform.sfe.data_plane_cpu_allocation_max }} |
 {%             endif %}
+{## Platform Sfe Interface #}
+{%             if platform.sfe.interface is arista.avd.defined %}
+
+##### Platform Software Forwarding Engine Interface Summary
+
+{%                 if platform.sfe.interface.interface_profile is arista.avd.defined %}
+###### RSS Profile to apply
+
+####### {{ platform.sfe.interface.interface_profile }}
+{%                 endif %}
+
+{%                 if platform.sfe.interface.profiles is arista.avd.defined %}
+###### RSS Profiles
+{%                     for profile_data in platform.sfe.interface.profiles | arista.avd.natural_sort('name') %}
+
+####### {{ profile_data.name }}
+{%                         if profile_data.interfaces is arista.avd.defined %}
+
+| Interface | Rx-Queue Count | Rx-Queue Worker | Rx-Queue Mode |
+| --------- | -------------- | --------------- | ------------- |
+{%                             for interface_data in profile_data.interfaces | arista.avd.natural_sort('name') %}
+{%                                 if interface_data.rx_queue is arista.avd.defined %}
+{%                                     if interface_data.rx_queue.count is arista.avd.defined %}
+{%                                         set rx_queue_count = interface_data.rx_queue.count %}
+{%                                     endif %}
+{%                                     if interface_data.rx_queue.worker is arista.avd.defined %}
+{%                                         set rx_queue_worker = interface_data.rx_queue.worker %}
+{%                                     endif %}
+{%                                     if interface_data.rx_queue.mode is arista.avd.defined %}
+{%                                         set rx_queue_mode = interface_data.rx_queue.mode %}
+{%                                     endif %}
+| {{ interface_data.name }} | {{ rx_queue_count | arista.avd.default('-') }} | {{ rx_queue_worker | arista.avd.default('-') }} | {{ rx_queue_mode | arista.avd.default('-') }} |
+{%                                 else %}
+{# Rx_queue parameters were not specified for interface #}
+| {{ interface_data.name }} | - | - | - |
+{%                                 endif %}
+{%                             endfor %}
+{%                         endif %}
+{%                     endfor %}
+{%                 endif %}
+
+##### Platform Software Forwarding Engine Interface Device Configuration
+
+```eos
+{%                 include 'eos/platform-sfe-interface.j2' %}
+```
+{%             endif %}
 {%         endif %}
 {%     endif %}
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-intended-config.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-intended-config.j2
@@ -64,6 +64,8 @@
 {% include 'eos/load-interval.j2' %}
 {# transceiver qsfp default mode #}
 {% include 'eos/transceiver-qsfp-default-mode.j2' %}
+{# platform sfe interface #}
+{% include 'eos/platform-sfe-interface.j2' %}
 {# interface defaults #}
 {% include 'eos/interface-defaults.j2' %}
 {# service routing protocols model #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/platform-sfe-interface.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/platform-sfe-interface.j2
@@ -1,0 +1,34 @@
+{#
+ Copyright (c) 2023-2025 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# eos - platform sfe interface #}
+{% if platform.sfe.interface is arista.avd.defined %}
+!
+platform sfe interface
+{# interface profile to apply #}
+{%     if platform.sfe.interface.interface_profile is arista.avd.defined %}
+   interface profile {{ platform.sfe.interface.interface_profile }}
+{%     endif %}
+{%     for profile_data in platform.sfe.interface.profiles | arista.avd.natural_sort('name') %}
+{# profiles available #}
+   !
+   profile {{ profile_data.name }}
+{%         for interface_data in profile_data.interfaces | arista.avd.natural_sort('name') %}
+      interface {{ interface_data.name }}
+{%             if interface_data.rx_queue.count is arista.avd.defined %}
+         rx-queue count {{ interface_data.rx_queue.count }}
+{%             endif %}
+{%             if interface_data.rx_queue.worker is arista.avd.defined %}
+         rx-queue worker {{ interface_data.rx_queue.worker }}
+{%             endif %}
+{%             if interface_data.rx_queue.mode is arista.avd.defined %}
+         rx-queue mode {{ interface_data.rx_queue.mode }}
+{%             endif %}
+{%             if not loop.last %}
+      !
+{%             endif %}
+{%         endfor %}
+{%     endfor %}
+{% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -24822,13 +24822,184 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         class Sfe(AvdModel):
             """Subclass of AvdModel."""
 
-            _fields: ClassVar[dict] = {"data_plane_cpu_allocation_max": {"type": int}}
+            class Interface(AvdModel):
+                """Subclass of AvdModel."""
+
+                class ProfilesItem(AvdModel):
+                    """Subclass of AvdModel."""
+
+                    class InterfacesItem(AvdModel):
+                        """Subclass of AvdModel."""
+
+                        class RxQueue(AvdModel):
+                            """Subclass of AvdModel."""
+
+                            _fields: ClassVar[dict] = {"count": {"type": int}, "worker": {"type": str}, "mode": {"type": str}}
+                            count: int | None
+                            """
+                            Number of receive queues.
+                            The maximum value is platform dependent.
+                            """
+                            worker: str | None
+                            """
+                            Worker ids specified as combination of range and/or comma separated values
+                            such as 0-4,7.
+                            """
+                            mode: Literal["shared", "exclusive"] | None
+                            """Mode applicable to the workers. Default mode is 'shared'."""
+
+                            if TYPE_CHECKING:
+
+                                def __init__(
+                                    self,
+                                    *,
+                                    count: int | None | UndefinedType = Undefined,
+                                    worker: str | None | UndefinedType = Undefined,
+                                    mode: Literal["shared", "exclusive"] | None | UndefinedType = Undefined,
+                                ) -> None:
+                                    """
+                                    RxQueue.
+
+
+                                    Subclass of AvdModel.
+
+                                    Args:
+                                        count:
+                                           Number of receive queues.
+                                           The maximum value is platform dependent.
+                                        worker:
+                                           Worker ids specified as combination of range and/or comma separated values
+                                           such as 0-4,7.
+                                        mode: Mode applicable to the workers. Default mode is 'shared'.
+
+                                    """
+
+                        _fields: ClassVar[dict] = {"name": {"type": str}, "rx_queue": {"type": RxQueue}}
+                        name: str
+                        """Interface name such as 'Ethernet2'."""
+                        rx_queue: RxQueue
+                        """
+                        Receive queue parameters for the selected interface.
+
+                        Subclass of AvdModel.
+                        """
+
+                        if TYPE_CHECKING:
+
+                            def __init__(self, *, name: str | UndefinedType = Undefined, rx_queue: RxQueue | UndefinedType = Undefined) -> None:
+                                """
+                                InterfacesItem.
+
+
+                                Subclass of AvdModel.
+
+                                Args:
+                                    name: Interface name such as 'Ethernet2'.
+                                    rx_queue:
+                                       Receive queue parameters for the selected interface.
+
+                                       Subclass of AvdModel.
+
+                                """
+
+                    class Interfaces(AvdIndexedList[str, InterfacesItem]):
+                        """Subclass of AvdIndexedList with `InterfacesItem` items. Primary key is `name` (`str`)."""
+
+                        _primary_key: ClassVar[str] = "name"
+
+                    Interfaces._item_type = InterfacesItem
+
+                    _fields: ClassVar[dict] = {"name": {"type": str}, "interfaces": {"type": Interfaces}}
+                    name: str
+                    """RSS interface profile name."""
+                    interfaces: Interfaces
+                    """
+                    Interfaces within RSS profile.
+
+                    Subclass of AvdIndexedList with `InterfacesItem` items. Primary key
+                    is `name` (`str`).
+                    """
+
+                    if TYPE_CHECKING:
+
+                        def __init__(self, *, name: str | UndefinedType = Undefined, interfaces: Interfaces | UndefinedType = Undefined) -> None:
+                            """
+                            ProfilesItem.
+
+
+                            Subclass of AvdModel.
+
+                            Args:
+                                name: RSS interface profile name.
+                                interfaces:
+                                   Interfaces within RSS profile.
+
+                                   Subclass of AvdIndexedList with `InterfacesItem` items. Primary key
+                                   is `name` (`str`).
+
+                            """
+
+                class Profiles(AvdIndexedList[str, ProfilesItem]):
+                    """Subclass of AvdIndexedList with `ProfilesItem` items. Primary key is `name` (`str`)."""
+
+                    _primary_key: ClassVar[str] = "name"
+
+                Profiles._item_type = ProfilesItem
+
+                _fields: ClassVar[dict] = {"profiles": {"type": Profiles}, "interface_profile": {"type": str}}
+                profiles: Profiles
+                """
+                Configure one or more Receive Side Scaling (RSS) interface profiles.
+                This is supported on specific
+                platforms.
+
+                Subclass of AvdIndexedList with `ProfilesItem` items. Primary key is `name` (`str`).
+                """
+                interface_profile: str | None
+                """
+                RSS interface profile name to apply for the platform.
+                Needs system reload or Sfe agent restart for
+                change to take effect.
+                """
+
+                if TYPE_CHECKING:
+
+                    def __init__(self, *, profiles: Profiles | UndefinedType = Undefined, interface_profile: str | None | UndefinedType = Undefined) -> None:
+                        """
+                        Interface.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            profiles:
+                               Configure one or more Receive Side Scaling (RSS) interface profiles.
+                               This is supported on specific
+                               platforms.
+
+                               Subclass of AvdIndexedList with `ProfilesItem` items. Primary key is `name` (`str`).
+                            interface_profile:
+                               RSS interface profile name to apply for the platform.
+                               Needs system reload or Sfe agent restart for
+                               change to take effect.
+
+                        """
+
+            _fields: ClassVar[dict] = {"data_plane_cpu_allocation_max": {"type": int}, "interface": {"type": Interface}}
             data_plane_cpu_allocation_max: int | None
             """Maximum number of CPUs used for data plane traffic forwarding."""
+            interface: Interface
+            """
+            Configure interface related settings for Sfe platform.
+
+            Subclass of AvdModel.
+            """
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, data_plane_cpu_allocation_max: int | None | UndefinedType = Undefined) -> None:
+                def __init__(
+                    self, *, data_plane_cpu_allocation_max: int | None | UndefinedType = Undefined, interface: Interface | UndefinedType = Undefined
+                ) -> None:
                     """
                     Sfe.
 
@@ -24837,6 +25008,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     Args:
                         data_plane_cpu_allocation_max: Maximum number of CPUs used for data plane traffic forwarding.
+                        interface:
+                           Configure interface related settings for Sfe platform.
+
+                           Subclass of AvdModel.
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -9829,6 +9829,64 @@ keys:
             - str
             min: 1
             max: 128
+          interface:
+            type: dict
+            description: Configure interface related settings for Sfe platform.
+            keys:
+              profiles:
+                type: list
+                primary_key: name
+                description: 'Configure one or more Receive Side Scaling (RSS) interface
+                  profiles.
+
+                  This is supported on specific platforms.'
+                items:
+                  type: dict
+                  keys:
+                    name:
+                      type: str
+                      description: RSS interface profile name.
+                    interfaces:
+                      type: list
+                      description: Interfaces within RSS profile.
+                      primary_key: name
+                      items:
+                        type: dict
+                        keys:
+                          name:
+                            type: str
+                            description: Interface name such as 'Ethernet2'.
+                          rx_queue:
+                            type: dict
+                            description: Receive queue parameters for the selected
+                              interface.
+                            keys:
+                              count:
+                                type: int
+                                min: 1
+                                convert_types:
+                                - str
+                                description: 'Number of receive queues.
+
+                                  The maximum value is platform dependent.'
+                              worker:
+                                type: str
+                                description: 'Worker ids specified as combination
+                                  of range and/or comma separated values
+
+                                  such as 0-4,7.'
+                              mode:
+                                type: str
+                                description: Mode applicable to the workers. Default
+                                  mode is 'shared'.
+                                valid_values:
+                                - shared
+                                - exclusive
+              interface_profile:
+                type: str
+                description: 'RSS interface profile name to apply for the platform.
+
+                  Needs system reload or Sfe agent restart for change to take effect.'
   poe:
     type: dict
     keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/platform.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/platform.schema.yml
@@ -182,3 +182,58 @@ keys:
               - str
             min: 1
             max: 128
+          interface:
+            type: dict
+            description: Configure interface related settings for Sfe platform.
+            keys:
+              profiles:
+                type: list
+                primary_key: name
+                description: |-
+                  Configure one or more Receive Side Scaling (RSS) interface profiles.
+                  This is supported on specific platforms.
+                items:
+                  type: dict
+                  keys:
+                    name:
+                      type: str
+                      description: RSS interface profile name.
+                    interfaces:
+                      type: list
+                      description: Interfaces within RSS profile.
+                      primary_key: name
+                      items:
+                        type: dict
+                        keys:
+                          name:
+                            type: str
+                            description: Interface name such as 'Ethernet2'.
+                            # pattern: "Ethernet[\\d/]+"
+                          rx_queue:
+                            type: dict
+                            description: Receive queue parameters for the selected interface.
+                            keys:
+                              count:
+                                type: int
+                                min: 1
+                                convert_types:
+                                  - str
+                                description: |-
+                                  Number of receive queues.
+                                  The maximum value is platform dependent.
+                              worker:
+                                type: str
+                                description: |-
+                                  Worker ids specified as combination of range and/or comma separated values
+                                  such as 0-4,7.
+                              mode:
+                                type: str
+                                description: Mode applicable to the workers. Default mode is 'shared'.
+                                valid_values:
+                                  - shared
+                                  - exclusive
+              interface_profile:
+                type: str
+                description: |-
+                  RSS interface profile name to apply for the platform.
+                  Needs system reload or Sfe agent restart for change to take effect.


### PR DESCRIPTION
Add eos_cli_config_gen schema support for Receive Side Scaling (RSS) interface profile

## Change Summary

Receive Side Scaling (RSS) interface profile schema to be later supported with jinja templates for generating EOS cli

## Related Issue(s)

Fixes #4983 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Modeling the Receive Side Scaling (RSS) interface profile schema for eos_cli_config_gen
The associated CLI is supported on select hardware platforms namely - 
models  AWE-5310 , AWE-7230R 
models AWE-5510, AWE-7250R 

There are two sets of CLI commands we need to target from schema perspective
1) Configuring one or more RSS profiles
2) Selecting one such profile for the system

**Configure one or more RSS profiles**

```
ind445(config)#
ind445(config)#platform sfe interface
ind445(config-platform-sfe-interface)#profile Test1
ind445(config-interface-profile-Test1)#interface Ethernet1/1
ind445(config-interface-profile-Test1-if-Et1/1)#rx-queue count 2
ind445(config-interface-profile-Test1-if-Et1/1)#rx-queue worker 3-4
ind445(config-interface-profile-Test1-if-Et1/1)#rx-queue mode shared
ind445(config-interface-profile-Test1-if-Et1/1)#exit
ind445(config-interface-profile-Test1)#interface Ethernet1/2
ind445(config-interface-profile-Test1-if-Et1/2)#rx-queue 1
% Invalid input
ind445(config-interface-profile-Test1-if-Et1/2)#rx-queue count 1
ind445(config-interface-profile-Test1-if-Et1/2)#rx-queue worker 5
ind445(config-interface-profile-Test1-if-Et1/2)#rx-queue mode exclusive
ind445(config-interface-profile-Test1-if-Et1/2)#exit
ind445(config-interface-profile-Test1)#interface ?
  Ethernet  Ethernet interface

ind445(config-interface-profile-Test1)#interface Ethernet1/1
ind445(config-interface-profile-Test1-if-Et1/1)#rx-queue ?
  count   Number of receive queues
  mode    Receive queues to worker affinity mode type
  worker  Assign receive queues to workers

ind445(config-interface-profile-Test1-if-Et1/1)#rx-queue count ?
  <1-16>  Number of receive queues

ind445(config-interface-profile-Test1-if-Et1/1)#rx-queue worker ?
  $       list end
  <0-15>  list of workers

ind445(config-interface-profile-Test1-if-Et1/1)#rx-queue worker 0-2,3,16
% Invalid input
ind445(config-interface-profile-Test1-if-Et1/1)#rx-queue worker 0-2,3,8
ind445(config-interface-profile-Test1-if-Et1/1)#rx-queue mode ?
  exclusive  workers will be exclusive
  shared     workers will be shared

ind445(config-interface-profile-Test1-if-Et1/1)#exit
ind445(config-interface-profile-Test1)#exit
ind445(config-platform-sfe-interface)#profile ?
  WORD  Interface profile name
```


Apply specific RSS profile for platform

```
ind445(config)#platform sfe interface
ind445(config-platform-sfe-interface)#?
  interface  Apply interface profile
  profile    Create interface profile
  ----------------------------------------
  comment    Up to 240 characters, comment for this mode
  default    Set a command to its defaults
  exit       Leave Interface configuration mode mode
  no         Disable the command that follows
  show       Display details of switch operation
  !!         Append to comment

ind445(config-platform-sfe-interface)#interface ?
  profile  profile

ind445(config-platform-sfe-interface)#interface profile ?
  WORD  Interface profile name

ind445(config-platform-sfe-interface)#interface profile Test1
ind445(config-platform-sfe-interface)#exit

Please save your config and **reload the system or restart Sfe agent for your changes to take effect.**
ind445(config)#
```

“show running-config” snippet  
```
platform sfe interface
   interface profile amsProf1
   !
   profile amsProf1
      interface Ethernet1/1
         rx-queue count 5
         rx-queue worker 1-3,6,9
      !
      interface Ethernet1/10
         rx-queue count 2
      !
      interface Ethernet1/16
   !
   profile amsProf2
      interface Ethernet1/2
      !
      interface Ethernet1/5
         rx-queue count 3
         rx-queue worker 5
         rx-queue mode exclusive
      !
      interface Ethernet1/6
   !
   profile amsProf3
      interface Ethernet1/8
         rx-queue count 2
         rx-queue worker 3-4
   !
   profile amsProf4
```


## How to test
Ensure the generated EOS cli for RSS interface profile can be pasted without any error on supported hardware platform model such as AWE-5310 or AWE-5510
Please note, this needs feature-toggle "SfeRssCaravan" to be enabled on EOS device running latest trunk image (Jan 31 2025) => need to check with the team which EOS release this toggle will be enabled.

<!--- Please describe in detail how you tested your changes. -->
Pasted generated EOS cli with interface RSS profiles on supported platform such as CouncilBlufff AWE-5310-F
and issued "show run" and "show platform sfe interface profile" to validate output.

<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
