### PR TITLE
Fix(eos_cli_config_gen): Fix the errdisable documentation J2 expects recovery.interval to be always set

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11612,24 +11612,26 @@ ip nat synchronization
 | xcvr-overheat | True |
 | xcvr-power-unsupported | True |
 
-|  Detect Cause | Enabled | Interval |
-| ------------- | ------- | -------- |
-| arp-inspection | True | 300 |
-| bpduguard | True | 300 |
-| dot1x | True | 300 |
-| hitless-reload-down | True | 300 |
-| lacp-rate-limit | True | 300 |
-| link-flap | True | 300 |
-| no-internal-vlan | True | 300 |
-| portchannelguard | True | 300 |
-| portsec | True | 300 |
-| speed-misconfigured | True | 300 |
-| tapagg | True | 300 |
-| uplink-failure-detection | True | 300 |
-| xcvr-misconfigured | True | 300 |
-| xcvr-overheat | True | 300 |
-| xcvr-power-unsupported | True | 300 |
-| xcvr-unsupported | True | 300 |
+|  Detect Cause | Enabled |
+| ------------- | ------- |
+| arp-inspection | True |
+| bpduguard | True |
+| dot1x | True |
+| hitless-reload-down | True |
+| lacp-rate-limit | True |
+| link-flap | True |
+| no-internal-vlan | True |
+| portchannelguard | True |
+| portsec | True |
+| speed-misconfigured | True |
+| tapagg | True |
+| uplink-failure-detection | True |
+| xcvr-misconfigured | True |
+| xcvr-overheat | True |
+| xcvr-power-unsupported | True |
+| xcvr-unsupported | True |
+
+Errdisable recovery timer interval: 300
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11631,7 +11631,7 @@ ip nat synchronization
 | xcvr-power-unsupported | True |
 | xcvr-unsupported | True |
 
-Errdisable recovery timer interval: 300
+Errdisable recovery timer interval: 300 seconds
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11601,8 +11601,10 @@ ip nat synchronization
 
 ### Errdisable Summary
 
-|  Detect Cause | Detection Enabled | Recovery Enabled |
-| ------------- | ----------------- | ---------------- |
+Errdisable recovery timer interval: 300 seconds
+
+|  Cause | Detection Enabled | Recovery Enabled |
+| ------ | ----------------- | ---------------- |
 | acl | True | False |
 | arp-inspection | True | True |
 | bpduguard | - | True |
@@ -11621,8 +11623,6 @@ ip nat synchronization
 | xcvr-overheat | True | True |
 | xcvr-power-unsupported | True | True |
 | xcvr-unsupported | - | True |
-
-Errdisable recovery timer interval: 300 seconds
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11601,6 +11601,8 @@ ip nat synchronization
 
 ### Errdisable Summary
 
+Errdisable recovery timer interval: 300 seconds
+
 |  Detect Cause | Enabled |
 | ------------- | ------- |
 | acl | True |
@@ -11630,8 +11632,6 @@ ip nat synchronization
 | xcvr-overheat | True |
 | xcvr-power-unsupported | True |
 | xcvr-unsupported | True |
-
-Errdisable recovery timer interval: 300 seconds
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11605,13 +11605,13 @@ Errdisable recovery timer interval: 300 seconds
 
 |  Cause | Detection Enabled | Recovery Enabled |
 | ------ | ----------------- | ---------------- |
-| acl | True | False |
+| acl | True | - |
 | arp-inspection | True | True |
 | bpduguard | - | True |
 | dot1x | True | True |
 | hitless-reload-down | - | True |
 | lacp-rate-limit | - | True |
-| link-change | True | False |
+| link-change | True | - |
 | link-flap | - | True |
 | no-internal-vlan | - | True |
 | portchannelguard | - | True |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11601,37 +11601,28 @@ ip nat synchronization
 
 ### Errdisable Summary
 
