### PR TITLE
Fix(cv_deploy): Abandon Workspaces that failed at Build phase if their requested_state was `abandoned`

### DIFF
--- a/ansible_collections/arista/avd/molecule/cv_deploy/converge.yml
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/converge.yml
@@ -11,5 +11,8 @@
 - name: Test Workspace Force False
   import_playbook: workspace_force_false.yml
 
+- name: Test Workspace build with invalid Designed Config
+  import_playbook: invalid_config.yml
+
 - name: Test Change Control False
   import_playbook: cc_false.yml

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-core1.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-core1.cfg
@@ -10,7 +10,7 @@ username ci-avd privilege 15 role network-admin secret sha512 $6$tzBIHQDpZ.10NDx
 username cvpadmin privilege 15 role network-admin secret sha512 $6$3gTtM9zyRVpL6w7v$5nbd38Y7ZU0ZWty/ycn82iiC4ikX79hdopKWLusZaaFgr0spRqewcRBLKuY5qUaPdgg9h8CZjC4pFqLeQ5GRI1
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt cvaas_stg.addr=apiserver.cv-staging.corp.arista.io:443 -cvopt cvaas_stg.auth=token-secure,/tmp/cv-onboarding-token-stg -cvopt cvaas_stg.vrf=MGMT -cvopt cvaas_prd.addr=apiserver.arista.io:443 -cvopt cvaas_prd.auth=token-secure,/tmp/cv-onboarding-token-prd -cvopt cvaas_prd.vrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 transceiver qsfp default-mode 4x10G

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-core1.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-core1.cfg
@@ -1,0 +1,69 @@
+! Command: show running-config
+! device: avd-ci-core1 (vEOS-lab, EOS-4.32.0F)
+!
+! boot system flash:/vEOS-lab.swi
+!
+no aaa root
+!
+username arista privilege 15 role network-admin shell /bin/bash secret sha512 $6$OSN5th7Q.Zy1QRhW$8HY40ylC/h2J/0jvlx46IbEeRGJSxNyUZR9BS1XHdelKmDilESlLnSefscDczRzi/f9PHUVdXXPsQUsXerJbu.
+username ci-avd privilege 15 role network-admin secret sha512 $6$tzBIHQDpZ.10NDxw$y7G0mA5usuiew0nx1HKNe3E1HpiRSZtKd9gS2XhUx9vsa59.E0qLYyzUtwzore34t8cfnFGlvYmf6OH157X6w.
+username cvpadmin privilege 15 role network-admin secret sha512 $6$3gTtM9zyRVpL6w7v$5nbd38Y7ZU0ZWty/ycn82iiC4ikX79hdopKWLusZaaFgr0spRqewcRBLKuY5qUaPdgg9h8CZjC4pFqLeQ5GRI1
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname avd-ci-core1
+ip name-server vrf MGMT 10.90.231.26
+!
+spanning-tree mode core1
+!
+system l1
+   unsupported speed action error
+   unsupported error-correction action error
+!
+vrf instance MGMT
+!
+management api http-commands
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+aaa authentication login console local
+aaa authorization exec default local
+!
+interface Ethernet1
+   description this_should_not_work
+!
+interface Ethernet2
+!
+interface Ethernet3
+!
+interface Ethernet4
+!
+interface Ethernet5
+!
+interface Ethernet6
+!
+interface Ethernet7
+!
+interface Ethernet8
+!
+interface Management1
+   description oob_management
+   vrf MGMT
+   ip address 10.90.231.70/24
+!
+no ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 10.90.231.1
+!
+ntp server vrf MGMT 1.pool.ntp.org iburst local-interface Management1
+!
+end

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf1-missing.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf1-missing.cfg
@@ -1,0 +1,187 @@
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname avd-ci-leaf1
+ip name-server vrf MGMT 10.90.231.26
+!
+ntp server vrf MGMT 1.pool.ntp.org iburst local-interface Management1
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4093-4094
+spanning-tree mst 0 priority 16384
+!
+aaa authentication login console local
+aaa authorization exec default local
+!
+no enable password
+no aaa root
+!
+username arista privilege 15 role network-admin shell /bin/bash secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username ci-avd privilege 15 role network-admin secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username cvpadmin privilege 15 role network-admin secret sha512 $6$3gTtM9zyRVpL6w7v$5nbd38Y7ZU0ZWty/ycn82iiC4ikX79hdopKWLusZaaFgr0spRqewcRBLKuY5qUaPdgg9h8CZjC4pFqLeQ5GRI1
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel10
+   description MLAG_PEER_avd-ci-leaf2_Po10
+   no shutdown
+   switchport
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description P2P_LINK_TO_AVD-CI-SPINE1_Ethernet1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.1/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_AVD-CI-SPINE2_Ethernet1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.3/31
+!
+interface Ethernet10
+   description MLAG_PEER_avd-ci-leaf2_Ethernet10
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description MLAG_PEER_avd-ci-leaf2_Ethernet11
+   no shutdown
+   channel-group 10 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.21.0.1/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 10.22.0.1/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 10.90.231.64/24
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 1500
+   ip address 192.168.21.0/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 192.168.20.0/31
+!
+interface Vxlan1
+   description avd-ci-leaf1_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.21.0.0/24 eq 32
+   seq 20 permit 10.22.0.0/24 eq 32
+!
+mlag configuration
+   domain-id RACK1
+   local-interface Vlan4094
+   peer-address 192.168.20.1
+   peer-link Port-Channel10
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 10.90.231.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 10.21.0.1
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description avd-ci-leaf2
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.20.0.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.1 remote-as 65000
+   neighbor 10.20.0.1 description avd-ci-spine1
+   neighbor 10.20.0.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.2 remote-as 65000
+   neighbor 10.20.0.2 description avd-ci-spine2
+   neighbor 10.23.0.0 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.0 remote-as 65000
+   neighbor 10.23.0.0 description avd-ci-spine1_Ethernet1
+   neighbor 10.23.0.2 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.2 remote-as 65000
+   neighbor 10.23.0.2 description avd-ci-spine2_Ethernet1
+   neighbor 192.168.21.1 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.21.1 description avd-ci-leaf2
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf1-missing.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf1-missing.cfg
@@ -1,6 +1,6 @@
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt cvaas_stg.addr=apiserver.cv-staging.corp.arista.io:443 -cvopt cvaas_stg.auth=token-secure,/tmp/cv-onboarding-token-stg -cvopt cvaas_stg.vrf=MGMT -cvopt cvaas_prd.addr=apiserver.arista.io:443 -cvopt cvaas_prd.auth=token-secure,/tmp/cv-onboarding-token-prd -cvopt cvaas_prd.vrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 vlan internal order ascending range 1006 1199

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf1.cfg
@@ -1,0 +1,188 @@
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname avd-ci-leaf1
+ip name-server vrf MGMT 10.90.231.26
+!
+ntp server vrf MGMT 1.pool.ntp.org iburst local-interface Management1
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4093-4094
+spanning-tree mst 0 priority 16384
+!
+aaa authentication login console local
+aaa authorization exec default local
+!
+no enable password
+no aaa root
+!
+username arista privilege 15 role network-admin shell /bin/bash secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username ci-avd privilege 15 role network-admin secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username cvpadmin privilege 15 role network-admin secret sha512 $6$3gTtM9zyRVpL6w7v$5nbd38Y7ZU0ZWty/ycn82iiC4ikX79hdopKWLusZaaFgr0spRqewcRBLKuY5qUaPdgg9h8CZjC4pFqLeQ5GRI1
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel10
+   description MLAG_PEER_avd-ci-leaf2_Po10
+   no shutdown
+   switchport
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description P2P_LINK_TO_AVD-CI-SPINE1_Ethernet1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.1/31
+!
+interface Ethernet2
+   switchport
+   no shutdown
+   spanning-tree portfast
+!
+interface Ethernet3
+   description test
+!
+interface Ethernet10
+   description MLAG_PEER_avd-ci-leaf2_Ethernet10
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description MLAG_PEER_avd-ci-leaf2_Ethernet11
+   no shutdown
+   channel-group 10 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.21.0.1/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 10.22.0.1/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 10.90.231.64/24
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 1500
+   ip address 192.168.21.0/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 192.168.20.0/31
+!
+interface Vxlan1
+   description avd-ci-leaf1_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.21.0.0/24 eq 32
+   seq 20 permit 10.22.0.0/24 eq 32
+!
+mlag configuration
+   domain-id RACK1
+   local-interface Vlan4094
+   peer-address 192.168.20.1
+   peer-link Port-Channel10
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 10.90.231.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 10.21.0.1
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description avd-ci-leaf2
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.20.0.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.1 remote-as 65000
+   neighbor 10.20.0.1 description avd-ci-spine1
+   neighbor 10.20.0.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.2 remote-as 65000
+   neighbor 10.20.0.2 description avd-ci-spine2
+   neighbor 10.23.0.0 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.0 remote-as 65000
+   neighbor 10.23.0.0 description avd-ci-spine1_Ethernet1
+   neighbor 10.23.0.2 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.2 remote-as 65000
+   neighbor 10.23.0.2 description avd-ci-spine2_Ethernet1
+   neighbor 192.168.21.1 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.21.1 description avd-ci-leaf2
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf1.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf1.cfg
@@ -1,6 +1,6 @@
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt cvaas_stg.addr=apiserver.cv-staging.corp.arista.io:443 -cvopt cvaas_stg.auth=token-secure,/tmp/cv-onboarding-token-stg -cvopt cvaas_stg.vrf=MGMT -cvopt cvaas_prd.addr=apiserver.arista.io:443 -cvopt cvaas_prd.auth=token-secure,/tmp/cv-onboarding-token-prd -cvopt cvaas_prd.vrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 vlan internal order ascending range 1006 1199

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf2.cfg
@@ -1,6 +1,6 @@
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt cvaas_stg.addr=apiserver.cv-staging.corp.arista.io:443 -cvopt cvaas_stg.auth=token-secure,/tmp/cv-onboarding-token-stg -cvopt cvaas_stg.vrf=MGMT -cvopt cvaas_prd.addr=apiserver.arista.io:443 -cvopt cvaas_prd.auth=token-secure,/tmp/cv-onboarding-token-prd -cvopt cvaas_prd.vrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 vlan internal order ascending range 1006 1199

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf2.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf2.cfg
@@ -1,0 +1,187 @@
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname avd-ci-leaf2
+ip name-server vrf MGMT 10.90.231.26
+!
+ntp server vrf MGMT 1.pool.ntp.org iburst local-interface Management1
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4093-4094
+spanning-tree mst 0 priority 16384
+!
+aaa authentication login console local
+aaa authorization exec default local
+!
+no enable password
+no aaa root
+!
+username arista privilege 15 role network-admin shell /bin/bash secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username ci-avd privilege 15 role network-admin secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username cvpadmin privilege 15 role network-admin secret sha512 $6$3gTtM9zyRVpL6w7v$5nbd38Y7ZU0ZWty/ycn82iiC4ikX79hdopKWLusZaaFgr0spRqewcRBLKuY5qUaPdgg9h8CZjC4pFqLeQ5GRI1
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel10
+   description MLAG_PEER_avd-ci-leaf1_Po10
+   no shutdown
+   switchport
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description P2P_LINK_TO_AVD-CI-SPINE1_Ethernet2
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.5/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_AVD-CI-SPINE2_Ethernet2
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.7/31
+!
+interface Ethernet10
+   description MLAG_PEER_avd-ci-leaf1_Ethernet10
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description MLAG_PEER_avd-ci-leaf1_Ethernet11
+   no shutdown
+   channel-group 10 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.21.0.2/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 10.22.0.1/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 10.90.231.65/24
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 1500
+   ip address 192.168.21.1/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 192.168.20.1/31
+!
+interface Vxlan1
+   description avd-ci-leaf2_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.21.0.0/24 eq 32
+   seq 20 permit 10.22.0.0/24 eq 32
+!
+mlag configuration
+   domain-id RACK1
+   local-interface Vlan4094
+   peer-address 192.168.20.0
+   peer-link Port-Channel10
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 10.90.231.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 10.21.0.2
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65001
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description avd-ci-leaf1
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.20.0.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.1 remote-as 65000
+   neighbor 10.20.0.1 description avd-ci-spine1
+   neighbor 10.20.0.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.2 remote-as 65000
+   neighbor 10.20.0.2 description avd-ci-spine2
+   neighbor 10.23.0.4 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.4 remote-as 65000
+   neighbor 10.23.0.4 description avd-ci-spine1_Ethernet2
+   neighbor 10.23.0.6 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.6 remote-as 65000
+   neighbor 10.23.0.6 description avd-ci-spine2_Ethernet2
+   neighbor 192.168.21.0 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.21.0 description avd-ci-leaf1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf3.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf3.cfg
@@ -1,6 +1,6 @@
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt cvaas_stg.addr=apiserver.cv-staging.corp.arista.io:443 -cvopt cvaas_stg.auth=token-secure,/tmp/cv-onboarding-token-stg -cvopt cvaas_stg.vrf=MGMT -cvopt cvaas_prd.addr=apiserver.arista.io:443 -cvopt cvaas_prd.auth=token-secure,/tmp/cv-onboarding-token-prd -cvopt cvaas_prd.vrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 vlan internal order ascending range 1006 1199

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf3.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf3.cfg
@@ -1,0 +1,187 @@
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname avd-ci-leaf3
+ip name-server vrf MGMT 10.90.231.26
+!
+ntp server vrf MGMT 1.pool.ntp.org iburst local-interface Management1
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4093-4094
+spanning-tree mst 0 priority 16384
+!
+aaa authentication login console local
+aaa authorization exec default local
+!
+no enable password
+no aaa root
+!
+username arista privilege 15 role network-admin shell /bin/bash secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username ci-avd privilege 15 role network-admin secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username cvpadmin privilege 15 role network-admin secret sha512 $6$3gTtM9zyRVpL6w7v$5nbd38Y7ZU0ZWty/ycn82iiC4ikX79hdopKWLusZaaFgr0spRqewcRBLKuY5qUaPdgg9h8CZjC4pFqLeQ5GRI1
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel10
+   description MLAG_PEER_avd-ci-leaf4_Po10
+   no shutdown
+   switchport
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description P2P_LINK_TO_AVD-CI-SPINE1_Ethernet3
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.9/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_AVD-CI-SPINE2_Ethernet3
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.11/31
+!
+interface Ethernet10
+   description MLAG_PEER_avd-ci-leaf4_Ethernet10
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description MLAG_PEER_avd-ci-leaf4_Ethernet11
+   no shutdown
+   channel-group 10 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.21.0.3/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 10.22.0.3/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 10.90.231.66/24
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 1500
+   ip address 192.168.21.4/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 192.168.20.4/31
+!
+interface Vxlan1
+   description avd-ci-leaf3_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.21.0.0/24 eq 32
+   seq 20 permit 10.22.0.0/24 eq 32
+!
+mlag configuration
+   domain-id RACK2
+   local-interface Vlan4094
+   peer-address 192.168.20.5
+   peer-link Port-Channel10
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 10.90.231.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65002
+   router-id 10.21.0.3
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65002
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description avd-ci-leaf4
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.20.0.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.1 remote-as 65000
+   neighbor 10.20.0.1 description avd-ci-spine1
+   neighbor 10.20.0.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.2 remote-as 65000
+   neighbor 10.20.0.2 description avd-ci-spine2
+   neighbor 10.23.0.8 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.8 remote-as 65000
+   neighbor 10.23.0.8 description avd-ci-spine1_Ethernet3
+   neighbor 10.23.0.10 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.10 remote-as 65000
+   neighbor 10.23.0.10 description avd-ci-spine2_Ethernet3
+   neighbor 192.168.21.5 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.21.5 description avd-ci-leaf4
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf4.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf4.cfg
@@ -1,0 +1,187 @@
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname avd-ci-leaf4
+ip name-server vrf MGMT 10.90.231.26
+!
+ntp server vrf MGMT 1.pool.ntp.org iburst local-interface Management1
+!
+spanning-tree mode mstp
+no spanning-tree vlan-id 4093-4094
+spanning-tree mst 0 priority 16384
+!
+aaa authentication login console local
+aaa authorization exec default local
+!
+no enable password
+no aaa root
+!
+username arista privilege 15 role network-admin shell /bin/bash secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username ci-avd privilege 15 role network-admin secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username cvpadmin privilege 15 role network-admin secret sha512 $6$3gTtM9zyRVpL6w7v$5nbd38Y7ZU0ZWty/ycn82iiC4ikX79hdopKWLusZaaFgr0spRqewcRBLKuY5qUaPdgg9h8CZjC4pFqLeQ5GRI1
+!
+vlan 4093
+   name LEAF_PEER_L3
+   trunk group LEAF_PEER_L3
+!
+vlan 4094
+   name MLAG_PEER
+   trunk group MLAG
+!
+vrf instance MGMT
+!
+interface Port-Channel10
+   description MLAG_PEER_avd-ci-leaf3_Po10
+   no shutdown
+   switchport
+   switchport mode trunk
+   switchport trunk group LEAF_PEER_L3
+   switchport trunk group MLAG
+!
+interface Ethernet1
+   description P2P_LINK_TO_AVD-CI-SPINE1_Ethernet4
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.13/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_AVD-CI-SPINE2_Ethernet4
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.15/31
+!
+interface Ethernet10
+   description MLAG_PEER_avd-ci-leaf3_Ethernet10
+   no shutdown
+   channel-group 10 mode active
+!
+interface Ethernet11
+   description MLAG_PEER_avd-ci-leaf3_Ethernet11
+   no shutdown
+   channel-group 10 mode active
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.21.0.4/32
+!
+interface Loopback1
+   description VTEP_VXLAN_Tunnel_Source
+   no shutdown
+   ip address 10.22.0.3/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 10.90.231.67/24
+!
+interface Vlan4093
+   description MLAG_PEER_L3_PEERING
+   no shutdown
+   mtu 1500
+   ip address 192.168.21.5/31
+!
+interface Vlan4094
+   description MLAG_PEER
+   no shutdown
+   mtu 1500
+   no autostate
+   ip address 192.168.20.5/31
+!
+interface Vxlan1
+   description avd-ci-leaf4_VTEP
+   vxlan source-interface Loopback1
+   vxlan virtual-router encapsulation mac-address mlag-system-id
+   vxlan udp-port 4789
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.21.0.0/24 eq 32
+   seq 20 permit 10.22.0.0/24 eq 32
+!
+mlag configuration
+   domain-id RACK2
+   local-interface Vlan4094
+   peer-address 192.168.20.4
+   peer-link Port-Channel10
+   reload-delay mlag 300
+   reload-delay non-mlag 330
+!
+ip route vrf MGMT 0.0.0.0/0 10.90.231.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-MLAG-PEER-IN permit 10
+   description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing
+   set origin incomplete
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65002
+   router-id 10.21.0.4
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
+   neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65002
+   neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
+   neighbor MLAG-IPv4-UNDERLAY-PEER description avd-ci-leaf3
+   neighbor MLAG-IPv4-UNDERLAY-PEER send-community
+   neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000
+   neighbor MLAG-IPv4-UNDERLAY-PEER route-map RM-MLAG-PEER-IN in
+   neighbor 10.20.0.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.1 remote-as 65000
+   neighbor 10.20.0.1 description avd-ci-spine1
+   neighbor 10.20.0.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.20.0.2 remote-as 65000
+   neighbor 10.20.0.2 description avd-ci-spine2
+   neighbor 10.23.0.12 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.12 remote-as 65000
+   neighbor 10.23.0.12 description avd-ci-spine1_Ethernet4
+   neighbor 10.23.0.14 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.14 remote-as 65000
+   neighbor 10.23.0.14 description avd-ci-spine2_Ethernet4
+   neighbor 192.168.21.4 peer group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.168.21.4 description avd-ci-leaf3
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+      neighbor MLAG-IPv4-UNDERLAY-PEER activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf4.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-leaf4.cfg
@@ -1,6 +1,6 @@
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt cvaas_stg.addr=apiserver.cv-staging.corp.arista.io:443 -cvopt cvaas_stg.auth=token-secure,/tmp/cv-onboarding-token-stg -cvopt cvaas_stg.vrf=MGMT -cvopt cvaas_prd.addr=apiserver.arista.io:443 -cvopt cvaas_prd.auth=token-secure,/tmp/cv-onboarding-token-prd -cvopt cvaas_prd.vrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 vlan internal order ascending range 1006 1199

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-spine1.cfg
@@ -1,0 +1,138 @@
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname avd-ci-spine1
+ip name-server vrf MGMT 10.90.231.26
+!
+ntp server vrf MGMT 1.pool.ntp.org iburst local-interface Management1
+!
+spanning-tree mode spine1
+!
+aaa authentication login console local
+aaa authorization exec default local
+!
+no enable password
+no aaa root
+!
+username arista privilege 15 role network-admin shell /bin/bash secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username ci-avd privilege 15 role network-admin secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username cvpadmin privilege 15 role network-admin secret sha512 $6$3gTtM9zyRVpL6w7v$5nbd38Y7ZU0ZWty/ycn82iiC4ikX79hdopKWLusZaaFgr0spRqewcRBLKuY5qUaPdgg9h8CZjC4pFqLeQ5GRI1
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_AVD-CI-LEAF1_Ethernet1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.0/31
+!
+interface Ethernet2
+   switchport
+   no shutdown
+   spanning-tree portfast
+!
+interface Ethernet3
+   description P2P_LINK_TO_AVD-CI-LEAF3_Ethernet1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.8/31
+   node-segment ipv4 index 1
+!
+interface Ethernet4
+   description P2P_LINK_TO_AVD-CI-LEAF4_Ethernet1
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.12/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.20.0.1/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 10.90.231.68/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seqq 10 permit 10.20.0.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 10.90.231.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 10.20.0.1
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.21.0.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.21.0.1 remote-as 65001
+   neighbor 10.21.0.1 description avd-ci-leaf1
+   neighbor 10.21.0.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.21.0.2 remote-as 65001
+   neighbor 10.21.0.2 description avd-ci-leaf2
+   neighbor 10.21.0.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.21.0.3 remote-as 65002
+   neighbor 10.21.0.3 description avd-ci-leaf3
+   neighbor 10.21.0.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.21.0.4 remote-as 65002
+   neighbor 10.21.0.4 description avd-ci-leaf4
+   neighbor 10.23.0.1 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.1 remote-as 65001
+   neighbor 10.23.0.1 description avd-ci-leaf1_Ethernet1
+   neighbor 10.23.0.5 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.5 remote-as 65001
+   neighbor 10.23.0.5 description avd-ci-leaf2_Ethernet1
+   neighbor 10.23.0.9 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.9 remote-as 65002
+   neighbor 10.23.0.9 description avd-ci-leaf3_Ethernet1
+   neighbor 10.23.0.13 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.13 remote-as 65002
+   neighbor 10.23.0.13 description avd-ci-leaf4_Ethernet1
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-spine1.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-spine1.cfg
@@ -1,6 +1,6 @@
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt cvaas_stg.addr=apiserver.cv-staging.corp.arista.io:443 -cvopt cvaas_stg.auth=token-secure,/tmp/cv-onboarding-token-stg -cvopt cvaas_stg.vrf=MGMT -cvopt cvaas_prd.addr=apiserver.arista.io:443 -cvopt cvaas_prd.auth=token-secure,/tmp/cv-onboarding-token-prd -cvopt cvaas_prd.vrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 vlan internal order ascending range 1006 1199

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-spine2.cfg
@@ -1,0 +1,139 @@
+!
+daemon TerminAttr
+   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   no shutdown
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname avd-ci-spine2
+ip name-server vrf MGMT 10.90.231.26
+!
+ntp server vrf MGMT 1.pool.ntp.org iburst local-interface Management1
+!
+spanning-tree mode spine2
+!
+aaa authentication login console local
+aaa authorization exec default local
+!
+no enable password
+no aaa root
+!
+username arista privilege 15 role network-admin shell /bin/bash secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username ci-avd privilege 15 role network-admin secret sha512 $6$arista$v8nDCIcRzulmeREaxjY5yFktUpc9y/j9pCGRtNLplY3Oq8VofM1fKehi.G7hC/5bm8B34yQinkT8/uyf3RCij1
+username cvpadmin privilege 15 role network-admin secret sha512 $6$3gTtM9zyRVpL6w7v$5nbd38Y7ZU0ZWty/ycn82iiC4ikX79hdopKWLusZaaFgr0spRqewcRBLKuY5qUaPdgg9h8CZjC4pFqLeQ5GRI1
+!
+vrf instance MGMT
+!
+interface Ethernet1
+   description P2P_LINK_TO_AVD-CI-LEAF1_Ethernet2
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.2/31
+!
+interface Ethernet2
+   description P2P_LINK_TO_AVD-CI-LEAF2_Ethernet2
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.6/31
+!
+interface Ethernet3
+   description P2P_LINK_TO_AVD-CI-LEAF3_Ethernet2
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.10/31
+!
+interface Ethernet4
+   description P2P_LINK_TO_AVD-CI-LEAF4_Ethernet2
+   no shutdown
+   mtu 1500
+   no switchport
+   ip address 10.23.0.14/31
+!
+interface Loopback0
+   description EVPN_Overlay_Peering
+   no shutdown
+   ip address 10.20.0.2/32
+!
+interface Management1
+   description oob_management
+   no shutdown
+   vrf MGMT
+   ip address 10.90.231.69/24
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+   seq 10 permit 10.20.0.0/24 eq 32
+!
+ip route vrf MGMT 0.0.0.0/0 10.90.231.1
+!
+route-map RM-CONN-2-BGP permit 10
+   match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65000
+   router-id 10.20.0.2
+   maximum-paths 4 ecmp 4
+   update wait-install
+   no bgp default ipv4-unicast
+   neighbor EVPN-OVERLAY-PEERS peer group
+   neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
+   neighbor EVPN-OVERLAY-PEERS update-source Loopback0
+   neighbor EVPN-OVERLAY-PEERS bfd
+   neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
+   neighbor EVPN-OVERLAY-PEERS send-community
+   neighbor EVPN-OVERLAY-PEERS maximum-routes 0
+   neighbor IPv4-UNDERLAY-PEERS peer group
+   neighbor IPv4-UNDERLAY-PEERS send-community
+   neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
+   neighbor 10.21.0.1 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.21.0.1 remote-as 65001
+   neighbor 10.21.0.1 description avd-ci-leaf1
+   neighbor 10.21.0.2 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.21.0.2 remote-as 65001
+   neighbor 10.21.0.2 description avd-ci-leaf2
+   neighbor 10.21.0.3 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.21.0.3 remote-as 65002
+   neighbor 10.21.0.3 description avd-ci-leaf3
+   neighbor 10.21.0.4 peer group EVPN-OVERLAY-PEERS
+   neighbor 10.21.0.4 remote-as 65002
+   neighbor 10.21.0.4 description avd-ci-leaf4
+   neighbor 10.23.0.3 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.3 remote-as 65001
+   neighbor 10.23.0.3 description avd-ci-leaf1_Ethernet2
+   neighbor 10.23.0.7 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.7 remote-as 65001
+   neighbor 10.23.0.7 description avd-ci-leaf2_Ethernet2
+   neighbor 10.23.0.11 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.11 remote-as 65002
+   neighbor 10.23.0.11 description avd-ci-leaf3_Ethernet2
+   neighbor 10.23.0.15 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.23.0.15 remote-as 65002
+   neighbor 10.23.0.15 description avd-ci-leaf4_Ethernet2
+   redistribute connected route-map RM-CONN-2-BGP
+   !
+   address-family evpn
+      neighbor EVPN-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor EVPN-OVERLAY-PEERS activate
+      neighbor IPv4-UNDERLAY-PEERS activate
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-spine2.cfg
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/configs/test_invalid_configs/avd-ci-spine2.cfg
@@ -1,6 +1,6 @@
 !
 daemon TerminAttr
