### PR TITLE
Fix(eos_designs): Avoid returning objects in facts

### DIFF
--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/overlay.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/overlay.py
@@ -38,8 +38,8 @@ class OverlayMixin(Protocol):
         """
         if self.shared_utils.underlay_router is True:
             if self.evpn_role == "client":
-                return self.shared_utils.node_config.evpn_route_servers or self.shared_utils.uplink_switches
-            return self.shared_utils.node_config.evpn_route_servers
+                return self.shared_utils.node_config.evpn_route_servers._as_list() or self.shared_utils.uplink_switches
+            return self.shared_utils.node_config.evpn_route_servers._as_list()
         return []
 
     @cached_property
@@ -48,7 +48,7 @@ class OverlayMixin(Protocol):
         if self.shared_utils.underlay_router is True and (
             self.mpls_overlay_role in ["client", "server"] or (self.evpn_role in ["client", "server"] and self.overlay["evpn_mpls"])
         ):
-            return self.shared_utils.node_config.mpls_route_reflectors
+            return self.shared_utils.node_config.mpls_route_reflectors._as_list()
         return None
 
     @cached_property

--- a/python-avd/tests/pyavd/molecule_scenarios/test_get_avd_facts.py
+++ b/python-avd/tests/pyavd/molecule_scenarios/test_get_avd_facts.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
+import json
 from copy import deepcopy
 
 import pytest
@@ -39,3 +40,5 @@ def test_get_avd_facts(molecule_scenario: MoleculeScenario) -> None:
     assert isinstance(avd_facts["avd_overlay_peers"], dict)
     assert "avd_topology_peers" in avd_facts
     assert isinstance(avd_facts["avd_topology_peers"], dict)
+    # Test that we can dump the returned data as json.
+    assert json.dumps(avd_facts)

--- a/python-avd/tests/pyavd/molecule_scenarios/test_get_device_structured_config.py
+++ b/python-avd/tests/pyavd/molecule_scenarios/test_get_device_structured_config.py
@@ -1,6 +1,7 @@
 # Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
+import json
 from copy import deepcopy
 
 import pytest
@@ -40,3 +41,5 @@ def test_get_device_structured_config(molecule_host: MoleculeHost) -> None:
     assert isinstance(structured_config, dict)
     assert molecule_host.name == structured_config["hostname"]
     assert expected_structured_config == structured_config
+    # Test that we can dump the returned data as json.
+    assert json.dumps(structured_config)


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix(eos_designs): Avoid returning objects in facts

## Related Issue(s)

Fixes #5014

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Fix a couple of facts that sometimes returned a schema object instead of the native types.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added pytest coverage to ensure the returned objects are JSON serializable, so this will not happen again.
  - Saw the issue before applying the fix.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
