### PR TITLE
Refactor(eos_designs): structured_config for network_services vlan_interfaces

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
@@ -3,11 +3,12 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
 
+from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
+from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 from pyavd._errors import AristaAvdInvalidInputsError
-from pyavd._utils import append_if_not_duplicate, default, get, strip_empties_from_dict
+from pyavd._utils import Undefined, default, get
 from pyavd.api.interface_descriptions import InterfaceDescriptionData
 
 if TYPE_CHECKING:
@@ -23,85 +24,65 @@ class VlanInterfacesMixin(Protocol):
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
 
-    @cached_property
-    def vlan_interfaces(self: AvdStructuredConfigNetworkServicesProtocol) -> list | None:
+    @structured_config_contributor
+    def vlan_interfaces(self: AvdStructuredConfigNetworkServicesProtocol) -> None:
         """
         Return structured config for vlan_interfaces.
 
         Consist of svis and mlag peering vlans from filtered tenants
         """
         if not (self.shared_utils.network_services_l2 and self.shared_utils.network_services_l3):
-            return None
+            return
 
-        vlan_interfaces = []
         for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant.vrfs:
                 for svi in vrf.svis:
-                    vlan_interface = self._get_vlan_interface_config_for_svi(svi, vrf)
-                    append_if_not_duplicate(
-                        list_of_dicts=vlan_interfaces,
-                        primary_key="name",
-                        new_dict=vlan_interface,
-                        context="VLAN Interfaces",
-                        context_keys=["name", "tenant"],
-                        ignore_keys={"tenant"},
-                    )
+                    self.structured_config.vlan_interfaces.append(self._get_vlan_interface_config_for_svi(svi, vrf), ignore_fields=("tenant",))
 
                 # MLAG IBGP Peering VLANs per VRF
                 # Continue to next VRF if mlag vlan_id is not set
                 if (vlan_id := self._mlag_ibgp_peering_vlan_vrf(vrf, tenant)) is None:
                     continue
 
-                vlan_interface = {"name": f"Vlan{vlan_id}", **self._get_vlan_interface_config_for_mlag_peering(vrf, vlan_id)}
-                append_if_not_duplicate(
-                    list_of_dicts=vlan_interfaces,
-                    primary_key="name",
-                    new_dict=vlan_interface,
-                    context="MLAG iBGP Peering VLAN Interfaces",
-                    context_keys=["name", "tenant"],
-                    ignore_keys={"tenant"},
-                )
+                self.structured_config.vlan_interfaces.append(self._get_vlan_interface_config_for_mlag_peering(vrf, vlan_id), ignore_fields=("tenant",))
 
-        if vlan_interfaces:
-            return vlan_interfaces
+    def _check_virtual_router_mac_address(
+        self: AvdStructuredConfigNetworkServicesProtocol, vlan_interface_config: EosCliConfigGen.VlanInterfacesItem, variables: tuple[str, ...]
+    ) -> None:
+        """
+        Error if virtual router mac address is required but missing.
 
-        return None
+        Check if any variable in the list of variables is not None in vlan_interface_config
+        and if it is the case, raise an Exception if virtual_router_mac_address is None.
+
+        NOTE: SVI settings are also used for subinterfaces for uplink_type: 'lan'.
+        So any changes here may also be needed in underlay.utils.UtilsMixin._get_l2_as_subint().
+        """
+        if any(vlan_interface_config._get(var) for var in variables) and self.shared_utils.node_config.virtual_router_mac_address is None:
+            quoted_vars = [f"'{var}'" for var in variables]
+            msg = f"'virtual_router_mac_address' must be set for node '{self.shared_utils.hostname}' when using {' or '.join(quoted_vars)} under 'svi'"
+            raise AristaAvdInvalidInputsError(msg)
 
     def _get_vlan_interface_config_for_svi(
         self: AvdStructuredConfigNetworkServicesProtocol,
         svi: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.SvisItem,
         vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem,
-    ) -> dict:
-        def _check_virtual_router_mac_address(vlan_interface_config: dict, variables: list) -> None:
-            """
-            Error if virtual router mac address is required but missing.
-
-            Check if any variable in the list of variables is not None in vlan_interface_config
-            and if it is the case, raise an Exception if virtual_router_mac_address is None.
-
-            NOTE: SVI settings are also used for subinterfaces for uplink_type: 'lan'.
-            So any changes here may also be needed in underlay.utils.UtilsMixin._get_l2_as_subint().
-            """
-            if any(vlan_interface_config.get(var) for var in variables) and self.shared_utils.node_config.virtual_router_mac_address is None:
-                quoted_vars = [f"'{var}'" for var in variables]
-                msg = f"'virtual_router_mac_address' must be set for node '{self.shared_utils.hostname}' when using {' or '.join(quoted_vars)} under 'svi'"
-                raise AristaAvdInvalidInputsError(msg)
-
+    ) -> EosCliConfigGen.VlanInterfacesItem:
         interface_name = f"Vlan{svi.id}"
