### PR TITLE
Fix(eos_designs): Wrong structured config for overlapping network ports

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/duplicate-interfaces-network-ports-with-port-channel.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/duplicate-interfaces-network-ports-with-port-channel.yml
@@ -1,0 +1,32 @@
+loopback_ipv4_pool: 192.168.0.0/24
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    - name: duplicate-interfaces-network-ports-with-port-channel
+
+network_ports:
+  # port-channel provide physical and individual port-channel descriptions
+  - switches:
+      - duplicate-interfaces-network-ports-with-port-channel
+    switch_ports:
+      - Ethernet9
+    port_channel:
+      channel_id: 9
+      mode: "active"
+      description: "PORT_CHANNEL_DESCRIPTION"
+  - switches:
+      - duplicate-interfaces-network-ports-with-port-channel
+    switch_ports:
+      - Ethernet10
+    port_channel:
+      channel_id: 9
+      mode: "active"
+      description: "DIFFERENT_PORT_CHANNEL_DESCRIPTION"
+
+expected_error_message: >-
+  Found duplicate objects with conflicting data while generating configuration for PortChannelInterfaces.
+  {'name': 'Port-Channel9', 'description': 'DIFFERENT_PORT_CHANNEL_DESCRIPTION', 'shutdown': False, 'switchport': {'enabled': True}}
+  conflicts with
+  {'name': 'Port-Channel9', 'description': 'PORT_CHANNEL_DESCRIPTION', 'shutdown': False, 'switchport': {'enabled': True}}.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -85,6 +85,7 @@ all:
             duplicate-interface-l3-edge:
             duplicate-l3-interfaces-network-services:
             duplicate-peer-ip-address-network-services:
+            duplicate-interfaces-network-ports-with-port-channel:
             duplicate-interfaces-point-to-point-services-1:
             duplicate-interfaces-point-to-point-services-2:
             duplicate-interfaces-point-to-point-services-3:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests-2.cfg
@@ -604,6 +604,7 @@ interface Ethernet24
 !
 interface Ethernet51
    no shutdown
+   switchport access vlan 123
    channel-group 43 mode active
 !
 interface Ethernet52

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -41,6 +41,13 @@ interface Port-Channel101
    switchport trunk group MLAG
    switchport
 !
+interface Port-Channel222
+   description This should be the only one render and no vlan 666
+   no shutdown
+   switchport access vlan 666
+   switchport
+   mlag 222
+!
 interface Ethernet1
    description PCs
    no shutdown
@@ -557,22 +564,14 @@ interface Ethernet21
    switchport
 !
 interface Ethernet22
-   description Range
+   description Single overwrite
    no shutdown
-   switchport access vlan 666
-   switchport
+   channel-group 222 mode active
 !
 interface Ethernet23
    description Range
    no shutdown
-   switchport access vlan 666
-   switchport
-!
-interface Ethernet24
-   description Range
-   no shutdown
-   switchport access vlan 666
-   switchport
+   channel-group 222 mode active
 !
 interface Ethernet48
    description Matched on all hostnames and 48 port platform

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -44,7 +44,6 @@ interface Port-Channel101
 interface Port-Channel222
    description This should be the only one render and no vlan 666
    no shutdown
-   switchport access vlan 666
    switchport
    mlag 222
 !
@@ -580,6 +579,7 @@ interface Ethernet48
 !
 interface Ethernet51
    shutdown
+   switchport access vlan 123
    switchport
 !
 interface Ethernet52

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -42,8 +42,9 @@ interface Port-Channel101
    switchport
 !
 interface Port-Channel222
-   description This should be the only one render and no vlan 666
+   description Range
    no shutdown
+   switchport access vlan 666
    switchport
    mlag 222
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -544,6 +544,36 @@ interface Ethernet14
    no shutdown
    switchport
 !
+interface Ethernet20
+   description Single overwrite
+   no shutdown
+   switchport access vlan 42
+   switchport
+!
+interface Ethernet21
+   description Range
+   no shutdown
+   switchport access vlan 42
+   switchport
+!
+interface Ethernet22
+   description Range
+   no shutdown
+   switchport access vlan 42
+   switchport
+!
+interface Ethernet23
+   description Range
+   no shutdown
+   switchport access vlan 42
+   switchport
+!
+interface Ethernet24
+   description Range
+   no shutdown
+   switchport access vlan 42
+   switchport
+!
 interface Ethernet48
    description Matched on all hostnames and 48 port platform
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-ports-tests.1.cfg
@@ -553,25 +553,25 @@ interface Ethernet20
 interface Ethernet21
    description Range
    no shutdown
