### PR TITLE
Refactor(eos_designs): Refactor eos_designs structured_config code for router_ospf(underlay)

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_ospf.py
@@ -3,9 +3,10 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
 
+from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
+from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 from pyavd._utils import default
 
 if TYPE_CHECKING:
@@ -19,40 +20,27 @@ class RouterOspfMixin(Protocol):
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
 
-    @cached_property
-    def router_ospf(self: AvdStructuredConfigUnderlayProtocol) -> dict | None:
-        """Return structured config for router_ospf."""
+    @structured_config_contributor
+    def router_ospf(self: AvdStructuredConfigUnderlayProtocol) -> None:
+        """Set the structured config for router_ospf."""
         if self.shared_utils.underlay_ospf is not True:
-            return None
+            return
 
-        ospf_processes = []
-
-        no_passive_interfaces = [link["interface"] for link in self._underlay_links if link["type"] == "underlay_p2p"]
+        process = EosCliConfigGen.RouterOspf.ProcessIdsItem(
+            id=self.inputs.underlay_ospf_process_id,
+            passive_interface_default=True,
+            router_id=self.shared_utils.router_id if not self.inputs.use_router_general_for_router_id else None,
+            max_lsa=self.inputs.underlay_ospf_max_lsa,
+            bfd_enable=self.inputs.underlay_ospf_bfd_enable,
+        )
+        for link in self._underlay_links:
+            if link["type"] == "underlay_p2p":
+                process.no_passive_interfaces.append(link["interface"])
 
         if self.shared_utils.mlag_l3 is True:
             mlag_l3_vlan = default(self.shared_utils.mlag_peer_l3_vlan, self.shared_utils.node_config.mlag_peer_vlan)
-            no_passive_interfaces.append(f"Vlan{mlag_l3_vlan}")
-
-        process = {
-            "id": self.inputs.underlay_ospf_process_id,
-            "passive_interface_default": True,
-            "router_id": self.shared_utils.router_id if not self.inputs.use_router_general_for_router_id else None,
-            "max_lsa": self.inputs.underlay_ospf_max_lsa,
-            "no_passive_interfaces": no_passive_interfaces,
-            "bfd_enable": self.inputs.underlay_ospf_bfd_enable,
-        }
+            process.no_passive_interfaces.append(f"Vlan{mlag_l3_vlan}")
 
         if self.shared_utils.overlay_routing_protocol == "none":
-            process["redistribute"] = {
-                "connected": {"enabled": True},
-            }
-
-        # Strip None values from process before adding to list
-        process = {key: value for key, value in process.items() if value is not None}
-
-        ospf_processes.append(process)
-
-        if ospf_processes:
-            return {"process_ids": ospf_processes}
-
-        return None
+            process.redistribute.connected.enabled = True
+        self.structured_config.router_ospf.process_ids.append(process)


### PR DESCRIPTION

## Change Summary

Refactor eos_designs structured_config code for router_ospf(underlay)

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Refactor eos_designs structured_config code for router_ospf(underlay)

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
