### PR TITLE
Fix(eos_designs): Wrong duplicate detection between SVIs and L2VLANs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -91,6 +91,9 @@ vlan 164
 vlan 165
    name overlapping_name
 !
+vlan 166
+   name L2VLAN_AND_SVI
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -297,6 +300,12 @@ interface Vlan151
    vrf Tenant_A_WAN_Zone
    ip address virtual 10.1.51.1/24
 !
+interface Vlan166
+   description L2VLAN_AND_SVI
+   no shutdown
+   vrf Tenant_A_WAN_Zone
+   ip address virtual 10.1.66.1/24
+!
 interface Vlan210
    description Tenant_B_OP_Zone_1
    no shutdown
@@ -430,6 +439,7 @@ interface Vxlan1
    vxlan vlan 163 vni 10163
    vxlan vlan 164 vni 10164
    vxlan vlan 165 vni 10165
+   vxlan vlan 166 vni 10166
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -539,6 +549,12 @@ router bgp 101
       redistribute learned
       vlan 1234
    !
+   vlan-aware-bundle L2VLAN_AND_SVI
+      rd 192.168.255.109:20166
+      route-target both 20166:20166
+      redistribute learned
+      vlan 166
+   !
    vlan-aware-bundle l2vlan_with_no_tags
       rd 192.168.255.109:20162
       route-target both 20162:20162
@@ -591,7 +607,7 @@ router bgp 101
       rd 192.168.255.109:14
       route-target both 14:14
       redistribute learned
-      vlan 150-151
+      vlan 150-151,166
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.109:11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_true.cfg
@@ -91,6 +91,9 @@ vlan 164
 vlan 165
    name overlapping_name
 !
+vlan 166
+   name L2VLAN_AND_SVI
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !
@@ -186,6 +189,7 @@ interface Vxlan1
    vxlan vlan 163 vni 10163
    vxlan vlan 164 vni 10164
    vxlan vlan 165 vni 10165
+   vxlan vlan 166 vni 10166
    vxlan vlan 210 vni 20210
    vxlan vlan 211 vni 20211
    vxlan vlan 250 vni 20250
@@ -251,6 +255,12 @@ router bgp 101
       redistribute learned
       vlan 1234
    !
+   vlan-aware-bundle L2VLAN_AND_SVI
+      rd 192.168.255.109:20166
+      route-target both 20166:20166
+      redistribute learned
+      vlan 166
+   !
    vlan-aware-bundle l2vlan_with_no_tags
       rd 192.168.255.109:20162
       route-target both 20162:20162
@@ -303,7 +313,7 @@ router bgp 101
       rd 192.168.255.109:14
       route-target both 14:14
       redistribute learned
-      vlan 150-151
+      vlan 150-151,166
    !
    vlan-aware-bundle Tenant_A_WEB_Zone
       rd 192.168.255.109:11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_default.cfg
@@ -91,6 +91,9 @@ vlan 164
 vlan 165
    name overlapping_name
 !
+vlan 166
+   name L2VLAN_AND_SVI
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_fabric.cfg
@@ -91,6 +91,9 @@ vlan 164
 vlan 165
    name overlapping_name
 !
+vlan 166
+   name L2VLAN_AND_SVI
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_host.cfg
@@ -93,6 +93,9 @@ vlan 164
 vlan 165
    name overlapping_name
 !
+vlan 166
+   name L2VLAN_AND_SVI
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/mgmt_interface_platform.cfg
@@ -93,6 +93,9 @@ vlan 164
 vlan 165
    name overlapping_name
 !
+vlan 166
+   name L2VLAN_AND_SVI
+!
 vlan 210
    name Tenant_B_OP_Zone_1
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -191,7 +191,7 @@ router_bgp:
       - '14:14'
     redistribute_routes:
     - learned
-    vlan: 150-151
+    vlan: 150-151,166
   - name: Tenant_A_WEB_Zone
     rd: 192.168.255.109:11
     route_targets:
@@ -200,6 +200,15 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 120-121
+  - name: L2VLAN_AND_SVI
+    tenant: Tenant_A
+    rd: 192.168.255.109:20166
+    route_targets:
+      both:
+      - 20166:20166
+    redistribute_routes:
+    - learned
+    vlan: '166'
   - name: Tenant_A_NFS
     tenant: Tenant_A
     rd: 192.168.255.109:20161
@@ -670,6 +679,12 @@ vlan_interfaces:
   vrf: Tenant_A_WAN_Zone
   ip_address_virtual: 10.1.51.1/24
   tenant: Tenant_A
+- name: Vlan166
+  description: L2VLAN_AND_SVI
+  shutdown: false
+  vrf: Tenant_A_WAN_Zone
+  ip_address_virtual: 10.1.66.1/24
+  tenant: Tenant_A
 - name: Vlan120
   description: Tenant_A_WEB_Zone_1
   shutdown: false
@@ -890,6 +905,9 @@ vlans:
 - id: 151
   name: svi_with_no_tags
   tenant: Tenant_A
+- id: 166
+  name: L2VLAN_AND_SVI
+  tenant: Tenant_A
 - id: 120
   name: Tenant_A_WEB_Zone_1
   tenant: Tenant_A