-   switchport access vlan 42
+   switchport access vlan 666
    switchport
 !
 interface Ethernet22
    description Range
    no shutdown
-   switchport access vlan 42
+   switchport access vlan 666
    switchport
 !
 interface Ethernet23
    description Range
    no shutdown
-   switchport access vlan 42
+   switchport access vlan 666
    switchport
 !
 interface Ethernet24
    description Range
    no shutdown
-   switchport access vlan 42
+   switchport access vlan 666
    switchport
 !
 interface Ethernet48

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -721,6 +721,8 @@ ethernet_interfaces:
     id: 43
     mode: active
   peer_type: network_port
+  switchport:
+    access_vlan: 123
 - name: Ethernet52
   shutdown: false
   channel_group:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -703,6 +703,41 @@ ethernet_interfaces:
   peer_type: network_port
   switchport:
     enabled: true
+- name: Ethernet20
+  description: Single overwrite
+  shutdown: false
+  peer_type: network_port
+  switchport:
+    enabled: true
+    access_vlan: 42
+- name: Ethernet21
+  description: Range
+  shutdown: false
+  peer_type: network_port
+  switchport:
+    enabled: true
+    access_vlan: 42
+- name: Ethernet22
+  description: Range
+  shutdown: false
+  peer_type: network_port
+  switchport:
+    enabled: true
+    access_vlan: 42
+- name: Ethernet23
+  description: Range
+  shutdown: false
+  peer_type: network_port
+  switchport:
+    enabled: true
+    access_vlan: 42
+- name: Ethernet24
+  description: Range
+  shutdown: false
+  peer_type: network_port
+  switchport:
+    enabled: true
+    access_vlan: 42
 hostname: network-ports-tests.1
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -718,26 +718,19 @@ ethernet_interfaces:
     enabled: true
     access_vlan: 666
 - name: Ethernet22
-  description: Range
+  description: Single overwrite
   shutdown: false
+  channel_group:
+    id: 222
+    mode: active
   peer_type: network_port
-  switchport:
-    enabled: true
-    access_vlan: 666
 - name: Ethernet23
   description: Range
   shutdown: false
+  channel_group:
+    id: 222
+    mode: active
   peer_type: network_port
-  switchport:
-    enabled: true
-    access_vlan: 666
-- name: Ethernet24
-  description: Range
-  shutdown: false
-  peer_type: network_port
-  switchport:
-    enabled: true
-    access_vlan: 666
 hostname: network-ports-tests.1
 ip_igmp_snooping:
   globally_enabled: true
@@ -766,6 +759,13 @@ port_channel_interfaces:
     trunk:
       groups:
       - MLAG
+- name: Port-Channel222
+  description: This should be the only one render and no vlan 666
+  shutdown: false
+  mlag: 222
+  switchport:
+    enabled: true
+    access_vlan: 666
 service_routing_protocols_model: multi-agent
 spanning_tree:
   no_spanning_tree_vlan: '4094'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -682,6 +682,7 @@ ethernet_interfaces:
   peer_type: network_port
   switchport:
     enabled: true
+    access_vlan: 123
 - name: Ethernet52
   shutdown: true
   peer_type: network_port
@@ -765,7 +766,6 @@ port_channel_interfaces:
   mlag: 222
   switchport:
     enabled: true
-    access_vlan: 666
 service_routing_protocols_model: multi-agent
 spanning_tree:
   no_spanning_tree_vlan: '4094'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -761,11 +761,12 @@ port_channel_interfaces:
       groups:
       - MLAG
 - name: Port-Channel222
-  description: This should be the only one render and no vlan 666
+  description: Range
   shutdown: false
   mlag: 222
   switchport:
     enabled: true
+    access_vlan: 666
 service_routing_protocols_model: multi-agent
 spanning_tree:
   no_spanning_tree_vlan: '4094'

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -716,28 +716,28 @@ ethernet_interfaces:
   peer_type: network_port
   switchport:
     enabled: true
