### PR TITLE
Fix(eos_designs): Invalid class returned from snmp_settings.vrfs (#5035)

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/custom-structured-configuration.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/custom-structured-configuration.cfg
@@ -27,6 +27,9 @@ ip name-server vrf MGMT 192.168.42.40
 ip name-server vrf VRF2 192.168.42.40
 ip name-server vrf MGMT 192.168.42.50
 !
+snmp-server vrf foo
+snmp-server vrf bar
+!
 vrf instance MGMT
 !
 management api http-commands

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/custom-structured-configuration.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/custom-structured-configuration.yml
@@ -63,6 +63,12 @@ management_api_http:
 metadata:
   fabric_name: EOS_DESIGNS_UNIT_TESTS
 service_routing_protocols_model: multi-agent
+snmp_server:
+  vrfs:
+  - name: foo
+    enable: true
+  - name: bar
+    enable: true
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/custom-structured-configuration.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/custom-structured-configuration.yml
@@ -107,3 +107,14 @@ csc_1_domain_list:
   - foo.foo
   - bar.bar
 csc_2_domain_list: null
+
+# Testing a model where we are using a $ref for the entire schema, so the classes will be cli_gen classes.
+snmp_settings:
+  vrfs:
+    - name: foo
+      enable: true
+
+csc_1_snmp_server:
+  vrfs:
+    - name: bar
+      enable: true

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -20,9 +20,6 @@ if TYPE_CHECKING:
 class EosDesigns(EosDesignsRootModel):
     """Subclass of AvdModel."""
 
-    class ApplicationClassification(EosCliConfigGen.ApplicationTrafficRecognition):
-        """Subclass of AvdModel."""
-
     class BfdMultihop(AvdModel):
         """Subclass of AvdModel."""
 
@@ -48,9 +45,6 @@ class EosDesigns(EosDesignsRootModel):
                     multiplier: multiplier
 
                 """
-
-    class BgpDistance(EosCliConfigGen.RouterBgp.Distance):
-        """Subclass of AvdModel."""
 
     class BgpGracefulRestart(AvdModel):
         """Subclass of AvdModel."""
@@ -90,14 +84,11 @@ class EosDesigns(EosDesignsRootModel):
         class Ipv4UnderlayPeers(AvdModel):
             """Subclass of AvdModel."""
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str, "default": "IPv4-UNDERLAY-PEERS"},
                 "password": {"type": str},
                 "bfd": {"type": bool, "default": False},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """
@@ -109,11 +100,8 @@ class EosDesigns(EosDesignsRootModel):
             """Type 7 encrypted password."""
             bfd: bool
             """Default value: `False`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -123,7 +111,7 @@ class EosDesigns(EosDesignsRootModel):
                     name: str | UndefinedType = Undefined,
                     password: str | None | UndefinedType = Undefined,
                     bfd: bool | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     Ipv4UnderlayPeers.
@@ -135,23 +123,18 @@ class EosDesigns(EosDesignsRootModel):
                         name: Name of peer group.
                         password: Type 7 encrypted password.
                         bfd: bfd
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
         class MlagIpv4VrfsPeer(AvdModel):
             """Subclass of AvdModel."""
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str},
                 "password": {"type": str},
                 "bfd": {"type": bool, "default": False},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """Name of peer group."""
@@ -159,11 +142,8 @@ class EosDesigns(EosDesignsRootModel):
             """Type 7 encrypted password."""
             bfd: bool
             """Default value: `False`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -173,7 +153,7 @@ class EosDesigns(EosDesignsRootModel):
                     name: str | UndefinedType = Undefined,
                     password: str | None | UndefinedType = Undefined,
                     bfd: bool | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     MlagIpv4VrfsPeer.
@@ -185,23 +165,18 @@ class EosDesigns(EosDesignsRootModel):
                         name: Name of peer group.
                         password: Type 7 encrypted password.
                         bfd: bfd
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
         class MlagIpv4UnderlayPeer(AvdModel):
             """Subclass of AvdModel."""
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str, "default": "MLAG-IPv4-UNDERLAY-PEER"},
                 "password": {"type": str},
                 "bfd": {"type": bool, "default": False},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """
@@ -213,11 +188,8 @@ class EosDesigns(EosDesignsRootModel):
             """Type 7 encrypted password."""
             bfd: bool
             """Default value: `False`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -227,7 +199,7 @@ class EosDesigns(EosDesignsRootModel):
                     name: str | UndefinedType = Undefined,
                     password: str | None | UndefinedType = Undefined,
                     bfd: bool | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     MlagIpv4UnderlayPeer.
@@ -239,23 +211,18 @@ class EosDesigns(EosDesignsRootModel):
                         name: Name of peer group.
                         password: Type 7 encrypted password.
                         bfd: bfd
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
         class EvpnOverlayPeers(AvdModel):
             """Subclass of AvdModel."""
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str, "default": "EVPN-OVERLAY-PEERS"},
                 "password": {"type": str},
                 "bfd": {"type": bool, "default": True},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """
@@ -267,11 +234,8 @@ class EosDesigns(EosDesignsRootModel):
             """Type 7 encrypted password."""
             bfd: bool
             """Default value: `True`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -281,7 +245,7 @@ class EosDesigns(EosDesignsRootModel):
                     name: str | UndefinedType = Undefined,
                     password: str | None | UndefinedType = Undefined,
                     bfd: bool | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     EvpnOverlayPeers.
@@ -293,23 +257,18 @@ class EosDesigns(EosDesignsRootModel):
                         name: Name of peer group.
                         password: Type 7 encrypted password.
                         bfd: bfd
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
         class EvpnOverlayCore(AvdModel):
             """Subclass of AvdModel."""
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str, "default": "EVPN-OVERLAY-CORE"},
                 "password": {"type": str},
                 "bfd": {"type": bool, "default": True},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """
@@ -321,11 +280,8 @@ class EosDesigns(EosDesignsRootModel):
             """Type 7 encrypted password."""
             bfd: bool
             """Default value: `True`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -335,7 +291,7 @@ class EosDesigns(EosDesignsRootModel):
                     name: str | UndefinedType = Undefined,
                     password: str | None | UndefinedType = Undefined,
                     bfd: bool | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     EvpnOverlayCore.
@@ -347,23 +303,18 @@ class EosDesigns(EosDesignsRootModel):
                         name: Name of peer group.
                         password: Type 7 encrypted password.
                         bfd: bfd
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
         class MplsOverlayPeers(AvdModel):
             """Subclass of AvdModel."""
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str, "default": "MPLS-OVERLAY-PEERS"},
                 "password": {"type": str},
                 "bfd": {"type": bool, "default": True},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """
@@ -375,11 +326,8 @@ class EosDesigns(EosDesignsRootModel):
             """Type 7 encrypted password."""
             bfd: bool
             """Default value: `True`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -389,7 +337,7 @@ class EosDesigns(EosDesignsRootModel):
                     name: str | UndefinedType = Undefined,
                     password: str | None | UndefinedType = Undefined,
                     bfd: bool | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     MplsOverlayPeers.
@@ -401,23 +349,18 @@ class EosDesigns(EosDesignsRootModel):
                         name: Name of peer group.
                         password: Type 7 encrypted password.
                         bfd: bfd
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
         class RrOverlayPeers(AvdModel):
             """Subclass of AvdModel."""
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str, "default": "RR-OVERLAY-PEERS"},
                 "password": {"type": str},
                 "bfd": {"type": bool, "default": True},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """
@@ -429,11 +372,8 @@ class EosDesigns(EosDesignsRootModel):
             """Type 7 encrypted password."""
             bfd: bool
             """Default value: `True`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -443,7 +383,7 @@ class EosDesigns(EosDesignsRootModel):
                     name: str | UndefinedType = Undefined,
                     password: str | None | UndefinedType = Undefined,
                     bfd: bool | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     RrOverlayPeers.
@@ -455,23 +395,18 @@ class EosDesigns(EosDesignsRootModel):
                         name: Name of peer group.
                         password: Type 7 encrypted password.
                         bfd: bfd
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
         class IpvpnGatewayPeers(AvdModel):
             """Subclass of AvdModel."""
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str, "default": "IPVPN-GATEWAY-PEERS"},
                 "password": {"type": str},
                 "bfd": {"type": bool, "default": True},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """
@@ -483,11 +418,8 @@ class EosDesigns(EosDesignsRootModel):
             """Type 7 encrypted password."""
             bfd: bool
             """Default value: `True`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -497,7 +429,7 @@ class EosDesigns(EosDesignsRootModel):
                     name: str | UndefinedType = Undefined,
                     password: str | None | UndefinedType = Undefined,
                     bfd: bool | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     IpvpnGatewayPeers.
@@ -509,9 +441,7 @@ class EosDesigns(EosDesignsRootModel):
                         name: Name of peer group.
                         password: Type 7 encrypted password.
                         bfd: bfd
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
@@ -564,9 +494,6 @@ class EosDesigns(EosDesignsRootModel):
 
             ListenRangePrefixes._item_type = str
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str, "default": "WAN-OVERLAY-PEERS"},
                 "password": {"type": str},
@@ -574,7 +501,7 @@ class EosDesigns(EosDesignsRootModel):
                 "bfd_timers": {"type": BfdTimers},
                 "listen_range_prefixes": {"type": ListenRangePrefixes},
                 "ttl_maximum_hops": {"type": int, "default": 1},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """
@@ -615,11 +542,8 @@ class EosDesigns(EosDesignsRootModel):
             """
             ttl_maximum_hops: int
             """Default value: `1`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -632,7 +556,7 @@ class EosDesigns(EosDesignsRootModel):
                     bfd_timers: BfdTimers | UndefinedType = Undefined,
                     listen_range_prefixes: ListenRangePrefixes | UndefinedType = Undefined,
                     ttl_maximum_hops: int | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     WanOverlayPeers.
@@ -667,9 +591,7 @@ class EosDesigns(EosDesignsRootModel):
                            Subclass of AvdList with `str`
                            items.
                         ttl_maximum_hops: ttl_maximum_hops
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
@@ -717,16 +639,13 @@ class EosDesigns(EosDesignsRootModel):
 
                         """
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.PeerGroupsItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "name": {"type": str, "default": "WAN-RR-OVERLAY-PEERS"},
                 "password": {"type": str},
                 "bfd": {"type": bool, "default": True},
                 "bfd_timers": {"type": BfdTimers},
                 "ttl_maximum_hops": {"type": int, "default": 1},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.RouterBgp.PeerGroupsItem},
             }
             name: str
             """
@@ -758,11 +677,8 @@ class EosDesigns(EosDesignsRootModel):
             """
             ttl_maximum_hops: int
             """Default value: `1`"""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem
+            """Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen."""
 
             if TYPE_CHECKING:
 
@@ -774,7 +690,7 @@ class EosDesigns(EosDesignsRootModel):
                     bfd: bool | UndefinedType = Undefined,
                     bfd_timers: BfdTimers | UndefinedType = Undefined,
                     ttl_maximum_hops: int | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.RouterBgp.PeerGroupsItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     WanRrOverlayPeers.
@@ -802,9 +718,7 @@ class EosDesigns(EosDesignsRootModel):
 
                            Subclass of AvdModel.
                         ttl_maximum_hops: ttl_maximum_hops
-                        structured_config:
-                           Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under router_bgp.peer_groups.[name=<name>] for eos_cli_config_gen.
 
                     """
 
@@ -2858,12 +2772,6 @@ class EosDesigns(EosDesignsRootModel):
 
                 """
 
-    class EventHandlers(EosCliConfigGen.EventHandlers):
-        pass
-
-    class EventMonitor(EosCliConfigGen.EventMonitor):
-        """Subclass of AvdModel."""
-
     class EvpnHostflapDetection(AvdModel):
         """Subclass of AvdModel."""
 
@@ -4292,9 +4200,6 @@ class EosDesigns(EosDesignsRootModel):
                        Subclass of AvdList with `DeviceTagsItem` items.
 
                 """
-
-    class HardwareCounters(EosCliConfigGen.HardwareCounters):
-        """Subclass of AvdModel."""
 
     class InternalVlanOrder(AvdModel):
         """Subclass of AvdModel."""
@@ -6056,9 +5961,6 @@ class EosDesigns(EosDesignsRootModel):
 
                     """
 
-        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-            """Subclass of AvdModel."""
-
         _fields: ClassVar[dict] = {
             "profile": {"type": str},
             "name": {"type": str},
@@ -6084,7 +5986,7 @@ class EosDesigns(EosDesignsRootModel):
             "cv_pathfinder_internet_exit": {"type": CvPathfinderInternetExit},
             "raw_eos_cli": {"type": str},
             "flow_tracking": {"type": FlowTracking},
-            "structured_config": {"type": StructuredConfig},
+            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
         }
         profile: str
         """
@@ -6225,12 +6127,8 @@ class EosDesigns(EosDesignsRootModel):
         Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
         Subclass of AvdModel.
         """
-        structured_config: StructuredConfig
-        """
-        Custom structured config for the Ethernet interface.
-
-        Subclass of AvdModel.
-        """
+        structured_config: EosCliConfigGen.EthernetInterfacesItem
+        """Custom structured config for the Ethernet interface."""
 
         if TYPE_CHECKING:
 
@@ -6261,7 +6159,7 @@ class EosDesigns(EosDesignsRootModel):
                 cv_pathfinder_internet_exit: CvPathfinderInternetExit | UndefinedType = Undefined,
                 raw_eos_cli: str | None | UndefinedType = Undefined,
                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                structured_config: StructuredConfig | UndefinedType = Undefined,
+                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
             ) -> None:
                 """
                 L3InterfaceProfilesItem.
@@ -6357,10 +6255,7 @@ class EosDesigns(EosDesignsRootModel):
                     flow_tracking:
                        Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                        Subclass of AvdModel.
-                    structured_config:
-                       Custom structured config for the Ethernet interface.
-
-                       Subclass of AvdModel.
+                    structured_config: Custom structured config for the Ethernet interface.
 
                 """
 
@@ -6370,12 +6265,6 @@ class EosDesigns(EosDesignsRootModel):
         _primary_key: ClassVar[str] = "profile"
 
     L3InterfaceProfiles._item_type = L3InterfaceProfilesItem
-
-    class LoadInterval(EosCliConfigGen.LoadInterval):
-        """Subclass of AvdModel."""
-
-    class LocalUsers(EosCliConfigGen.LocalUsers):
-        pass
 
     class MacAddressTable(AvdModel):
         """Subclass of AvdModel."""
@@ -6492,9 +6381,6 @@ class EosDesigns(EosDesignsRootModel):
             """Subclass of AvdList with `str` items."""
 
         TrunkGroups._item_type = str
-
-        class Flowcontrol(EosCliConfigGen.EthernetInterfacesItem.Flowcontrol):
-            """Subclass of AvdModel."""
 
         class Ptp(AvdModel):
             """Subclass of AvdModel."""
@@ -6617,12 +6503,6 @@ class EosDesigns(EosDesignsRootModel):
                            link_tracking settings are configured on the node.
 
                     """
-
-        class Dot1x(EosCliConfigGen.EthernetInterfacesItem.Dot1x):
-            """Subclass of AvdModel."""
-
-        class Poe(EosCliConfigGen.EthernetInterfacesItem.Poe):
-            """Subclass of AvdModel."""
 
         class StormControl(AvdModel):
             """Subclass of AvdModel."""
@@ -7323,9 +7203,6 @@ class EosDesigns(EosDesignsRootModel):
 
             Subinterfaces._item_type = SubinterfacesItem
 
-            class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "mode": {"type": str},
                 "channel_id": {"type": int},
@@ -7337,7 +7214,7 @@ class EosDesigns(EosDesignsRootModel):
                 "lacp_timer": {"type": LacpTimer},
                 "subinterfaces": {"type": Subinterfaces},
                 "raw_eos_cli": {"type": str},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
             }
             mode: Literal["active", "passive", "on"] | None
             """Port-Channel Mode."""
@@ -7423,12 +7300,10 @@ class EosDesigns(EosDesignsRootModel):
             """
             raw_eos_cli: str | None
             """EOS CLI rendered directly on the port-channel interface in the final EOS configuration."""
-            structured_config: StructuredConfig
+            structured_config: EosCliConfigGen.PortChannelInterfacesItem
             """
             Custom structured config added under port_channel_interfaces.[name=<interface>] for
             eos_cli_config_gen.
-
-            Subclass of AvdModel.
             """
 
             if TYPE_CHECKING:
@@ -7446,7 +7321,7 @@ class EosDesigns(EosDesignsRootModel):
                     lacp_timer: LacpTimer | UndefinedType = Undefined,
                     subinterfaces: Subinterfaces | UndefinedType = Undefined,
                     raw_eos_cli: str | None | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     PortChannel.
@@ -7521,12 +7396,7 @@ class EosDesigns(EosDesignsRootModel):
                            Custom structured config added under port_channel_interfaces.[name=<interface>] for
                            eos_cli_config_gen.
 
-                           Subclass of AvdModel.
-
                     """
-
-        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-            """Subclass of AvdModel."""
 
         _fields: ClassVar[dict] = {
             "switches": {"type": Switches},
@@ -7550,14 +7420,14 @@ class EosDesigns(EosDesignsRootModel):
             "spanning_tree_portfast": {"type": str},
             "spanning_tree_bpdufilter": {"type": str},
             "spanning_tree_bpduguard": {"type": str},
-            "flowcontrol": {"type": Flowcontrol},
+            "flowcontrol": {"type": EosCliConfigGen.EthernetInterfacesItem.Flowcontrol},
             "qos_profile": {"type": str},
             "ptp": {"type": Ptp},
             "sflow": {"type": bool},
             "flow_tracking": {"type": FlowTracking},
             "link_tracking": {"type": LinkTracking},
-            "dot1x": {"type": Dot1x},
-            "poe": {"type": Poe},
+            "dot1x": {"type": EosCliConfigGen.EthernetInterfacesItem.Dot1x},
+            "poe": {"type": EosCliConfigGen.EthernetInterfacesItem.Poe},
             "storm_control": {"type": StormControl},
             "monitor_sessions": {"type": MonitorSessions},
             "ethernet_segment": {"type": EthernetSegment},
@@ -7565,7 +7435,7 @@ class EosDesigns(EosDesignsRootModel):
             "validate_state": {"type": bool},
             "validate_lldp": {"type": bool},
             "raw_eos_cli": {"type": str},
-            "structured_config": {"type": StructuredConfig},
+            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
         }
         switches: Switches
         """
@@ -7693,8 +7563,7 @@ class EosDesigns(EosDesignsRootModel):
         spanning_tree_portfast: Literal["edge", "network"] | None
         spanning_tree_bpdufilter: Literal["enabled", "disabled", "True", "False", "true", "false"] | None
         spanning_tree_bpduguard: Literal["enabled", "disabled", "True", "False", "true", "false"] | None
-        flowcontrol: Flowcontrol
-        """Subclass of AvdModel."""
+        flowcontrol: EosCliConfigGen.EthernetInterfacesItem.Flowcontrol
         qos_profile: str | None
         """QOS profile name."""
         ptp: Ptp
@@ -7725,19 +7594,10 @@ class EosDesigns(EosDesignsRootModel):
 
         Subclass of AvdModel.
         """
-        dot1x: Dot1x
-        """
-        802.1x
-
-        Subclass of AvdModel.
-        """
-        poe: Poe
-        """
-        Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
-
-        Subclass of
-        AvdModel.
-        """
+        dot1x: EosCliConfigGen.EthernetInterfacesItem.Dot1x
+        """802.1x"""
+        poe: EosCliConfigGen.EthernetInterfacesItem.Poe
+        """Power Over Ethernet settings applied on port. Only configured if platform supports PoE."""
         storm_control: StormControl
         """
         Storm control settings applied on port toward the endpoint.
@@ -7772,11 +7632,8 @@ class EosDesigns(EosDesignsRootModel):
         """Set to false to disable the LLDP topology validation performed by the `eos_validate_state` role."""
         raw_eos_cli: str | None
         """EOS CLI rendered directly on the ethernet interface in the final EOS configuration."""
-        structured_config: StructuredConfig
-        """
-        Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
-        Subclass of AvdModel.
-        """
+        structured_config: EosCliConfigGen.EthernetInterfacesItem
+        """Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen."""
 
         if TYPE_CHECKING:
 
@@ -7804,14 +7661,14 @@ class EosDesigns(EosDesignsRootModel):
                 spanning_tree_portfast: Literal["edge", "network"] | None | UndefinedType = Undefined,
                 spanning_tree_bpdufilter: Literal["enabled", "disabled", "True", "False", "true", "false"] | None | UndefinedType = Undefined,
                 spanning_tree_bpduguard: Literal["enabled", "disabled", "True", "False", "true", "false"] | None | UndefinedType = Undefined,
-                flowcontrol: Flowcontrol | UndefinedType = Undefined,
+                flowcontrol: EosCliConfigGen.EthernetInterfacesItem.Flowcontrol | UndefinedType = Undefined,
                 qos_profile: str | None | UndefinedType = Undefined,
                 ptp: Ptp | UndefinedType = Undefined,
                 sflow: bool | None | UndefinedType = Undefined,
                 flow_tracking: FlowTracking | UndefinedType = Undefined,
                 link_tracking: LinkTracking | UndefinedType = Undefined,
-                dot1x: Dot1x | UndefinedType = Undefined,
-                poe: Poe | UndefinedType = Undefined,
+                dot1x: EosCliConfigGen.EthernetInterfacesItem.Dot1x | UndefinedType = Undefined,
+                poe: EosCliConfigGen.EthernetInterfacesItem.Poe | UndefinedType = Undefined,
                 storm_control: StormControl | UndefinedType = Undefined,
                 monitor_sessions: MonitorSessions | UndefinedType = Undefined,
                 ethernet_segment: EthernetSegment | UndefinedType = Undefined,
@@ -7819,7 +7676,7 @@ class EosDesigns(EosDesignsRootModel):
                 validate_state: bool | None | UndefinedType = Undefined,
                 validate_lldp: bool | None | UndefinedType = Undefined,
                 raw_eos_cli: str | None | UndefinedType = Undefined,
