### PR TITLE
Fix(eos_designs): Revert changed behavior for management_eapi

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -87,7 +87,8 @@ queue-monitor streaming
    no shutdown
 !
 management api http-commands
-   protocol https
+   no protocol https
+   no protocol http
    no default-services
    no shutdown
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -254,7 +254,8 @@ mac_address_table:
   notification_host_flap:
     logging: true
 management_api_http:
-  enable_https: true
+  enable_http: false
+  enable_https: false
   default_services: false
   enable_vrfs:
   - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
@@ -82,3 +82,10 @@ override_mac_address_table: "{{ my_mac_address_table }}"
 # eos_designs_unit_tests should not have any CloudVision tags generated for them
 generate_cv_tags:
   topology_hints: true
+
+# Management api-http
+# Expicitely disabling http and https
+management_eapi:
+  enable_https: false
+  enable_http: false
+  default_services: false

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -53,7 +53,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;secondary_ssh_key</samp>](## "local_users.[].secondary_ssh_key") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shell</samp>](## "local_users.[].shell") | String |  |  | Valid Values:<br>- <code>/bin/bash</code><br>- <code>/bin/sh</code><br>- <code>/sbin/nologin</code> | Specify shell for the user.<br> |
     | [<samp>management_eapi</samp>](## "management_eapi") | Dictionary |  |  |  | Default is HTTPS management eAPI enabled.<br>The VRF is set to < mgmt_interface_vrf >.<br> |
-    | [<samp>&nbsp;&nbsp;enable_http</samp>](## "management_eapi.enable_http") | Boolean |  | `False` |  |  |
+    | [<samp>&nbsp;&nbsp;enable_http</samp>](## "management_eapi.enable_http") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;enable_https</samp>](## "management_eapi.enable_https") | Boolean |  | `True` |  |  |
     | [<samp>&nbsp;&nbsp;default_services</samp>](## "management_eapi.default_services") | Boolean |  |  |  |  |
     | [<samp>name_servers</samp>](## "name_servers") | List, items: String |  |  |  | List of DNS servers. The VRF is set to < mgmt_interface_vrf >. |
@@ -212,7 +212,7 @@
     # Default is HTTPS management eAPI enabled.
     # The VRF is set to < mgmt_interface_vrf >.
     management_eapi:
-      enable_http: <bool; default=False>
+      enable_http: <bool>
       enable_https: <bool; default=True>
       default_services: <bool>
 

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -6391,13 +6391,8 @@ class EosDesigns(EosDesignsRootModel):
     class ManagementEapi(AvdModel):
         """Subclass of AvdModel."""
 
-        _fields: ClassVar[dict] = {
-            "enable_http": {"type": bool, "default": False},
-            "enable_https": {"type": bool, "default": True},
-            "default_services": {"type": bool},
-        }
-        enable_http: bool
-        """Default value: `False`"""
+        _fields: ClassVar[dict] = {"enable_http": {"type": bool}, "enable_https": {"type": bool, "default": True}, "default_services": {"type": bool}}
+        enable_http: bool | None
         enable_https: bool
         """Default value: `True`"""
         default_services: bool | None
@@ -6407,7 +6402,7 @@ class EosDesigns(EosDesignsRootModel):
             def __init__(
                 self,
                 *,
-                enable_http: bool | UndefinedType = Undefined,
+                enable_http: bool | None | UndefinedType = Undefined,
                 enable_https: bool | UndefinedType = Undefined,
                 default_services: bool | None | UndefinedType = Undefined,
             ) -> None:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -2194,7 +2194,6 @@ keys:
     keys:
       enable_http:
         type: bool
-        default: false
       enable_https:
         type: bool
         default: true

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/management_eapi.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/management_eapi.schema.yml
@@ -16,7 +16,6 @@ keys:
     keys:
       enable_http:
         type: bool
-        default: false
       enable_https:
         type: bool
         default: true

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -13,7 +13,7 @@ from pyavd._eos_designs.structured_config.structured_config_generator import (
     structured_config_contributor,
 )
 from pyavd._errors import AristaAvdInvalidInputsError, AristaAvdMissingVariableError
-from pyavd._utils import default, get, strip_empties_from_dict, strip_null_from_data
+from pyavd._utils import Undefined, default, get, strip_empties_from_dict, strip_null_from_data
 from pyavd.j2filters import natural_sort
 
 from .ntp import NtpMixin
@@ -530,8 +530,9 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
         return strip_empties_from_dict(
             {
                 "enable_vrfs": [{"name": self.inputs.mgmt_interface_vrf}],
-                "enable_http": self.inputs.management_eapi.enable_http or None,
-                "enable_https": self.inputs.management_eapi.enable_https or None,
+                # Hack to respect the legacy behavior but this is wrong according to schema
+                "enable_http": defined_value if (defined_value := self.inputs.management_eapi._get_defined_attr("enable_http")) is not Undefined else None,
+                "enable_https": self.inputs.management_eapi.enable_https,
                 "default_services": self.inputs.management_eapi.default_services,
             }
         )

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -13,7 +13,7 @@ from pyavd._eos_designs.structured_config.structured_config_generator import (
     structured_config_contributor,
 )
 from pyavd._errors import AristaAvdInvalidInputsError, AristaAvdMissingVariableError
-from pyavd._utils import Undefined, default, get, strip_empties_from_dict, strip_null_from_data
+from pyavd._utils import default, get, strip_empties_from_dict, strip_null_from_data
 from pyavd.j2filters import natural_sort
 
 from .ntp import NtpMixin
@@ -530,8 +530,7 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
         return strip_empties_from_dict(
             {
                 "enable_vrfs": [{"name": self.inputs.mgmt_interface_vrf}],
-                # Hack to respect the legacy behavior but this is wrong according to schema
-                "enable_http": defined_value if (defined_value := self.inputs.management_eapi._get_defined_attr("enable_http")) is not Undefined else None,
+                "enable_http": self.inputs.management_eapi.enable_http,
                 "enable_https": self.inputs.management_eapi.enable_https,
                 "default_services": self.inputs.management_eapi.default_services,
             }


### PR DESCRIPTION
## Change Summary

Behavior of `management_eapi` was changed in AVD 5.2 - this PR restores the previous behavior.

## Related Issue(s)

Fixes #5107

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

~Respecting behavior from 5.1 - though this was not follwoing the schema for `enable_http: false` as it was ignoring the value (not rendering it) when Undefined. This is what is mimicked now but it could mean that we need to change the schema.~

Removed the schema default which was never respected, fix the code.

## How to test

molecule tests added

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
