### PR TITLE
Bump(pyavd): Add distlib to pyavd ansible-collection extra to support manifest directives

### DIFF
--- a/.github/requirements-ci-dev.txt
+++ b/.github/requirements-ci-dev.txt
@@ -1,5 +1,3 @@
 # Installing PyAVD from source.
 # The package path below is relative to the repo root and will only work if the pip install is executed from there.
 ./python-avd[ansible-collection]
-# required for manifest when installing from source
-distlib

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -17,6 +17,7 @@ title: Release Notes for AVD 5.x.x
 ### Changes to requirements
 
 - The file `ansible_collections/arista/avd/collections.yml` has been renamed `ansible_collections/arista/avd/requirements.yml` to work well with ansible-lint. A symlink has been kept and will be removed in AVD 6.0.0.
+- `distlib` has been added to the pyavd extras `ansible-collection` to enable installing the collection from source after adding manifest directives to galaxy.yml https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html#manifest-directives
 
 ## Release 5.2.2
 

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -57,6 +57,8 @@ ansible-collection = [
     "treelib>=1.5.5",
     # jsonschema is required for the arista.cvp Ansible collection
     "jsonschema>=3.2.0",
+    # distlib is required to install the collection from source as it is using manifest
+    "distlib>=0.3.9",
 ]
 
 [build-system]


### PR DESCRIPTION
## Change Summary

PR #5053 broke universal container build as it cannot find distlib when installing the colleciton from source. This fixes it.

## Related Issue(s)

CI failing in devel

## Component(s) name

`pyavd`

## Proposed changes

Adding `distlib` to pyavd[ansible-collection] extra

## How to test

Container can build (visible in CI only in devel) 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
