### PR TITLE
CI: Exclude CV bindings from coverage for now

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=aristanetworks-1
 # Path to sources
 sonar.sources=python-avd/,ansible_collections/arista/avd/plugins/
 # Exclude generated classes
-sonar.exclusions=python-avd/tests/**,python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py,python-avd/pyavd/_eos_designs/schema/__init__.py,python-avd/pyavd/_cv/api
+sonar.exclusions=python-avd/tests/**,python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py,python-avd/pyavd/_eos_designs/schema/__init__.py,python-avd/pyavd/_cv/api/**
 
 # Path to tests
 sonar.tests=python-avd/tests/

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -4,7 +4,7 @@ sonar.organization=aristanetworks-1
 # Path to sources
 sonar.sources=python-avd/,ansible_collections/arista/avd/plugins/
 # Exclude generated classes
-sonar.exclusions=python-avd/tests/**,python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py,python-avd/pyavd/_eos_designs/schema/__init__.py
+sonar.exclusions=python-avd/tests/**,python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py,python-avd/pyavd/_eos_designs/schema/__init__.py,python-avd/pyavd/_cv/api
 
 # Path to tests
 sonar.tests=python-avd/tests/


### PR DESCRIPTION
## Change Summary

Removing cv API bindings from coverage for now to address the core of pyavd first

## Component(s) name

`ci`