### PR TITLE
Refactor(eos_designs): Refactor eos_designs structured_config code for router_internet_exit

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-internet-exit.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-internet-exit.md
@@ -11,12 +11,12 @@
     | [<samp>&nbsp;&nbsp;policies</samp>](## "router_internet_exit.policies") | List, items: Dictionary |  |  |  | Internet-exit policy represent a policy which can be attached to a virtual topology profile. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_internet_exit.policies.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;exit_groups</samp>](## "router_internet_exit.policies.[].exit_groups") | List, items: Dictionary |  |  |  | The exit groups that are configured under a policy are strictly ordered, meaning an exit group appearing first has more priority than the exit group that follows it. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_internet_exit.policies.[].exit_groups.[].name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_internet_exit.policies.[].exit_groups.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;exit_groups</samp>](## "router_internet_exit.exit_groups") | List, items: Dictionary |  |  |  | Exit groups represent a group of exit options (connections).<br>Traffic flows are load balanced in a round robin fashion across all the members (exits) of the exit-group. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_internet_exit.exit_groups.[].name") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;fib_default</samp>](## "router_internet_exit.exit_groups.[].fib_default") | Boolean |  |  |  | Fib default exit indicates that the flows that select this exit will follow the default route available in the VRF of the flow. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_connections</samp>](## "router_internet_exit.exit_groups.[].local_connections") | List, items: Dictionary |  |  |  | Local connections refer to connections configured under the `router_service_insertion`.<br>The service-insertion module reports the health of the connection and the exit will qualify for use only when it is healthy. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_internet_exit.exit_groups.[].local_connections.[].name") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "router_internet_exit.exit_groups.[].local_connections.[].name") | String | Required, Unique |  |  |  |
 
 === "YAML"
 
@@ -30,7 +30,7 @@
 
           # The exit groups that are configured under a policy are strictly ordered, meaning an exit group appearing first has more priority than the exit group that follows it.
           exit_groups:
-            - name: <str>
+            - name: <str; required; unique>
 
       # Exit groups represent a group of exit options (connections).
       # Traffic flows are load balanced in a round robin fashion across all the members (exits) of the exit-group.
@@ -43,5 +43,5 @@
           # Local connections refer to connections configured under the `router_service_insertion`.
           # The service-insertion module reports the health of the connection and the exit will qualify for use only when it is healthy.
           local_connections:
-            - name: <str>
+            - name: <str; required; unique>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -51359,11 +51359,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 """Subclass of AvdModel."""
 
                 _fields: ClassVar[dict] = {"name": {"type": str}}
-                name: str | None
+                name: str
 
                 if TYPE_CHECKING:
 
-                    def __init__(self, *, name: str | None | UndefinedType = Undefined) -> None:
+                    def __init__(self, *, name: str | UndefinedType = Undefined) -> None:
                         """
                         ExitGroupsItem.
 
@@ -51375,8 +51375,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         """
 
-            class ExitGroups(AvdList[ExitGroupsItem]):
-                """Subclass of AvdList with `ExitGroupsItem` items."""
+            class ExitGroups(AvdIndexedList[str, ExitGroupsItem]):
+                """Subclass of AvdIndexedList with `ExitGroupsItem` items. Primary key is `name` (`str`)."""
+
+                _primary_key: ClassVar[str] = "name"
 
             ExitGroups._item_type = ExitGroupsItem
 
@@ -51387,8 +51389,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             The exit groups that are configured under a policy are strictly ordered, meaning an exit group
             appearing first has more priority than the exit group that follows it.
 
-            Subclass of AvdList with
-            `ExitGroupsItem` items.
+            Subclass of AvdIndexedList
+            with `ExitGroupsItem` items. Primary key is `name` (`str`).
             """
 
             if TYPE_CHECKING:
@@ -51406,8 +51408,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                            The exit groups that are configured under a policy are strictly ordered, meaning an exit group
                            appearing first has more priority than the exit group that follows it.
 
-                           Subclass of AvdList with
-                           `ExitGroupsItem` items.
+                           Subclass of AvdIndexedList
+                           with `ExitGroupsItem` items. Primary key is `name` (`str`).
 
                     """
 
@@ -51425,11 +51427,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 """Subclass of AvdModel."""
 
                 _fields: ClassVar[dict] = {"name": {"type": str}}
-                name: str | None
+                name: str
 
                 if TYPE_CHECKING:
 
-                    def __init__(self, *, name: str | None | UndefinedType = Undefined) -> None:
+                    def __init__(self, *, name: str | UndefinedType = Undefined) -> None:
                         """
                         LocalConnectionsItem.
 
@@ -51441,8 +51443,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         """
 
-            class LocalConnections(AvdList[LocalConnectionsItem]):
-                """Subclass of AvdList with `LocalConnectionsItem` items."""
+            class LocalConnections(AvdIndexedList[str, LocalConnectionsItem]):
+                """Subclass of AvdIndexedList with `LocalConnectionsItem` items. Primary key is `name` (`str`)."""
+
+                _primary_key: ClassVar[str] = "name"
 
             LocalConnections._item_type = LocalConnectionsItem
 
@@ -51460,7 +51464,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             insertion module reports the health of the connection and the exit will qualify for use only when it
             is healthy.
 
-            Subclass of AvdList with `LocalConnectionsItem` items.
+            Subclass of AvdIndexedList with `LocalConnectionsItem` items. Primary key is `name`
+            (`str`).
             """
 
             if TYPE_CHECKING:
@@ -51489,7 +51494,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                            insertion module reports the health of the connection and the exit will qualify for use only when it
                            is healthy.
 
-                           Subclass of AvdList with `LocalConnectionsItem` items.
+                           Subclass of AvdIndexedList with `LocalConnectionsItem` items. Primary key is `name`
+                           (`str`).
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -19168,6 +19168,7 @@ keys:
               type: str
             exit_groups:
               type: list
+              primary_key: name
               description: The exit groups that are configured under a policy are
                 strictly ordered, meaning an exit group appearing first has more priority
                 than the exit group that follows it.
@@ -19193,6 +19194,7 @@ keys:
               description: Fib default exit indicates that the flows that select this
                 exit will follow the default route available in the VRF of the flow.
             local_connections:
+              primary_key: name
               type: list
               description: 'Local connections refer to connections configured under
                 the `router_service_insertion`.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_internet_exit.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_internet_exit.schema.yml
@@ -21,6 +21,7 @@ keys:
               type: str
             exit_groups:
               type: list
+              primary_key: name
               description: The exit groups that are configured under a policy are strictly ordered, meaning an exit group appearing first has more priority than the exit group that follows it.
               items:
                 type: dict
@@ -42,6 +43,7 @@ keys:
               type: bool
               description: Fib default exit indicates that the flows that select this exit will follow the default route available in the VRF of the flow.
             local_connections:
+              primary_key: name
               type: list
               description: |-
                 Local connections refer to connections configured under the `router_service_insertion`.

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/router_internet_exit.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/router_internet_exit.py
@@ -3,9 +3,9 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from collections import defaultdict
-from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
+
+from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigNetworkServicesProtocol
@@ -18,19 +18,15 @@ class RouterInternetExitMixin(Protocol):
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
 
-    @cached_property
-    def router_internet_exit(self: AvdStructuredConfigNetworkServicesProtocol) -> dict | None:
+    @structured_config_contributor
+    def router_internet_exit(self: AvdStructuredConfigNetworkServicesProtocol) -> None:
         """
-        Return structured config for router_internet_exit.
+        Set the structured config for router_internet_exit.
 
         Only used for CV Pathfinder edge routers today
         """
         if not self._filtered_internet_exit_policies_and_connections:
-            return None
-
-        router_internet_exit = {}
-        exit_groups_dict = defaultdict(lambda: {"local_connections": []})
-        policies = []
+            return
 
         for policy, connections in self._filtered_internet_exit_policies_and_connections:
             policy_exit_groups = []
@@ -38,7 +34,7 @@ class RouterInternetExitMixin(Protocol):
             #       This works for zscaler but later we may need to use some sorting intelligence as order matters.
             for connection in connections:
                 exit_group_name = connection["exit_group"]
-                exit_groups_dict[exit_group_name]["local_connections"].append({"name": connection["name"]})
+                self.structured_config.router_internet_exit.exit_groups.obtain(exit_group_name).local_connections.append_new(name=connection["name"])
                 # Recording the exit_group in the policy
                 if exit_group_name not in policy_exit_groups:
                     policy_exit_groups.append(exit_group_name)
@@ -46,16 +42,5 @@ class RouterInternetExitMixin(Protocol):
             if policy.fallback_to_system_default:
                 policy_exit_groups.append("system-default-exit-group")
 
-            policies.append({"name": policy.name, "exit_groups": [{"name": exit_group_name} for exit_group_name in policy_exit_groups]})
-
-        if exit_groups_dict:
-            router_internet_exit["exit_groups"] = [
-                {"name": exit_group_name, **exit_group_data} for exit_group_name, exit_group_data in exit_groups_dict.items()
-            ]
-        if policies:
-            router_internet_exit["policies"] = policies
-
-        if router_internet_exit:
-            return router_internet_exit
-
-        return None
+            for exit_group_name in policy_exit_groups:
+                self.structured_config.router_internet_exit.policies.obtain(policy.name).exit_groups.append_new(name=exit_group_name)

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/router_internet_exit.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/router_internet_exit.py
@@ -36,11 +36,9 @@ class RouterInternetExitMixin(Protocol):
             #       This works for zscaler but later we may need to use some sorting intelligence as order matters.
             for connection in connections:
                 exit_group_name = connection["exit_group"]
-                exit_groups.obtain(exit_group_name).local_connections.append_unique(
-                    EosCliConfigGen.RouterInternetExit.ExitGroupsItem.LocalConnectionsItem(name=connection["name"])
-                )
+                exit_groups.obtain(exit_group_name).local_connections.append_new(name=connection["name"])
                 # Recording the exit_group in the policy
-                policies.obtain(policy.name).exit_groups.append_unique(EosCliConfigGen.RouterInternetExit.PoliciesItem.ExitGroupsItem(name=exit_group_name))
+                policies.obtain(policy.name).exit_groups.append_new(name=exit_group_name)
 
             if policy.fallback_to_system_default:
                 policies.obtain(policy.name).exit_groups.append_new(name="system-default-exit-group")

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/router_internet_exit.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/router_internet_exit.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Protocol
 
+from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 
 if TYPE_CHECKING:
@@ -28,19 +29,20 @@ class RouterInternetExitMixin(Protocol):
         if not self._filtered_internet_exit_policies_and_connections:
             return
 
+        policies = EosCliConfigGen.RouterInternetExit.Policies()
+        exit_groups = EosCliConfigGen.RouterInternetExit.ExitGroups()
         for policy, connections in self._filtered_internet_exit_policies_and_connections:
-            policy_exit_groups = []
             # TODO: Today we use the order of the connection list to order the exit-groups inside the policy.
             #       This works for zscaler but later we may need to use some sorting intelligence as order matters.
             for connection in connections:
                 exit_group_name = connection["exit_group"]
-                self.structured_config.router_internet_exit.exit_groups.obtain(exit_group_name).local_connections.append_new(name=connection["name"])
+                exit_groups.obtain(exit_group_name).local_connections.append_unique(
+                    EosCliConfigGen.RouterInternetExit.ExitGroupsItem.LocalConnectionsItem(name=connection["name"])
+                )
                 # Recording the exit_group in the policy
-                if exit_group_name not in policy_exit_groups:
-                    policy_exit_groups.append(exit_group_name)
+                policies.obtain(policy.name).exit_groups.append_unique(EosCliConfigGen.RouterInternetExit.PoliciesItem.ExitGroupsItem(name=exit_group_name))
 
             if policy.fallback_to_system_default:
-                policy_exit_groups.append("system-default-exit-group")
+                policies.obtain(policy.name).exit_groups.append_new(name="system-default-exit-group")
 
-            for exit_group_name in policy_exit_groups:
-                self.structured_config.router_internet_exit.policies.obtain(policy.name).exit_groups.append_new(name=exit_group_name)
+        self.structured_config.router_internet_exit._update(policies=policies, exit_groups=exit_groups)


### PR DESCRIPTION

## Change Summary

Refactor eos_designs structured_config code for router_internet_exit

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Refactor eos_designs structured_config code for router_internet_exit

## How to test
Run Molecule 

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