-                structured_config: StructuredConfig | UndefinedType = Undefined,
+                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
             ) -> None:
                 """
                 NetworkPortsItem.
@@ -7924,7 +7781,7 @@ class EosDesigns(EosDesignsRootModel):
                     spanning_tree_portfast: spanning_tree_portfast
                     spanning_tree_bpdufilter: spanning_tree_bpdufilter
                     spanning_tree_bpduguard: spanning_tree_bpduguard
-                    flowcontrol: Subclass of AvdModel.
+                    flowcontrol: flowcontrol
                     qos_profile: QOS profile name.
                     ptp:
                        The global PTP profile parameters will be applied to all connected endpoints where `ptp` is manually
@@ -7947,15 +7804,8 @@ class EosDesigns(EosDesignsRootModel):
 
 
                        Subclass of AvdModel.
-                    dot1x:
-                       802.1x
-
-                       Subclass of AvdModel.
-                    poe:
-                       Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
-
-                       Subclass of
-                       AvdModel.
+                    dot1x: 802.1x
+                    poe: Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
                     storm_control:
                        Storm control settings applied on port toward the endpoint.
 
@@ -7978,9 +7828,7 @@ class EosDesigns(EosDesignsRootModel):
                        `eos_validate_state` role.
                     validate_lldp: Set to false to disable the LLDP topology validation performed by the `eos_validate_state` role.
                     raw_eos_cli: EOS CLI rendered directly on the ethernet interface in the final EOS configuration.
-                    structured_config:
-                       Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
-                       Subclass of AvdModel.
+                    structured_config: Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
 
                 """
 
@@ -9133,15 +8981,12 @@ class EosDesigns(EosDesignsRootModel):
 
         Servers._item_type = ServersItem
 
-        class AuthenticationKeys(EosCliConfigGen.Ntp.AuthenticationKeys):
-            pass
-
         _fields: ClassVar[dict] = {
             "server_vrf": {"type": str},
             "servers": {"type": Servers},
             "authenticate": {"type": bool},
             "authenticate_servers_only": {"type": bool},
-            "authentication_keys": {"type": AuthenticationKeys},
+            "authentication_keys": {"type": EosCliConfigGen.Ntp.AuthenticationKeys},
             "trusted_keys": {"type": str},
         }
         server_vrf: str | None
@@ -9170,7 +9015,7 @@ class EosDesigns(EosDesignsRootModel):
         """
         authenticate: bool | None
         authenticate_servers_only: bool | None
-        authentication_keys: AuthenticationKeys
+        authentication_keys: EosCliConfigGen.Ntp.AuthenticationKeys
         trusted_keys: str | None
         """List of trusted-keys as string ex. 10-12,15."""
 
@@ -9183,7 +9028,7 @@ class EosDesigns(EosDesignsRootModel):
                 servers: Servers | UndefinedType = Undefined,
                 authenticate: bool | None | UndefinedType = Undefined,
                 authenticate_servers_only: bool | None | UndefinedType = Undefined,
-                authentication_keys: AuthenticationKeys | UndefinedType = Undefined,
+                authentication_keys: EosCliConfigGen.Ntp.AuthenticationKeys | UndefinedType = Undefined,
                 trusted_keys: str | None | UndefinedType = Undefined,
             ) -> None:
                 """
@@ -9666,9 +9511,6 @@ class EosDesigns(EosDesignsRootModel):
 
                     """
 
-        class StructuredConfig(EosCliConfigGen):
-            """Subclass of AvdModel."""
-
         _fields: ClassVar[dict] = {
             "platforms": {"type": Platforms},
             "trident_forwarding_table_partition": {"type": str},
@@ -9680,7 +9522,7 @@ class EosDesigns(EosDesignsRootModel):
             "feature_support": {"type": FeatureSupport},
             "management_interface": {"type": str, "default": "Management1"},
             "security_entropy_sources": {"type": SecurityEntropySources},
-            "structured_config": {"type": StructuredConfig},
+            "structured_config": {"type": EosCliConfigGen},
             "raw_eos_cli": {"type": str},
         }
         platforms: Platforms
@@ -9712,12 +9554,8 @@ class EosDesigns(EosDesignsRootModel):
         Entropy source improves the randomness of the numbers used to generate MACsec's cryptographic keys.
         Subclass of AvdModel.
         """
-        structured_config: StructuredConfig
-        """
-        Custom structured config for eos_cli_config_gen.
-
-        Subclass of AvdModel.
-        """
+        structured_config: EosCliConfigGen
+        """Custom structured config for eos_cli_config_gen."""
         raw_eos_cli: str | None
         """EOS CLI rendered directly on the root level of the final EOS configuration."""
 
@@ -9736,7 +9574,7 @@ class EosDesigns(EosDesignsRootModel):
                 feature_support: FeatureSupport | UndefinedType = Undefined,
                 management_interface: str | UndefinedType = Undefined,
                 security_entropy_sources: SecurityEntropySources | UndefinedType = Undefined,
-                structured_config: StructuredConfig | UndefinedType = Undefined,
+                structured_config: EosCliConfigGen | UndefinedType = Undefined,
                 raw_eos_cli: str | None | UndefinedType = Undefined,
             ) -> None:
                 """
@@ -9764,10 +9602,7 @@ class EosDesigns(EosDesignsRootModel):
                     security_entropy_sources:
                        Entropy source improves the randomness of the numbers used to generate MACsec's cryptographic keys.
                        Subclass of AvdModel.
-                    structured_config:
-                       Custom structured config for eos_cli_config_gen.
-
-                       Subclass of AvdModel.
+                    structured_config: Custom structured config for eos_cli_config_gen.
                     raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
 
                 """
@@ -9940,9 +9775,6 @@ class EosDesigns(EosDesignsRootModel):
 
                     """
 
-        class StructuredConfig(EosCliConfigGen):
-            """Subclass of AvdModel."""
-
         _fields: ClassVar[dict] = {
             "platforms": {"type": Platforms},
             "trident_forwarding_table_partition": {"type": str},
@@ -9954,7 +9786,7 @@ class EosDesigns(EosDesignsRootModel):
             "feature_support": {"type": FeatureSupport},
             "management_interface": {"type": str, "default": "Management1"},
             "security_entropy_sources": {"type": SecurityEntropySources},
-            "structured_config": {"type": StructuredConfig},
+            "structured_config": {"type": EosCliConfigGen},
             "raw_eos_cli": {"type": str},
         }
         platforms: Platforms
@@ -9986,12 +9818,8 @@ class EosDesigns(EosDesignsRootModel):
         Entropy source improves the randomness of the numbers used to generate MACsec's cryptographic keys.
         Subclass of AvdModel.
         """
-        structured_config: StructuredConfig
-        """
-        Custom structured config for eos_cli_config_gen.
-
-        Subclass of AvdModel.
-        """
+        structured_config: EosCliConfigGen
+        """Custom structured config for eos_cli_config_gen."""
         raw_eos_cli: str | None
         """EOS CLI rendered directly on the root level of the final EOS configuration."""
 
@@ -10010,7 +9838,7 @@ class EosDesigns(EosDesignsRootModel):
                 feature_support: FeatureSupport | UndefinedType = Undefined,
                 management_interface: str | UndefinedType = Undefined,
                 security_entropy_sources: SecurityEntropySources | UndefinedType = Undefined,
-                structured_config: StructuredConfig | UndefinedType = Undefined,
+                structured_config: EosCliConfigGen | UndefinedType = Undefined,
                 raw_eos_cli: str | None | UndefinedType = Undefined,
             ) -> None:
                 """
@@ -10038,10 +9866,7 @@ class EosDesigns(EosDesignsRootModel):
                     security_entropy_sources:
                        Entropy source improves the randomness of the numbers used to generate MACsec's cryptographic keys.
                        Subclass of AvdModel.
-                    structured_config:
-                       Custom structured config for eos_cli_config_gen.
-
-                       Subclass of AvdModel.
+                    structured_config: Custom structured config for eos_cli_config_gen.
                     raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
 
                 """
@@ -10123,9 +9948,6 @@ class EosDesigns(EosDesignsRootModel):
             """Subclass of AvdList with `str` items."""
 
         TrunkGroups._item_type = str
-
-        class Flowcontrol(EosCliConfigGen.EthernetInterfacesItem.Flowcontrol):
-            """Subclass of AvdModel."""
 
         class Ptp(AvdModel):
             """Subclass of AvdModel."""
@@ -10248,12 +10070,6 @@ class EosDesigns(EosDesignsRootModel):
                            link_tracking settings are configured on the node.
 
                     """
-
-        class Dot1x(EosCliConfigGen.EthernetInterfacesItem.Dot1x):
-            """Subclass of AvdModel."""
-
-        class Poe(EosCliConfigGen.EthernetInterfacesItem.Poe):
-            """Subclass of AvdModel."""
 
         class StormControl(AvdModel):
             """Subclass of AvdModel."""
@@ -10954,9 +10770,6 @@ class EosDesigns(EosDesignsRootModel):
 
             Subinterfaces._item_type = SubinterfacesItem
 
-            class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                """Subclass of AvdModel."""
-
             _fields: ClassVar[dict] = {
                 "mode": {"type": str},
                 "channel_id": {"type": int},
@@ -10968,7 +10781,7 @@ class EosDesigns(EosDesignsRootModel):
                 "lacp_timer": {"type": LacpTimer},
                 "subinterfaces": {"type": Subinterfaces},
                 "raw_eos_cli": {"type": str},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
             }
             mode: Literal["active", "passive", "on"] | None
             """Port-Channel Mode."""
@@ -11054,12 +10867,10 @@ class EosDesigns(EosDesignsRootModel):
             """
             raw_eos_cli: str | None
             """EOS CLI rendered directly on the port-channel interface in the final EOS configuration."""
-            structured_config: StructuredConfig
+            structured_config: EosCliConfigGen.PortChannelInterfacesItem
             """
             Custom structured config added under port_channel_interfaces.[name=<interface>] for
             eos_cli_config_gen.
-
-            Subclass of AvdModel.
             """
 
             if TYPE_CHECKING:
@@ -11077,7 +10888,7 @@ class EosDesigns(EosDesignsRootModel):
                     lacp_timer: LacpTimer | UndefinedType = Undefined,
                     subinterfaces: Subinterfaces | UndefinedType = Undefined,
                     raw_eos_cli: str | None | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                 ) -> None:
                     """
                     PortChannel.
@@ -11152,12 +10963,7 @@ class EosDesigns(EosDesignsRootModel):
                            Custom structured config added under port_channel_interfaces.[name=<interface>] for
                            eos_cli_config_gen.
 
-                           Subclass of AvdModel.
-
                     """
-
-        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-            """Subclass of AvdModel."""
 
         _fields: ClassVar[dict] = {
             "profile": {"type": str},
@@ -11178,14 +10984,14 @@ class EosDesigns(EosDesignsRootModel):
             "spanning_tree_portfast": {"type": str},
             "spanning_tree_bpdufilter": {"type": str},
             "spanning_tree_bpduguard": {"type": str},
-            "flowcontrol": {"type": Flowcontrol},
+            "flowcontrol": {"type": EosCliConfigGen.EthernetInterfacesItem.Flowcontrol},
             "qos_profile": {"type": str},
             "ptp": {"type": Ptp},
             "sflow": {"type": bool},
             "flow_tracking": {"type": FlowTracking},
             "link_tracking": {"type": LinkTracking},
-            "dot1x": {"type": Dot1x},
-            "poe": {"type": Poe},
+            "dot1x": {"type": EosCliConfigGen.EthernetInterfacesItem.Dot1x},
+            "poe": {"type": EosCliConfigGen.EthernetInterfacesItem.Poe},
             "storm_control": {"type": StormControl},
             "monitor_sessions": {"type": MonitorSessions},
             "ethernet_segment": {"type": EthernetSegment},
@@ -11193,7 +10999,7 @@ class EosDesigns(EosDesignsRootModel):
             "validate_state": {"type": bool},
             "validate_lldp": {"type": bool},
             "raw_eos_cli": {"type": str},
-            "structured_config": {"type": StructuredConfig},
+            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
         }
         profile: str
         """Port profile name."""
@@ -11278,8 +11084,7 @@ class EosDesigns(EosDesignsRootModel):
         spanning_tree_portfast: Literal["edge", "network"] | None
         spanning_tree_bpdufilter: Literal["enabled", "disabled", "True", "False", "true", "false"] | None
         spanning_tree_bpduguard: Literal["enabled", "disabled", "True", "False", "true", "false"] | None
-        flowcontrol: Flowcontrol
-        """Subclass of AvdModel."""
+        flowcontrol: EosCliConfigGen.EthernetInterfacesItem.Flowcontrol
         qos_profile: str | None
         """QOS profile name."""
         ptp: Ptp
@@ -11310,19 +11115,10 @@ class EosDesigns(EosDesignsRootModel):
 
         Subclass of AvdModel.
         """
-        dot1x: Dot1x
-        """
-        802.1x
-
-        Subclass of AvdModel.
-        """
-        poe: Poe
-        """
-        Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
-
-        Subclass of
-        AvdModel.
-        """
+        dot1x: EosCliConfigGen.EthernetInterfacesItem.Dot1x
+        """802.1x"""
+        poe: EosCliConfigGen.EthernetInterfacesItem.Poe
+        """Power Over Ethernet settings applied on port. Only configured if platform supports PoE."""
         storm_control: StormControl
         """
         Storm control settings applied on port toward the endpoint.
@@ -11357,11 +11153,8 @@ class EosDesigns(EosDesignsRootModel):
         """Set to false to disable the LLDP topology validation performed by the `eos_validate_state` role."""
         raw_eos_cli: str | None
         """EOS CLI rendered directly on the ethernet interface in the final EOS configuration."""
-        structured_config: StructuredConfig
-        """
-        Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
-        Subclass of AvdModel.
-        """
+        structured_config: EosCliConfigGen.EthernetInterfacesItem
+        """Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen."""
 
         if TYPE_CHECKING:
 
@@ -11386,14 +11179,14 @@ class EosDesigns(EosDesignsRootModel):
                 spanning_tree_portfast: Literal["edge", "network"] | None | UndefinedType = Undefined,
                 spanning_tree_bpdufilter: Literal["enabled", "disabled", "True", "False", "true", "false"] | None | UndefinedType = Undefined,
                 spanning_tree_bpduguard: Literal["enabled", "disabled", "True", "False", "true", "false"] | None | UndefinedType = Undefined,
-                flowcontrol: Flowcontrol | UndefinedType = Undefined,
+                flowcontrol: EosCliConfigGen.EthernetInterfacesItem.Flowcontrol | UndefinedType = Undefined,
                 qos_profile: str | None | UndefinedType = Undefined,
                 ptp: Ptp | UndefinedType = Undefined,
                 sflow: bool | None | UndefinedType = Undefined,
                 flow_tracking: FlowTracking | UndefinedType = Undefined,
                 link_tracking: LinkTracking | UndefinedType = Undefined,
-                dot1x: Dot1x | UndefinedType = Undefined,
-                poe: Poe | UndefinedType = Undefined,
+                dot1x: EosCliConfigGen.EthernetInterfacesItem.Dot1x | UndefinedType = Undefined,
+                poe: EosCliConfigGen.EthernetInterfacesItem.Poe | UndefinedType = Undefined,
                 storm_control: StormControl | UndefinedType = Undefined,
                 monitor_sessions: MonitorSessions | UndefinedType = Undefined,
                 ethernet_segment: EthernetSegment | UndefinedType = Undefined,
@@ -11401,7 +11194,7 @@ class EosDesigns(EosDesignsRootModel):
                 validate_state: bool | None | UndefinedType = Undefined,
                 validate_lldp: bool | None | UndefinedType = Undefined,
                 raw_eos_cli: str | None | UndefinedType = Undefined,
-                structured_config: StructuredConfig | UndefinedType = Undefined,
+                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
             ) -> None:
                 """
                 PortProfilesItem.
@@ -11468,7 +11261,7 @@ class EosDesigns(EosDesignsRootModel):
                     spanning_tree_portfast: spanning_tree_portfast
                     spanning_tree_bpdufilter: spanning_tree_bpdufilter
                     spanning_tree_bpduguard: spanning_tree_bpduguard
-                    flowcontrol: Subclass of AvdModel.
+                    flowcontrol: flowcontrol
                     qos_profile: QOS profile name.
                     ptp:
                        The global PTP profile parameters will be applied to all connected endpoints where `ptp` is manually
@@ -11491,15 +11284,8 @@ class EosDesigns(EosDesignsRootModel):
 
 
                        Subclass of AvdModel.
-                    dot1x:
-                       802.1x
-
-                       Subclass of AvdModel.
-                    poe:
-                       Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
-
-                       Subclass of
-                       AvdModel.
+                    dot1x: 802.1x
+                    poe: Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
                     storm_control:
                        Storm control settings applied on port toward the endpoint.
 
@@ -11522,9 +11308,7 @@ class EosDesigns(EosDesignsRootModel):
                        `eos_validate_state` role.
                     validate_lldp: Set to false to disable the LLDP topology validation performed by the `eos_validate_state` role.
                     raw_eos_cli: EOS CLI rendered directly on the ethernet interface in the final EOS configuration.
-                    structured_config:
-                       Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
-                       Subclass of AvdModel.
+                    structured_config: Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
 
                 """
 
@@ -11823,9 +11607,6 @@ class EosDesigns(EosDesignsRootModel):
 
                 """
 
-    class QueueMonitorStreaming(EosCliConfigGen.QueueMonitorStreaming):
-        """Subclass of AvdModel."""
-
     class Redundancy(AvdModel):
         """Subclass of AvdModel."""
 
@@ -12028,9 +11809,6 @@ class EosDesigns(EosDesignsRootModel):
     class SnmpSettings(AvdModel):
         """Subclass of AvdModel."""
 
-        class Vrfs(EosCliConfigGen.SnmpServer.Vrfs):
-            pass
-
         class UsersItem(AvdModel):
             """Subclass of AvdModel."""
 
@@ -12208,9 +11986,6 @@ class EosDesigns(EosDesignsRootModel):
 
         Hosts._item_type = HostsItem
 
-        class Communities(EosCliConfigGen.SnmpServer.Communities):
-            pass
-
         class Ipv4AclsItem(AvdModel):
             """Subclass of AvdModel."""
 
@@ -12358,13 +12133,10 @@ class EosDesigns(EosDesignsRootModel):
 
         Groups._item_type = GroupsItem
 
-        class Traps(EosCliConfigGen.SnmpServer.Traps):
-            """Subclass of AvdModel."""
-
         _fields: ClassVar[dict] = {
             "contact": {"type": str},
             "location": {"type": bool, "default": False},
-            "vrfs": {"type": Vrfs},
+            "vrfs": {"type": EosCliConfigGen.SnmpServer.Vrfs},
             "enable_mgmt_interface_vrf": {"type": bool},
             "enable_inband_mgmt_vrf": {"type": bool},
             "compute_local_engineid": {"type": bool, "default": False},
@@ -12372,12 +12144,12 @@ class EosDesigns(EosDesignsRootModel):
             "compute_v3_user_localized_key": {"type": bool, "default": False},
             "users": {"type": Users},
             "hosts": {"type": Hosts},
-            "communities": {"type": Communities},
+            "communities": {"type": EosCliConfigGen.SnmpServer.Communities},
             "ipv4_acls": {"type": Ipv4Acls},
             "ipv6_acls": {"type": Ipv6Acls},
             "views": {"type": Views},
             "groups": {"type": Groups},
-            "traps": {"type": Traps},
+            "traps": {"type": EosCliConfigGen.SnmpServer.Traps},
         }
         contact: str | None
         """SNMP contact."""
@@ -12388,7 +12160,7 @@ class EosDesigns(EosDesignsRootModel):
 
         Default value: `False`
         """
-        vrfs: Vrfs
+        vrfs: EosCliConfigGen.SnmpServer.Vrfs
         """
         Enable/disable SNMP for one or more VRFs.
         Can be used in combination with
@@ -12451,7 +12223,7 @@ class EosDesigns(EosDesignsRootModel):
         """
         hosts: Hosts
         """Subclass of AvdList with `HostsItem` items."""
-        communities: Communities
+        communities: EosCliConfigGen.SnmpServer.Communities
         ipv4_acls: Ipv4Acls
         """Subclass of AvdList with `Ipv4AclsItem` items."""
         ipv6_acls: Ipv6Acls
@@ -12460,8 +12232,7 @@ class EosDesigns(EosDesignsRootModel):
         """Subclass of AvdList with `ViewsItem` items."""
         groups: Groups
         """Subclass of AvdList with `GroupsItem` items."""
-        traps: Traps
-        """Subclass of AvdModel."""
+        traps: EosCliConfigGen.SnmpServer.Traps
 
         if TYPE_CHECKING:
 
@@ -12470,7 +12241,7 @@ class EosDesigns(EosDesignsRootModel):
                 *,
                 contact: str | None | UndefinedType = Undefined,
                 location: bool | UndefinedType = Undefined,
-                vrfs: Vrfs | UndefinedType = Undefined,
+                vrfs: EosCliConfigGen.SnmpServer.Vrfs | UndefinedType = Undefined,
                 enable_mgmt_interface_vrf: bool | None | UndefinedType = Undefined,
                 enable_inband_mgmt_vrf: bool | None | UndefinedType = Undefined,
                 compute_local_engineid: bool | UndefinedType = Undefined,
@@ -12478,12 +12249,12 @@ class EosDesigns(EosDesignsRootModel):
                 compute_v3_user_localized_key: bool | UndefinedType = Undefined,
                 users: Users | UndefinedType = Undefined,
                 hosts: Hosts | UndefinedType = Undefined,
-                communities: Communities | UndefinedType = Undefined,
+                communities: EosCliConfigGen.SnmpServer.Communities | UndefinedType = Undefined,
                 ipv4_acls: Ipv4Acls | UndefinedType = Undefined,
                 ipv6_acls: Ipv6Acls | UndefinedType = Undefined,
                 views: Views | UndefinedType = Undefined,
                 groups: Groups | UndefinedType = Undefined,
-                traps: Traps | UndefinedType = Undefined,
+                traps: EosCliConfigGen.SnmpServer.Traps | UndefinedType = Undefined,
             ) -> None:
                 """
                 SnmpSettings.
@@ -12542,7 +12313,7 @@ class EosDesigns(EosDesignsRootModel):
                     ipv6_acls: Subclass of AvdList with `Ipv6AclsItem` items.
                     views: Subclass of AvdList with `ViewsItem` items.
                     groups: Subclass of AvdList with `GroupsItem` items.
-                    traps: Subclass of AvdModel.
+                    traps: traps
 
                 """
 