-    access_vlan: 42
+    access_vlan: 666
 - name: Ethernet22
   description: Range
   shutdown: false
   peer_type: network_port
   switchport:
     enabled: true
-    access_vlan: 42
+    access_vlan: 666
 - name: Ethernet23
   description: Range
   shutdown: false
   peer_type: network_port
   switchport:
     enabled: true
-    access_vlan: 42
+    access_vlan: 666
 - name: Ethernet24
   description: Range
   shutdown: false
   peer_type: network_port
   switchport:
     enabled: true
-    access_vlan: 42
+    access_vlan: 666
 hostname: network-ports-tests.1
 ip_igmp_snooping:
   globally_enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -211,7 +211,10 @@ network_ports:
       channel_id: 222
       mode: "active"
       structured_config:
-        description: This should be the only one render and no vlan 666
+        # TODO: Make this error out since we have conflicting structured_config
+        # Ethernet22 was inserted before 23, so even though we overwrite 22 here,
+        # it is still rendered first, so the 23 variant of structured config "wins"
+        description: This will not be rendered since it is overwritten by "Range" coming from the Eth22-23 range.
 
 # Overwriting one interface from a range to ensure that we don't reuse objects in memory across multiple interfaces.
 # We should only see updates for this interface.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -172,6 +172,24 @@ network_ports:
       - Ethernet25
     description: No criteria, no config
 
+  # Test overwrite network ports structured_config
+  - switches:
+      - network-ports-tests.1
+    switch_ports:
+      - Ethernet20-24
+    description: Range
+    structured_config:
+      switchport:
+        access_vlan: 666
+  - switches:
+      - network-ports-tests.1
+    switch_ports:
+      - Ethernet20
+    description: Single overwrite
+    structured_config:
+      switchport:
+        access_vlan: 42
+
 servers:
   - name: CONNECTED_ENDPOINT_OVERWRITING_NETWORK_PORT
     adapters:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -176,7 +176,7 @@ network_ports:
   - switches:
       - network-ports-tests.1
     switch_ports:
-      - Ethernet20-24
+      - Ethernet20-21
     description: Range
     structured_config:
       switchport:
@@ -189,6 +189,29 @@ network_ports:
     structured_config:
       switchport:
         access_vlan: 42
+  # Test overwrite network ports structured_config with port-channel
+  - switches:
+      - network-ports-tests.1
+    switch_ports:
+      - Ethernet22-23
+    description: Range
+    port_channel:
+      channel_id: 222
+      mode: "active"
+      structured_config:
+        description: Range
+        switchport:
+          access_vlan: 666
+  - switches:
+      - network-ports-tests.1
+    switch_ports:
+      - Ethernet22
+    description: Single overwrite
+    port_channel:
+      channel_id: 222
+      mode: "active"
+      structured_config:
+        description: This should be the only one render and no vlan 666
 
 servers:
   - name: CONNECTED_ENDPOINT_OVERWRITING_NETWORK_PORT
@@ -238,5 +261,6 @@ custom_platform_settings:
     reload_delay:
       mlag: 300
       non_mlag: 330
-    trident_forwarding_table_partition: flexible exact-match 16000 l2-shared 18000 l3-shared
+    trident_forwarding_table_partition:
+      flexible exact-match 16000 l2-shared 18000 l3-shared
       22000

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/NETWORK_PORTS_TESTS.yml
@@ -213,6 +213,13 @@ network_ports:
       structured_config:
         description: This should be the only one render and no vlan 666
 
+# Overwriting one interface from a range to ensure that we don't reuse objects in memory across multiple interfaces.
+# We should only see updates for this interface.
+custom_structured_configuration_ethernet_interfaces:
+  - name: Ethernet51
+    switchport:
+      access_vlan: 123
+
 servers:
   - name: CONNECTED_ENDPOINT_OVERWRITING_NETWORK_PORT
     adapters:
@@ -261,6 +268,5 @@ custom_platform_settings:
     reload_delay:
       mlag: 300
       non_mlag: 330
-    trident_forwarding_table_partition:
-      flexible exact-match 16000 l2-shared 18000 l3-shared
+    trident_forwarding_table_partition: flexible exact-match 16000 l2-shared 18000 l3-shared
       22000