-   exec /usr/bin/TerminAttr -cvaddr=apiserver.cv-staging.corp.arista.io:443 -cvauth=token-secure,/mnt/flash/cv-onboarding-token -cvvrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
+   exec /usr/bin/TerminAttr -cvopt cvaas_stg.addr=apiserver.cv-staging.corp.arista.io:443 -cvopt cvaas_stg.auth=token-secure,/tmp/cv-onboarding-token-stg -cvopt cvaas_stg.vrf=MGMT -cvopt cvaas_prd.addr=apiserver.arista.io:443 -cvopt cvaas_prd.auth=token-secure,/tmp/cv-onboarding-token-prd -cvopt cvaas_prd.vrf=MGMT -smashexcludes=ale,flexCounter,hardware,kni,pulse,strata -ingestexclude=/Sysdb/cell/1/agent,/Sysdb/cell/2/agent -taillogs
    no shutdown
 !
 vlan internal order ascending range 1006 1199

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/structured_configs/test_invalid_configs/avd-ci-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/structured_configs/test_invalid_configs/avd-ci-leaf1.yml
@@ -1,0 +1,26 @@
+hostname: avd-ci-leaf1
+is_deployed: true
+metadata:
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: edge
+    - name: Region
+      value: AVD_Land_East
+    - name: Zone
+      value: DEFAULT-ZONE
+    - name: Site
+      value: Site511
+    interface_tags:
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: wan
+    - interface: Ethernet2
+      tags:
+      - name: Type
+        value: wan
+    - interface: Ethernet3
+      tags:
+      - name: Type
+        value: wan