@@ -13192,18 +12963,12 @@ class EosDesigns(EosDesignsRootModel):
             class Bgp(AvdModel):
                 """Subclass of AvdModel."""
 
-                class StructuredConfig(EosCliConfigGen.RouterBgp.VlansItem):
-                    """Subclass of AvdModel."""
-
-                _fields: ClassVar[dict] = {"structured_config": {"type": StructuredConfig}, "raw_eos_cli": {"type": str}}
-                structured_config: StructuredConfig
+                _fields: ClassVar[dict] = {"structured_config": {"type": EosCliConfigGen.RouterBgp.VlansItem}, "raw_eos_cli": {"type": str}}
+                structured_config: EosCliConfigGen.RouterBgp.VlansItem
                 """
                 Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>].
                 This
                 configuration will not be applied to vlan aware bundles.
-
-
-                Subclass of AvdModel.
                 """
                 raw_eos_cli: str | None
                 """EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration."""
@@ -13211,7 +12976,10 @@ class EosDesigns(EosDesignsRootModel):
                 if TYPE_CHECKING:
 
                     def __init__(
-                        self, *, structured_config: StructuredConfig | UndefinedType = Undefined, raw_eos_cli: str | None | UndefinedType = Undefined
+                        self,
+                        *,
+                        structured_config: EosCliConfigGen.RouterBgp.VlansItem | UndefinedType = Undefined,
+                        raw_eos_cli: str | None | UndefinedType = Undefined,
                     ) -> None:
                         """
                         Bgp.
@@ -13224,15 +12992,9 @@ class EosDesigns(EosDesignsRootModel):
                                Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>].
                                This
                                configuration will not be applied to vlan aware bundles.
-
-
-                               Subclass of AvdModel.
                             raw_eos_cli: EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration.
 
                         """
-
-            class StructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                """Subclass of AvdModel."""
 
             _fields: ClassVar[dict] = {
                 "node": {"type": str},
@@ -13264,7 +13026,7 @@ class EosDesigns(EosDesignsRootModel):
                 "ospf": {"type": Ospf},
                 "bgp": {"type": Bgp},
                 "raw_eos_cli": {"type": str},
-                "structured_config": {"type": StructuredConfig},
+                "structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                 "evpn_l2_multi_domain": {"type": bool},
             }
             node: str
@@ -13432,11 +13194,8 @@ class EosDesigns(EosDesignsRootModel):
             """Subclass of AvdModel."""
             raw_eos_cli: str | None
             """EOS CLI rendered directly on the VLAN interface in the final EOS configuration."""
-            structured_config: StructuredConfig
-            """
-            Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
-            Subclass of AvdModel.
-            """
+            structured_config: EosCliConfigGen.VlanInterfacesItem
+            """Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen."""
             evpn_l2_multi_domain: bool | None
             """
             Explicitly extend SVI to remote EVPN domains.
@@ -13482,7 +13241,7 @@ class EosDesigns(EosDesignsRootModel):
                     ospf: Ospf | UndefinedType = Undefined,
                     bgp: Bgp | UndefinedType = Undefined,
                     raw_eos_cli: str | None | UndefinedType = Undefined,
-                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                    structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                     evpn_l2_multi_domain: bool | None | UndefinedType = Undefined,
                 ) -> None:
                     """
@@ -13609,9 +13368,7 @@ class EosDesigns(EosDesignsRootModel):
                            Subclass of AvdModel.
                         bgp: Subclass of AvdModel.
                         raw_eos_cli: EOS CLI rendered directly on the VLAN interface in the final EOS configuration.
-                        structured_config:
-                           Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
-                           Subclass of AvdModel.
+                        structured_config: Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
                         evpn_l2_multi_domain:
                            Explicitly extend SVI to remote EVPN domains.
                            Overrides
@@ -13900,18 +13657,12 @@ class EosDesigns(EosDesignsRootModel):
         class Bgp(AvdModel):
             """Subclass of AvdModel."""
 
-            class StructuredConfig(EosCliConfigGen.RouterBgp.VlansItem):
-                """Subclass of AvdModel."""
-
-            _fields: ClassVar[dict] = {"structured_config": {"type": StructuredConfig}, "raw_eos_cli": {"type": str}}
-            structured_config: StructuredConfig
+            _fields: ClassVar[dict] = {"structured_config": {"type": EosCliConfigGen.RouterBgp.VlansItem}, "raw_eos_cli": {"type": str}}
+            structured_config: EosCliConfigGen.RouterBgp.VlansItem
             """
             Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>].
             This
             configuration will not be applied to vlan aware bundles.
-
-
-            Subclass of AvdModel.
             """
             raw_eos_cli: str | None
             """EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration."""
@@ -13919,7 +13670,10 @@ class EosDesigns(EosDesignsRootModel):
             if TYPE_CHECKING:
 
                 def __init__(
-                    self, *, structured_config: StructuredConfig | UndefinedType = Undefined, raw_eos_cli: str | None | UndefinedType = Undefined
+                    self,
+                    *,
+                    structured_config: EosCliConfigGen.RouterBgp.VlansItem | UndefinedType = Undefined,
+                    raw_eos_cli: str | None | UndefinedType = Undefined,
                 ) -> None:
                     """
                     Bgp.
@@ -13932,15 +13686,9 @@ class EosDesigns(EosDesignsRootModel):
                            Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>].
                            This
                            configuration will not be applied to vlan aware bundles.
-
-
-                           Subclass of AvdModel.
                         raw_eos_cli: EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration.
 
                     """
-
-        class StructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-            """Subclass of AvdModel."""
 
         _fields: ClassVar[dict] = {
             "profile": {"type": str},
@@ -13974,7 +13722,7 @@ class EosDesigns(EosDesignsRootModel):
             "ospf": {"type": Ospf},
             "bgp": {"type": Bgp},
             "raw_eos_cli": {"type": str},
-            "structured_config": {"type": StructuredConfig},
+            "structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
             "evpn_l2_multi_domain": {"type": bool},
         }
         profile: str
@@ -14158,11 +13906,8 @@ class EosDesigns(EosDesignsRootModel):
         """Subclass of AvdModel."""
         raw_eos_cli: str | None
         """EOS CLI rendered directly on the VLAN interface in the final EOS configuration."""
-        structured_config: StructuredConfig
-        """
-        Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
-        Subclass of AvdModel.
-        """
+        structured_config: EosCliConfigGen.VlanInterfacesItem
+        """Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen."""
         evpn_l2_multi_domain: bool | None
         """
         Explicitly extend SVI to remote EVPN domains.
@@ -14210,7 +13955,7 @@ class EosDesigns(EosDesignsRootModel):
                 ospf: Ospf | UndefinedType = Undefined,
                 bgp: Bgp | UndefinedType = Undefined,
                 raw_eos_cli: str | None | UndefinedType = Undefined,
-                structured_config: StructuredConfig | UndefinedType = Undefined,
+                structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                 evpn_l2_multi_domain: bool | None | UndefinedType = Undefined,
             ) -> None:
                 """
@@ -14349,9 +14094,7 @@ class EosDesigns(EosDesignsRootModel):
                        Subclass of AvdModel.
                     bgp: Subclass of AvdModel.
                     raw_eos_cli: EOS CLI rendered directly on the VLAN interface in the final EOS configuration.
-                    structured_config:
-                       Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
-                       Subclass of AvdModel.
+                    structured_config: Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
                     evpn_l2_multi_domain:
                        Explicitly extend SVI to remote EVPN domains.
                        Overrides
@@ -14699,9 +14442,6 @@ class EosDesigns(EosDesignsRootModel):
                     message_digest_keys: Subclass of AvdIndexedList with `MessageDigestKeysItem` items. Primary key is `id` (`int`).
 
                 """
-
-    class UnsupportedTransceiver(EosCliConfigGen.ServiceUnsupportedTransceiver):
-        """Subclass of AvdModel."""
 
     class UplinkPtp(AvdModel):
         """Subclass of AvdModel."""
@@ -16522,9 +16262,6 @@ class EosDesigns(EosDesignsRootModel):
 
                     TrunkGroups._item_type = str
 
-                    class Flowcontrol(EosCliConfigGen.EthernetInterfacesItem.Flowcontrol):
-                        """Subclass of AvdModel."""
-
                     class Ptp(AvdModel):
                         """Subclass of AvdModel."""
 
@@ -16646,12 +16383,6 @@ class EosDesigns(EosDesignsRootModel):
                                        link_tracking settings are configured on the node.
 
                                 """
-
-                    class Dot1x(EosCliConfigGen.EthernetInterfacesItem.Dot1x):
-                        """Subclass of AvdModel."""
-
-                    class Poe(EosCliConfigGen.EthernetInterfacesItem.Poe):
-                        """Subclass of AvdModel."""
 
                     class StormControl(AvdModel):
                         """Subclass of AvdModel."""
@@ -17368,9 +17099,6 @@ class EosDesigns(EosDesignsRootModel):
 
                         Subinterfaces._item_type = SubinterfacesItem
 
-                        class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "mode": {"type": str},
                             "channel_id": {"type": int},
@@ -17382,7 +17110,7 @@ class EosDesigns(EosDesignsRootModel):
                             "lacp_timer": {"type": LacpTimer},
                             "subinterfaces": {"type": Subinterfaces},
                             "raw_eos_cli": {"type": str},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
                         }
                         mode: Literal["active", "passive", "on"] | None
                         """Port-Channel Mode."""
@@ -17468,12 +17196,10 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         raw_eos_cli: str | None
                         """EOS CLI rendered directly on the port-channel interface in the final EOS configuration."""
-                        structured_config: StructuredConfig
+                        structured_config: EosCliConfigGen.PortChannelInterfacesItem
                         """
                         Custom structured config added under port_channel_interfaces.[name=<interface>] for
                         eos_cli_config_gen.
-
-                        Subclass of AvdModel.
                         """
 
                         if TYPE_CHECKING:
@@ -17491,7 +17217,7 @@ class EosDesigns(EosDesignsRootModel):
                                 lacp_timer: LacpTimer | UndefinedType = Undefined,
                                 subinterfaces: Subinterfaces | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 PortChannel.
@@ -17566,12 +17292,7 @@ class EosDesigns(EosDesignsRootModel):
                                        Custom structured config added under port_channel_interfaces.[name=<interface>] for
                                        eos_cli_config_gen.
 
-                                       Subclass of AvdModel.
-
                                 """
-
-                    class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                        """Subclass of AvdModel."""
 
                     _fields: ClassVar[dict] = {
                         "switch_ports": {"type": SwitchPorts},
@@ -17595,14 +17316,14 @@ class EosDesigns(EosDesignsRootModel):
                         "spanning_tree_portfast": {"type": str},
                         "spanning_tree_bpdufilter": {"type": str},
                         "spanning_tree_bpduguard": {"type": str},
-                        "flowcontrol": {"type": Flowcontrol},
+                        "flowcontrol": {"type": EosCliConfigGen.EthernetInterfacesItem.Flowcontrol},
                         "qos_profile": {"type": str},
                         "ptp": {"type": Ptp},
                         "sflow": {"type": bool},
                         "flow_tracking": {"type": FlowTracking},
                         "link_tracking": {"type": LinkTracking},
-                        "dot1x": {"type": Dot1x},
-                        "poe": {"type": Poe},
+                        "dot1x": {"type": EosCliConfigGen.EthernetInterfacesItem.Dot1x},
+                        "poe": {"type": EosCliConfigGen.EthernetInterfacesItem.Poe},
                         "storm_control": {"type": StormControl},
                         "monitor_sessions": {"type": MonitorSessions},
                         "ethernet_segment": {"type": EthernetSegment},
@@ -17610,7 +17331,7 @@ class EosDesigns(EosDesignsRootModel):
                         "validate_state": {"type": bool},
                         "validate_lldp": {"type": bool},
                         "raw_eos_cli": {"type": str},
-                        "structured_config": {"type": StructuredConfig},
+                        "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                     }
                     switch_ports: SwitchPorts
                     """
@@ -17735,8 +17456,7 @@ class EosDesigns(EosDesignsRootModel):
                     spanning_tree_portfast: Literal["edge", "network"] | None
                     spanning_tree_bpdufilter: Literal["enabled", "disabled", "True", "False", "true", "false"] | None
                     spanning_tree_bpduguard: Literal["enabled", "disabled", "True", "False", "true", "false"] | None
-                    flowcontrol: Flowcontrol
-                    """Subclass of AvdModel."""
+                    flowcontrol: EosCliConfigGen.EthernetInterfacesItem.Flowcontrol
                     qos_profile: str | None
                     """QOS profile name."""
                     ptp: Ptp
@@ -17767,19 +17487,10 @@ class EosDesigns(EosDesignsRootModel):
 
                     Subclass of AvdModel.
                     """
-                    dot1x: Dot1x
-                    """
-                    802.1x
-
-                    Subclass of AvdModel.
-                    """
-                    poe: Poe
-                    """
-                    Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
-
-                    Subclass of
-                    AvdModel.
-                    """
+                    dot1x: EosCliConfigGen.EthernetInterfacesItem.Dot1x
+                    """802.1x"""
+                    poe: EosCliConfigGen.EthernetInterfacesItem.Poe
+                    """Power Over Ethernet settings applied on port. Only configured if platform supports PoE."""
                     storm_control: StormControl
                     """
                     Storm control settings applied on port toward the endpoint.
@@ -17814,11 +17525,8 @@ class EosDesigns(EosDesignsRootModel):
                     """Set to false to disable the LLDP topology validation performed by the `eos_validate_state` role."""
                     raw_eos_cli: str | None
                     """EOS CLI rendered directly on the ethernet interface in the final EOS configuration."""
-                    structured_config: StructuredConfig
-                    """
-                    Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
-                    Subclass of AvdModel.
-                    """
+                    structured_config: EosCliConfigGen.EthernetInterfacesItem
+                    """Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen."""
 
                     if TYPE_CHECKING:
 
@@ -17846,14 +17554,14 @@ class EosDesigns(EosDesignsRootModel):
                             spanning_tree_portfast: Literal["edge", "network"] | None | UndefinedType = Undefined,
                             spanning_tree_bpdufilter: Literal["enabled", "disabled", "True", "False", "true", "false"] | None | UndefinedType = Undefined,
                             spanning_tree_bpduguard: Literal["enabled", "disabled", "True", "False", "true", "false"] | None | UndefinedType = Undefined,
-                            flowcontrol: Flowcontrol | UndefinedType = Undefined,
+                            flowcontrol: EosCliConfigGen.EthernetInterfacesItem.Flowcontrol | UndefinedType = Undefined,
                             qos_profile: str | None | UndefinedType = Undefined,
                             ptp: Ptp | UndefinedType = Undefined,
                             sflow: bool | None | UndefinedType = Undefined,
                             flow_tracking: FlowTracking | UndefinedType = Undefined,
                             link_tracking: LinkTracking | UndefinedType = Undefined,
-                            dot1x: Dot1x | UndefinedType = Undefined,
-                            poe: Poe | UndefinedType = Undefined,
+                            dot1x: EosCliConfigGen.EthernetInterfacesItem.Dot1x | UndefinedType = Undefined,
+                            poe: EosCliConfigGen.EthernetInterfacesItem.Poe | UndefinedType = Undefined,
                             storm_control: StormControl | UndefinedType = Undefined,
                             monitor_sessions: MonitorSessions | UndefinedType = Undefined,
                             ethernet_segment: EthernetSegment | UndefinedType = Undefined,
@@ -17861,7 +17569,7 @@ class EosDesigns(EosDesignsRootModel):
                             validate_state: bool | None | UndefinedType = Undefined,
                             validate_lldp: bool | None | UndefinedType = Undefined,
                             raw_eos_cli: str | None | UndefinedType = Undefined,
-                            structured_config: StructuredConfig | UndefinedType = Undefined,
+                            structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                         ) -> None:
                             """
                             AdaptersItem.
@@ -17962,7 +17670,7 @@ class EosDesigns(EosDesignsRootModel):
                                 spanning_tree_portfast: spanning_tree_portfast
                                 spanning_tree_bpdufilter: spanning_tree_bpdufilter
                                 spanning_tree_bpduguard: spanning_tree_bpduguard
-                                flowcontrol: Subclass of AvdModel.
+                                flowcontrol: flowcontrol
                                 qos_profile: QOS profile name.
                                 ptp:
                                    The global PTP profile parameters will be applied to all connected endpoints where `ptp` is manually
@@ -17985,15 +17693,8 @@ class EosDesigns(EosDesignsRootModel):
 
 
                                    Subclass of AvdModel.
-                                dot1x:
-                                   802.1x
-
-                                   Subclass of AvdModel.
-                                poe:
-                                   Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
-
-                                   Subclass of
-                                   AvdModel.
+                                dot1x: 802.1x
+                                poe: Power Over Ethernet settings applied on port. Only configured if platform supports PoE.
                                 storm_control:
                                    Storm control settings applied on port toward the endpoint.
 
@@ -18016,9 +17717,7 @@ class EosDesigns(EosDesignsRootModel):
                                    `eos_validate_state` role.
                                 validate_lldp: Set to false to disable the LLDP topology validation performed by the `eos_validate_state` role.
                                 raw_eos_cli: EOS CLI rendered directly on the ethernet interface in the final EOS configuration.
-                                structured_config:
-                                   Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
-                                   Subclass of AvdModel.
+                                structured_config: Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
 
                             """
 
@@ -18237,9 +17936,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                 """
 
-                    class StructuredConfig(EosCliConfigGen):
-                        """Subclass of AvdModel."""
-
                     class UplinkInterfaces(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
 
@@ -18295,15 +17991,6 @@ class EosDesigns(EosDesignsRootModel):
                                     profile: profile
 
                                 """
-
-                    class MlagPortChannelStructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerVlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerL3VlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
 
                     class BgpDefaults(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
@@ -19510,9 +19197,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "profile": {"type": str},
                             "name": {"type": str},
@@ -19538,7 +19222,7 @@ class EosDesigns(EosDesignsRootModel):
                             "cv_pathfinder_internet_exit": {"type": CvPathfinderInternetExit},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
                         profile: str | None
                         """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
@@ -19676,12 +19360,8 @@ class EosDesigns(EosDesignsRootModel):
                         Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Ethernet interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.EthernetInterfacesItem
+                        """Custom structured config for the Ethernet interface."""
 
                         if TYPE_CHECKING:
 
@@ -19712,7 +19392,7 @@ class EosDesigns(EosDesignsRootModel):
                                 cv_pathfinder_internet_exit: CvPathfinderInternetExit | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3InterfacesItem.
@@ -19806,10 +19486,7 @@ class EosDesigns(EosDesignsRootModel):
                                     flow_tracking:
                                        Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Ethernet interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Ethernet interface.
 
                                 """
 
@@ -19826,16 +19503,13 @@ class EosDesigns(EosDesignsRootModel):
                         class MemberInterfacesItem(AvdModel):
                             """Subclass of AvdModel."""
 
-                            class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "name": {"type": str},
                                 "description": {"type": str},
                                 "peer": {"type": str},
                                 "peer_interface": {"type": str},
                                 "speed": {"type": str},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
                             name: str
                             """
@@ -19861,12 +19535,8 @@ class EosDesigns(EosDesignsRootModel):
                             Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                             <interface_speed>`.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the member ethernet interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.EthernetInterfacesItem
+                            """Custom structured config for the member ethernet interface."""
 
                             if TYPE_CHECKING:
 
@@ -19878,7 +19548,7 @@ class EosDesigns(EosDesignsRootModel):
                                     peer: str | None | UndefinedType = Undefined,
                                     peer_interface: str | None | UndefinedType = Undefined,
                                     speed: str | None | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     MemberInterfacesItem.
@@ -19902,10 +19572,7 @@ class EosDesigns(EosDesignsRootModel):
                                         speed:
                                            Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                            <interface_speed>`.
-                                        structured_config:
-                                           Custom structured config for the member ethernet interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the member ethernet interface.
 
                                     """
 
@@ -20021,9 +19688,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "name": {"type": str},
                             "description": {"type": str},
@@ -20048,7 +19712,7 @@ class EosDesigns(EosDesignsRootModel):
                             "connected_to_pathfinder": {"type": bool, "default": True},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
                         }
                         name: str
                         """
@@ -20190,12 +19854,8 @@ class EosDesigns(EosDesignsRootModel):
 
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Port-Channel interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.PortChannelInterfacesItem
+                        """Custom structured config for the Port-Channel interface."""
 
                         if TYPE_CHECKING:
 
@@ -20225,7 +19885,7 @@ class EosDesigns(EosDesignsRootModel):
                                 connected_to_pathfinder: bool | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3PortChannelsItem.
@@ -20322,10 +19982,7 @@ class EosDesigns(EosDesignsRootModel):
                                        setting.
 
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Port-Channel interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Port-Channel interface.
 
                                 """
 
@@ -20352,7 +20009,7 @@ class EosDesigns(EosDesignsRootModel):
                         "lacp_port_id_range": {"type": LacpPortIdRange},
                         "always_configure_ip_routing": {"type": bool, "default": False},
                         "raw_eos_cli": {"type": str},
-                        "structured_config": {"type": StructuredConfig},
+                        "structured_config": {"type": EosCliConfigGen},
                         "uplink_type": {"type": str},
                         "uplink_ipv4_pool": {"type": str},
                         "uplink_interfaces": {"type": UplinkInterfaces},
@@ -20370,9 +20027,9 @@ class EosDesigns(EosDesignsRootModel):
                         "uplink_port_channel_id": {"type": int},
                         "uplink_switch_port_channel_id": {"type": int},
                         "uplink_structured_config": {"type": dict},
-                        "mlag_port_channel_structured_config": {"type": MlagPortChannelStructuredConfig},
-                        "mlag_peer_vlan_structured_config": {"type": MlagPeerVlanStructuredConfig},
-                        "mlag_peer_l3_vlan_structured_config": {"type": MlagPeerL3VlanStructuredConfig},
+                        "mlag_port_channel_structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
+                        "mlag_peer_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
+                        "mlag_peer_l3_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                         "short_esi": {"type": str},
                         "isis_system_id_prefix": {"type": str},
                         "isis_maximum_paths": {"type": int},
