### PR TITLE
Refactor(eos_designs): structured_config for ipv6_static_routes

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -155,29 +155,22 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
             }
         ]
 
-    @cached_property
-    def ipv6_static_routes(self) -> list | None:
+    @structured_config_contributor
+    def ipv6_static_routes(self) -> None:
         """ipv6_static_routes set based on ipv6_mgmt_gateway, ipv6_mgmt_destination_networks and mgmt_interface_vrf."""
         if self.shared_utils.ipv6_mgmt_gateway is None or self.shared_utils.node_config.ipv6_mgmt_ip is None:
-            return None
+            return
 
         if self.inputs.ipv6_mgmt_destination_networks:
-            return [
-                {
-                    "vrf": self.inputs.mgmt_interface_vrf,
-                    "destination_address_prefix": mgmt_destination_network,
-                    "gateway": self.shared_utils.ipv6_mgmt_gateway,
-                }
-                for mgmt_destination_network in self.inputs.ipv6_mgmt_destination_networks
-            ]
+            for mgmt_destination_network in self.inputs.ipv6_mgmt_destination_networks:
+                self.structured_config.ipv6_static_routes.append_new(
+                    vrf=self.inputs.mgmt_interface_vrf, destination_address_prefix=mgmt_destination_network, gateway=self.shared_utils.ipv6_mgmt_gateway
+                )
+            return
 
-        return [
-            {
-                "vrf": self.inputs.mgmt_interface_vrf,
-                "destination_address_prefix": "::/0",
-                "gateway": self.shared_utils.ipv6_mgmt_gateway,
-            },
-        ]
+        self.structured_config.ipv6_static_routes.append_new(
+            vrf=self.inputs.mgmt_interface_vrf, destination_address_prefix="::/0", gateway=self.shared_utils.ipv6_mgmt_gateway
+        )
 
     @cached_property
     def service_routing_protocols_model(self) -> str:

--- a/python-avd/pyavd/_eos_designs/structured_config/inband_management/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/inband_management/__init__.py
@@ -73,20 +73,14 @@ class AvdStructuredConfigInbandManagement(StructuredConfigGenerator):
             ),
         ]
 
-    @cached_property
-    def ipv6_static_routes(self) -> list | None:
+    @structured_config_contributor
+    def ipv6_static_routes(self) -> None:
         if not self.shared_utils.configure_inband_mgmt_ipv6 or self.shared_utils.inband_mgmt_ipv6_gateway is None:
-            return None
+            return
 
-        return [
-            strip_empties_from_dict(
-                {
-                    "destination_address_prefix": "::/0",
-                    "gateway": self.shared_utils.inband_mgmt_ipv6_gateway,
-                    "vrf": self.shared_utils.inband_mgmt_vrf,
-                },
-            ),
-        ]
+        self.structured_config.ipv6_static_routes.append_new(
+            destination_address_prefix="::/0", gateway=self.shared_utils.inband_mgmt_ipv6_gateway, vrf=self.shared_utils.inband_mgmt_vrf
+        )
 
     @structured_config_contributor
     def vrfs(self) -> None:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
@@ -3,8 +3,10 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
+
+from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
+from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigNetworkServicesProtocol
@@ -17,31 +19,21 @@ class Ipv6StaticRoutesMixin(Protocol):
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
 
-    @cached_property
-    def ipv6_static_routes(self: AvdStructuredConfigNetworkServicesProtocol) -> list[dict] | None:
+    @structured_config_contributor
+    def ipv6_static_routes(self: AvdStructuredConfigNetworkServicesProtocol) -> None:
         """
-        Returns structured config for ipv6_static_routes.
+        Set the structured config for ipv6_static_routes.
 
         Consist of
         - ipv6 static_routes defined under the vrfs
         - static routes added automatically for VARPv6 with prefixes
         """
         if not self.shared_utils.network_services_l3:
-            return None
+            return
 
-        ipv6_static_routes = []
         for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant.vrfs:
                 for static_route in vrf.ipv6_static_routes:
-                    ipv6_static_route = static_route._as_dict()
-                    ipv6_static_route["vrf"] = vrf.name
-                    ipv6_static_route.pop("nodes", None)
-
-                    # Ignore duplicate items in case of duplicate VRF definitions across multiple tenants.
-                    if static_route not in ipv6_static_routes:
-                        ipv6_static_routes.append(ipv6_static_route)
-
-        if ipv6_static_routes:
-            return ipv6_static_routes
-
-        return None
+                    static_route_obj = static_route._cast_as(EosCliConfigGen.Ipv6StaticRoutesItem, ignore_extra_keys=True)
+                    static_route_obj.vrf = vrf.name
+                    self.structured_config.ipv6_static_routes.append_unique(static_route_obj)

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
@@ -34,6 +34,6 @@ class Ipv6StaticRoutesMixin(Protocol):
         for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant.vrfs:
                 for static_route in vrf.ipv6_static_routes:
-                    static_route_items = static_route._cast_as(EosCliConfigGen.Ipv6StaticRoutesItem, ignore_extra_keys=True)
-                    static_route_items.vrf = vrf.name
-                    self.structured_config.ipv6_static_routes.append_unique(static_route_items)
+                    static_route_item = static_route._cast_as(EosCliConfigGen.Ipv6StaticRoutesItem, ignore_extra_keys=True)
+                    static_route_item.vrf = vrf.name
+                    self.structured_config.ipv6_static_routes.append_unique(static_route_item)

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
@@ -34,6 +34,6 @@ class Ipv6StaticRoutesMixin(Protocol):
         for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant.vrfs:
                 for static_route in vrf.ipv6_static_routes:
-                    static_route_obj = static_route._cast_as(EosCliConfigGen.Ipv6StaticRoutesItem, ignore_extra_keys=True)
-                    static_route_obj.vrf = vrf.name
-                    self.structured_config.ipv6_static_routes.append_unique(static_route_obj)
+                    static_route_items = static_route._cast_as(EosCliConfigGen.Ipv6StaticRoutesItem, ignore_extra_keys=True)
+                    static_route_items.vrf = vrf.name
+                    self.structured_config.ipv6_static_routes.append_unique(static_route_items)


### PR DESCRIPTION
## Change Summary

Refactoreos_designs structured_config code for ipv6_static_routes

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Refactor eos_designs structured_config code for network_services, base and inband_management ipv6_static_routes to use classes

## How to test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
