### PR TITLE
Refactor(eos_designs): structured_config for underlay mpls

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/mpls.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/mpls.py
@@ -26,7 +26,9 @@ class MplsMixin(Protocol):
 
         self.structured_config.mpls.ip = True
         if self.shared_utils.underlay_ldp is True:
-            self.structured_config.mpls.ldp._update(interface_disabled_default=True,
-            router_id=self.shared_utils.router_id if not self.inputs.use_router_general_for_router_id else None,
-            shutdown=False,
-            transport_address_interface="Loopback0")
+            self.structured_config.mpls.ldp._update(
+                interface_disabled_default=True,
+                router_id=self.shared_utils.router_id if not self.inputs.use_router_general_for_router_id else None,
+                shutdown=False,
+                transport_address_interface="Loopback0",
+            )

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/mpls.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/mpls.py
@@ -26,7 +26,7 @@ class MplsMixin(Protocol):
 
         self.structured_config.mpls.ip = True
         if self.shared_utils.underlay_ldp is True:
-            self.structured_config.mpls.ldp.interface_disabled_default = True
-            self.structured_config.mpls.ldp.router_id = self.shared_utils.router_id if not self.inputs.use_router_general_for_router_id else None
-            self.structured_config.mpls.ldp.shutdown = False
-            self.structured_config.mpls.ldp.transport_address_interface = "Loopback0"
+            self.structured_config.mpls.ldp._update(interface_disabled_default=True,
+            router_id=self.shared_utils.router_id if not self.inputs.use_router_general_for_router_id else None,
+            shutdown=False,
+            transport_address_interface="Loopback0")

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/mpls.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/mpls.py
@@ -3,10 +3,9 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
 
-from pyavd._utils import strip_empties_from_dict
+from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigUnderlayProtocol
@@ -19,23 +18,15 @@ class MplsMixin(Protocol):
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
 
-    @cached_property
-    def mpls(self: AvdStructuredConfigUnderlayProtocol) -> dict | None:
+    @structured_config_contributor
+    def mpls(self: AvdStructuredConfigUnderlayProtocol) -> None:
         """Return structured config for mpls."""
         if self.shared_utils.underlay_mpls is not True:
-            return None
+            return
 
+        self.structured_config.mpls.ip = True
         if self.shared_utils.underlay_ldp is True:
-            return strip_empties_from_dict(
-                {
-                    "ip": True,
-                    "ldp": {
-                        "interface_disabled_default": True,
-                        "router_id": self.shared_utils.router_id if not self.inputs.use_router_general_for_router_id else None,
-                        "shutdown": False,
-                        "transport_address_interface": "Loopback0",
-                    },
-                }
-            )
-
-        return {"ip": True}
+            self.structured_config.mpls.ldp.interface_disabled_default = True
+            self.structured_config.mpls.ldp.router_id = self.shared_utils.router_id if not self.inputs.use_router_general_for_router_id else None
+            self.structured_config.mpls.ldp.shutdown = False
+            self.structured_config.mpls.ldp.transport_address_interface = "Loopback0"


### PR DESCRIPTION
## Change Summary

Refactor eos_designs structured_config code for underlay mpls

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Refactor eos_designs structured_config code for underlay mpls to use classes

## How to test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