-        vlan_interface_config = {
-            "name": interface_name,
-            "tenant": svi._tenant,
-            "tags": list(svi._get("tags", [])) or None,  # Historic behavior is to not output the default ["all"]
-            "description": default(svi.description, svi.name),
-            "shutdown": not default(svi.enabled, False),  # noqa: FBT003
-            "ip_address": svi.ip_address,
-            "ipv6_address": svi.ipv6_address,
-            "ipv6_enable": svi.ipv6_enable,
-            "access_group_in": get(self._svi_acls, f"{interface_name}.ipv4_acl_in.name"),
-            "access_group_out": get(self._svi_acls, f"{interface_name}.ipv4_acl_out.name"),
-            "mtu": svi.mtu if self.shared_utils.platform_settings.feature_support.per_interface_mtu else None,
-            "eos_cli": svi.raw_eos_cli,
-        }
+        vlan_interface_config = EosCliConfigGen.VlanInterfacesItem(
+            name=interface_name,
+            tenant=svi._tenant,
+            tags=EosCliConfigGen.VlanInterfacesItem.Tags(svi._get("tags", [])),  # Historic behavior is to not output the default ["all"]
+            description=default(svi.description, svi.name),
+            shutdown=not default(svi.enabled, False),  # noqa: FBT003
+            ip_address=svi.ip_address,
+            ipv6_address=svi.ipv6_address,
+            ipv6_enable=svi.ipv6_enable,
+            access_group_in=get(self._svi_acls, f"{interface_name}.ipv4_acl_in.name"),
+            access_group_out=get(self._svi_acls, f"{interface_name}.ipv4_acl_out.name"),
+            mtu=svi.mtu if self.shared_utils.platform_settings.feature_support.per_interface_mtu else None,
+            eos_cli=svi.raw_eos_cli,
+        )
 
         if svi.structured_config:
             self.custom_structured_configs.nested.vlan_interfaces.obtain(interface_name)._deepmerge(
@@ -109,74 +90,73 @@ class VlanInterfacesMixin(Protocol):
             )
 
         # Only set VARP if ip_address is set
-        if vlan_interface_config["ip_address"] is not None:
-            vlan_interface_config["ip_virtual_router_addresses"] = svi.ip_virtual_router_addresses._as_list() or None
-            _check_virtual_router_mac_address(vlan_interface_config, ["ip_virtual_router_addresses"])
+        if vlan_interface_config.ip_address:
+            vlan_interface_config.ip_virtual_router_addresses.extend(svi.ip_virtual_router_addresses)
+            self._check_virtual_router_mac_address(vlan_interface_config, ("ip_virtual_router_addresses",))
 
         # Only set Anycast GW if VARP is not set
-        if vlan_interface_config.get("ip_virtual_router_addresses") is None:
-            vlan_interface_config["ip_address_virtual"] = svi.ip_address_virtual
-            vlan_interface_config["ip_address_virtual_secondaries"] = svi.ip_address_virtual_secondaries._as_list() or None
-            _check_virtual_router_mac_address(vlan_interface_config, ["ip_address_virtual", "ip_address_virtual_secondaries"])
+        if not vlan_interface_config.ip_virtual_router_addresses:
+            vlan_interface_config.ip_address_virtual = svi.ip_address_virtual
+            vlan_interface_config.ip_address_virtual_secondaries.extend(svi.ip_address_virtual_secondaries)
+            self._check_virtual_router_mac_address(vlan_interface_config, ("ip_address_virtual", "ip_address_virtual_secondaries"))
 
-        pim_config_ipv4 = {}
         if default(svi.evpn_l3_multicast.enabled, getattr(vrf, "_evpn_l3_multicast_enabled", False)) is True:
             if self.shared_utils.mlag:
