### PR TITLE
Fix(containers): fix docker/setup-qemu-action@v3 by setting image to tonistiigi/binfmt:qemu-v7.0.0-28

### DIFF
--- a/.github/workflows/container_build_template.yml
+++ b/.github/workflows/container_build_template.yml
@@ -153,6 +153,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ inputs.platform }}
+          image: tonistiigi/binfmt:qemu-v7.0.0-28
 
       - name: Setup Docker buildX for multi-arch builds 🏗️
         # if: ${{ steps.check-image-presence.outputs.not_present == '1' }}


### PR DESCRIPTION
## Change Summary

workaround for https://github.com/tonistiigi/binfmt/issues/240
setting image to tonistiigi/binfmt:qemu-v7.0.0-28

## Related Issue(s)

https://github.com/tonistiigi/binfmt/issues/240

## How to test
tested by updating end enabling universal workflow on my fork