@@ -1036,6 +1054,8 @@ vxlan_interface:
         vni: 10150
       - id: 151
         vni: 10151
+      - id: 166
+        vni: 10166
       - id: 120
         vni: 10120
       - id: 121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -168,7 +168,7 @@ router_bgp:
       - '14:14'
     redistribute_routes:
     - learned
-    vlan: 150-151
+    vlan: 150-151,166
   - name: Tenant_A_WEB_Zone
     rd: 192.168.255.109:11
     route_targets:
@@ -177,6 +177,15 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: 120-121
+  - name: L2VLAN_AND_SVI
+    tenant: Tenant_A
+    rd: 192.168.255.109:20166
+    route_targets:
+      both:
+      - 20166:20166
+    redistribute_routes:
+    - learned
+    vlan: '166'
   - name: Tenant_A_NFS
     tenant: Tenant_A
     rd: 192.168.255.109:20161
@@ -343,6 +352,9 @@ vlans:
 - id: 151
   name: svi_with_no_tags
   tenant: Tenant_A
+- id: 166
+  name: L2VLAN_AND_SVI
+  tenant: Tenant_A
 - id: 120
   name: Tenant_A_WEB_Zone_1
   tenant: Tenant_A
@@ -446,6 +458,8 @@ vxlan_interface:
         vni: 10150
       - id: 151
         vni: 10151
+      - id: 166
+        vni: 10166
       - id: 120
         vni: 10120
       - id: 121

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -121,6 +121,9 @@ vlans:
 - id: 151
   name: svi_with_no_tags
   tenant: Tenant_A
+- id: 166
+  name: L2VLAN_AND_SVI
+  tenant: Tenant_A
 - id: 120
   name: Tenant_A_WEB_Zone_1
   tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -121,6 +121,9 @@ vlans:
 - id: 151
   name: svi_with_no_tags
   tenant: Tenant_A
+- id: 166
+  name: L2VLAN_AND_SVI
+  tenant: Tenant_A
 - id: 120
   name: Tenant_A_WEB_Zone_1
   tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -128,6 +128,9 @@ vlans:
 - id: 151
   name: svi_with_no_tags
   tenant: Tenant_A
+- id: 166
+  name: L2VLAN_AND_SVI
+  tenant: Tenant_A
 - id: 120
   name: Tenant_A_WEB_Zone_1
   tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -128,6 +128,9 @@ vlans:
 - id: 151
   name: svi_with_no_tags
   tenant: Tenant_A
+- id: 166
+  name: L2VLAN_AND_SVI
+  tenant: Tenant_A
 - id: 120
   name: Tenant_A_WEB_Zone_1
   tenant: Tenant_A

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -236,6 +236,11 @@ tenant_a:
             enabled: true
             ip_address_virtual: 10.1.51.1/24
             # No "tags" defined - should render on switches with tag "all" or no tags
+          - id: 166
+            name: L2VLAN_AND_SVI
+            enabled: true
+            ip_address_virtual: 10.1.66.1/24
+            # ID defined both in L2VLAN and SVI, making sure this does not raise a conflict.
         additional_route_targets:
           - type: import
             address_family: vpn-ipv4
@@ -343,6 +348,11 @@ tenant_a:
         name: overlapping_name
       - id: 165
         name: overlapping_name
+      - id: 166
+        name: L2VLAN_AND_SVI
+        # ID defined both in L2VLAN and SVI, making sure this does not raise a conflict.
+
+
 
 ipv4_acls:
   - name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -352,8 +352,6 @@ tenant_a:
         name: L2VLAN_AND_SVI
         # ID defined both in L2VLAN and SVI, making sure this does not raise a conflict.
 
-
-
 ipv4_acls:
   - name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN
     entries:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vxlan_interface.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vxlan_interface.py
@@ -23,12 +23,22 @@ if TYPE_CHECKING:
 class VniContext:
     vni: int
     """The VNI."""
-    source_type: Literal["L2VLAN", "VRF", "SVI"]
+    source_type: Literal["L2VLAN", "VRF", "SVI"] = field(compare=False)
     """The source type of the VNI."""
     name: str
     """The VRF name or the VLAN ID as a string."""
     tenant: str = field(compare=False)
     """The tenant name."""
+    real_type: Literal["VLAN", "VRF"] = field(init=False)
+
+    def __post_init__(self) -> None:
+        """
+        Setting real_type to VLAN or VRF based on the source type.
+
+        The field is used in comparison to detect duplicates.
+        """
+        real_type = "VLAN" if self.source_type in ["L2VLAN", "SVI"] else "VRF"
+        object.__setattr__(self, "real_type", real_type)
 
     def __repr__(self) -> str:
         return f"{self.source_type} {self.name} in tenant {self.tenant}"


### PR DESCRIPTION
## Change Summary

The duplicate detection is using SVI / L2VLAN field in the match. This was not caught by our CI.

## Related Issue(s)

Fixes #5022

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- [x] Add failing test in molecule reproducing the issue (first commit)
- [x] Ignore the source_type in data class for comparison and use the real type instead.

## How to test

molecule passes

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