-                pim_config_ipv4["sparse_mode"] = True
+                vlan_interface_config.pim.ipv4.sparse_mode = True
             else:
-                vlan_interface_config["ip_igmp"] = True
+                vlan_interface_config.ip_igmp = True
 
-            if "ip_address_virtual" in vlan_interface_config:
+            if (
+                vlan_interface_config._get_defined_attr("ip_address_virtual") is not Undefined
+            ):  # Historic behavior of checking for mere presence of the key. TODO: Fix this but it is breaking.
                 if (vrf_diagnostic_loopback := vrf.vtep_diagnostic.loopback) is None:
                     msg = (
                         f"No vtep_diagnostic loopback defined on VRF '{vrf.name}' in Tenant '{svi._tenant}'."
                         "This is required when 'l3_multicast' is enabled on the VRF and ip_address_virtual is used on an SVI in that VRF."
                     )
                     raise AristaAvdInvalidInputsError(msg)
-                pim_config_ipv4["local_interface"] = f"Loopback{vrf_diagnostic_loopback}"
-
-            if pim_config_ipv4:
-                vlan_interface_config["pim"] = {"ipv4": pim_config_ipv4}
+                vlan_interface_config.pim.ipv4.local_interface = f"Loopback{vrf_diagnostic_loopback}"
 
         # Only set VARPv6 if ipv6_address is set or ipv6_enable is set to true
-        if vlan_interface_config["ipv6_address"] is not None or vlan_interface_config["ipv6_enable"]:
-            vlan_interface_config["ipv6_virtual_router_addresses"] = svi.ipv6_virtual_router_addresses._as_list() or None
-            _check_virtual_router_mac_address(vlan_interface_config, ["ipv6_virtual_router_addresses"])
+        if vlan_interface_config.ipv6_address or vlan_interface_config.ipv6_enable:
+            vlan_interface_config.ipv6_virtual_router_addresses.extend(svi.ipv6_virtual_router_addresses)
+            self._check_virtual_router_mac_address(vlan_interface_config, ("ipv6_virtual_router_addresses",))
 
         # Only set Anycast v6 GW if VARPv6 is not set
-        if vlan_interface_config.get("ipv6_virtual_router_addresses") is None:
+        if not vlan_interface_config.ipv6_virtual_router_addresses:
             if svi.ipv6_address_virtuals:
-                vlan_interface_config["ipv6_address_virtuals"] = svi.ipv6_address_virtuals._as_list()
+                vlan_interface_config.ipv6_address_virtuals.extend(svi.ipv6_address_virtuals)
 
-            _check_virtual_router_mac_address(vlan_interface_config, ["ipv6_address_virtuals"])
+            self._check_virtual_router_mac_address(vlan_interface_config, ("ipv6_address_virtuals",))
 
-            if vlan_interface_config.get("ipv6_address_virtuals"):
+            if vlan_interface_config.ipv6_address_virtuals:
                 # If any anycast IPs are set, we also enable link-local IPv6 per best practice, unless specifically disabled with 'ipv6_enable: false'
-                vlan_interface_config["ipv6_enable"] = get(vlan_interface_config, "ipv6_enable", default=True)
+                vlan_interface_config.ipv6_enable = default(vlan_interface_config.ipv6_enable, True)  # noqa: FBT003
 
         if vrf.name != "default":
-            vlan_interface_config["vrf"] = vrf.name
+            vlan_interface_config.vrf = vrf.name
 
         # Adding IP helpers and OSPF via a common function also used for subinterfaces when uplink_type: lan
         self.shared_utils.get_additional_svi_config(vlan_interface_config, svi, vrf)
 
-        return strip_empties_from_dict(vlan_interface_config)
+        return vlan_interface_config
 
     def _get_vlan_interface_config_for_mlag_peering(
         self: AvdStructuredConfigNetworkServicesProtocol, vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem, vlan_id: int
-    ) -> dict:
+    ) -> EosCliConfigGen.VlanInterfacesItem:
         """Build full config for MLAG peering SVI for the given VRF."""