--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/ethernet_interfaces.py
@@ -65,6 +65,11 @@ class EthernetInterfacesMixin(Protocol):
                 network_port_as_adapter.switches = EosDesigns._DynamicKeys.DynamicConnectedEndpointsItem.ConnectedEndpointsItem.AdaptersItem.Switches(
                     [self.shared_utils.hostname]
                 )
+                # TODO: this fix is not enough as it only prevent the same objects to be reused in all the
+                # structured_config for network_port and it solves the initial issue
+                # but this does not prevent an aggregation of all the structured_configs which is not
+                # the correct behavior.
+                # Need to keep track of the "network_port" structured configs
                 network_port_as_adapter.structured_config = network_port.structured_config._deepcopy()
                 ethernet_interface = self._get_ethernet_interface_cfg(network_port_as_adapter, 0, connected_endpoint)
 

--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/ethernet_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/ethernet_interfaces.py
@@ -65,6 +65,7 @@ class EthernetInterfacesMixin(Protocol):
                 network_port_as_adapter.switches = EosDesigns._DynamicKeys.DynamicConnectedEndpointsItem.ConnectedEndpointsItem.AdaptersItem.Switches(
                     [self.shared_utils.hostname]
                 )
+                network_port_as_adapter.structured_config = network_port.structured_config._deepcopy()
                 ethernet_interface = self._get_ethernet_interface_cfg(network_port_as_adapter, 0, connected_endpoint)
 
                 # Using __setitem__ to replace any previous network_port.

--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/port_channel_interfaces.py
@@ -43,9 +43,15 @@ class PortChannelInterfacesMixin(Protocol):
                 channel_group_id = adapter.port_channel.channel_id or default_channel_group_id
 
                 port_channel_interface_name = f"Port-Channel{channel_group_id}"
-                self.structured_config.port_channel_interfaces.append(
-                    self._get_port_channel_interface_cfg(adapter, port_channel_interface_name, channel_group_id, connected_endpoint)
+
+                port_channel_interface, structured_config = self._get_port_channel_interface_cfg(
+                    adapter, port_channel_interface_name, channel_group_id, connected_endpoint
                 )
+                self.structured_config.port_channel_interfaces.append(port_channel_interface)
+                if structured_config:
+                    self.custom_structured_configs.nested.port_channel_interfaces.obtain(port_channel_interface.name)._deepmerge(
+                        structured_config, list_merge=self.custom_structured_configs.list_merge_strategy
+                    )
 
                 for subinterface in adapter.port_channel.subinterfaces:
                     if not subinterface.number:
@@ -61,9 +67,13 @@ class PortChannelInterfacesMixin(Protocol):
                         )
                     )
 
-        # Temporary list of port-channel interfaces to be added by network ports.
+        # Temporary dict of port-channel interfaces to be added by network ports.
         # We need this since network ports can override each other, so the last one "wins"
-        network_ports_port_channel_interfaces = EosCliConfigGen.PortChannelInterfaces()
+        # Dict keyed by interface name. Value is a tuple of the interface config and any structured config for this interface.
+        network_ports_port_channel_interfaces: dict[
+            str, tuple[EosCliConfigGen.PortChannelInterfacesItem, EosCliConfigGen.PortChannelInterfacesItem | None]
+        ] = {}
+
         for network_port in self._filtered_network_ports:
             if not network_port.port_channel.mode:
                 continue
@@ -84,23 +94,23 @@ class PortChannelInterfacesMixin(Protocol):
                 network_port_as_adapter.switches = EosDesigns._DynamicKeys.DynamicConnectedEndpointsItem.ConnectedEndpointsItem.AdaptersItem.Switches(
                     [self.shared_utils.hostname, ""]
                 )
-                # TODO: this is not enough cf the current test with structured_config from both ranges
-                network_port_as_adapter.port_channel.structured_config = network_port.port_channel.structured_config._deepcopy()
-
                 default_channel_group_id = int("".join(re.findall(r"\d", ethernet_interface_name)))
                 channel_group_id = network_port_as_adapter.port_channel.channel_id or default_channel_group_id
 
                 port_channel_interface_name = f"Port-Channel{channel_group_id}"
 
