### PR TITLE
Refactor(eos_designs): Refactor eos_designs structured_config code for stun(underlay)

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/router_path_selection.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/router_path_selection.py
@@ -165,7 +165,7 @@ class RouterPathSelectionMixin(Protocol):
             if self.shared_utils.is_wan_client and self.shared_utils.should_connect_to_wan_rs([path_group_name]):
                 stun_server_profiles = self._stun_server_profiles.get(path_group_name, [])
                 if stun_server_profiles:
-                    local_interface["stun"] = {"server_profiles": [profile["name"] for profile in stun_server_profiles]}
+                    local_interface["stun"] = {"server_profiles": [profile.name for profile in stun_server_profiles]}
 
             local_interfaces.append(local_interface)
 

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/stun.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/stun.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import itertools
 from typing import TYPE_CHECKING, Protocol
 
+from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 
 if TYPE_CHECKING:
@@ -33,7 +34,6 @@ class StunMixin(Protocol):
                 self.structured_config.stun.server.local_interfaces.append(wan_port_channel.name)
 
         if self.shared_utils.is_wan_client:
-            for stun_profile in itertools.chain.from_iterable(self._stun_server_profiles.values()):
-                self.structured_config.stun.client.server_profiles.append_new(
-                    name=stun_profile["name"], ip_address=stun_profile["ip_address"], ssl_profile=stun_profile["ssl_profile"]
-                )
+            self.structured_config.stun.client.server_profiles = EosCliConfigGen.Stun.Client.ServerProfiles(
+                itertools.chain.from_iterable(self._stun_server_profiles.values())
+            )

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/stun.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/stun.py
@@ -4,10 +4,9 @@
 from __future__ import annotations
 
 import itertools
-from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
 
-from pyavd._utils import strip_empties_from_dict
+from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigOverlayProtocol
@@ -20,22 +19,21 @@ class StunMixin(Protocol):
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
 
-    @cached_property
-    def stun(self: AvdStructuredConfigOverlayProtocol) -> dict | None:
-        """Return structured config for stun."""
+    @structured_config_contributor
+    def stun(self: AvdStructuredConfigOverlayProtocol) -> None:
+        """Set the structured config for stun."""
         if not self.shared_utils.is_wan_router:
-            return None
+            return
 
-        stun = {}
         if self.shared_utils.is_wan_server:
-            local_interfaces = [wan_interface.name for wan_interface in self.shared_utils.wan_interfaces]
-            local_wan_port_channels = [wan_port_channel.name for wan_port_channel in self.shared_utils.wan_port_channels]
-            local_interfaces.extend(local_wan_port_channels)
-            stun["server"] = {
-                "local_interfaces": local_interfaces,
-                "ssl_profile": self.shared_utils.wan_stun_dtls_profile_name,
-            }
+            self.structured_config.stun.server.ssl_profile = self.shared_utils.wan_stun_dtls_profile_name
+            for wan_interface in self.shared_utils.wan_interfaces:
+                self.structured_config.stun.server.local_interfaces.append(wan_interface.name)
+            for wan_port_channel in self.shared_utils.wan_port_channels:
+                self.structured_config.stun.server.local_interfaces.append(wan_port_channel.name)
 
-        if self.shared_utils.is_wan_client and (server_profiles := list(itertools.chain.from_iterable(self._stun_server_profiles.values()))):
-            stun["client"] = {"server_profiles": server_profiles}
-        return strip_empties_from_dict(stun) or None
+        if self.shared_utils.is_wan_client:
+            for stun_profile in itertools.chain.from_iterable(self._stun_server_profiles.values()):
+                self.structured_config.stun.client.server_profiles.append_new(
+                    name=stun_profile["name"], ip_address=stun_profile["ip_address"], ssl_profile=stun_profile["ssl_profile"]
+                )


### PR DESCRIPTION

## Change Summary

Refactor eos_designs structured_config code for stun(underlay)

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Refactor eos_designs structured_config code for stun(underlay)

## How to test
Run Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
