### PR TITLE
CI: Making running from source work with molecule above 25.2

### DIFF
--- a/ansible_collections/arista/avd/plugins/__init__.py
+++ b/ansible_collections/arista/avd/plugins/__init__.py
@@ -7,7 +7,11 @@ from contextlib import suppress
 from os import environ
 from pathlib import Path
 
-PYTHON_AVD_PATH = Path(__file__).parents[4] / "python-avd"
+PYTHON_AVD_PATH = (
+    Path(molecule).parents[4] / "python-avd"
+    if (molecule := environ.get("MOLECULE_SCENARIO_DIRECTORY")) is not None
+    else Path(__file__).parents[4] / "python-avd"
+)
 RUNNING_FROM_SOURCE_PATH = PYTHON_AVD_PATH / "pyavd/running_from_src.txt"
 RUNNING_FROM_SOURCE = RUNNING_FROM_SOURCE_PATH.exists() and not environ.get("AVD_NEVER_RUN_FROM_SOURCE")
 


### PR DESCRIPTION
## Change Summary

Molecule started to implement 
https://ansible.readthedocs.io/projects/dev-tools/user-guide/test-isolation
in version 25.2

This PR allows to detect from the molecule scenario directory if we are running from source

## Component(s) name

`ci`

## Proposed changes

Detect MOLECULE_SCENARIO_DIRECTORY

## How to test

tested locally

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