+|  Detect Cause | Detection Enabled | Recovery Enabled |
+| ------------- | ----------------- | ---------------- |
+| acl | True | False |
+| arp-inspection | True | True |
+| bpduguard | False | True |
+| dot1x | True | True |
+| hitless-reload-down | False | True |
+| lacp-rate-limit | False | True |
+| link-change | True | False |
+| link-flap | False | True |
+| no-internal-vlan | False | True |
+| portchannelguard | False | True |
+| portsec | False | True |
+| speed-misconfigured | False | True |
+| tapagg | True | True |
+| uplink-failure-detection | False | True |
+| xcvr-misconfigured | True | True |
+| xcvr-overheat | True | True |
+| xcvr-power-unsupported | True | True |
+| xcvr-unsupported | False | True |
+
 Errdisable recovery timer interval: 300 seconds
-
-|  Detect Cause | Enabled |
-| ------------- | ------- |
-| acl | True |
-| arp-inspection | True |
-| dot1x | True |
-| link-change | True |
-| tapagg | True |
-| xcvr-misconfigured | True |
-| xcvr-overheat | True |
-| xcvr-power-unsupported | True |
-
-|  Detect Cause | Enabled |
-| ------------- | ------- |
-| arp-inspection | True |
-| bpduguard | True |
-| dot1x | True |
-| hitless-reload-down | True |
-| lacp-rate-limit | True |
-| link-flap | True |
-| no-internal-vlan | True |
-| portchannelguard | True |
-| portsec | True |
-| speed-misconfigured | True |
-| tapagg | True |
-| uplink-failure-detection | True |
-| xcvr-misconfigured | True |
-| xcvr-overheat | True |
-| xcvr-power-unsupported | True |
-| xcvr-unsupported | True |
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11605,22 +11605,22 @@ ip nat synchronization
 | ------------- | ----------------- | ---------------- |
 | acl | True | False |
 | arp-inspection | True | True |
-| bpduguard | False | True |
+| bpduguard | - | True |
 | dot1x | True | True |
-| hitless-reload-down | False | True |
-| lacp-rate-limit | False | True |
+| hitless-reload-down | - | True |
+| lacp-rate-limit | - | True |
 | link-change | True | False |
-| link-flap | False | True |
-| no-internal-vlan | False | True |
-| portchannelguard | False | True |
-| portsec | False | True |
-| speed-misconfigured | False | True |
+| link-flap | - | True |
+| no-internal-vlan | - | True |
+| portchannelguard | - | True |
+| portsec | - | True |
+| speed-misconfigured | - | True |
 | tapagg | True | True |
-| uplink-failure-detection | False | True |
+| uplink-failure-detection | - | True |
 | xcvr-misconfigured | True | True |
 | xcvr-overheat | True | True |
 | xcvr-power-unsupported | True | True |
-| xcvr-unsupported | False | True |
+| xcvr-unsupported | - | True |
 
 Errdisable recovery timer interval: 300 seconds
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1508,17 +1508,27 @@ ip nat synchronization
 | ------------- | ------- |
 | arp-inspection | True |
 | bpduguard | True |
-| xcvr-overheat | True |
-| xcvr-power-unsupported | True |
-| xcvr-unsupported | True |
+| hitless-reload-down | True |
+| lacp-rate-limit | True |
+| link-flap | True |
+| no-internal-vlan | True |
+| portchannelguard | True |
+| portsec | True |
+| tapagg | True |
+| uplink-failure-detection | True |
 
 ```eos
 !
 errdisable recovery cause arp-inspection
 errdisable recovery cause bpduguard
-errdisable recovery cause xcvr-overheat
-errdisable recovery cause xcvr-power-unsupported
-errdisable recovery cause xcvr-unsupported
+errdisable recovery cause hitless-reload-down
+errdisable recovery cause lacp-rate-limit
+errdisable recovery cause link-flap
+errdisable recovery cause no-internal-vlan
+errdisable recovery cause portchannelguard
+errdisable recovery cause portsec
+errdisable recovery cause tapagg
+errdisable recovery cause uplink-failure-detection
 ```
 
 ## MACsec

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1506,16 +1506,16 @@ ip nat synchronization
 
 |  Detect Cause | Detection Enabled | Recovery Enabled |
 | ------------- | ----------------- | ---------------- |