@@ -20519,12 +20176,8 @@ class EosDesigns(EosDesignsRootModel):
                     """
                     raw_eos_cli: str | None
                     """EOS CLI rendered directly on the root level of the final EOS configuration."""
-                    structured_config: StructuredConfig
-                    """
-                    Custom structured config for eos_cli_config_gen.
-
-                    Subclass of AvdModel.
-                    """
+                    structured_config: EosCliConfigGen
+                    """Custom structured config for eos_cli_config_gen."""
                     uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None
                     """
                     Override the default `uplink_type` set at the `node_type_key` level.
@@ -20669,7 +20322,7 @@ class EosDesigns(EosDesignsRootModel):
                     Note! The content of this dictionary is _not_ validated
                     by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
                     """
-                    mlag_port_channel_structured_config: MlagPortChannelStructuredConfig
+                    mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem
                     """
                     Custom structured config applied to MLAG peer link port-channel id.
                     Added under
@@ -20678,12 +20331,8 @@ class EosDesigns(EosDesignsRootModel):
                     port-channel interface level.
                     "mlag_port_channel_structured_config" is applied after
                     "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                    Subclass of
-                    AvdModel.
                     """
-                    mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig
+                    mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                     Added under
@@ -20692,11 +20341,8 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                     override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
-                    mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig
+                    mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                     Added under
@@ -20705,9 +20351,6 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                     can override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
                     short_esi: str | None
                     """
@@ -21266,7 +20909,7 @@ class EosDesigns(EosDesignsRootModel):
                             lacp_port_id_range: LacpPortIdRange | UndefinedType = Undefined,
                             always_configure_ip_routing: bool | UndefinedType = Undefined,
                             raw_eos_cli: str | None | UndefinedType = Undefined,
-                            structured_config: StructuredConfig | UndefinedType = Undefined,
+                            structured_config: EosCliConfigGen | UndefinedType = Undefined,
                             uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None | UndefinedType = Undefined,
                             uplink_ipv4_pool: str | None | UndefinedType = Undefined,
                             uplink_interfaces: UplinkInterfaces | UndefinedType = Undefined,
@@ -21284,9 +20927,9 @@ class EosDesigns(EosDesignsRootModel):
                             uplink_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_switch_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_structured_config: dict | UndefinedType = Undefined,
-                            mlag_port_channel_structured_config: MlagPortChannelStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig | UndefinedType = Undefined,
+                            mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                             short_esi: str | None | UndefinedType = Undefined,
                             isis_system_id_prefix: str | None | UndefinedType = Undefined,
                             isis_maximum_paths: int | None | UndefinedType = Undefined,
@@ -21415,10 +21058,7 @@ class EosDesigns(EosDesignsRootModel):
                                    Use this to retain behavior of AVD versions
                                    below 4.0.0.
                                 raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
-                                structured_config:
-                                   Custom structured config for eos_cli_config_gen.
-
-                                   Subclass of AvdModel.
+                                structured_config: Custom structured config for eos_cli_config_gen.
                                 uplink_type:
                                    Override the default `uplink_type` set at the `node_type_key` level.
                                    `uplink_type` must be "p2p" if
@@ -21534,10 +21174,6 @@ class EosDesigns(EosDesignsRootModel):
                                    port-channel interface level.
                                    "mlag_port_channel_structured_config" is applied after
                                    "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                                   Subclass of
-                                   AvdModel.
                                 mlag_peer_vlan_structured_config:
                                    Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                                    Added under
@@ -21546,9 +21182,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                                    override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 mlag_peer_l3_vlan_structured_config:
                                    Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                                    Added under
@@ -21557,9 +21190,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                                    can override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 short_esi:
                                    short_esi only valid for l2leaf devices using port-channel uplink.
                                    Setting short_esi to "auto"
@@ -22126,9 +21756,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen):
-                            """Subclass of AvdModel."""
-
                         class UplinkInterfaces(AvdList[str]):
                             """Subclass of AvdList with `str` items."""
 
@@ -22184,15 +21811,6 @@ class EosDesigns(EosDesignsRootModel):
                                         profile: profile
 
                                     """
-
-                        class MlagPortChannelStructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                            """Subclass of AvdModel."""
-
-                        class MlagPeerVlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                            """Subclass of AvdModel."""
-
-                        class MlagPeerL3VlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                            """Subclass of AvdModel."""
 
                         class BgpDefaults(AvdList[str]):
                             """Subclass of AvdList with `str` items."""
@@ -23410,9 +23028,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                         """
 
-                            class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "profile": {"type": str},
                                 "name": {"type": str},
@@ -23438,7 +23053,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "cv_pathfinder_internet_exit": {"type": CvPathfinderInternetExit},
                                 "raw_eos_cli": {"type": str},
                                 "flow_tracking": {"type": FlowTracking},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
                             profile: str | None
                             """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
@@ -23576,12 +23191,8 @@ class EosDesigns(EosDesignsRootModel):
                             Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                             Subclass of AvdModel.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the Ethernet interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.EthernetInterfacesItem
+                            """Custom structured config for the Ethernet interface."""
 
                             if TYPE_CHECKING:
 
@@ -23612,7 +23223,7 @@ class EosDesigns(EosDesignsRootModel):
                                     cv_pathfinder_internet_exit: CvPathfinderInternetExit | UndefinedType = Undefined,
                                     raw_eos_cli: str | None | UndefinedType = Undefined,
                                     flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     L3InterfacesItem.
@@ -23706,10 +23317,7 @@ class EosDesigns(EosDesignsRootModel):
                                         flow_tracking:
                                            Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                                            Subclass of AvdModel.
-                                        structured_config:
-                                           Custom structured config for the Ethernet interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the Ethernet interface.
 
                                     """
 
@@ -23726,16 +23334,13 @@ class EosDesigns(EosDesignsRootModel):
                             class MemberInterfacesItem(AvdModel):
                                 """Subclass of AvdModel."""
 
-                                class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                    """Subclass of AvdModel."""
-
                                 _fields: ClassVar[dict] = {
                                     "name": {"type": str},
                                     "description": {"type": str},
                                     "peer": {"type": str},
                                     "peer_interface": {"type": str},
                                     "speed": {"type": str},
-                                    "structured_config": {"type": StructuredConfig},
+                                    "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                                 }
                                 name: str
                                 """
@@ -23761,12 +23366,8 @@ class EosDesigns(EosDesignsRootModel):
                                 Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                 <interface_speed>`.
                                 """
-                                structured_config: StructuredConfig
-                                """
-                                Custom structured config for the member ethernet interface.
-
-                                Subclass of AvdModel.
-                                """
+                                structured_config: EosCliConfigGen.EthernetInterfacesItem
+                                """Custom structured config for the member ethernet interface."""
 
                                 if TYPE_CHECKING:
 
@@ -23778,7 +23379,7 @@ class EosDesigns(EosDesignsRootModel):
                                         peer: str | None | UndefinedType = Undefined,
                                         peer_interface: str | None | UndefinedType = Undefined,
                                         speed: str | None | UndefinedType = Undefined,
-                                        structured_config: StructuredConfig | UndefinedType = Undefined,
+                                        structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                     ) -> None:
                                         """
                                         MemberInterfacesItem.
@@ -23802,10 +23403,7 @@ class EosDesigns(EosDesignsRootModel):
                                             speed:
                                                Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                                <interface_speed>`.
-                                            structured_config:
-                                               Custom structured config for the member ethernet interface.
-
-                                               Subclass of AvdModel.
+                                            structured_config: Custom structured config for the member ethernet interface.
 
                                         """
 
@@ -23927,9 +23525,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                         """
 
-                            class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "name": {"type": str},
                                 "description": {"type": str},
@@ -23954,7 +23549,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "connected_to_pathfinder": {"type": bool, "default": True},
                                 "raw_eos_cli": {"type": str},
                                 "flow_tracking": {"type": FlowTracking},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
                             }
                             name: str
                             """
@@ -24096,12 +23691,8 @@ class EosDesigns(EosDesignsRootModel):
 
                             Subclass of AvdModel.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the Port-Channel interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.PortChannelInterfacesItem
+                            """Custom structured config for the Port-Channel interface."""
 
                             if TYPE_CHECKING:
 
@@ -24131,7 +23722,7 @@ class EosDesigns(EosDesignsRootModel):
                                     connected_to_pathfinder: bool | UndefinedType = Undefined,
                                     raw_eos_cli: str | None | UndefinedType = Undefined,
                                     flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     L3PortChannelsItem.
@@ -24228,10 +23819,7 @@ class EosDesigns(EosDesignsRootModel):
                                            setting.
 
                                            Subclass of AvdModel.
-                                        structured_config:
-                                           Custom structured config for the Port-Channel interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the Port-Channel interface.
 
                                     """
 
@@ -24260,7 +23848,7 @@ class EosDesigns(EosDesignsRootModel):
                             "lacp_port_id_range": {"type": LacpPortIdRange},
                             "always_configure_ip_routing": {"type": bool, "default": False},
                             "raw_eos_cli": {"type": str},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen},
                             "uplink_type": {"type": str},
                             "uplink_ipv4_pool": {"type": str},
                             "uplink_interfaces": {"type": UplinkInterfaces},
@@ -24278,9 +23866,9 @@ class EosDesigns(EosDesignsRootModel):
                             "uplink_port_channel_id": {"type": int},
                             "uplink_switch_port_channel_id": {"type": int},
                             "uplink_structured_config": {"type": dict},
-                            "mlag_port_channel_structured_config": {"type": MlagPortChannelStructuredConfig},
-                            "mlag_peer_vlan_structured_config": {"type": MlagPeerVlanStructuredConfig},
-                            "mlag_peer_l3_vlan_structured_config": {"type": MlagPeerL3VlanStructuredConfig},
+                            "mlag_port_channel_structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
+                            "mlag_peer_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
+                            "mlag_peer_l3_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                             "short_esi": {"type": str},
                             "isis_system_id_prefix": {"type": str},
                             "isis_maximum_paths": {"type": int},
@@ -24437,12 +24025,8 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         raw_eos_cli: str | None
                         """EOS CLI rendered directly on the root level of the final EOS configuration."""
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for eos_cli_config_gen.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen
+                        """Custom structured config for eos_cli_config_gen."""
                         uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None
                         """
                         Override the default `uplink_type` set at the `node_type_key` level.
@@ -24587,7 +24171,7 @@ class EosDesigns(EosDesignsRootModel):
                         Note! The content of this dictionary is _not_ validated
                         by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
                         """
-                        mlag_port_channel_structured_config: MlagPortChannelStructuredConfig
+                        mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem
                         """
                         Custom structured config applied to MLAG peer link port-channel id.
                         Added under
@@ -24596,12 +24180,8 @@ class EosDesigns(EosDesignsRootModel):
                         port-channel interface level.
                         "mlag_port_channel_structured_config" is applied after
                         "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                        Subclass of
-                        AvdModel.
                         """
-                        mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig
+                        mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                         """
                         Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                         Added under
@@ -24610,11 +24190,8 @@ class EosDesigns(EosDesignsRootModel):
                         interface level.
                         "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                         override "structured_config" defined on node-level.
-
-
-                        Subclass of AvdModel.
                         """
-                        mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig
+                        mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                         """
                         Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                         Added under
@@ -24623,9 +24200,6 @@ class EosDesigns(EosDesignsRootModel):
                         interface level.
                         "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                         can override "structured_config" defined on node-level.
-
-
-                        Subclass of AvdModel.
                         """
                         short_esi: str | None
                         """
@@ -25186,7 +24760,7 @@ class EosDesigns(EosDesignsRootModel):
                                 lacp_port_id_range: LacpPortIdRange | UndefinedType = Undefined,
                                 always_configure_ip_routing: bool | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen | UndefinedType = Undefined,
                                 uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None | UndefinedType = Undefined,
                                 uplink_ipv4_pool: str | None | UndefinedType = Undefined,
                                 uplink_interfaces: UplinkInterfaces | UndefinedType = Undefined,
@@ -25204,9 +24778,9 @@ class EosDesigns(EosDesignsRootModel):
                                 uplink_port_channel_id: int | None | UndefinedType = Undefined,
                                 uplink_switch_port_channel_id: int | None | UndefinedType = Undefined,
                                 uplink_structured_config: dict | UndefinedType = Undefined,
-                                mlag_port_channel_structured_config: MlagPortChannelStructuredConfig | UndefinedType = Undefined,
-                                mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig | UndefinedType = Undefined,
-                                mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig | UndefinedType = Undefined,
+                                mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
+                                mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
+                                mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                                 short_esi: str | None | UndefinedType = Undefined,
                                 isis_system_id_prefix: str | None | UndefinedType = Undefined,
                                 isis_maximum_paths: int | None | UndefinedType = Undefined,
@@ -25342,10 +24916,7 @@ class EosDesigns(EosDesignsRootModel):
                                        Use this to retain behavior of AVD versions
                                        below 4.0.0.
                                     raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
-                                    structured_config:
-                                       Custom structured config for eos_cli_config_gen.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for eos_cli_config_gen.
                                     uplink_type:
                                        Override the default `uplink_type` set at the `node_type_key` level.
                                        `uplink_type` must be "p2p" if
@@ -25461,10 +25032,6 @@ class EosDesigns(EosDesignsRootModel):
                                        port-channel interface level.
                                        "mlag_port_channel_structured_config" is applied after
                                        "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                                       Subclass of
-                                       AvdModel.
                                     mlag_peer_vlan_structured_config:
                                        Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                                        Added under
@@ -25473,9 +25040,6 @@ class EosDesigns(EosDesignsRootModel):
                                        interface level.
                                        "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                                        override "structured_config" defined on node-level.
-
-
-                                       Subclass of AvdModel.
                                     mlag_peer_l3_vlan_structured_config:
                                        Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                                        Added under
@@ -25484,9 +25048,6 @@ class EosDesigns(EosDesignsRootModel):
                                        interface level.
                                        "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                                        can override "structured_config" defined on node-level.
-
-
-                                       Subclass of AvdModel.
                                     short_esi:
                                        short_esi only valid for l2leaf devices using port-channel uplink.
                                        Setting short_esi to "auto"
@@ -25995,9 +25556,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                 """
 
-                    class StructuredConfig(EosCliConfigGen):
-                        """Subclass of AvdModel."""
-
                     class UplinkInterfaces(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
 
@@ -26053,15 +25611,6 @@ class EosDesigns(EosDesignsRootModel):
                                     profile: profile
 
                                 """
-
-                    class MlagPortChannelStructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerVlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerL3VlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
 
                     class BgpDefaults(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
@@ -27268,9 +26817,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "profile": {"type": str},
                             "name": {"type": str},
@@ -27296,7 +26842,7 @@ class EosDesigns(EosDesignsRootModel):
                             "cv_pathfinder_internet_exit": {"type": CvPathfinderInternetExit},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
                         profile: str | None
                         """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
@@ -27434,12 +26980,8 @@ class EosDesigns(EosDesignsRootModel):
                         Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Ethernet interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.EthernetInterfacesItem
+                        """Custom structured config for the Ethernet interface."""
 
                         if TYPE_CHECKING:
 
@@ -27470,7 +27012,7 @@ class EosDesigns(EosDesignsRootModel):
                                 cv_pathfinder_internet_exit: CvPathfinderInternetExit | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3InterfacesItem.
@@ -27564,10 +27106,7 @@ class EosDesigns(EosDesignsRootModel):
                                     flow_tracking:
                                        Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Ethernet interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Ethernet interface.
 
                                 """
 
@@ -27584,16 +27123,13 @@ class EosDesigns(EosDesignsRootModel):
                         class MemberInterfacesItem(AvdModel):
                             """Subclass of AvdModel."""
 
-                            class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "name": {"type": str},
                                 "description": {"type": str},
                                 "peer": {"type": str},
                                 "peer_interface": {"type": str},
                                 "speed": {"type": str},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
                             name: str
                             """
@@ -27619,12 +27155,8 @@ class EosDesigns(EosDesignsRootModel):
                             Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                             <interface_speed>`.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the member ethernet interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.EthernetInterfacesItem
+                            """Custom structured config for the member ethernet interface."""
 
                             if TYPE_CHECKING:
 
@@ -27636,7 +27168,7 @@ class EosDesigns(EosDesignsRootModel):
                                     peer: str | None | UndefinedType = Undefined,
                                     peer_interface: str | None | UndefinedType = Undefined,
                                     speed: str | None | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     MemberInterfacesItem.
@@ -27660,10 +27192,7 @@ class EosDesigns(EosDesignsRootModel):
                                         speed:
                                            Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                            <interface_speed>`.
-                                        structured_config:
-                                           Custom structured config for the member ethernet interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the member ethernet interface.
 
                                     """
 
@@ -27779,9 +27308,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "name": {"type": str},
                             "description": {"type": str},
@@ -27806,7 +27332,7 @@ class EosDesigns(EosDesignsRootModel):
                             "connected_to_pathfinder": {"type": bool, "default": True},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
                         }
                         name: str
                         """
@@ -27948,12 +27474,8 @@ class EosDesigns(EosDesignsRootModel):
 
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Port-Channel interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.PortChannelInterfacesItem
+                        """Custom structured config for the Port-Channel interface."""
 
                         if TYPE_CHECKING:
 
@@ -27983,7 +27505,7 @@ class EosDesigns(EosDesignsRootModel):
                                 connected_to_pathfinder: bool | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3PortChannelsItem.
@@ -28080,10 +27602,7 @@ class EosDesigns(EosDesignsRootModel):
                                        setting.
 
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Port-Channel interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Port-Channel interface.
 
                                 """
 
@@ -28112,7 +27631,7 @@ class EosDesigns(EosDesignsRootModel):
                         "lacp_port_id_range": {"type": LacpPortIdRange},
                         "always_configure_ip_routing": {"type": bool, "default": False},
                         "raw_eos_cli": {"type": str},
-                        "structured_config": {"type": StructuredConfig},
+                        "structured_config": {"type": EosCliConfigGen},
                         "uplink_type": {"type": str},
                         "uplink_ipv4_pool": {"type": str},
                         "uplink_interfaces": {"type": UplinkInterfaces},
@@ -28130,9 +27649,9 @@ class EosDesigns(EosDesignsRootModel):
                         "uplink_port_channel_id": {"type": int},
                         "uplink_switch_port_channel_id": {"type": int},
                         "uplink_structured_config": {"type": dict},
-                        "mlag_port_channel_structured_config": {"type": MlagPortChannelStructuredConfig},
-                        "mlag_peer_vlan_structured_config": {"type": MlagPeerVlanStructuredConfig},
-                        "mlag_peer_l3_vlan_structured_config": {"type": MlagPeerL3VlanStructuredConfig},
+                        "mlag_port_channel_structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
+                        "mlag_peer_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
+                        "mlag_peer_l3_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                         "short_esi": {"type": str},
                         "isis_system_id_prefix": {"type": str},
                         "isis_maximum_paths": {"type": int},
@@ -28292,12 +27811,8 @@ class EosDesigns(EosDesignsRootModel):
                     """
                     raw_eos_cli: str | None
                     """EOS CLI rendered directly on the root level of the final EOS configuration."""
-                    structured_config: StructuredConfig
-                    """
-                    Custom structured config for eos_cli_config_gen.
-
-                    Subclass of AvdModel.
-                    """
+                    structured_config: EosCliConfigGen
+                    """Custom structured config for eos_cli_config_gen."""
                     uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None
                     """
                     Override the default `uplink_type` set at the `node_type_key` level.
@@ -28442,7 +27957,7 @@ class EosDesigns(EosDesignsRootModel):
                     Note! The content of this dictionary is _not_ validated
                     by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
                     """
-                    mlag_port_channel_structured_config: MlagPortChannelStructuredConfig
+                    mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem
                     """
                     Custom structured config applied to MLAG peer link port-channel id.
                     Added under
@@ -28451,12 +27966,8 @@ class EosDesigns(EosDesignsRootModel):
                     port-channel interface level.
                     "mlag_port_channel_structured_config" is applied after
                     "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                    Subclass of
-                    AvdModel.
                     """
-                    mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig
+                    mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                     Added under
@@ -28465,11 +27976,8 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                     override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
-                    mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig
+                    mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                     Added under
@@ -28478,9 +27986,6 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                     can override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
                     short_esi: str | None
                     """
@@ -29041,7 +28546,7 @@ class EosDesigns(EosDesignsRootModel):
                             lacp_port_id_range: LacpPortIdRange | UndefinedType = Undefined,
                             always_configure_ip_routing: bool | UndefinedType = Undefined,
                             raw_eos_cli: str | None | UndefinedType = Undefined,
-                            structured_config: StructuredConfig | UndefinedType = Undefined,
+                            structured_config: EosCliConfigGen | UndefinedType = Undefined,
                             uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None | UndefinedType = Undefined,
                             uplink_ipv4_pool: str | None | UndefinedType = Undefined,
                             uplink_interfaces: UplinkInterfaces | UndefinedType = Undefined,
@@ -29059,9 +28564,9 @@ class EosDesigns(EosDesignsRootModel):
                             uplink_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_switch_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_structured_config: dict | UndefinedType = Undefined,
-                            mlag_port_channel_structured_config: MlagPortChannelStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig | UndefinedType = Undefined,
+                            mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                             short_esi: str | None | UndefinedType = Undefined,
                             isis_system_id_prefix: str | None | UndefinedType = Undefined,
                             isis_maximum_paths: int | None | UndefinedType = Undefined,
@@ -29199,10 +28704,7 @@ class EosDesigns(EosDesignsRootModel):
                                    Use this to retain behavior of AVD versions
                                    below 4.0.0.
                                 raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
-                                structured_config:
-                                   Custom structured config for eos_cli_config_gen.
-
-                                   Subclass of AvdModel.
+                                structured_config: Custom structured config for eos_cli_config_gen.
                                 uplink_type:
                                    Override the default `uplink_type` set at the `node_type_key` level.
                                    `uplink_type` must be "p2p" if
@@ -29318,10 +28820,6 @@ class EosDesigns(EosDesignsRootModel):
                                    port-channel interface level.
                                    "mlag_port_channel_structured_config" is applied after
                                    "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                                   Subclass of
-                                   AvdModel.
                                 mlag_peer_vlan_structured_config:
                                    Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                                    Added under
@@ -29330,9 +28828,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                                    override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 mlag_peer_l3_vlan_structured_config:
                                    Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                                    Added under
@@ -29341,9 +28836,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                                    can override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 short_esi:
                                    short_esi only valid for l2leaf devices using port-channel uplink.
                                    Setting short_esi to "auto"