-        vlan_interface_config = {
-            "tenant": vrf._tenant,
-            "type": "underlay_peering",
-            "shutdown": False,
-            "description": self.shared_utils.interface_descriptions.mlag_peer_l3_vrf_svi(
+        vlan_interface_config = EosCliConfigGen.VlanInterfacesItem(
+            name=f"Vlan{vlan_id}",
+            tenant=vrf._tenant,
+            type="underlay_peering",
+            shutdown=False,
+            description=self.shared_utils.interface_descriptions.mlag_peer_l3_vrf_svi(
                 InterfaceDescriptionData(shared_utils=self.shared_utils, interface=f"Vlan{vlan_id}", vrf=vrf.name, vlan=vlan_id)
             ),
-            "vrf": vrf.name,
-            "mtu": self.shared_utils.p2p_uplinks_mtu,
-        }
-        vlan_interface_config.update(self._get_vlan_ip_config_for_mlag_peering(vrf))
+            vrf=vrf.name,
+            mtu=self.shared_utils.p2p_uplinks_mtu,
+        )
+        vlan_interface_config._update(**self._get_vlan_ip_config_for_mlag_peering(vrf))
         return vlan_interface_config
 
     def _get_vlan_ip_config_for_mlag_peering(
@@ -186,6 +166,8 @@ class VlanInterfacesMixin(Protocol):
         Build IP config for MLAG peering SVI for the given VRF.
 
         Called from _get_vlan_interface_config_for_mlag_peering and prefix_lists.
+
+        TODO: Refactor to update the input in-place
         """
         if self.inputs.underlay_rfc5549 and self.inputs.overlay_mlag_rfc5549:
             return {"ipv6_enable": True}

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/utils.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._errors import AristaAvdError, AristaAvdMissingVariableError
-from pyavd._utils import default, get, get_ip_from_ip_prefix, get_item, strip_empties_from_dict
+from pyavd._utils import Undefined, default, get, get_ip_from_ip_prefix, get_item, strip_empties_from_dict
 from pyavd.api.interface_descriptions import InterfaceDescriptionData
 from pyavd.j2filters import natural_sort, range_expand
 
@@ -229,7 +229,7 @@ class UtilsMixin(Protocol):
                     if svi.id not in vlans:
                         continue
 
-                    interfaces.append(self._get_l2_as_subint(link, svi, vrf))
+                    interfaces.append(self._get_l2_as_subint(link, svi, vrf)._as_dict())
 
         # If we have the main interface covered, we can just exclude it from the list and return as main interface.
         # Otherwise we return an almost empty dict as the main interface since it was already covered by the calling function.
@@ -250,7 +250,7 @@ class UtilsMixin(Protocol):
         link: dict,
         svi: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.SvisItem,
         vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem,
-    ) -> dict:
+    ) -> EosCliConfigGen.EthernetInterfacesItem:
         """
         Return structured config for one subinterface representing the given SVI.
 
@@ -258,23 +258,26 @@ class UtilsMixin(Protocol):
         """
         is_native = svi.id == link.get("native_vlan")
         interface_name = link["interface"] if is_native else f"{link['interface']}.{svi.id}"
-        subinterface = {
-            "name": interface_name,
-            "peer": link["peer"],
-            "peer_interface": f"{link['peer_interface']} VLAN {svi.id}",
-            "peer_type": link["peer_type"],
-            "description": default(svi.description, svi.name),
-            "shutdown": not default(svi.enabled, False),  # noqa: FBT003
-            "switchport": {"enabled": False if is_native else None},
-            "encapsulation_dot1q": {"vlan": None if is_native else svi.id},
-            "vrf": vrf.name if vrf.name != "default" else None,
-            "ip_address": svi.ip_address,
-            "ipv6_address": svi.ipv6_address,
-            "ipv6_enable": svi.ipv6_enable,
-            "mtu": svi.mtu if self.shared_utils.platform_settings.feature_support.per_interface_mtu else None,
-            "eos_cli": svi.raw_eos_cli,
-            "flow_tracker": link.get("flow_tracker"),
-        }
+        subinterface = EosCliConfigGen.EthernetInterfacesItem(
+            name=interface_name,
+            peer=link["peer"],
+            peer_interface=f"{link['peer_interface']} VLAN {svi.id}",
+            peer_type=link["peer_type"],
+            description=default(svi.description, svi.name),
+            shutdown=not default(svi.enabled, False),  # noqa: FBT003
+            switchport=EosCliConfigGen.EthernetInterfacesItem.Switchport(enabled=False) if is_native else Undefined,
+            encapsulation_dot1q=EosCliConfigGen.EthernetInterfacesItem.EncapsulationDot1q(vlan=svi.id) if not is_native else Undefined,
+            vrf=vrf.name if vrf.name != "default" else None,
+            ip_address=svi.ip_address,
+            ipv6_address=svi.ipv6_address,
+            ipv6_enable=svi.ipv6_enable,
+            mtu=svi.mtu if self.shared_utils.platform_settings.feature_support.per_interface_mtu else None,
+            eos_cli=svi.raw_eos_cli,
+        )
+
+        if flowtracker := link.get("flow_tracker"):
+            ## TODO: When link has been refactored to a class this should be changed.
+            subinterface.flow_tracker._update(**flowtracker)
 
         if svi.structured_config:
             self.custom_structured_configs.nested.ethernet_interfaces.obtain(interface_name)._deepmerge(
@@ -282,28 +285,28 @@ class UtilsMixin(Protocol):
                 list_merge=self.custom_structured_configs.list_merge_strategy,
             )
 
-        if (mtu := subinterface["mtu"]) is not None and subinterface["mtu"] > self.shared_utils.p2p_uplinks_mtu:
+        if subinterface.mtu and self.shared_utils.p2p_uplinks_mtu and subinterface.mtu > self.shared_utils.p2p_uplinks_mtu:
             msg = (
-                f"MTU '{self.shared_utils.p2p_uplinks_mtu}' set for 'p2p_uplinks_mtu' must be larger or equal to MTU '{mtu}' "
+                f"MTU '{self.shared_utils.p2p_uplinks_mtu}' set for 'p2p_uplinks_mtu' must be larger or equal to MTU '{subinterface.mtu}' "
                 f"set on the SVI '{svi.id}'."
                 "Either adjust the MTU on the SVI or p2p_uplinks_mtu."
             )
             raise AristaAvdError(msg)
 
         # Only set VRRPv4 if ip_address is set
-        if subinterface["ip_address"] is not None:
+        if subinterface.ip_address:
             # TODO: in separate PR adding VRRP support for SVIs
             pass
 
         # Only set VRRPv6 if ipv6_address is set
-        if subinterface["ipv6_address"] is not None:
+        if subinterface.ipv6_address:
             # TODO: in separate PR adding VRRP support for SVIs
             pass
 
         # Adding IP helpers and OSPF via a common function also used for SVIs on L3 switches.
         self.shared_utils.get_additional_svi_config(subinterface, svi, vrf)
 
-        return strip_empties_from_dict(subinterface)
+        return subinterface
 
     @cached_property
     def _l3_interface_acls(self: AvdStructuredConfigUnderlayProtocol) -> dict[str, dict[str, dict]]:

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/utils.py
@@ -276,7 +276,7 @@ class UtilsMixin(Protocol):
         )
 
         if flowtracker := link.get("flow_tracker"):
-            ## TODO: When link has been refactored to a class this should be changed.
+            # TODO: When link has been refactored to a class this should be changed.
             subinterface.flow_tracker._update(**flowtracker)
 
         if svi.structured_config:

--- a/python-avd/pyavd/_schema/models/avd_model.py
+++ b/python-avd/pyavd/_schema/models/avd_model.py
@@ -410,10 +410,16 @@ class AvdModel(AvdBase):
             if field in ignore_fields:
                 continue
 
-            if (value := self._get_defined_attr(field)) == (other_value := other._get_defined_attr(field)) or value is Undefined:
+            if (value := self._get_defined_attr(field)) == (other_value := other._get_defined_attr(field)) or (
+                value in (Undefined, None) and other_value in (Undefined, None)
+            ):
                 continue
 
             field_type = field_info["type"]
+
+            if issubclass(field_type, AvdBase) and not value and not other_value:
+                # Ignore empty lists or classes since they could have been initialized in the code but they would be trimmed from the output.
+                continue
 
             # TODO: Handle deep comparison for lists and indexed lists as well.
             if not issubclass(field_type, AvdModel) or not isinstance(other_value, field_type):


### PR DESCRIPTION
Depends on #4955, otherwise negative tests will fail (because of execution reordering of refactored classes)

Refactor eos_designs structured_config for network_services vlan_interfaces to use output classes