-                port_channel_interface = self._get_port_channel_interface_cfg(
+                # Using __setitem__ to replace any previous network_port.
+                network_ports_port_channel_interfaces[port_channel_interface_name] = self._get_port_channel_interface_cfg(
                     network_port_as_adapter, port_channel_interface_name, channel_group_id, connected_endpoint
                 )
 
-                # Using __setitem__ to replace any previous network_port.
-                network_ports_port_channel_interfaces[port_channel_interface_name] = port_channel_interface
-
-        if network_ports_port_channel_interfaces:
-            self.structured_config.port_channel_interfaces.extend(network_ports_port_channel_interfaces)
+        # Now insert into the actual structured config and custom structured config
+        for port_channel_interface, structured_config in network_ports_port_channel_interfaces.values():
+            self.structured_config.port_channel_interfaces.append(port_channel_interface)
+            if structured_config:
+                self.custom_structured_configs.nested.port_channel_interfaces.obtain(port_channel_interface.name)._deepmerge(
+                    structured_config, list_merge=self.custom_structured_configs.list_merge_strategy
+                )
 
     def _get_port_channel_interface_cfg(
         self: AvdStructuredConfigConnectedEndpointsProtocol,
@@ -108,8 +118,23 @@ class PortChannelInterfacesMixin(Protocol):
         port_channel_interface_name: str,
         channel_group_id: int,
         connected_endpoint: EosDesigns._DynamicKeys.DynamicConnectedEndpointsItem.ConnectedEndpointsItem,
-    ) -> EosCliConfigGen.PortChannelInterfacesItem:
-        """Return structured_config for one port_channel_interface."""
+    ) -> tuple[EosCliConfigGen.PortChannelInterfacesItem, EosCliConfigGen.PortChannelInterfacesItem | None]:
+        """
+        Return structured_config for one port_channel_interface.
+
+        Args:
+            adapter: The adapter item containing port-channel configuration.
+            port_channel_interface_name: The name of the port-channel interface.
+            channel_group_id: The channel group ID for the port-channel.
+            connected_endpoint: The connected endpoint item.
+
+        Returns:
+            The port-channel interface configuration
+            Any structured config
+
+        Raises:
+            AristaAvdInvalidInputsError: If the 'vlans' value is invalid for the given mode.
+        """
         peer = connected_endpoint.name
         adapter_description = adapter.description
         port_channel_description = adapter.port_channel.description
@@ -148,10 +173,6 @@ class PortChannelInterfacesMixin(Protocol):
             validate_lldp=None if (adapter.validate_lldp if adapter.validate_lldp is not None else True) else False,
             eos_cli=adapter.port_channel.raw_eos_cli,
         )
-        if adapter.port_channel.structured_config:
-            self.custom_structured_configs.nested.port_channel_interfaces.obtain(port_channel_interface_name)._deepmerge(
-                adapter.port_channel.structured_config, list_merge=self.custom_structured_configs.list_merge_strategy
-            )
 
         if adapter.port_channel.subinterfaces:
             port_channel_interface.switchport.enabled = False
@@ -209,7 +230,7 @@ class PortChannelInterfacesMixin(Protocol):
             port_channel_interface.lacp_fallback_mode = adapter.port_channel.lacp_fallback.mode
             port_channel_interface.lacp_fallback_timeout = adapter.port_channel.lacp_fallback.timeout
 
-        return port_channel_interface
+        return port_channel_interface, adapter.port_channel.structured_config or None
 
     def _get_port_channel_subinterface_cfg(
         self: AvdStructuredConfigConnectedEndpointsProtocol,

--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/port_channel_interfaces.py
@@ -84,6 +84,8 @@ class PortChannelInterfacesMixin(Protocol):
                 network_port_as_adapter.switches = EosDesigns._DynamicKeys.DynamicConnectedEndpointsItem.ConnectedEndpointsItem.AdaptersItem.Switches(
                     [self.shared_utils.hostname, ""]
                 )
+                # TODO: this is not enough cf the current test with structured_config from both ranges
+                network_port_as_adapter.port_channel.structured_config = network_port.port_channel.structured_config._deepcopy()
 
                 default_channel_group_id = int("".join(re.findall(r"\d", ethernet_interface_name)))
                 channel_group_id = network_port_as_adapter.port_channel.channel_id or default_channel_group_id


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix(eos_designs): Wrong structured config for nested network ports

## Related Issue(s)

Fixes issue where structured config "leaked" between network ports when overridden.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Postpone application of `structured_config` until we have decided on which network_port to configure.
- Done for both ethernet_interfaces and port_channel_interfaces

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added tests

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