@@ -29911,9 +29403,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                 """
 
-                    class StructuredConfig(EosCliConfigGen):
-                        """Subclass of AvdModel."""
-
                     class UplinkInterfaces(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
 
@@ -29969,15 +29458,6 @@ class EosDesigns(EosDesignsRootModel):
                                     profile: profile
 
                                 """
-
-                    class MlagPortChannelStructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerVlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerL3VlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
 
                     class BgpDefaults(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
@@ -31184,9 +30664,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "profile": {"type": str},
                             "name": {"type": str},
@@ -31212,7 +30689,7 @@ class EosDesigns(EosDesignsRootModel):
                             "cv_pathfinder_internet_exit": {"type": CvPathfinderInternetExit},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
                         profile: str | None
                         """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
@@ -31350,12 +30827,8 @@ class EosDesigns(EosDesignsRootModel):
                         Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Ethernet interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.EthernetInterfacesItem
+                        """Custom structured config for the Ethernet interface."""
 
                         if TYPE_CHECKING:
 
@@ -31386,7 +30859,7 @@ class EosDesigns(EosDesignsRootModel):
                                 cv_pathfinder_internet_exit: CvPathfinderInternetExit | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3InterfacesItem.
@@ -31480,10 +30953,7 @@ class EosDesigns(EosDesignsRootModel):
                                     flow_tracking:
                                        Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Ethernet interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Ethernet interface.
 
                                 """
 
@@ -31500,16 +30970,13 @@ class EosDesigns(EosDesignsRootModel):
                         class MemberInterfacesItem(AvdModel):
                             """Subclass of AvdModel."""
 
-                            class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "name": {"type": str},
                                 "description": {"type": str},
                                 "peer": {"type": str},
                                 "peer_interface": {"type": str},
                                 "speed": {"type": str},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
                             name: str
                             """
@@ -31535,12 +31002,8 @@ class EosDesigns(EosDesignsRootModel):
                             Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                             <interface_speed>`.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the member ethernet interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.EthernetInterfacesItem
+                            """Custom structured config for the member ethernet interface."""
 
                             if TYPE_CHECKING:
 
@@ -31552,7 +31015,7 @@ class EosDesigns(EosDesignsRootModel):
                                     peer: str | None | UndefinedType = Undefined,
                                     peer_interface: str | None | UndefinedType = Undefined,
                                     speed: str | None | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     MemberInterfacesItem.
@@ -31576,10 +31039,7 @@ class EosDesigns(EosDesignsRootModel):
                                         speed:
                                            Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                            <interface_speed>`.
-                                        structured_config:
-                                           Custom structured config for the member ethernet interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the member ethernet interface.
 
                                     """
 
@@ -31695,9 +31155,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "name": {"type": str},
                             "description": {"type": str},
@@ -31722,7 +31179,7 @@ class EosDesigns(EosDesignsRootModel):
                             "connected_to_pathfinder": {"type": bool, "default": True},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
                         }
                         name: str
                         """
@@ -31864,12 +31321,8 @@ class EosDesigns(EosDesignsRootModel):
 
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Port-Channel interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.PortChannelInterfacesItem
+                        """Custom structured config for the Port-Channel interface."""
 
                         if TYPE_CHECKING:
 
@@ -31899,7 +31352,7 @@ class EosDesigns(EosDesignsRootModel):
                                 connected_to_pathfinder: bool | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3PortChannelsItem.
@@ -31996,10 +31449,7 @@ class EosDesigns(EosDesignsRootModel):
                                        setting.
 
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Port-Channel interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Port-Channel interface.
 
                                 """
 
@@ -32028,7 +31478,7 @@ class EosDesigns(EosDesignsRootModel):
                         "lacp_port_id_range": {"type": LacpPortIdRange},
                         "always_configure_ip_routing": {"type": bool, "default": False},
                         "raw_eos_cli": {"type": str},
-                        "structured_config": {"type": StructuredConfig},
+                        "structured_config": {"type": EosCliConfigGen},
                         "uplink_type": {"type": str},
                         "uplink_ipv4_pool": {"type": str},
                         "uplink_interfaces": {"type": UplinkInterfaces},
@@ -32046,9 +31496,9 @@ class EosDesigns(EosDesignsRootModel):
                         "uplink_port_channel_id": {"type": int},
                         "uplink_switch_port_channel_id": {"type": int},
                         "uplink_structured_config": {"type": dict},
-                        "mlag_port_channel_structured_config": {"type": MlagPortChannelStructuredConfig},
-                        "mlag_peer_vlan_structured_config": {"type": MlagPeerVlanStructuredConfig},
-                        "mlag_peer_l3_vlan_structured_config": {"type": MlagPeerL3VlanStructuredConfig},
+                        "mlag_port_channel_structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
+                        "mlag_peer_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
+                        "mlag_peer_l3_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                         "short_esi": {"type": str},
                         "isis_system_id_prefix": {"type": str},
                         "isis_maximum_paths": {"type": int},
@@ -32205,12 +31655,8 @@ class EosDesigns(EosDesignsRootModel):
                     """
                     raw_eos_cli: str | None
                     """EOS CLI rendered directly on the root level of the final EOS configuration."""
-                    structured_config: StructuredConfig
-                    """
-                    Custom structured config for eos_cli_config_gen.
-
-                    Subclass of AvdModel.
-                    """
+                    structured_config: EosCliConfigGen
+                    """Custom structured config for eos_cli_config_gen."""
                     uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None
                     """
                     Override the default `uplink_type` set at the `node_type_key` level.
@@ -32355,7 +31801,7 @@ class EosDesigns(EosDesignsRootModel):
                     Note! The content of this dictionary is _not_ validated
                     by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
                     """
-                    mlag_port_channel_structured_config: MlagPortChannelStructuredConfig
+                    mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem
                     """
                     Custom structured config applied to MLAG peer link port-channel id.
                     Added under
@@ -32364,12 +31810,8 @@ class EosDesigns(EosDesignsRootModel):
                     port-channel interface level.
                     "mlag_port_channel_structured_config" is applied after
                     "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                    Subclass of
-                    AvdModel.
                     """
-                    mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig
+                    mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                     Added under
@@ -32378,11 +31820,8 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                     override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
-                    mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig
+                    mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                     Added under
@@ -32391,9 +31830,6 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                     can override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
                     short_esi: str | None
                     """
@@ -32954,7 +32390,7 @@ class EosDesigns(EosDesignsRootModel):
                             lacp_port_id_range: LacpPortIdRange | UndefinedType = Undefined,
                             always_configure_ip_routing: bool | UndefinedType = Undefined,
                             raw_eos_cli: str | None | UndefinedType = Undefined,
-                            structured_config: StructuredConfig | UndefinedType = Undefined,
+                            structured_config: EosCliConfigGen | UndefinedType = Undefined,
                             uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None | UndefinedType = Undefined,
                             uplink_ipv4_pool: str | None | UndefinedType = Undefined,
                             uplink_interfaces: UplinkInterfaces | UndefinedType = Undefined,
@@ -32972,9 +32408,9 @@ class EosDesigns(EosDesignsRootModel):
                             uplink_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_switch_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_structured_config: dict | UndefinedType = Undefined,
-                            mlag_port_channel_structured_config: MlagPortChannelStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig | UndefinedType = Undefined,
+                            mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                             short_esi: str | None | UndefinedType = Undefined,
                             isis_system_id_prefix: str | None | UndefinedType = Undefined,
                             isis_maximum_paths: int | None | UndefinedType = Undefined,
@@ -33110,10 +32546,7 @@ class EosDesigns(EosDesignsRootModel):
                                    Use this to retain behavior of AVD versions
                                    below 4.0.0.
                                 raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
-                                structured_config:
-                                   Custom structured config for eos_cli_config_gen.
-
-                                   Subclass of AvdModel.
+                                structured_config: Custom structured config for eos_cli_config_gen.
                                 uplink_type:
                                    Override the default `uplink_type` set at the `node_type_key` level.
                                    `uplink_type` must be "p2p" if
@@ -33229,10 +32662,6 @@ class EosDesigns(EosDesignsRootModel):
                                    port-channel interface level.
                                    "mlag_port_channel_structured_config" is applied after
                                    "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                                   Subclass of
-                                   AvdModel.
                                 mlag_peer_vlan_structured_config:
                                    Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                                    Added under
@@ -33241,9 +32670,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                                    override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 mlag_peer_l3_vlan_structured_config:
                                    Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                                    Added under
@@ -33252,9 +32678,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                                    can override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 short_esi:
                                    short_esi only valid for l2leaf devices using port-channel uplink.
                                    Setting short_esi to "auto"
@@ -33728,20 +33151,14 @@ class EosDesigns(EosDesignsRootModel):
                     class AddressFamilyIpv4(AvdModel):
                         """Subclass of AvdModel."""
 
-                        class DefaultOriginate(EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.DefaultOriginate):
-                            """Subclass of AvdModel."""
-
-                        class NextHop(EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.NextHop):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "activate": {"type": bool},
                             "route_map_in": {"type": str},
                             "route_map_out": {"type": str},
                             "rcf_in": {"type": str},
                             "rcf_out": {"type": str},
-                            "default_originate": {"type": DefaultOriginate},
-                            "next_hop": {"type": NextHop},
+                            "default_originate": {"type": EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.DefaultOriginate},
+                            "next_hop": {"type": EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.NextHop},
                             "prefix_list_in": {"type": str},
                             "prefix_list_out": {"type": str},
                         }
@@ -33760,10 +33177,8 @@ class EosDesigns(EosDesignsRootModel):
                         Outbound RCF function name with parenthesis.
                         Example: MyFunction(myarg).
                         """
-                        default_originate: DefaultOriginate
-                        """Subclass of AvdModel."""
-                        next_hop: NextHop
-                        """Subclass of AvdModel."""
+                        default_originate: EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.DefaultOriginate
+                        next_hop: EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.NextHop
                         prefix_list_in: str | None
                         """Inbound prefix-list name."""
                         prefix_list_out: str | None
@@ -33779,8 +33194,8 @@ class EosDesigns(EosDesignsRootModel):
                                 route_map_out: str | None | UndefinedType = Undefined,
                                 rcf_in: str | None | UndefinedType = Undefined,
                                 rcf_out: str | None | UndefinedType = Undefined,
-                                default_originate: DefaultOriginate | UndefinedType = Undefined,
-                                next_hop: NextHop | UndefinedType = Undefined,
+                                default_originate: EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.DefaultOriginate | UndefinedType = Undefined,
+                                next_hop: EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.NextHop | UndefinedType = Undefined,
                                 prefix_list_in: str | None | UndefinedType = Undefined,
                                 prefix_list_out: str | None | UndefinedType = Undefined,
                             ) -> None:
@@ -33800,8 +33215,8 @@ class EosDesigns(EosDesignsRootModel):
                                     rcf_out:
                                        Outbound RCF function name with parenthesis.
                                        Example: MyFunction(myarg).
-                                    default_originate: Subclass of AvdModel.
-                                    next_hop: Subclass of AvdModel.
+                                    default_originate: default_originate
+                                    next_hop: next_hop
                                     prefix_list_in: Inbound prefix-list name.
                                     prefix_list_out: Outbound prefix-list name.
 
@@ -35607,18 +35022,12 @@ class EosDesigns(EosDesignsRootModel):
                             class Bgp(AvdModel):
                                 """Subclass of AvdModel."""
 
-                                class StructuredConfig(EosCliConfigGen.RouterBgp.VlansItem):
-                                    """Subclass of AvdModel."""
-
-                                _fields: ClassVar[dict] = {"structured_config": {"type": StructuredConfig}, "raw_eos_cli": {"type": str}}
-                                structured_config: StructuredConfig
+                                _fields: ClassVar[dict] = {"structured_config": {"type": EosCliConfigGen.RouterBgp.VlansItem}, "raw_eos_cli": {"type": str}}
+                                structured_config: EosCliConfigGen.RouterBgp.VlansItem
                                 """
                                 Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>].
                                 This
                                 configuration will not be applied to vlan aware bundles.
-
-
-                                Subclass of AvdModel.
                                 """
                                 raw_eos_cli: str | None
                                 """EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration."""
@@ -35628,7 +35037,7 @@ class EosDesigns(EosDesignsRootModel):
                                     def __init__(
                                         self,
                                         *,
-                                        structured_config: StructuredConfig | UndefinedType = Undefined,
+                                        structured_config: EosCliConfigGen.RouterBgp.VlansItem | UndefinedType = Undefined,
                                         raw_eos_cli: str | None | UndefinedType = Undefined,
                                     ) -> None:
                                         """
@@ -35642,15 +35051,9 @@ class EosDesigns(EosDesignsRootModel):
                                                Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>].
                                                This
                                                configuration will not be applied to vlan aware bundles.
-
-
-                                               Subclass of AvdModel.
                                             raw_eos_cli: EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration.
 
                                         """
-
-                            class StructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                                """Subclass of AvdModel."""
 
                             _fields: ClassVar[dict] = {
                                 "node": {"type": str},
@@ -35683,7 +35086,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "ospf": {"type": Ospf},
                                 "bgp": {"type": Bgp},
                                 "raw_eos_cli": {"type": str},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                                 "evpn_l2_multi_domain": {"type": bool},
                             }
                             node: str
@@ -35861,11 +35264,8 @@ class EosDesigns(EosDesignsRootModel):
                             """Subclass of AvdModel."""
                             raw_eos_cli: str | None
                             """EOS CLI rendered directly on the VLAN interface in the final EOS configuration."""
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.VlanInterfacesItem
+                            """Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen."""
                             evpn_l2_multi_domain: bool | None
                             """
                             Explicitly extend SVI to remote EVPN domains.
@@ -35912,7 +35312,7 @@ class EosDesigns(EosDesignsRootModel):
                                     ospf: Ospf | UndefinedType = Undefined,
                                     bgp: Bgp | UndefinedType = Undefined,
                                     raw_eos_cli: str | None | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                                     evpn_l2_multi_domain: bool | None | UndefinedType = Undefined,
                                 ) -> None:
                                     """
@@ -36045,9 +35445,7 @@ class EosDesigns(EosDesignsRootModel):
                                            Subclass of AvdModel.
                                         bgp: Subclass of AvdModel.
                                         raw_eos_cli: EOS CLI rendered directly on the VLAN interface in the final EOS configuration.
-                                        structured_config:
-                                           Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
                                         evpn_l2_multi_domain:
                                            Explicitly extend SVI to remote EVPN domains.
                                            Overrides
@@ -36341,18 +35739,12 @@ class EosDesigns(EosDesignsRootModel):
                         class Bgp(AvdModel):
                             """Subclass of AvdModel."""
 
-                            class StructuredConfig(EosCliConfigGen.RouterBgp.VlansItem):
-                                """Subclass of AvdModel."""
-
-                            _fields: ClassVar[dict] = {"structured_config": {"type": StructuredConfig}, "raw_eos_cli": {"type": str}}
-                            structured_config: StructuredConfig
+                            _fields: ClassVar[dict] = {"structured_config": {"type": EosCliConfigGen.RouterBgp.VlansItem}, "raw_eos_cli": {"type": str}}
+                            structured_config: EosCliConfigGen.RouterBgp.VlansItem
                             """
                             Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>].
                             This
                             configuration will not be applied to vlan aware bundles.
-
-
-                            Subclass of AvdModel.
                             """
                             raw_eos_cli: str | None
                             """EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration."""
@@ -36362,7 +35754,7 @@ class EosDesigns(EosDesignsRootModel):
                                 def __init__(
                                     self,
                                     *,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.RouterBgp.VlansItem | UndefinedType = Undefined,
                                     raw_eos_cli: str | None | UndefinedType = Undefined,
                                 ) -> None:
                                     """
@@ -36376,15 +35768,9 @@ class EosDesigns(EosDesignsRootModel):
                                            Structured configuration and EOS CLI commands rendered on router_bgp.vlans.[id=<vlan>].
                                            This
                                            configuration will not be applied to vlan aware bundles.
-
-
-                                           Subclass of AvdModel.
                                         raw_eos_cli: EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration.
 
                                     """
-
-                        class StructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                            """Subclass of AvdModel."""
 
                         _fields: ClassVar[dict] = {
                             "id": {"type": int},
@@ -36420,7 +35806,7 @@ class EosDesigns(EosDesignsRootModel):
                             "ospf": {"type": Ospf},
                             "bgp": {"type": Bgp},
                             "raw_eos_cli": {"type": str},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                             "evpn_l2_multi_domain": {"type": bool},
                         }
                         id: int
@@ -36622,11 +36008,8 @@ class EosDesigns(EosDesignsRootModel):
                         """Subclass of AvdModel."""
                         raw_eos_cli: str | None
                         """EOS CLI rendered directly on the VLAN interface in the final EOS configuration."""
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.VlanInterfacesItem
+                        """Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen."""
                         evpn_l2_multi_domain: bool | None
                         """
                         Explicitly extend SVI to remote EVPN domains.
@@ -36676,7 +36059,7 @@ class EosDesigns(EosDesignsRootModel):
                                 ospf: Ospf | UndefinedType = Undefined,
                                 bgp: Bgp | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                                 evpn_l2_multi_domain: bool | None | UndefinedType = Undefined,
                             ) -> None:
                                 """
@@ -36827,9 +36210,7 @@ class EosDesigns(EosDesignsRootModel):
                                        Subclass of AvdModel.
                                     bgp: Subclass of AvdModel.
                                     raw_eos_cli: EOS CLI rendered directly on the VLAN interface in the final EOS configuration.
-                                    structured_config:
-                                       Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.
                                     evpn_l2_multi_domain:
                                        Explicitly extend SVI to remote EVPN domains.
                                        Overrides
@@ -37013,9 +36394,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "interfaces": {"type": Interfaces},
                             "encapsulation_dot1q_vlan": {"type": EncapsulationDot1qVlan},
@@ -37030,7 +36408,7 @@ class EosDesigns(EosDesignsRootModel):
                             "ospf": {"type": Ospf},
                             "pim": {"type": Pim},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             "raw_eos_cli": {"type": str},
                         }
                         interfaces: Interfaces
@@ -37082,11 +36460,8 @@ class EosDesigns(EosDesignsRootModel):
                         Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.EthernetInterfacesItem
+                        """Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen."""
                         raw_eos_cli: str | None
                         """EOS CLI rendered directly on the Ethernet interface in the final EOS configuration."""
 
@@ -37108,7 +36483,7 @@ class EosDesigns(EosDesignsRootModel):
                                 ospf: Ospf | UndefinedType = Undefined,
                                 pim: Pim | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                             ) -> None:
                                 """
@@ -37153,9 +36528,7 @@ class EosDesigns(EosDesignsRootModel):
                                     flow_tracking:
                                        Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config added under ethernet_interfaces.[name=<interface>] for eos_cli_config_gen.
                                     raw_eos_cli: EOS CLI rendered directly on the Ethernet interface in the final EOS configuration.
 
                                 """
@@ -37626,14 +36999,11 @@ class EosDesigns(EosDesignsRootModel):
                     class Bgp(AvdModel):
                         """Subclass of AvdModel."""
 
-                        class StructuredConfig(EosCliConfigGen.RouterBgp.VrfsItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "enabled": {"type": bool},
                             "router_id": {"type": str, "default": "main_router_id"},
                             "raw_eos_cli": {"type": str},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.RouterBgp.VrfsItem},
                         }
                         enabled: bool | None
                         """
@@ -37663,13 +37033,8 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         raw_eos_cli: str | None
                         """EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration."""
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config added under router_bgp.vrfs.[name=<vrf>] for eos_cli_config_gen.
-
-                        Subclass
-                        of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.RouterBgp.VrfsItem
+                        """Custom structured config added under router_bgp.vrfs.[name=<vrf>] for eos_cli_config_gen."""
 
                         if TYPE_CHECKING:
 
@@ -37679,7 +37044,7 @@ class EosDesigns(EosDesignsRootModel):
                                 enabled: bool | None | UndefinedType = Undefined,
                                 router_id: str | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.RouterBgp.VrfsItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 Bgp.
@@ -37709,11 +37074,7 @@ class EosDesigns(EosDesignsRootModel):
                                        - "diagnostic_loopback" will use the IP
                                        address of the VRF Diagnostic Loopback interface.
                                     raw_eos_cli: EOS CLI rendered directly on the Router BGP, VRF definition in the final EOS configuration.
-                                    structured_config:
-                                       Custom structured config added under router_bgp.vrfs.[name=<vrf>] for eos_cli_config_gen.
-
-                                       Subclass
-                                       of AvdModel.
+                                    structured_config: Custom structured config added under router_bgp.vrfs.[name=<vrf>] for eos_cli_config_gen.
 
                                 """
 
@@ -37728,20 +37089,14 @@ class EosDesigns(EosDesignsRootModel):
                         class AddressFamilyIpv4(AvdModel):
                             """Subclass of AvdModel."""
 
-                            class DefaultOriginate(EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.DefaultOriginate):
-                                """Subclass of AvdModel."""
-
-                            class NextHop(EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.NextHop):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "activate": {"type": bool},
                                 "route_map_in": {"type": str},
                                 "route_map_out": {"type": str},
                                 "rcf_in": {"type": str},
                                 "rcf_out": {"type": str},
-                                "default_originate": {"type": DefaultOriginate},
-                                "next_hop": {"type": NextHop},
+                                "default_originate": {"type": EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.DefaultOriginate},
+                                "next_hop": {"type": EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.NextHop},
                                 "prefix_list_in": {"type": str},
                                 "prefix_list_out": {"type": str},
                             }
@@ -37760,10 +37115,8 @@ class EosDesigns(EosDesignsRootModel):
                             Outbound RCF function name with parenthesis.
                             Example: MyFunction(myarg).
                             """
-                            default_originate: DefaultOriginate
-                            """Subclass of AvdModel."""
-                            next_hop: NextHop
-                            """Subclass of AvdModel."""
+                            default_originate: EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.DefaultOriginate
+                            next_hop: EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.NextHop
                             prefix_list_in: str | None
                             """Inbound prefix-list name."""
                             prefix_list_out: str | None
@@ -37779,8 +37132,8 @@ class EosDesigns(EosDesignsRootModel):
                                     route_map_out: str | None | UndefinedType = Undefined,
                                     rcf_in: str | None | UndefinedType = Undefined,
                                     rcf_out: str | None | UndefinedType = Undefined,
