### PR TITLE
Refactor(eos_designs): structured_config for standard_access_list under network services and underlay

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/standard_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/standard_access_lists.py
@@ -37,6 +37,5 @@ class StandardAccessListsMixin(Protocol):
 
                     standard_access_list = EosCliConfigGen.StandardAccessListsItem(name=rp_entry.access_list_name)
                     for index, group in enumerate(rp_entry.groups, 1):
-                        sequence_number = EosCliConfigGen.StandardAccessListsItem.SequenceNumbersItem(sequence=(index) * 10, action=f"permit {group}")
-                        standard_access_list.sequence_numbers.append(sequence_number)
+                        standard_access_list.sequence_numbers.append_new(sequence=(index) * 10, action=f"permit {group}")
                     self.structured_config.standard_access_lists.append(standard_access_list)

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/standard_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/standard_access_lists.py
@@ -3,10 +3,10 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
 
-from pyavd._utils import append_if_not_duplicate
+from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
+from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigNetworkServicesProtocol
@@ -19,43 +19,24 @@ class StandardAccessListsMixin(Protocol):
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
 
-    @cached_property
-    def standard_access_lists(self: AvdStructuredConfigNetworkServicesProtocol) -> list | None:
+    @structured_config_contributor
+    def standard_access_lists(self: AvdStructuredConfigNetworkServicesProtocol) -> None:
         """
         Return structured config for standard_access_lists.
 
         Used for to configure ACLs used by multicast RPs in each VRF
         """
         if not self.shared_utils.network_services_l3:
-            return None
+            return
 
-        standard_access_lists = []
         for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant.vrfs:
                 for rp_entry in vrf.pim_rp_addresses or tenant.pim_rp_addresses:
                     if (rp_entry.nodes and self.shared_utils.hostname not in rp_entry.nodes) or not rp_entry.groups or not rp_entry.access_list_name:
                         continue
 
-                    standard_access_list = {
-                        "name": rp_entry.access_list_name,
-                        "sequence_numbers": [
-                            {
-                                "sequence": (index) * 10,
-                                "action": f"permit {group}",
-                            }
-                            for index, group in enumerate(rp_entry.groups, 1)
-                        ],
-                    }
-
-                    append_if_not_duplicate(
-                        list_of_dicts=standard_access_lists,
-                        primary_key="name",
-                        new_dict=standard_access_list,
-                        context="PIM RP Address ACL for VRFs",
-                        context_keys=["name"],
-                    )
-
-        if standard_access_lists:
-            return standard_access_lists
-
-        return None
+                    standard_access_list = EosCliConfigGen.StandardAccessListsItem(name=rp_entry.access_list_name)
+                    for index, group in enumerate(rp_entry.groups, 1):
+                        sequence_number = EosCliConfigGen.StandardAccessListsItem.SequenceNumbersItem(sequence=(index) * 10, action=f"permit {group}")
+                        standard_access_list.sequence_numbers.append(sequence_number)
+                    self.structured_config.standard_access_lists.append(standard_access_list)

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/standard_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/standard_access_lists.py
@@ -3,8 +3,10 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
+
+from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
+from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigUnderlayProtocol
@@ -17,35 +19,21 @@ class StandardAccessListsMixin(Protocol):
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
 
-    @cached_property
-    def standard_access_lists(self: AvdStructuredConfigUnderlayProtocol) -> list | None:
+    @structured_config_contributor
+    def standard_access_lists(self: AvdStructuredConfigUnderlayProtocol) -> None:
         """
         Return structured config for standard_access_lists.
 
         Used for to configure ACLs used by multicast RPs for the underlay
         """
         if not self.shared_utils.underlay_multicast or not self.inputs.underlay_multicast_rps:
-            return None
+            return
 
-        standard_access_lists = []
         for rp_entry in self.inputs.underlay_multicast_rps:
             if not rp_entry.groups or not rp_entry.access_list_name:
                 continue
-
-            standard_access_lists.append(
-                {
-                    "name": rp_entry.access_list_name,
-                    "sequence_numbers": [
-                        {
-                            "sequence": (index + 1) * 10,
-                            "action": f"permit {group}",
-                        }
-                        for index, group in enumerate(rp_entry.groups)
-                    ],
-                },
-            )
-
-        if standard_access_lists:
-            return standard_access_lists
-
-        return None
+            standard_access_list = EosCliConfigGen.StandardAccessListsItem(name=rp_entry.access_list_name)
+            for index, group in enumerate(rp_entry.groups):
+                sequence_number = EosCliConfigGen.StandardAccessListsItem.SequenceNumbersItem(sequence=(index + 1) * 10, action=f"permit {group}")
+                standard_access_list.sequence_numbers.append(sequence_number)
+            self.structured_config.standard_access_lists.append(standard_access_list)

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/standard_access_lists.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/standard_access_lists.py
@@ -34,6 +34,5 @@ class StandardAccessListsMixin(Protocol):
                 continue
             standard_access_list = EosCliConfigGen.StandardAccessListsItem(name=rp_entry.access_list_name)
             for index, group in enumerate(rp_entry.groups):
-                sequence_number = EosCliConfigGen.StandardAccessListsItem.SequenceNumbersItem(sequence=(index + 1) * 10, action=f"permit {group}")
-                standard_access_list.sequence_numbers.append(sequence_number)
+                standard_access_list.sequence_numbers.append_new(sequence=(index + 1) * 10, action=f"permit {group}")
             self.structured_config.standard_access_lists.append(standard_access_list)


### PR DESCRIPTION

## Change Summary

Refactor(eos_designs): structured_config for standard_access_list under network services and underlay

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Refactor(eos_designs): structured_config for standard_access_list under network services and underlay

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