--- a/ansible_collections/arista/avd/molecule/cv_deploy/intended/structured_configs/test_invalid_configs/avd-ci-missing.yml
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/intended/structured_configs/test_invalid_configs/avd-ci-missing.yml
@@ -1,0 +1,20 @@
+hostname: avd-ci-leaf1
+is_deployed: true
+metadata:
+  cv_tags:
+    device_tags:
+    - name: Role
+      value: edge
+    interface_tags:
+    - interface: Ethernet1
+      tags:
+      - name: Type
+        value: wan
+    - interface: Ethernet2
+      tags:
+      - name: Type
+        value: wan
+    - interface: Ethernet3
+      tags:
+      - name: Type
+        value: wan

--- a/ansible_collections/arista/avd/molecule/cv_deploy/invalid_config.yml
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/invalid_config.yml
@@ -1,0 +1,101 @@
+---
+- name: "{{ test_id | upper }} Converge - cv_deploy with invalid Designed Config"
+  hosts: SITE1_FABRIC
+  connection: local
+  gather_facts: false
+  vars:
+    cv_server: "{{ lookup('env', 'CV_SERVER') }}"
+    cv_token: "{{ lookup('env', 'CV_ACCESS_TOKEN') }}"
+    cv_verify_certs: true
+    cv_skip_missing_devices: true
+    eos_config_dir: "{{ playbook_dir }}/intended/configs/test_invalid_configs"
+    structured_dir: "{{ playbook_dir }}/intended/structured_configs/test_invalid_configs"
+    intended_tag_device: avd-ci-leaf1
+    intended_tags: "{{ lookup('file', structured_dir ~ '/' ~ intended_tag_device ~ '.yml')| from_yaml }}"
+    test_id: "workspace-invalid-configs"
+    cv_common_pattern: "avd-cv-deploy-{{ test_id }}"
+
+  tasks:
+    - name: "{{ test_id | upper }} Banner"
+      tags: ["{{ test_id }}"]
+      run_once: true
+      ansible.builtin.debug:
+        msg:
+          - "######################################################################"
+          - "### STARTING MOLECULE TEST {{ '{:<38}'.format(test_id[:38]) | upper }} ####"
+          - "######################################################################"
+
+    - name: "{{ test_id | upper }} Generate random string"
+      tags: ["{{ test_id }}"]
+      run_once: true
+      ansible.builtin.set_fact:
+        r: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=4') }}"
+
+    - name: "{{ test_id | upper }} Natively engage arista.avd.cv_workflow module to test abandoned Workspace"
+      tags: ["{{ test_id }}"]
+      run_once: true
+      delegate_to: localhost
+
+      block:
+
+        - name: "{{ test_id | upper }} engage arista.avd.cv_workflow module to test failing build when workspace.requested_state == abandoned"
+          tags: ["{{ test_id }}"]
+          run_once: true
+          delegate_to: localhost
+          arista.avd.cv_workflow:
+            cv_servers: [ "{{ cv_server }}" ]
+            cv_token: "{{ cv_token }}"
+            cv_verify_certs: "{{ cv_verify_certs }}"
+            configuration_dir: "{{ eos_config_dir }}"
+            structured_config_dir: "{{ structured_dir }}"
+            device_list: "{{ ansible_play_hosts_all }}"
+            workspace:
+              name: "{{ cv_common_pattern }}-{{ r }}-converge"
+              description: "{{ (cv_common_pattern + '-' + r + '-converge') | upper }}"
+              requested_state: "abandoned"
+            return_details: true
+          register: cv_deploy_results
+
+      rescue:
+
+        - name: "{{ test_id | upper }} Display CVP result for basic invalid configuration"
+          tags: ["{{ test_id }}"]
+          run_once: true
+          ansible.builtin.debug:
+            msg: '{{ cv_deploy_results }}'
+
+        - name: "{{ test_id | upper }} Assert CVP returns for basic invalid configuration"
+          tags: ["{{ test_id }}"]
+          run_once: true
+          ansible.builtin.assert:
+            that:
+              - cv_deploy_results.workspace.requested_state == "abandoned"
+              - cv_deploy_results.workspace.state == "abandoned"
+              - cv_deploy_results.failed is true
+              - cv_deploy_results.warnings == []
+              - cv_deploy_results.errors | length == 1
+              - "'Failed to build workspace' in cv_deploy_results.errors[0]"
+              - "'device build error' in cv_deploy_results.errors[0]"
+
+    - name: "{{ test_id | upper }} Cleanup"
+      tags: ["{{ test_id }}"]
+      run_once: true
+      delegate_to: localhost
+      ansible.builtin.import_role:
+        name: arista.avd.cv_deploy
+      vars:
+        cv_workspace_name: "{{ cv_common_pattern }}-{{ r }}-cleanup"
+        cv_workspace_description: "{{ cv_common_pattern + '-' + r + '-cleanup' | upper }}"
+        cv_change_control_name: "{{ cv_common_pattern }}-{{ r }}-cleanup"
+        cv_change_control_description: "{{ cv_common_pattern + '-' + r + '-cleanup' | upper }}"
+        cv_register_detailed_results: true
+        cv_devices: "{{ ansible_play_hosts_all }}"
+        eos_config_dir: "{{ playbook_dir }}/intended/configs/base_configs"
+        structured_dir: "{{ playbook_dir }}/intended/structured_configs/base_configs"
+        cv_submit_workspace_force: true
+        cv_run_change_control: true
+
+    # Clear failed state of failed hosts for next engaged playbook (no impact within running playbook)
+    - name: Reset ansible_play_hosts for next playbook (no impact within running playbook)
+      tags: ["{{ test_id }}"]
+      ansible.builtin.meta: clear_host_errors