-                                    default_originate: DefaultOriginate | UndefinedType = Undefined,
-                                    next_hop: NextHop | UndefinedType = Undefined,
+                                    default_originate: EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.DefaultOriginate | UndefinedType = Undefined,
+                                    next_hop: EosCliConfigGen.RouterBgp.AddressFamilyIpv4.PeerGroupsItem.NextHop | UndefinedType = Undefined,
                                     prefix_list_in: str | None | UndefinedType = Undefined,
                                     prefix_list_out: str | None | UndefinedType = Undefined,
                                 ) -> None:
@@ -37800,8 +37153,8 @@ class EosDesigns(EosDesignsRootModel):
                                         rcf_out:
                                            Outbound RCF function name with parenthesis.
                                            Example: MyFunction(myarg).
-                                        default_originate: Subclass of AvdModel.
-                                        next_hop: Subclass of AvdModel.
+                                        default_originate: default_originate
+                                        next_hop: next_hop
                                         prefix_list_in: Inbound prefix-list name.
                                         prefix_list_out: Outbound prefix-list name.
 
@@ -38565,9 +37918,6 @@ class EosDesigns(EosDesignsRootModel):
 
                     AdditionalRouteTargets._item_type = AdditionalRouteTargetsItem
 
-                    class StructuredConfig(EosCliConfigGen):
-                        """Subclass of AvdModel."""
-
                     _fields: ClassVar[dict] = {
                         "name": {"type": str},
                         "address_families": {"type": AddressFamilies, "default": lambda cls: coerce_type(["evpn"], target_type=cls)},
@@ -38599,7 +37949,7 @@ class EosDesigns(EosDesignsRootModel):
                         "bgp_peer_groups": {"type": BgpPeerGroups},
                         "additional_route_targets": {"type": AdditionalRouteTargets},
                         "raw_eos_cli": {"type": str},
-                        "structured_config": {"type": StructuredConfig},
+                        "structured_config": {"type": EosCliConfigGen},
                     }
                     name: str
                     address_families: AddressFamilies
@@ -38835,12 +38185,8 @@ class EosDesigns(EosDesignsRootModel):
                     """
                     raw_eos_cli: str | None
                     """EOS CLI rendered directly on the root level of the final EOS configuration."""
-                    structured_config: StructuredConfig
-                    """
-                    Custom structured config for eos_cli_config_gen.
-
-                    Subclass of AvdModel.
-                    """
+                    structured_config: EosCliConfigGen
+                    """Custom structured config for eos_cli_config_gen."""
 
                     if TYPE_CHECKING:
 
@@ -38877,7 +38223,7 @@ class EosDesigns(EosDesignsRootModel):
                             bgp_peer_groups: BgpPeerGroups | UndefinedType = Undefined,
                             additional_route_targets: AdditionalRouteTargets | UndefinedType = Undefined,
                             raw_eos_cli: str | None | UndefinedType = Undefined,
-                            structured_config: StructuredConfig | UndefinedType = Undefined,
+                            structured_config: EosCliConfigGen | UndefinedType = Undefined,
                         ) -> None:
                             """
                             VrfsItem.
@@ -39059,10 +38405,7 @@ class EosDesigns(EosDesignsRootModel):
 
                                    Subclass of AvdList with `AdditionalRouteTargetsItem` items.
                                 raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
-                                structured_config:
-                                   Custom structured config for eos_cli_config_gen.
-
-                                   Subclass of AvdModel.
+                                structured_config: Custom structured config for eos_cli_config_gen.
 
                             """
 
@@ -39156,18 +38499,12 @@ class EosDesigns(EosDesignsRootModel):
                     class Bgp(AvdModel):
                         """Subclass of AvdModel."""
 
-                        class StructuredConfig(EosCliConfigGen.RouterBgp.VlansItem):
-                            """Subclass of AvdModel."""
-
-                        _fields: ClassVar[dict] = {"structured_config": {"type": StructuredConfig}, "raw_eos_cli": {"type": str}}
-                        structured_config: StructuredConfig
+                        _fields: ClassVar[dict] = {"structured_config": {"type": EosCliConfigGen.RouterBgp.VlansItem}, "raw_eos_cli": {"type": str}}
+                        structured_config: EosCliConfigGen.RouterBgp.VlansItem
                         """
                         Custom structured config added under router_bgp.vlans.[id=<vlan>] for eos_cli_config_gen.
                         This
                         configuration will not be applied to vlan aware bundles.
-
-
-                        Subclass of AvdModel.
                         """
                         raw_eos_cli: str | None
                         """
@@ -39179,7 +38516,10 @@ class EosDesigns(EosDesignsRootModel):
                         if TYPE_CHECKING:
 
                             def __init__(
-                                self, *, structured_config: StructuredConfig | UndefinedType = Undefined, raw_eos_cli: str | None | UndefinedType = Undefined
+                                self,
+                                *,
+                                structured_config: EosCliConfigGen.RouterBgp.VlansItem | UndefinedType = Undefined,
+                                raw_eos_cli: str | None | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 Bgp.
@@ -39192,9 +38532,6 @@ class EosDesigns(EosDesignsRootModel):
                                        Custom structured config added under router_bgp.vlans.[id=<vlan>] for eos_cli_config_gen.
                                        This
                                        configuration will not be applied to vlan aware bundles.
-
-
-                                       Subclass of AvdModel.
                                     raw_eos_cli:
                                        EOS cli commands rendered on router_bgp.vlans.
                                        This configuration will not be applied to vlan aware
@@ -40202,9 +39539,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                 """
 
-                    class StructuredConfig(EosCliConfigGen):
-                        """Subclass of AvdModel."""
-
                     class UplinkInterfaces(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
 
@@ -40260,15 +39594,6 @@ class EosDesigns(EosDesignsRootModel):
                                     profile: profile
 
                                 """
-
-                    class MlagPortChannelStructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerVlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerL3VlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
 
                     class BgpDefaults(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
@@ -41475,9 +40800,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "profile": {"type": str},
                             "name": {"type": str},
@@ -41503,7 +40825,7 @@ class EosDesigns(EosDesignsRootModel):
                             "cv_pathfinder_internet_exit": {"type": CvPathfinderInternetExit},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
                         profile: str | None
                         """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
@@ -41641,12 +40963,8 @@ class EosDesigns(EosDesignsRootModel):
                         Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Ethernet interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.EthernetInterfacesItem
+                        """Custom structured config for the Ethernet interface."""
 
                         if TYPE_CHECKING:
 
@@ -41677,7 +40995,7 @@ class EosDesigns(EosDesignsRootModel):
                                 cv_pathfinder_internet_exit: CvPathfinderInternetExit | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3InterfacesItem.
@@ -41771,10 +41089,7 @@ class EosDesigns(EosDesignsRootModel):
                                     flow_tracking:
                                        Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Ethernet interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Ethernet interface.
 
                                 """
 
@@ -41791,16 +41106,13 @@ class EosDesigns(EosDesignsRootModel):
                         class MemberInterfacesItem(AvdModel):
                             """Subclass of AvdModel."""
 
-                            class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "name": {"type": str},
                                 "description": {"type": str},
                                 "peer": {"type": str},
                                 "peer_interface": {"type": str},
                                 "speed": {"type": str},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
                             name: str
                             """
@@ -41826,12 +41138,8 @@ class EosDesigns(EosDesignsRootModel):
                             Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                             <interface_speed>`.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the member ethernet interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.EthernetInterfacesItem
+                            """Custom structured config for the member ethernet interface."""
 
                             if TYPE_CHECKING:
 
@@ -41843,7 +41151,7 @@ class EosDesigns(EosDesignsRootModel):
                                     peer: str | None | UndefinedType = Undefined,
                                     peer_interface: str | None | UndefinedType = Undefined,
                                     speed: str | None | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     MemberInterfacesItem.
@@ -41867,10 +41175,7 @@ class EosDesigns(EosDesignsRootModel):
                                         speed:
                                            Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                            <interface_speed>`.
-                                        structured_config:
-                                           Custom structured config for the member ethernet interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the member ethernet interface.
 
                                     """
 
@@ -41986,9 +41291,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "name": {"type": str},
                             "description": {"type": str},
@@ -42013,7 +41315,7 @@ class EosDesigns(EosDesignsRootModel):
                             "connected_to_pathfinder": {"type": bool, "default": True},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
                         }
                         name: str
                         """
@@ -42155,12 +41457,8 @@ class EosDesigns(EosDesignsRootModel):
 
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Port-Channel interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.PortChannelInterfacesItem
+                        """Custom structured config for the Port-Channel interface."""
 
                         if TYPE_CHECKING:
 
@@ -42190,7 +41488,7 @@ class EosDesigns(EosDesignsRootModel):
                                 connected_to_pathfinder: bool | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3PortChannelsItem.
@@ -42287,10 +41585,7 @@ class EosDesigns(EosDesignsRootModel):
                                        setting.
 
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Port-Channel interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Port-Channel interface.
 
                                 """
 
@@ -42317,7 +41612,7 @@ class EosDesigns(EosDesignsRootModel):
                         "lacp_port_id_range": {"type": LacpPortIdRange},
                         "always_configure_ip_routing": {"type": bool, "default": False},
                         "raw_eos_cli": {"type": str},
-                        "structured_config": {"type": StructuredConfig},
+                        "structured_config": {"type": EosCliConfigGen},
                         "uplink_type": {"type": str},
                         "uplink_ipv4_pool": {"type": str},
                         "uplink_interfaces": {"type": UplinkInterfaces},
@@ -42335,9 +41630,9 @@ class EosDesigns(EosDesignsRootModel):
                         "uplink_port_channel_id": {"type": int},
                         "uplink_switch_port_channel_id": {"type": int},
                         "uplink_structured_config": {"type": dict},
-                        "mlag_port_channel_structured_config": {"type": MlagPortChannelStructuredConfig},
-                        "mlag_peer_vlan_structured_config": {"type": MlagPeerVlanStructuredConfig},
-                        "mlag_peer_l3_vlan_structured_config": {"type": MlagPeerL3VlanStructuredConfig},
+                        "mlag_port_channel_structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
+                        "mlag_peer_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
+                        "mlag_peer_l3_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                         "short_esi": {"type": str},
                         "isis_system_id_prefix": {"type": str},
                         "isis_maximum_paths": {"type": int},
@@ -42484,12 +41779,8 @@ class EosDesigns(EosDesignsRootModel):
                     """
                     raw_eos_cli: str | None
                     """EOS CLI rendered directly on the root level of the final EOS configuration."""
-                    structured_config: StructuredConfig
-                    """
-                    Custom structured config for eos_cli_config_gen.
-
-                    Subclass of AvdModel.
-                    """
+                    structured_config: EosCliConfigGen
+                    """Custom structured config for eos_cli_config_gen."""
                     uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None
                     """
                     Override the default `uplink_type` set at the `node_type_key` level.
@@ -42634,7 +41925,7 @@ class EosDesigns(EosDesignsRootModel):
                     Note! The content of this dictionary is _not_ validated
                     by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
                     """
-                    mlag_port_channel_structured_config: MlagPortChannelStructuredConfig
+                    mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem
                     """
                     Custom structured config applied to MLAG peer link port-channel id.
                     Added under
@@ -42643,12 +41934,8 @@ class EosDesigns(EosDesignsRootModel):
                     port-channel interface level.
                     "mlag_port_channel_structured_config" is applied after
                     "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                    Subclass of
-                    AvdModel.
                     """
-                    mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig
+                    mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                     Added under
@@ -42657,11 +41944,8 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                     override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
-                    mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig
+                    mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                     Added under
@@ -42670,9 +41954,6 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                     can override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
                     short_esi: str | None
                     """
@@ -43231,7 +42512,7 @@ class EosDesigns(EosDesignsRootModel):
                             lacp_port_id_range: LacpPortIdRange | UndefinedType = Undefined,
                             always_configure_ip_routing: bool | UndefinedType = Undefined,
                             raw_eos_cli: str | None | UndefinedType = Undefined,
-                            structured_config: StructuredConfig | UndefinedType = Undefined,
+                            structured_config: EosCliConfigGen | UndefinedType = Undefined,
                             uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None | UndefinedType = Undefined,
                             uplink_ipv4_pool: str | None | UndefinedType = Undefined,
                             uplink_interfaces: UplinkInterfaces | UndefinedType = Undefined,
@@ -43249,9 +42530,9 @@ class EosDesigns(EosDesignsRootModel):
                             uplink_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_switch_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_structured_config: dict | UndefinedType = Undefined,
-                            mlag_port_channel_structured_config: MlagPortChannelStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig | UndefinedType = Undefined,
+                            mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                             short_esi: str | None | UndefinedType = Undefined,
                             isis_system_id_prefix: str | None | UndefinedType = Undefined,
                             isis_maximum_paths: int | None | UndefinedType = Undefined,
@@ -43380,10 +42661,7 @@ class EosDesigns(EosDesignsRootModel):
                                    Use this to retain behavior of AVD versions
                                    below 4.0.0.
                                 raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
-                                structured_config:
-                                   Custom structured config for eos_cli_config_gen.
-
-                                   Subclass of AvdModel.
+                                structured_config: Custom structured config for eos_cli_config_gen.
                                 uplink_type:
                                    Override the default `uplink_type` set at the `node_type_key` level.
                                    `uplink_type` must be "p2p" if
@@ -43499,10 +42777,6 @@ class EosDesigns(EosDesignsRootModel):
                                    port-channel interface level.
                                    "mlag_port_channel_structured_config" is applied after
                                    "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                                   Subclass of
-                                   AvdModel.
                                 mlag_peer_vlan_structured_config:
                                    Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                                    Added under
@@ -43511,9 +42785,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                                    override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 mlag_peer_l3_vlan_structured_config:
                                    Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                                    Added under
@@ -43522,9 +42793,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                                    can override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 short_esi:
                                    short_esi only valid for l2leaf devices using port-channel uplink.
                                    Setting short_esi to "auto"
@@ -44091,9 +43359,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen):
-                            """Subclass of AvdModel."""
-
                         class UplinkInterfaces(AvdList[str]):
                             """Subclass of AvdList with `str` items."""
 
@@ -44149,15 +43414,6 @@ class EosDesigns(EosDesignsRootModel):
                                         profile: profile
 
                                     """
-
-                        class MlagPortChannelStructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                            """Subclass of AvdModel."""
-
-                        class MlagPeerVlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                            """Subclass of AvdModel."""
-
-                        class MlagPeerL3VlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                            """Subclass of AvdModel."""
 
                         class BgpDefaults(AvdList[str]):
                             """Subclass of AvdList with `str` items."""
@@ -45375,9 +44631,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                         """
 
-                            class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "profile": {"type": str},
                                 "name": {"type": str},
@@ -45403,7 +44656,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "cv_pathfinder_internet_exit": {"type": CvPathfinderInternetExit},
                                 "raw_eos_cli": {"type": str},
                                 "flow_tracking": {"type": FlowTracking},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
                             profile: str | None
                             """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
@@ -45541,12 +44794,8 @@ class EosDesigns(EosDesignsRootModel):
                             Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                             Subclass of AvdModel.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the Ethernet interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.EthernetInterfacesItem
+                            """Custom structured config for the Ethernet interface."""
 
                             if TYPE_CHECKING:
 
@@ -45577,7 +44826,7 @@ class EosDesigns(EosDesignsRootModel):
                                     cv_pathfinder_internet_exit: CvPathfinderInternetExit | UndefinedType = Undefined,
                                     raw_eos_cli: str | None | UndefinedType = Undefined,
                                     flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     L3InterfacesItem.
@@ -45671,10 +44920,7 @@ class EosDesigns(EosDesignsRootModel):
                                         flow_tracking:
                                            Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                                            Subclass of AvdModel.
-                                        structured_config:
-                                           Custom structured config for the Ethernet interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the Ethernet interface.
 
                                     """
 
@@ -45691,16 +44937,13 @@ class EosDesigns(EosDesignsRootModel):
                             class MemberInterfacesItem(AvdModel):
                                 """Subclass of AvdModel."""
 
-                                class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                    """Subclass of AvdModel."""
-
                                 _fields: ClassVar[dict] = {
                                     "name": {"type": str},
                                     "description": {"type": str},
                                     "peer": {"type": str},
                                     "peer_interface": {"type": str},
                                     "speed": {"type": str},
-                                    "structured_config": {"type": StructuredConfig},
+                                    "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                                 }
                                 name: str
                                 """
@@ -45726,12 +44969,8 @@ class EosDesigns(EosDesignsRootModel):
                                 Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                 <interface_speed>`.
                                 """
-                                structured_config: StructuredConfig
-                                """
-                                Custom structured config for the member ethernet interface.
-
-                                Subclass of AvdModel.
-                                """
+                                structured_config: EosCliConfigGen.EthernetInterfacesItem
+                                """Custom structured config for the member ethernet interface."""
 
                                 if TYPE_CHECKING:
 
@@ -45743,7 +44982,7 @@ class EosDesigns(EosDesignsRootModel):
                                         peer: str | None | UndefinedType = Undefined,
                                         peer_interface: str | None | UndefinedType = Undefined,
                                         speed: str | None | UndefinedType = Undefined,
-                                        structured_config: StructuredConfig | UndefinedType = Undefined,
+                                        structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                     ) -> None:
                                         """
                                         MemberInterfacesItem.
@@ -45767,10 +45006,7 @@ class EosDesigns(EosDesignsRootModel):
                                             speed:
                                                Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                                <interface_speed>`.
-                                            structured_config:
-                                               Custom structured config for the member ethernet interface.
-
-                                               Subclass of AvdModel.
+                                            structured_config: Custom structured config for the member ethernet interface.
 
                                         """
 
@@ -45892,9 +45128,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                         """
 
-                            class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "name": {"type": str},
                                 "description": {"type": str},
@@ -45919,7 +45152,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "connected_to_pathfinder": {"type": bool, "default": True},
                                 "raw_eos_cli": {"type": str},
                                 "flow_tracking": {"type": FlowTracking},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
                             }
                             name: str
                             """
@@ -46061,12 +45294,8 @@ class EosDesigns(EosDesignsRootModel):
 
                             Subclass of AvdModel.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the Port-Channel interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.PortChannelInterfacesItem
+                            """Custom structured config for the Port-Channel interface."""
 
                             if TYPE_CHECKING:
 
@@ -46096,7 +45325,7 @@ class EosDesigns(EosDesignsRootModel):
                                     connected_to_pathfinder: bool | UndefinedType = Undefined,
                                     raw_eos_cli: str | None | UndefinedType = Undefined,
                                     flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     L3PortChannelsItem.
@@ -46193,10 +45422,7 @@ class EosDesigns(EosDesignsRootModel):
                                            setting.
 
                                            Subclass of AvdModel.
-                                        structured_config:
-                                           Custom structured config for the Port-Channel interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the Port-Channel interface.
 
                                     """
 
@@ -46225,7 +45451,7 @@ class EosDesigns(EosDesignsRootModel):
                             "lacp_port_id_range": {"type": LacpPortIdRange},
                             "always_configure_ip_routing": {"type": bool, "default": False},
                             "raw_eos_cli": {"type": str},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen},
                             "uplink_type": {"type": str},
                             "uplink_ipv4_pool": {"type": str},
                             "uplink_interfaces": {"type": UplinkInterfaces},
@@ -46243,9 +45469,9 @@ class EosDesigns(EosDesignsRootModel):
                             "uplink_port_channel_id": {"type": int},
                             "uplink_switch_port_channel_id": {"type": int},
                             "uplink_structured_config": {"type": dict},
-                            "mlag_port_channel_structured_config": {"type": MlagPortChannelStructuredConfig},
-                            "mlag_peer_vlan_structured_config": {"type": MlagPeerVlanStructuredConfig},
-                            "mlag_peer_l3_vlan_structured_config": {"type": MlagPeerL3VlanStructuredConfig},
+                            "mlag_port_channel_structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
+                            "mlag_peer_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
+                            "mlag_peer_l3_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                             "short_esi": {"type": str},
                             "isis_system_id_prefix": {"type": str},
                             "isis_maximum_paths": {"type": int},
@@ -46402,12 +45628,8 @@ class EosDesigns(EosDesignsRootModel):
                         """
                         raw_eos_cli: str | None
                         """EOS CLI rendered directly on the root level of the final EOS configuration."""
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for eos_cli_config_gen.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen
+                        """Custom structured config for eos_cli_config_gen."""
                         uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None
                         """
                         Override the default `uplink_type` set at the `node_type_key` level.
@@ -46552,7 +45774,7 @@ class EosDesigns(EosDesignsRootModel):
                         Note! The content of this dictionary is _not_ validated
                         by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
                         """
-                        mlag_port_channel_structured_config: MlagPortChannelStructuredConfig
+                        mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem
                         """
                         Custom structured config applied to MLAG peer link port-channel id.
                         Added under
@@ -46561,12 +45783,8 @@ class EosDesigns(EosDesignsRootModel):
                         port-channel interface level.
                         "mlag_port_channel_structured_config" is applied after
                         "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                        Subclass of
-                        AvdModel.
                         """
-                        mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig
+                        mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                         """
                         Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                         Added under
@@ -46575,11 +45793,8 @@ class EosDesigns(EosDesignsRootModel):
                         interface level.
                         "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                         override "structured_config" defined on node-level.
-
-
-                        Subclass of AvdModel.
                         """