-| arp-inspection | False | True |
-| bpduguard | False | True |
-| hitless-reload-down | False | True |
-| lacp-rate-limit | False | True |
-| link-flap | False | True |
-| no-internal-vlan | False | True |
-| portchannelguard | False | True |
-| portsec | False | True |
-| tapagg | False | True |
-| uplink-failure-detection | False | True |
+| arp-inspection | - | True |
+| bpduguard | - | True |
+| hitless-reload-down | - | True |
+| lacp-rate-limit | - | True |
+| link-flap | - | True |
+| no-internal-vlan | - | True |
+| portchannelguard | - | True |
+| portsec | - | True |
+| tapagg | - | True |
+| uplink-failure-detection | - | True |
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -111,6 +111,8 @@
   - [IP DHCP Snooping Device Configuration](#ip-dhcp-snooping-device-configuration)
 - [IP NAT](#ip-nat)
   - [IP NAT Device Configuration](#ip-nat-device-configuration)
+- [Errdisable](#errdisable)
+  - [Errdisable Summary](#errdisable-summary)
 - [MACsec](#macsec)
   - [MACsec Summary](#macsec-summary)
   - [MACsec Device Configuration](#macsec-device-configuration)
@@ -1496,6 +1498,27 @@ ip dhcp snooping
 !
 !
 ip nat synchronization
+```
+
+## Errdisable
+
+### Errdisable Summary
+
+|  Detect Cause | Enabled | Interval |
+| ------------- | ------- | -------- |
+| arp-inspection | True | - |
+| bpduguard | True | - |
+| xcvr-overheat | True | - |
+| xcvr-power-unsupported | True | - |
+| xcvr-unsupported | True | - |
+
+```eos
+!
+errdisable recovery cause arp-inspection
+errdisable recovery cause bpduguard
+errdisable recovery cause xcvr-overheat
+errdisable recovery cause xcvr-power-unsupported
+errdisable recovery cause xcvr-unsupported
 ```
 
 ## MACsec

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1504,8 +1504,8 @@ ip nat synchronization
 
 ### Errdisable Summary
 
-|  Detect Cause | Detection Enabled | Recovery Enabled |
-| ------------- | ----------------- | ---------------- |
+|  Cause | Detection Enabled | Recovery Enabled |
+| ------ | ----------------- | ---------------- |
 | arp-inspection | - | True |
 | bpduguard | - | True |
 | hitless-reload-down | - | True |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1504,13 +1504,13 @@ ip nat synchronization
 
 ### Errdisable Summary
 
-|  Detect Cause | Enabled | Interval |
-| ------------- | ------- | -------- |
-| arp-inspection | True | - |
-| bpduguard | True | - |
-| xcvr-overheat | True | - |
-| xcvr-power-unsupported | True | - |
-| xcvr-unsupported | True | - |
+|  Detect Cause | Enabled |
+| ------------- | ------- |
+| arp-inspection | True |
+| bpduguard | True |
+| xcvr-overheat | True |
+| xcvr-power-unsupported | True |
+| xcvr-unsupported | True |
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1504,18 +1504,18 @@ ip nat synchronization
 
 ### Errdisable Summary
 
-|  Detect Cause | Enabled |
-| ------------- | ------- |
-| arp-inspection | True |
-| bpduguard | True |
-| hitless-reload-down | True |
-| lacp-rate-limit | True |
-| link-flap | True |
-| no-internal-vlan | True |
-| portchannelguard | True |
-| portsec | True |
-| tapagg | True |
-| uplink-failure-detection | True |
+|  Detect Cause | Detection Enabled | Recovery Enabled |
+| ------------- | ----------------- | ---------------- |
+| arp-inspection | False | True |
+| bpduguard | False | True |
+| hitless-reload-down | False | True |
+| lacp-rate-limit | False | True |
+| link-flap | False | True |
+| no-internal-vlan | False | True |
+| portchannelguard | False | True |
+| portsec | False | True |
+| tapagg | False | True |
+| uplink-failure-detection | False | True |
 
 ```eos
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
@@ -22,9 +22,14 @@ switchport default mode routed
 !
 errdisable recovery cause arp-inspection
 errdisable recovery cause bpduguard
-errdisable recovery cause xcvr-overheat
-errdisable recovery cause xcvr-power-unsupported
-errdisable recovery cause xcvr-unsupported
+errdisable recovery cause hitless-reload-down
+errdisable recovery cause lacp-rate-limit
+errdisable recovery cause link-flap
+errdisable recovery cause no-internal-vlan
+errdisable recovery cause portchannelguard
+errdisable recovery cause portsec
+errdisable recovery cause tapagg
+errdisable recovery cause uplink-failure-detection
 !
 flow tracking sampled
    sample 666

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
@@ -20,6 +20,12 @@ ip dhcp snooping
 !
 switchport default mode routed
 !
+errdisable recovery cause arp-inspection
+errdisable recovery cause bpduguard
+errdisable recovery cause xcvr-overheat
+errdisable recovery cause xcvr-power-unsupported
+errdisable recovery cause xcvr-unsupported
+!
 flow tracking sampled
    sample 666
    hardware offload ipv4 ipv6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/errdisable.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/errdisable.yml
@@ -1,0 +1,11 @@
+---
+### Errdisable ###
+
+errdisable:
+  recovery:
+    causes:
+      - bpduguard
+      - xcvr-overheat
+      - xcvr-power-unsupported
+      - xcvr-unsupported
+      - arp-inspection

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/errdisable.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/errdisable.yml
@@ -1,11 +1,14 @@
 ---
-### Errdisable ###
-
 errdisable:
   recovery:
     causes:
       - bpduguard
-      - xcvr-overheat
-      - xcvr-power-unsupported
-      - xcvr-unsupported
       - arp-inspection
+      - portsec
+      - hitless-reload-down
+      - lacp-rate-limit
+      - link-flap
+      - no-internal-vlan
+      - portchannelguard
+      - tapagg
+      - uplink-failure-detection

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -9,25 +9,20 @@
 ## Errdisable
 
 ### Errdisable Summary
+{%     if errdisable.detect.causes is arista.avd.defined or errdisable.recovery.causes is arista.avd.defined %}
+{%         set combined_causes = ( errdisable.detect.causes | arista.avd.default([]) + errdisable.recovery.causes | arista.avd.default([]) ) | unique %}
+
+|  Detect Cause | Detection Enabled | Recovery Enabled |
+| ------------- | ----------------- | ---------------- |
+{%         for cause in combined_causes | arista.avd.natural_sort %}
+{%             set detect_status = cause in errdisable.detect.causes | arista.avd.default([]) %}
+{%             set recovery_status = cause in errdisable.recovery.causes | arista.avd.default([]) %}
+| {{ cause }} | {{ detect_status }} | {{ recovery_status }} |
+{%         endfor %}
+{%     endif %}
 {%     if errdisable.recovery.interval is arista.avd.defined %}
 
 Errdisable recovery timer interval: {{ errdisable.recovery.interval }} seconds
-{%     endif %}
-{%     if errdisable.detect.causes is arista.avd.defined %}
-
-|  Detect Cause | Enabled |
-| ------------- | ------- |
-{%         for cause in errdisable.detect.causes | arista.avd.natural_sort %}
-| {{ cause }} | True |
-{%         endfor %}
-{%     endif %}
-{%     if errdisable.recovery.causes is arista.avd.defined %}
-
-|  Detect Cause | Enabled |
-| ------------- | ------- |
-{%         for cause in errdisable.recovery.causes | arista.avd.natural_sort %}
-| {{ cause }} | True |
-{%         endfor %}
 {%     endif %}
 
 ```eos

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -19,12 +19,15 @@
 {%     endif %}
 {%     if errdisable.recovery.causes is arista.avd.defined %}
 
-|  Detect Cause | Enabled | Interval |
-| ------------- | ------- | -------- |
-{%         set interval = errdisable.recovery.interval | arista.avd.default("-") %}
+|  Detect Cause | Enabled |
+| ------------- | ------- |
 {%         for cause in errdisable.recovery.causes | arista.avd.natural_sort %}
-| {{ cause }} | True | {{ interval }} |
+| {{ cause }} | True |
 {%         endfor %}
+{%     endif %}
+{%     if errdisable.recovery.interval is arista.avd.defined %}
+
+Errdisable recovery timer interval: {{ errdisable.recovery.interval }}
 {%     endif %}
 
 ```eos

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -15,65 +15,16 @@
 |  Detect Cause | Enabled |
 | ------------- | ------- |
 {%             for cause in errdisable.detect.causes | arista.avd.natural_sort %}
-{%                 if cause == 'acl' %}
 | {{ cause }} | True |
-{%                 elif cause == 'arp-inspection' %}
-| {{ cause }} | True |
-{%                 elif cause == 'dot1x' %}
-| {{ cause }} | True |
-{%                 elif cause == 'link-change' %}
-| {{ cause }} | True |
-{%                 elif cause == 'tapagg' %}
-| {{ cause }} | True |
-{%                 elif cause == 'xcvr-misconfigured' %}
-| {{ cause }} | True |
-{%                 elif cause == 'xcvr-overheat' %}
-| {{ cause }} | True |
-{%                 elif cause == 'xcvr-power-unsupported' %}
-| {{ cause }} | True |
-{%                 endif %}
 {%             endfor %}
 {%         endif %}
 
-{%         if errdisable.recovery.interval is arista.avd.defined %}
-{%         endif %}
 {%         if errdisable.recovery.causes is defined %}
 |  Detect Cause | Enabled | Interval |
 | ------------- | ------- | -------- |
+{%             set interval = errdisable.recovery.interval | arista.avd.default("-") %}
 {%             for cause in errdisable.recovery.causes | arista.avd.natural_sort %}
-{%                 if cause == 'arp-inspection' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'bpduguard' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'dot1x' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'hitless-reload-down' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'lacp-rate-limit' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'link-flap' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'no-internal-vlan' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'portchannelguard' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'portsec' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'speed-misconfigured' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'tapagg' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'uplink-failure-detection' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'xcvr-misconfigured' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'xcvr-overheat' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'xcvr-power-unsupported' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 elif cause == 'xcvr-unsupported' %}
-| {{ cause }} | True | {{ errdisable.recovery.interval }} |
-{%                 endif %}
+| {{ cause }} | True | {{ interval }} |
 {%             endfor %}
 {%         endif %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -9,24 +9,22 @@
 ## Errdisable
 
 ### Errdisable Summary
+{%     if errdisable.detect.causes is defined %}
 
-{%     if errdisable.recovery is defined %}
-{%         if errdisable.detect.causes is defined %}
 |  Detect Cause | Enabled |
 | ------------- | ------- |
-{%             for cause in errdisable.detect.causes | arista.avd.natural_sort %}
+{%         for cause in errdisable.detect.causes | arista.avd.natural_sort %}
 | {{ cause }} | True |
-{%             endfor %}
-{%         endif %}
+{%         endfor %}
+{%     endif %}
+{%     if errdisable.recovery.causes is defined %}
 
-{%         if errdisable.recovery.causes is defined %}
 |  Detect Cause | Enabled | Interval |
 | ------------- | ------- | -------- |
-{%             set interval = errdisable.recovery.interval | arista.avd.default("-") %}
-{%             for cause in errdisable.recovery.causes | arista.avd.natural_sort %}
+{%         set interval = errdisable.recovery.interval | arista.avd.default("-") %}
+{%         for cause in errdisable.recovery.causes | arista.avd.natural_sort %}
 | {{ cause }} | True | {{ interval }} |
-{%             endfor %}
-{%         endif %}
+{%         endfor %}
 {%     endif %}
 
 ```eos

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -9,6 +9,10 @@
 ## Errdisable
 
 ### Errdisable Summary
+{%     if errdisable.recovery.interval is arista.avd.defined %}
+
+Errdisable recovery timer interval: {{ errdisable.recovery.interval }} seconds
+{%     endif %}
 {%     if errdisable.detect.causes is arista.avd.defined %}
 
 |  Detect Cause | Enabled |
@@ -24,10 +28,6 @@
 {%         for cause in errdisable.recovery.causes | arista.avd.natural_sort %}
 | {{ cause }} | True |
 {%         endfor %}
-{%     endif %}
-{%     if errdisable.recovery.interval is arista.avd.defined %}
-
-Errdisable recovery timer interval: {{ errdisable.recovery.interval }} seconds
 {%     endif %}
 
 ```eos

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -24,7 +24,11 @@ Errdisable recovery timer interval: {{ errdisable.recovery.interval }} seconds
 {%             else %}
 {%                 set detect_status = "-" %}
 {%             endif %}
-{%             set recovery_status = cause in errdisable.recovery.causes | arista.avd.default([]) %}
+{%             if cause in errdisable.recovery.causes | arista.avd.default([]) %}
+{%                 set recovery_status = True %}
+{%             else %}
+{%                 set recovery_status = "-" %}
+{%             endif %}
 | {{ cause }} | {{ detect_status }} | {{ recovery_status }} |
 {%         endfor %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -9,11 +9,15 @@
 ## Errdisable
 
 ### Errdisable Summary
+{%     if errdisable.recovery.interval is arista.avd.defined %}
+
+Errdisable recovery timer interval: {{ errdisable.recovery.interval }} seconds
+{%     endif %}
 {%     if errdisable.detect.causes is arista.avd.defined or errdisable.recovery.causes is arista.avd.defined %}
 {%         set combined_causes = ( errdisable.detect.causes | arista.avd.default([]) + errdisable.recovery.causes | arista.avd.default([]) ) | unique %}
 
-|  Detect Cause | Detection Enabled | Recovery Enabled |
-| ------------- | ----------------- | ---------------- |
+|  Cause | Detection Enabled | Recovery Enabled |
+| ------ | ----------------- | ---------------- |
 {%         for cause in combined_causes | arista.avd.natural_sort %}
 {%             if cause in errdisable.detect.causes | arista.avd.default([]) %}
 {%                 set detect_status = True %}
@@ -23,10 +27,6 @@
 {%             set recovery_status = cause in errdisable.recovery.causes | arista.avd.default([]) %}
 | {{ cause }} | {{ detect_status }} | {{ recovery_status }} |
 {%         endfor %}
-{%     endif %}
-{%     if errdisable.recovery.interval is arista.avd.defined %}
-
-Errdisable recovery timer interval: {{ errdisable.recovery.interval }} seconds
 {%     endif %}
 
 ```eos

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -9,7 +9,7 @@
 ## Errdisable
 
 ### Errdisable Summary
-{%     if errdisable.detect.causes is defined %}
+{%     if errdisable.detect.causes is arista.avd.defined %}
 
 |  Detect Cause | Enabled |
 | ------------- | ------- |
@@ -17,7 +17,7 @@
 | {{ cause }} | True |
 {%         endfor %}
 {%     endif %}
-{%     if errdisable.recovery.causes is defined %}
+{%     if errdisable.recovery.causes is arista.avd.defined %}
 
 |  Detect Cause | Enabled | Interval |
 | ------------- | ------- | -------- |

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -15,7 +15,11 @@
 |  Detect Cause | Detection Enabled | Recovery Enabled |
 | ------------- | ----------------- | ---------------- |
 {%         for cause in combined_causes | arista.avd.natural_sort %}
-{%             set detect_status = cause in errdisable.detect.causes | arista.avd.default([]) %}
+{%             if cause in errdisable.detect.causes | arista.avd.default([]) %}
+{%                 set detect_status = True %}
+{%             else %}
+{%                 set detect_status = "-" %}
+{%             endif %}
 {%             set recovery_status = cause in errdisable.recovery.causes | arista.avd.default([]) %}
 | {{ cause }} | {{ detect_status }} | {{ recovery_status }} |
 {%         endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2
@@ -27,7 +27,7 @@
 {%     endif %}
 {%     if errdisable.recovery.interval is arista.avd.defined %}
 
-Errdisable recovery timer interval: {{ errdisable.recovery.interval }}
+Errdisable recovery timer interval: {{ errdisable.recovery.interval }} seconds
 {%     endif %}
 
 ```eos


### PR DESCRIPTION

## Change Summary

Documentation template python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/errdisable.j2 unconditionally accesses errdisable.recovery.interval without trying to confirm it's existence or to set a default value (defined in schema but not implemented in J2).
Fix to use default as - if not defined.

## Related Issue(s)

Fixes #4971 

## Component(s) name

`eos_cli_config_gen`

## Proposed changes
Updated the j2 logic in errdisable.j2 for documentation to fix the recovery.interval to be always set

## How to test
Run molecule with new tests

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