--- a/ansible_collections/arista/avd/molecule/cv_deploy/workspace_force_false.yml
+++ b/ansible_collections/arista/avd/molecule/cv_deploy/workspace_force_false.yml
@@ -51,6 +51,7 @@
             that:
               # errors and warnings
               - "'Failed to submit workspace' in cv_deploy_results.errors[0]"
+              - cv_deploy_results.workspace.state == "submit failed"
 
     - name: Cleanup orphan workspace
       run_once: true

--- a/python-avd/pyavd/_cv/workflows/finalize_workspace_on_cv.py
+++ b/python-avd/pyavd/_cv/workflows/finalize_workspace_on_cv.py
@@ -43,6 +43,9 @@ async def finalize_workspace_on_cv(workspace: CVWorkspace, cv_client: CVClient) 
     if build_result.status != ResponseStatus.SUCCESS:
         workspace.state = "build failed"
         LOGGER.info("finalize_workspace_on_cv: %s", workspace)
+        if workspace.requested_state == "abandoned":
+            await cv_client.abandon_workspace(workspace_id=workspace.id)
+            workspace.state = "abandoned"
         msg = (
             f"Failed to build workspace {workspace.id}: {build_result}. "
             f"See details: https://{cv_client._servers[0]}/cv/provisioning/workspaces?ws={workspace.id}"

--- a/python-avd/pyavd/_cv/workflows/finalize_workspace_on_cv.py
+++ b/python-avd/pyavd/_cv/workflows/finalize_workspace_on_cv.py
@@ -46,6 +46,7 @@ async def finalize_workspace_on_cv(workspace: CVWorkspace, cv_client: CVClient) 
         if workspace.requested_state == "abandoned":
             await cv_client.abandon_workspace(workspace_id=workspace.id)
             workspace.state = "abandoned"
+        LOGGER.info("finalize_workspace_on_cv: Workspace %s has been successfully abandoned.", workspace.id)
         msg = (
             f"Failed to build workspace {workspace.id}: {build_result}. "
             f"See details: https://{cv_client._servers[0]}/cv/provisioning/workspaces?ws={workspace.id}"

--- a/python-avd/pyavd/_cv/workflows/finalize_workspace_on_cv.py
+++ b/python-avd/pyavd/_cv/workflows/finalize_workspace_on_cv.py
@@ -46,7 +46,7 @@ async def finalize_workspace_on_cv(workspace: CVWorkspace, cv_client: CVClient) 
         if workspace.requested_state == "abandoned":
             await cv_client.abandon_workspace(workspace_id=workspace.id)
             workspace.state = "abandoned"
-        LOGGER.info("finalize_workspace_on_cv: Workspace %s has been successfully abandoned.", workspace.id)
+            LOGGER.info("finalize_workspace_on_cv: Workspace %s has been successfully abandoned.", workspace.id)
         msg = (
             f"Failed to build workspace {workspace.id}: {build_result}. "
             f"See details: https://{cv_client._servers[0]}/cv/provisioning/workspaces?ws={workspace.id}"


### PR DESCRIPTION
## Change Summary

Abandon Workspaces that failed at Build phase if their requested_state was `abandoned`

## Related Issue(s)

Fixes #4574 

## Component(s) name

`arista.avd.cv_deploy`

## Proposed changes

## How to test
 - Run cd_deploy molecule tests against CI
 - Check results of the invalid_config.yml execution. Verify that failed WS gets abandoned if it's `requested_state` is "abandoned".

```
        "errors": [
            "Failed to build workspace ws-4f3177eb-9149-4941-8622-50533f31b874: Response(status=ResponseStatus.FAIL, message='device build error'). See details: https://www.cv-staging.corp.arista.io/cv/provisioning/workspaces?ws=ws-4f3177eb-9149-4941-8622-50533f31b874"
        ],
        "failed": true,

        "workspace": {
            "requested_state": "abandoned",
            "state": "abandoned"
```

- Validate presence of the log message confirming that failed Workspace was successfully abandoned.

Example:
```
finalize_workspace_on_cv: Workspace ws-f3284373-9f4f-4b7c-b137-ead4b91ec5ff has been successfully abandoned.
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