-                        mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig
+                        mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                         """
                         Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                         Added under
@@ -46588,9 +45803,6 @@ class EosDesigns(EosDesignsRootModel):
                         interface level.
                         "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                         can override "structured_config" defined on node-level.
-
-
-                        Subclass of AvdModel.
                         """
                         short_esi: str | None
                         """
@@ -47151,7 +46363,7 @@ class EosDesigns(EosDesignsRootModel):
                                 lacp_port_id_range: LacpPortIdRange | UndefinedType = Undefined,
                                 always_configure_ip_routing: bool | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen | UndefinedType = Undefined,
                                 uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None | UndefinedType = Undefined,
                                 uplink_ipv4_pool: str | None | UndefinedType = Undefined,
                                 uplink_interfaces: UplinkInterfaces | UndefinedType = Undefined,
@@ -47169,9 +46381,9 @@ class EosDesigns(EosDesignsRootModel):
                                 uplink_port_channel_id: int | None | UndefinedType = Undefined,
                                 uplink_switch_port_channel_id: int | None | UndefinedType = Undefined,
                                 uplink_structured_config: dict | UndefinedType = Undefined,
-                                mlag_port_channel_structured_config: MlagPortChannelStructuredConfig | UndefinedType = Undefined,
-                                mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig | UndefinedType = Undefined,
-                                mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig | UndefinedType = Undefined,
+                                mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
+                                mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
+                                mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                                 short_esi: str | None | UndefinedType = Undefined,
                                 isis_system_id_prefix: str | None | UndefinedType = Undefined,
                                 isis_maximum_paths: int | None | UndefinedType = Undefined,
@@ -47307,10 +46519,7 @@ class EosDesigns(EosDesignsRootModel):
                                        Use this to retain behavior of AVD versions
                                        below 4.0.0.
                                     raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
-                                    structured_config:
-                                       Custom structured config for eos_cli_config_gen.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for eos_cli_config_gen.
                                     uplink_type:
                                        Override the default `uplink_type` set at the `node_type_key` level.
                                        `uplink_type` must be "p2p" if
@@ -47426,10 +46635,6 @@ class EosDesigns(EosDesignsRootModel):
                                        port-channel interface level.
                                        "mlag_port_channel_structured_config" is applied after
                                        "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                                       Subclass of
-                                       AvdModel.
                                     mlag_peer_vlan_structured_config:
                                        Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                                        Added under
@@ -47438,9 +46643,6 @@ class EosDesigns(EosDesignsRootModel):
                                        interface level.
                                        "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                                        override "structured_config" defined on node-level.
-
-
-                                       Subclass of AvdModel.
                                     mlag_peer_l3_vlan_structured_config:
                                        Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                                        Added under
@@ -47449,9 +46651,6 @@ class EosDesigns(EosDesignsRootModel):
                                        interface level.
                                        "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                                        can override "structured_config" defined on node-level.
-
-
-                                       Subclass of AvdModel.
                                     short_esi:
                                        short_esi only valid for l2leaf devices using port-channel uplink.
                                        Setting short_esi to "auto"
@@ -47960,9 +47159,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                 """
 
-                    class StructuredConfig(EosCliConfigGen):
-                        """Subclass of AvdModel."""
-
                     class UplinkInterfaces(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
 
@@ -48018,15 +47214,6 @@ class EosDesigns(EosDesignsRootModel):
                                     profile: profile
 
                                 """
-
-                    class MlagPortChannelStructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerVlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerL3VlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
 
                     class BgpDefaults(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
@@ -49233,9 +48420,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "profile": {"type": str},
                             "name": {"type": str},
@@ -49261,7 +48445,7 @@ class EosDesigns(EosDesignsRootModel):
                             "cv_pathfinder_internet_exit": {"type": CvPathfinderInternetExit},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
                         profile: str | None
                         """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
@@ -49399,12 +48583,8 @@ class EosDesigns(EosDesignsRootModel):
                         Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Ethernet interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.EthernetInterfacesItem
+                        """Custom structured config for the Ethernet interface."""
 
                         if TYPE_CHECKING:
 
@@ -49435,7 +48615,7 @@ class EosDesigns(EosDesignsRootModel):
                                 cv_pathfinder_internet_exit: CvPathfinderInternetExit | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3InterfacesItem.
@@ -49529,10 +48709,7 @@ class EosDesigns(EosDesignsRootModel):
                                     flow_tracking:
                                        Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Ethernet interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Ethernet interface.
 
                                 """
 
@@ -49549,16 +48726,13 @@ class EosDesigns(EosDesignsRootModel):
                         class MemberInterfacesItem(AvdModel):
                             """Subclass of AvdModel."""
 
-                            class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "name": {"type": str},
                                 "description": {"type": str},
                                 "peer": {"type": str},
                                 "peer_interface": {"type": str},
                                 "speed": {"type": str},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
                             name: str
                             """
@@ -49584,12 +48758,8 @@ class EosDesigns(EosDesignsRootModel):
                             Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                             <interface_speed>`.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the member ethernet interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.EthernetInterfacesItem
+                            """Custom structured config for the member ethernet interface."""
 
                             if TYPE_CHECKING:
 
@@ -49601,7 +48771,7 @@ class EosDesigns(EosDesignsRootModel):
                                     peer: str | None | UndefinedType = Undefined,
                                     peer_interface: str | None | UndefinedType = Undefined,
                                     speed: str | None | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     MemberInterfacesItem.
@@ -49625,10 +48795,7 @@ class EosDesigns(EosDesignsRootModel):
                                         speed:
                                            Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                            <interface_speed>`.
-                                        structured_config:
-                                           Custom structured config for the member ethernet interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the member ethernet interface.
 
                                     """
 
@@ -49744,9 +48911,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "name": {"type": str},
                             "description": {"type": str},
@@ -49771,7 +48935,7 @@ class EosDesigns(EosDesignsRootModel):
                             "connected_to_pathfinder": {"type": bool, "default": True},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
                         }
                         name: str
                         """
@@ -49913,12 +49077,8 @@ class EosDesigns(EosDesignsRootModel):
 
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Port-Channel interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.PortChannelInterfacesItem
+                        """Custom structured config for the Port-Channel interface."""
 
                         if TYPE_CHECKING:
 
@@ -49948,7 +49108,7 @@ class EosDesigns(EosDesignsRootModel):
                                 connected_to_pathfinder: bool | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3PortChannelsItem.
@@ -50045,10 +49205,7 @@ class EosDesigns(EosDesignsRootModel):
                                        setting.
 
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Port-Channel interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Port-Channel interface.
 
                                 """
 
@@ -50077,7 +49234,7 @@ class EosDesigns(EosDesignsRootModel):
                         "lacp_port_id_range": {"type": LacpPortIdRange},
                         "always_configure_ip_routing": {"type": bool, "default": False},
                         "raw_eos_cli": {"type": str},
-                        "structured_config": {"type": StructuredConfig},
+                        "structured_config": {"type": EosCliConfigGen},
                         "uplink_type": {"type": str},
                         "uplink_ipv4_pool": {"type": str},
                         "uplink_interfaces": {"type": UplinkInterfaces},
@@ -50095,9 +49252,9 @@ class EosDesigns(EosDesignsRootModel):
                         "uplink_port_channel_id": {"type": int},
                         "uplink_switch_port_channel_id": {"type": int},
                         "uplink_structured_config": {"type": dict},
-                        "mlag_port_channel_structured_config": {"type": MlagPortChannelStructuredConfig},
-                        "mlag_peer_vlan_structured_config": {"type": MlagPeerVlanStructuredConfig},
-                        "mlag_peer_l3_vlan_structured_config": {"type": MlagPeerL3VlanStructuredConfig},
+                        "mlag_port_channel_structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
+                        "mlag_peer_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
+                        "mlag_peer_l3_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                         "short_esi": {"type": str},
                         "isis_system_id_prefix": {"type": str},
                         "isis_maximum_paths": {"type": int},
@@ -50257,12 +49414,8 @@ class EosDesigns(EosDesignsRootModel):
                     """
                     raw_eos_cli: str | None
                     """EOS CLI rendered directly on the root level of the final EOS configuration."""
-                    structured_config: StructuredConfig
-                    """
-                    Custom structured config for eos_cli_config_gen.
-
-                    Subclass of AvdModel.
-                    """
+                    structured_config: EosCliConfigGen
+                    """Custom structured config for eos_cli_config_gen."""
                     uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None
                     """
                     Override the default `uplink_type` set at the `node_type_key` level.
@@ -50407,7 +49560,7 @@ class EosDesigns(EosDesignsRootModel):
                     Note! The content of this dictionary is _not_ validated
                     by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
                     """
-                    mlag_port_channel_structured_config: MlagPortChannelStructuredConfig
+                    mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem
                     """
                     Custom structured config applied to MLAG peer link port-channel id.
                     Added under
@@ -50416,12 +49569,8 @@ class EosDesigns(EosDesignsRootModel):
                     port-channel interface level.
                     "mlag_port_channel_structured_config" is applied after
                     "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                    Subclass of
-                    AvdModel.
                     """
-                    mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig
+                    mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                     Added under
@@ -50430,11 +49579,8 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                     override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
-                    mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig
+                    mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                     Added under
@@ -50443,9 +49589,6 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                     can override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
                     short_esi: str | None
                     """
@@ -51006,7 +50149,7 @@ class EosDesigns(EosDesignsRootModel):
                             lacp_port_id_range: LacpPortIdRange | UndefinedType = Undefined,
                             always_configure_ip_routing: bool | UndefinedType = Undefined,
                             raw_eos_cli: str | None | UndefinedType = Undefined,
-                            structured_config: StructuredConfig | UndefinedType = Undefined,
+                            structured_config: EosCliConfigGen | UndefinedType = Undefined,
                             uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None | UndefinedType = Undefined,
                             uplink_ipv4_pool: str | None | UndefinedType = Undefined,
                             uplink_interfaces: UplinkInterfaces | UndefinedType = Undefined,
@@ -51024,9 +50167,9 @@ class EosDesigns(EosDesignsRootModel):
                             uplink_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_switch_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_structured_config: dict | UndefinedType = Undefined,
-                            mlag_port_channel_structured_config: MlagPortChannelStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig | UndefinedType = Undefined,
+                            mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                             short_esi: str | None | UndefinedType = Undefined,
                             isis_system_id_prefix: str | None | UndefinedType = Undefined,
                             isis_maximum_paths: int | None | UndefinedType = Undefined,
@@ -51164,10 +50307,7 @@ class EosDesigns(EosDesignsRootModel):
                                    Use this to retain behavior of AVD versions
                                    below 4.0.0.
                                 raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
-                                structured_config:
-                                   Custom structured config for eos_cli_config_gen.
-
-                                   Subclass of AvdModel.
+                                structured_config: Custom structured config for eos_cli_config_gen.
                                 uplink_type:
                                    Override the default `uplink_type` set at the `node_type_key` level.
                                    `uplink_type` must be "p2p" if
@@ -51283,10 +50423,6 @@ class EosDesigns(EosDesignsRootModel):
                                    port-channel interface level.
                                    "mlag_port_channel_structured_config" is applied after
                                    "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                                   Subclass of
-                                   AvdModel.
                                 mlag_peer_vlan_structured_config:
                                    Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                                    Added under
@@ -51295,9 +50431,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                                    override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 mlag_peer_l3_vlan_structured_config:
                                    Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                                    Added under
@@ -51306,9 +50439,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                                    can override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 short_esi:
                                    short_esi only valid for l2leaf devices using port-channel uplink.
                                    Setting short_esi to "auto"
@@ -51876,9 +51006,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                 """
 
-                    class StructuredConfig(EosCliConfigGen):
-                        """Subclass of AvdModel."""
-
                     class UplinkInterfaces(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
 
@@ -51934,15 +51061,6 @@ class EosDesigns(EosDesignsRootModel):
                                     profile: profile
 
                                 """
-
-                    class MlagPortChannelStructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerVlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
-
-                    class MlagPeerL3VlanStructuredConfig(EosCliConfigGen.VlanInterfacesItem):
-                        """Subclass of AvdModel."""
 
                     class BgpDefaults(AvdList[str]):
                         """Subclass of AvdList with `str` items."""
@@ -53149,9 +52267,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "profile": {"type": str},
                             "name": {"type": str},
@@ -53177,7 +52292,7 @@ class EosDesigns(EosDesignsRootModel):
                             "cv_pathfinder_internet_exit": {"type": CvPathfinderInternetExit},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
                         profile: str | None
                         """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
@@ -53315,12 +52430,8 @@ class EosDesigns(EosDesignsRootModel):
                         Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Ethernet interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.EthernetInterfacesItem
+                        """Custom structured config for the Ethernet interface."""
 
                         if TYPE_CHECKING:
 
@@ -53351,7 +52462,7 @@ class EosDesigns(EosDesignsRootModel):
                                 cv_pathfinder_internet_exit: CvPathfinderInternetExit | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3InterfacesItem.
@@ -53445,10 +52556,7 @@ class EosDesigns(EosDesignsRootModel):
                                     flow_tracking:
                                        Configures flow-tracking on the interface. Overrides `fabric_flow_tracking.l3_interfaces` setting.
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Ethernet interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Ethernet interface.
 
                                 """
 
@@ -53465,16 +52573,13 @@ class EosDesigns(EosDesignsRootModel):
                         class MemberInterfacesItem(AvdModel):
                             """Subclass of AvdModel."""
 
-                            class StructuredConfig(EosCliConfigGen.EthernetInterfacesItem):
-                                """Subclass of AvdModel."""
-
                             _fields: ClassVar[dict] = {
                                 "name": {"type": str},
                                 "description": {"type": str},
                                 "peer": {"type": str},
                                 "peer_interface": {"type": str},
                                 "speed": {"type": str},
-                                "structured_config": {"type": StructuredConfig},
+                                "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
                             name: str
                             """
@@ -53500,12 +52605,8 @@ class EosDesigns(EosDesignsRootModel):
                             Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                             <interface_speed>`.
                             """
-                            structured_config: StructuredConfig
-                            """
-                            Custom structured config for the member ethernet interface.
-
-                            Subclass of AvdModel.
-                            """
+                            structured_config: EosCliConfigGen.EthernetInterfacesItem
+                            """Custom structured config for the member ethernet interface."""
 
                             if TYPE_CHECKING:
 
@@ -53517,7 +52618,7 @@ class EosDesigns(EosDesignsRootModel):
                                     peer: str | None | UndefinedType = Undefined,
                                     peer_interface: str | None | UndefinedType = Undefined,
                                     speed: str | None | UndefinedType = Undefined,
-                                    structured_config: StructuredConfig | UndefinedType = Undefined,
+                                    structured_config: EosCliConfigGen.EthernetInterfacesItem | UndefinedType = Undefined,
                                 ) -> None:
                                     """
                                     MemberInterfacesItem.
@@ -53541,10 +52642,7 @@ class EosDesigns(EosDesignsRootModel):
                                         speed:
                                            Speed should be set in the format `<interface_speed>` or `forced <interface_speed>` or `auto
                                            <interface_speed>`.
-                                        structured_config:
-                                           Custom structured config for the member ethernet interface.
-
-                                           Subclass of AvdModel.
+                                        structured_config: Custom structured config for the member ethernet interface.
 
                                     """
 
@@ -53660,9 +52758,6 @@ class EosDesigns(EosDesignsRootModel):
 
                                     """
 
-                        class StructuredConfig(EosCliConfigGen.PortChannelInterfacesItem):
-                            """Subclass of AvdModel."""
-
                         _fields: ClassVar[dict] = {
                             "name": {"type": str},
                             "description": {"type": str},
@@ -53687,7 +52782,7 @@ class EosDesigns(EosDesignsRootModel):
                             "connected_to_pathfinder": {"type": bool, "default": True},
                             "raw_eos_cli": {"type": str},
                             "flow_tracking": {"type": FlowTracking},
-                            "structured_config": {"type": StructuredConfig},
+                            "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
                         }
                         name: str
                         """
@@ -53829,12 +52924,8 @@ class EosDesigns(EosDesignsRootModel):
 
                         Subclass of AvdModel.
                         """
-                        structured_config: StructuredConfig
-                        """
-                        Custom structured config for the Port-Channel interface.
-
-                        Subclass of AvdModel.
-                        """
+                        structured_config: EosCliConfigGen.PortChannelInterfacesItem
+                        """Custom structured config for the Port-Channel interface."""
 
                         if TYPE_CHECKING:
 
@@ -53864,7 +52955,7 @@ class EosDesigns(EosDesignsRootModel):
                                 connected_to_pathfinder: bool | UndefinedType = Undefined,
                                 raw_eos_cli: str | None | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
-                                structured_config: StructuredConfig | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 L3PortChannelsItem.
@@ -53961,10 +53052,7 @@ class EosDesigns(EosDesignsRootModel):
                                        setting.
 
                                        Subclass of AvdModel.
-                                    structured_config:
-                                       Custom structured config for the Port-Channel interface.
-
-                                       Subclass of AvdModel.
+                                    structured_config: Custom structured config for the Port-Channel interface.
 
                                 """
 
@@ -53993,7 +53081,7 @@ class EosDesigns(EosDesignsRootModel):
                         "lacp_port_id_range": {"type": LacpPortIdRange},
                         "always_configure_ip_routing": {"type": bool, "default": False},
                         "raw_eos_cli": {"type": str},
-                        "structured_config": {"type": StructuredConfig},
+                        "structured_config": {"type": EosCliConfigGen},
                         "uplink_type": {"type": str},
                         "uplink_ipv4_pool": {"type": str},
                         "uplink_interfaces": {"type": UplinkInterfaces},
@@ -54011,9 +53099,9 @@ class EosDesigns(EosDesignsRootModel):
                         "uplink_port_channel_id": {"type": int},
                         "uplink_switch_port_channel_id": {"type": int},
                         "uplink_structured_config": {"type": dict},
-                        "mlag_port_channel_structured_config": {"type": MlagPortChannelStructuredConfig},
-                        "mlag_peer_vlan_structured_config": {"type": MlagPeerVlanStructuredConfig},
-                        "mlag_peer_l3_vlan_structured_config": {"type": MlagPeerL3VlanStructuredConfig},
+                        "mlag_port_channel_structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
+                        "mlag_peer_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
+                        "mlag_peer_l3_vlan_structured_config": {"type": EosCliConfigGen.VlanInterfacesItem},
                         "short_esi": {"type": str},
                         "isis_system_id_prefix": {"type": str},
                         "isis_maximum_paths": {"type": int},
@@ -54170,12 +53258,8 @@ class EosDesigns(EosDesignsRootModel):
                     """
                     raw_eos_cli: str | None
                     """EOS CLI rendered directly on the root level of the final EOS configuration."""
-                    structured_config: StructuredConfig
-                    """
-                    Custom structured config for eos_cli_config_gen.
-
-                    Subclass of AvdModel.
-                    """
+                    structured_config: EosCliConfigGen
+                    """Custom structured config for eos_cli_config_gen."""
                     uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None
                     """
                     Override the default `uplink_type` set at the `node_type_key` level.
@@ -54320,7 +53404,7 @@ class EosDesigns(EosDesignsRootModel):
                     Note! The content of this dictionary is _not_ validated
                     by the schema, since it can be either ethernet_interfaces or port_channel_interfaces.
                     """
-                    mlag_port_channel_structured_config: MlagPortChannelStructuredConfig
+                    mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem
                     """
                     Custom structured config applied to MLAG peer link port-channel id.
                     Added under
@@ -54329,12 +53413,8 @@ class EosDesigns(EosDesignsRootModel):
                     port-channel interface level.
                     "mlag_port_channel_structured_config" is applied after
                     "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                    Subclass of
-                    AvdModel.
                     """
-                    mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig
+                    mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                     Added under
@@ -54343,11 +53423,8 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                     override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
-                    mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig
+                    mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem
                     """
                     Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                     Added under
@@ -54356,9 +53433,6 @@ class EosDesigns(EosDesignsRootModel):
                     interface level.
                     "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                     can override "structured_config" defined on node-level.
-
-
-                    Subclass of AvdModel.
                     """
                     short_esi: str | None
                     """
@@ -54919,7 +53993,7 @@ class EosDesigns(EosDesignsRootModel):
                             lacp_port_id_range: LacpPortIdRange | UndefinedType = Undefined,
                             always_configure_ip_routing: bool | UndefinedType = Undefined,
                             raw_eos_cli: str | None | UndefinedType = Undefined,
-                            structured_config: StructuredConfig | UndefinedType = Undefined,
+                            structured_config: EosCliConfigGen | UndefinedType = Undefined,
                             uplink_type: Literal["p2p", "port-channel", "p2p-vrfs", "lan"] | None | UndefinedType = Undefined,
                             uplink_ipv4_pool: str | None | UndefinedType = Undefined,
                             uplink_interfaces: UplinkInterfaces | UndefinedType = Undefined,
@@ -54937,9 +54011,9 @@ class EosDesigns(EosDesignsRootModel):
                             uplink_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_switch_port_channel_id: int | None | UndefinedType = Undefined,
                             uplink_structured_config: dict | UndefinedType = Undefined,
-                            mlag_port_channel_structured_config: MlagPortChannelStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_vlan_structured_config: MlagPeerVlanStructuredConfig | UndefinedType = Undefined,
-                            mlag_peer_l3_vlan_structured_config: MlagPeerL3VlanStructuredConfig | UndefinedType = Undefined,
+                            mlag_port_channel_structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
+                            mlag_peer_l3_vlan_structured_config: EosCliConfigGen.VlanInterfacesItem | UndefinedType = Undefined,
                             short_esi: str | None | UndefinedType = Undefined,
                             isis_system_id_prefix: str | None | UndefinedType = Undefined,
                             isis_maximum_paths: int | None | UndefinedType = Undefined,
@@ -55075,10 +54149,7 @@ class EosDesigns(EosDesignsRootModel):
                                    Use this to retain behavior of AVD versions
                                    below 4.0.0.
                                 raw_eos_cli: EOS CLI rendered directly on the root level of the final EOS configuration.
-                                structured_config:
-                                   Custom structured config for eos_cli_config_gen.
-
-                                   Subclass of AvdModel.
+                                structured_config: Custom structured config for eos_cli_config_gen.
                                 uplink_type:
                                    Override the default `uplink_type` set at the `node_type_key` level.
                                    `uplink_type` must be "p2p" if
@@ -55194,10 +54265,6 @@ class EosDesigns(EosDesignsRootModel):
                                    port-channel interface level.
                                    "mlag_port_channel_structured_config" is applied after
                                    "structured_config", so it can override "structured_config" defined on node-level.
-
-
-                                   Subclass of
-                                   AvdModel.
                                 mlag_peer_vlan_structured_config:
                                    Custom structured config applied to MLAG Peer Link (control link) SVI interface id.
                                    Added under
@@ -55206,9 +54273,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_vlan_structured_config" is applied after "structured_config", so it can
                                    override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 mlag_peer_l3_vlan_structured_config:
                                    Custom structured config applied to MLAG underlay L3 peering SVI interface id.
                                    Added under
@@ -55217,9 +54281,6 @@ class EosDesigns(EosDesignsRootModel):
                                    interface level.
                                    "mlag_peer_l3_vlan_structured_config" is applied after "structured_config", so it
                                    can override "structured_config" defined on node-level.
-
-
-                                   Subclass of AvdModel.
                                 short_esi:
                                    short_esi only valid for l2leaf devices using port-channel uplink.
                                    Setting short_esi to "auto"
@@ -55724,7 +54785,7 @@ class EosDesigns(EosDesignsRootModel):
                 """
 
     _fields: ClassVar[dict] = {
-        "application_classification": {"type": ApplicationClassification},
+        "application_classification": {"type": EosCliConfigGen.ApplicationTrafficRecognition},
         "avd_data_validation_mode": {"type": str, "default": "error"},
         "avd_eos_designs_debug": {"type": bool, "default": False},
         "avd_eos_designs_enforce_duplication_checks_across_all_models": {"type": bool, "default": False},
@@ -55733,7 +54794,7 @@ class EosDesigns(EosDesignsRootModel):
         "bfd_multihop": {"type": BfdMultihop, "default": lambda cls: coerce_type({"interval": 300, "min_rx": 300, "multiplier": 3}, target_type=cls)},
         "bgp_as": {"type": str},
         "bgp_default_ipv4_unicast": {"type": bool, "default": False},
-        "bgp_distance": {"type": BgpDistance},
+        "bgp_distance": {"type": EosCliConfigGen.RouterBgp.Distance},
         "bgp_ecmp": {"type": int},
         "bgp_graceful_restart": {"type": BgpGracefulRestart},
         "bgp_maximum_paths": {"type": int},
@@ -55794,8 +54855,8 @@ class EosDesigns(EosDesignsRootModel):
         "enable_trunk_groups": {"type": bool, "default": False},
         "eos_designs_custom_templates": {"type": EosDesignsCustomTemplates},
         "eos_designs_documentation": {"type": EosDesignsDocumentation},
-        "event_handlers": {"type": EventHandlers},
-        "event_monitor": {"type": EventMonitor},
+        "event_handlers": {"type": EosCliConfigGen.EventHandlers},
+        "event_monitor": {"type": EosCliConfigGen.EventMonitor},
         "evpn_ebgp_gateway_inter_domain": {"type": bool},
         "evpn_ebgp_gateway_multihop": {"type": int, "default": 15},
         "evpn_ebgp_multihop": {"type": int, "default": 3},
@@ -55814,7 +54875,7 @@ class EosDesigns(EosDesignsRootModel):
         "fabric_sflow": {"type": FabricSflow},
         "flow_tracking_settings": {"type": FlowTrackingSettings},
         "generate_cv_tags": {"type": GenerateCvTags},
-        "hardware_counters": {"type": HardwareCounters},
+        "hardware_counters": {"type": EosCliConfigGen.HardwareCounters},
         "internal_vlan_order": {
             "type": InternalVlanOrder,
             "default": lambda cls: coerce_type({"allocation": "ascending", "range": {"beginning": 1006, "ending": 1199}}, target_type=cls),
@@ -55834,8 +54895,8 @@ class EosDesigns(EosDesignsRootModel):
         "isis_ti_lfa": {"type": IsisTiLfa},
         "l3_edge": {"type": L3Edge},
         "l3_interface_profiles": {"type": L3InterfaceProfiles},
-        "load_interval": {"type": LoadInterval},
-        "local_users": {"type": LocalUsers},
+        "load_interval": {"type": EosCliConfigGen.LoadInterval},
+        "local_users": {"type": EosCliConfigGen.LocalUsers},
         "mac_address_table": {"type": MacAddressTable},
         "management_eapi": {"type": ManagementEapi},
         "mgmt_destination_networks": {"type": MgmtDestinationNetworks},
@@ -56023,7 +55084,7 @@ class EosDesigns(EosDesignsRootModel):
         },
         "ptp_settings": {"type": PtpSettings},
         "queue_monitor_length": {"type": QueueMonitorLength},
-        "queue_monitor_streaming": {"type": QueueMonitorStreaming},
+        "queue_monitor_streaming": {"type": EosCliConfigGen.QueueMonitorStreaming},
         "redundancy": {"type": Redundancy},
         "router_id_loopback_description": {"type": str, "default": "ROUTER_ID"},
         "serial_number": {"type": str},
@@ -56060,7 +55121,7 @@ class EosDesigns(EosDesignsRootModel):
         "underlay_ospf_process_id": {"type": int, "default": 100},
         "underlay_rfc5549": {"type": bool, "default": False},
         "underlay_routing_protocol": {"type": str},
-        "unsupported_transceiver": {"type": UnsupportedTransceiver},
+        "unsupported_transceiver": {"type": EosCliConfigGen.ServiceUnsupportedTransceiver},
         "uplink_ptp": {"type": UplinkPtp},
         "use_cv_topology": {"type": bool},
         "use_router_general_for_router_id": {"type": bool, "default": False},
@@ -56081,12 +55142,8 @@ class EosDesigns(EosDesignsRootModel):
         "_dynamic_keys": {"type": _DynamicKeys},
     }
     _allow_other_keys: ClassVar[bool] = True
-    application_classification: ApplicationClassification
-    """
-    Application traffic recognition configuration.
-
-    Subclass of AvdModel.
-    """
+    application_classification: EosCliConfigGen.ApplicationTrafficRecognition
+    """Application traffic recognition configuration."""
     avd_data_validation_mode: Literal["error", "warning"]
     """
     Validation Mode for AVD input data validation.
@@ -56160,8 +55217,7 @@ class EosDesigns(EosDesignsRootModel):
 
     Default value: `False`
     """
-    bgp_distance: BgpDistance
-    """Subclass of AvdModel."""
+    bgp_distance: EosCliConfigGen.RouterBgp.Distance
     bgp_ecmp: int | None
     """
     Maximum ECMP for BGP multi-path.
@@ -56632,7 +55688,7 @@ class EosDesigns(EosDesignsRootModel):
 
     Subclass of AvdModel.
     """
-    event_handlers: EventHandlers
+    event_handlers: EosCliConfigGen.EventHandlers
     """
     Gives the ability to monitor and react to Syslog messages.
     Event Handlers provide a powerful and
@@ -56640,8 +55696,7 @@ class EosDesigns(EosDesignsRootModel):
     customize the system behavior, and
     implement workarounds to problems discovered in the field.
     """
-    event_monitor: EventMonitor
-    """Subclass of AvdModel."""
+    event_monitor: EosCliConfigGen.EventMonitor
     evpn_ebgp_gateway_inter_domain: bool | None
     evpn_ebgp_gateway_multihop: int
     """
@@ -56781,8 +55836,7 @@ class EosDesigns(EosDesignsRootModel):
     Subclass
     of AvdModel.
     """
-    hardware_counters: HardwareCounters
-    """Subclass of AvdModel."""
+    hardware_counters: EosCliConfigGen.HardwareCounters
     internal_vlan_order: InternalVlanOrder
     """
     Internal vlan allocation order and range.
@@ -56888,9 +55942,8 @@ class EosDesigns(EosDesignsRootModel):
     Subclass of AvdIndexedList with
     `L3InterfaceProfilesItem` items. Primary key is `profile` (`str`).
     """
-    load_interval: LoadInterval
-    """Subclass of AvdModel."""
-    local_users: LocalUsers
+    load_interval: EosCliConfigGen.LoadInterval
+    local_users: EosCliConfigGen.LocalUsers
     mac_address_table: MacAddressTable
     """
     MAC address-table aging time.
@@ -57412,8 +56465,7 @@ class EosDesigns(EosDesignsRootModel):
     """
     queue_monitor_length: QueueMonitorLength
     """Subclass of AvdModel."""
-    queue_monitor_streaming: QueueMonitorStreaming
-    """Subclass of AvdModel."""
+    queue_monitor_streaming: EosCliConfigGen.QueueMonitorStreaming
     redundancy: Redundancy
     """
     Redundancy for chassis platforms with dual supervisors | Optional.
@@ -57724,8 +56776,7 @@ class EosDesigns(EosDesignsRootModel):
     *Only supported with
     core_interfaces data model.
     """
-    unsupported_transceiver: UnsupportedTransceiver
-    """Subclass of AvdModel."""
+    unsupported_transceiver: EosCliConfigGen.ServiceUnsupportedTransceiver
     uplink_ptp: UplinkPtp
     """
     Enable PTP on all infrastructure links.
@@ -57862,7 +56913,7 @@ class EosDesigns(EosDesignsRootModel):
         def __init__(
             self,
             *,
-            application_classification: ApplicationClassification | UndefinedType = Undefined,
+            application_classification: EosCliConfigGen.ApplicationTrafficRecognition | UndefinedType = Undefined,
             avd_data_validation_mode: Literal["error", "warning"] | UndefinedType = Undefined,
             avd_eos_designs_debug: bool | UndefinedType = Undefined,
             avd_eos_designs_enforce_duplication_checks_across_all_models: bool | UndefinedType = Undefined,
@@ -57871,7 +56922,7 @@ class EosDesigns(EosDesignsRootModel):
             bfd_multihop: BfdMultihop | UndefinedType = Undefined,
             bgp_as: str | None | UndefinedType = Undefined,
             bgp_default_ipv4_unicast: bool | UndefinedType = Undefined,
-            bgp_distance: BgpDistance | UndefinedType = Undefined,
+            bgp_distance: EosCliConfigGen.RouterBgp.Distance | UndefinedType = Undefined,
             bgp_ecmp: int | None | UndefinedType = Undefined,
             bgp_graceful_restart: BgpGracefulRestart | UndefinedType = Undefined,
             bgp_maximum_paths: int | None | UndefinedType = Undefined,
@@ -57910,8 +56961,8 @@ class EosDesigns(EosDesignsRootModel):
             enable_trunk_groups: bool | UndefinedType = Undefined,
             eos_designs_custom_templates: EosDesignsCustomTemplates | UndefinedType = Undefined,
             eos_designs_documentation: EosDesignsDocumentation | UndefinedType = Undefined,
-            event_handlers: EventHandlers | UndefinedType = Undefined,
-            event_monitor: EventMonitor | UndefinedType = Undefined,
+            event_handlers: EosCliConfigGen.EventHandlers | UndefinedType = Undefined,
+            event_monitor: EosCliConfigGen.EventMonitor | UndefinedType = Undefined,
             evpn_ebgp_gateway_inter_domain: bool | None | UndefinedType = Undefined,
             evpn_ebgp_gateway_multihop: int | UndefinedType = Undefined,
             evpn_ebgp_multihop: int | UndefinedType = Undefined,
@@ -57930,7 +56981,7 @@ class EosDesigns(EosDesignsRootModel):
             fabric_sflow: FabricSflow | UndefinedType = Undefined,
             flow_tracking_settings: FlowTrackingSettings | UndefinedType = Undefined,
             generate_cv_tags: GenerateCvTags | UndefinedType = Undefined,
-            hardware_counters: HardwareCounters | UndefinedType = Undefined,
+            hardware_counters: EosCliConfigGen.HardwareCounters | UndefinedType = Undefined,
             internal_vlan_order: InternalVlanOrder | UndefinedType = Undefined,
             ipv4_acls: Ipv4Acls | UndefinedType = Undefined,
             ipv4_prefix_list_catalog: Ipv4PrefixListCatalog | UndefinedType = Undefined,
@@ -57947,8 +56998,8 @@ class EosDesigns(EosDesignsRootModel):
             isis_ti_lfa: IsisTiLfa | UndefinedType = Undefined,
             l3_edge: L3Edge | UndefinedType = Undefined,
             l3_interface_profiles: L3InterfaceProfiles | UndefinedType = Undefined,
-            load_interval: LoadInterval | UndefinedType = Undefined,
-            local_users: LocalUsers | UndefinedType = Undefined,
+            load_interval: EosCliConfigGen.LoadInterval | UndefinedType = Undefined,
+            local_users: EosCliConfigGen.LocalUsers | UndefinedType = Undefined,
             mac_address_table: MacAddressTable | UndefinedType = Undefined,
             management_eapi: ManagementEapi | UndefinedType = Undefined,
             mgmt_destination_networks: MgmtDestinationNetworks | UndefinedType = Undefined,
@@ -57996,7 +57047,7 @@ class EosDesigns(EosDesignsRootModel):
             ptp_profiles: PtpProfiles | UndefinedType = Undefined,
             ptp_settings: PtpSettings | UndefinedType = Undefined,
             queue_monitor_length: QueueMonitorLength | UndefinedType = Undefined,
-            queue_monitor_streaming: QueueMonitorStreaming | UndefinedType = Undefined,
+            queue_monitor_streaming: EosCliConfigGen.QueueMonitorStreaming | UndefinedType = Undefined,
             redundancy: Redundancy | UndefinedType = Undefined,
             router_id_loopback_description: str | UndefinedType = Undefined,
             serial_number: str | None | UndefinedType = Undefined,
@@ -58035,7 +57086,7 @@ class EosDesigns(EosDesignsRootModel):
             underlay_routing_protocol: Literal["ebgp", "ospf", "ospf-ldp", "isis", "isis-sr", "isis-ldp", "isis-sr-ldp", "none"]
             | None
             | UndefinedType = Undefined,
-            unsupported_transceiver: UnsupportedTransceiver | UndefinedType = Undefined,
+            unsupported_transceiver: EosCliConfigGen.ServiceUnsupportedTransceiver | UndefinedType = Undefined,
             uplink_ptp: UplinkPtp | UndefinedType = Undefined,
             use_cv_topology: bool | None | UndefinedType = Undefined,
             use_router_general_for_router_id: bool | UndefinedType = Undefined,
@@ -58062,10 +57113,7 @@ class EosDesigns(EosDesignsRootModel):
             Subclass of AvdModel.
 
             Args:
-                application_classification:
-                   Application traffic recognition configuration.
-
-                   Subclass of AvdModel.
+                application_classification: Application traffic recognition configuration.
                 avd_data_validation_mode:
                    Validation Mode for AVD input data validation.
                    Input data validation will validate the input
@@ -58107,7 +57155,7 @@ class EosDesigns(EosDesignsRootModel):
                    Default activation of IPv4 unicast address-family on all IPv4 neighbors.
                    It is best practice to
                    disable activation.
-                bgp_distance: Subclass of AvdModel.
+                bgp_distance: bgp_distance
                 bgp_ecmp:
                    Maximum ECMP for BGP multi-path.
                    The default value is 4 except for WAN Routers where the default
@@ -58478,7 +57526,7 @@ class EosDesigns(EosDesignsRootModel):
                    flexible tool that can be used to apply self-healing actions,
                    customize the system behavior, and
                    implement workarounds to problems discovered in the field.
-                event_monitor: Subclass of AvdModel.
+                event_monitor: event_monitor
                 evpn_ebgp_gateway_inter_domain: evpn_ebgp_gateway_inter_domain
                 evpn_ebgp_gateway_multihop:
                    Default of 15, considering a large value to avoid BGP reachability issues in very complex DCI
@@ -58570,7 +57618,7 @@ class EosDesigns(EosDesignsRootModel):
 
                    Subclass
                    of AvdModel.
-                hardware_counters: Subclass of AvdModel.
+                hardware_counters: hardware_counters
                 internal_vlan_order:
                    Internal vlan allocation order and range.
 
@@ -58636,7 +57684,7 @@ class EosDesigns(EosDesignsRootModel):
 
                    Subclass of AvdIndexedList with
                    `L3InterfaceProfilesItem` items. Primary key is `profile` (`str`).
-                load_interval: Subclass of AvdModel.
+                load_interval: load_interval
                 local_users: local_users
                 mac_address_table:
                    MAC address-table aging time.
@@ -59014,7 +58062,7 @@ class EosDesigns(EosDesignsRootModel):
 
                    Subclass of AvdModel.
                 queue_monitor_length: Subclass of AvdModel.
-                queue_monitor_streaming: Subclass of AvdModel.
+                queue_monitor_streaming: queue_monitor_streaming
                 redundancy:
                    Redundancy for chassis platforms with dual supervisors | Optional.
 
@@ -59240,7 +58288,7 @@ class EosDesigns(EosDesignsRootModel):
                    - The variables should be applied to all devices in the fabric.
                    *Only supported with
                    core_interfaces data model.
-                unsupported_transceiver: Subclass of AvdModel.
+                unsupported_transceiver: unsupported_transceiver
                 uplink_ptp:
                    Enable PTP on all infrastructure links.
 

--- a/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
@@ -195,7 +195,7 @@ class SnmpServerMixin(Protocol):
         for local_interface in local_interfaces:
             self.structured_config.snmp_server.local_interfaces.append(EosCliConfigGen.SnmpServer.LocalInterfacesItem(**local_interface))
 
-    def _snmp_vrfs(self: AvdStructuredConfigBaseProtocol, snmp_settings: EosDesigns.SnmpSettings) -> EosDesigns.SnmpSettings.Vrfs:
+    def _snmp_vrfs(self: AvdStructuredConfigBaseProtocol, snmp_settings: EosDesigns.SnmpSettings) -> None:
         """
         Set list of dicts for enabling/disabling SNMP for VRFs.
 

--- a/python-avd/schema_tools/generate_classes/class_src_gen.py
+++ b/python-avd/schema_tools/generate_classes/class_src_gen.py
@@ -159,6 +159,8 @@ class SrcGenList(SrcGenBase):
     schema: AvdSchemaList
 
     def get_type(self) -> str:
+        if self.schema.field_ref:
+            return generate_class_name_from_ref(self.schema.field_ref)
         return self.get_class_name()
 
     def generate_class_src(self, schema: AvdSchemaList, class_name: str | None = None) -> SrcData:
@@ -176,14 +178,11 @@ class SrcGenList(SrcGenBase):
         return SrcData(field=self.field_src, cls=self.class_src, item_classes=self.get_item_classes())
 
     @cached_property
-    def class_src(self) -> ListSrc:
+    def class_src(self) -> ListSrc | None:
         """Returns ListSrc for the given schema to be used for the class definition in the parent object."""
         if self.schema.field_ref:
             # TODO: Currently we only skip resolving ref for indexedlists. Improve this.
-            return ListSrc(
-                name=self.get_class_name(),
-                base_class=generate_class_name_from_ref(self.schema.field_ref),
-            )
+            return None
 
         class_name = self.get_class_name()
         if self.schema.items is None:
@@ -237,7 +236,9 @@ class SrcGenList(SrcGenBase):
     @cached_property
     def type_hints_src(self) -> list[FieldTypeHintSrc]:
         """Returns a list of FieldTypeHintSrc representing the type hints for this schema."""
-        return [FieldTypeHintSrc(field_type=self.class_src.name)]
+        if self.schema.field_ref:
+            return [FieldTypeHintSrc(field_type=generate_class_name_from_ref(self.schema.field_ref))]
+        return super().type_hints_src
 
     def get_default(self) -> str | None:
         """Returns the default value from the schema as a source code string."""
@@ -261,11 +262,11 @@ class SrcGenList(SrcGenBase):
         return primary_key
 
     def get_description(self) -> str:
-        descriptions = [super().get_description(), self.class_src.description]
+        descriptions = [super().get_description(), cls_src.description if (cls_src := self.class_src) is not None else None]
         return "\n\n".join(description for description in descriptions if description is not None)
 
     def get_imports(self) -> set[str]:
-        """Return a set of strings with Python imports that are needed for this class."""
+        """Return a set of strings with Python imports that are needed for this class or field."""
         imports = set()
         if self.schema.items is None:
             imports.add("from typing import Any")
@@ -279,21 +280,26 @@ class SrcGenDict(SrcGenBase):
     schema: AvdSchemaDict
 
     def get_type(self) -> str:
+        if self.schema.field_ref:
+            return generate_class_name_from_ref(self.schema.field_ref)
         if self.class_src is not None:
             return self.get_class_name()
         return "dict"
 
     @cached_property
+    def type_hints_src(self) -> list[FieldTypeHintSrc]:
+        """Returns a list of FieldTypeHintSrc representing the type hints for this schema."""
+        if self.schema.field_ref:
+            return [FieldTypeHintSrc(field_type=generate_class_name_from_ref(self.schema.field_ref))]
+        return super().type_hints_src
+
+    @cached_property
     def class_src(self) -> ModelSrc | None:
         """Returns ModelSrc for the given schema to be used for the class definition in the parent object."""
-        if not self.schema.keys:
-            if not self.schema.field_ref:
-                return None
+        if self.schema.field_ref or not self.schema.keys:
+            return None
 
-            classes, fields = [], []
-
-        else:
-            classes, fields = self.get_children_classes_and_fields()
+        classes, fields = self.get_children_classes_and_fields()
         return ModelSrc(
             name=self.get_class_name(),
             base_classes=self.get_base_classes(),
@@ -305,20 +311,12 @@ class SrcGenDict(SrcGenBase):
         )
 
     def get_base_classes(self) -> list[str]:
-        """Return a list of base classes. Only used if there is an unresolved $ref in the schema."""
-        if not self.schema.field_ref:
-            return []
-
-        return [generate_class_name_from_ref(self.schema.field_ref)]
+        """Return a list of base classes. Only used by the root dict class."""
+        return []
 
     def get_imports(self) -> set[str]:
-        """Return a set of strings with Python imports that are needed for this class."""
-        imports = set()
-        if self.schema.field_ref:
-            schema_name = self.schema.field_ref.split("#", maxsplit=1)[0]
-            imports.add(f"from pyavd._{schema_name}.schema import {generate_class_name(schema_name)}")
-
-        return imports
+        """Return a set of strings with Python imports that are needed for this class or field. Only used for rootdict."""
+        return set()
 
     def get_children_classes_and_fields(self) -> tuple[list[ModelSrc | ListSrc], list[FieldSrc]]:
         """Return lists of ModelSrc and FieldSrc for any nested fields."""

--- a/python-avd/schema_tools/generate_classes/src_generators.py
+++ b/python-avd/schema_tools/generate_classes/src_generators.py
@@ -434,6 +434,9 @@ class FieldTypeHintSrc(AnnotationSrc):
         if "Literal[" in self.field_type:
             imports.add("from typing import Literal")
 
+        if self.field_type.startswith("EosCliConfigGen."):
+            imports.add("from pyavd._eos_cli_config_gen.schema import EosCliConfigGen")
+
         if not self.annotations:
             return imports
 


### PR DESCRIPTION
## Change Summary

Cherry-pick of Fix(eos_designs): Invalid class returned from snmp_settings.vrfs (#5035)

