### PR TITLE
Refactor(eos_designs): structured_config for underlay router_pim_sparse_mode

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
@@ -47,5 +47,11 @@ class RouterPimSparseModeMixin(Protocol):
             # Anycast-RP using PIM (default)
             other_anycast_rp_addresses = EosCliConfigGen.RouterPimSparseMode.Ipv4.AnycastRpsItem.OtherAnycastRpAddresses()
             for node in rp_entry.nodes:
-                other_anycast_rp_addresses.append(EosCliConfigGen.RouterPimSparseMode.Ipv4.AnycastRpsItem.OtherAnycastRpAddressesItem(address=get(self.shared_utils.get_peer_facts(node.name), "router_id", required=True)))
-            self.structured_config.router_pim_sparse_mode.ipv4.anycast_rps.append_new(address=rp_entry.rp,other_anycast_rp_addresses=other_anycast_rp_addresses)
+                other_anycast_rp_addresses.append(
+                    EosCliConfigGen.RouterPimSparseMode.Ipv4.AnycastRpsItem.OtherAnycastRpAddressesItem(
+                        address=get(self.shared_utils.get_peer_facts(node.name), "router_id", required=True)
+                    )
+                )
+            self.structured_config.router_pim_sparse_mode.ipv4.anycast_rps.append_new(
+                address=rp_entry.rp, other_anycast_rp_addresses=other_anycast_rp_addresses
+            )

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
@@ -3,9 +3,10 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
 
+from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
+from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 from pyavd._utils import get
 
 if TYPE_CHECKING:
@@ -19,53 +20,32 @@ class RouterPimSparseModeMixin(Protocol):
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
 
-    @cached_property
-    def router_pim_sparse_mode(self: AvdStructuredConfigUnderlayProtocol) -> dict | None:
+    @structured_config_contributor
+    def router_pim_sparse_mode(self: AvdStructuredConfigUnderlayProtocol) -> None:
         """
-        Return structured config for router_pim_sparse_mode.
+        Set the structured config for router_pim_sparse_mode.
 
         Used for to configure multicast RPs for the underlay
         """
         if not self.shared_utils.underlay_multicast or not self.inputs.underlay_multicast_rps:
-            return None
+            return
 
-        rp_addresses = []
-        anycast_rps = []
         for rp_entry in self.inputs.underlay_multicast_rps:
-            rp_address = {"address": rp_entry.rp}
+            rp_address = EosCliConfigGen.RouterPimSparseMode.Ipv4.RpAddressesItem(address=rp_entry.rp)
             if rp_entry.groups:
                 if rp_entry.access_list_name:
-                    rp_address["access_lists"] = [rp_entry.access_list_name]
+                    rp_address.access_lists.append(rp_entry.access_list_name)
                 else:
-                    rp_address["groups"] = rp_entry.groups._as_list()
+                    for group in rp_entry.groups:
+                        rp_address.groups.append(group)
 
-            rp_addresses.append(rp_address)
+            self.structured_config.router_pim_sparse_mode.ipv4.rp_addresses.append(rp_address)
 
             if len(rp_entry.nodes) < 2 or self.shared_utils.hostname not in rp_entry.nodes or self.inputs.underlay_multicast_anycast_rp.mode != "pim":
                 continue
 
             # Anycast-RP using PIM (default)
-            anycast_rps.append(
-                {
-                    "address": rp_entry.rp,
-                    "other_anycast_rp_addresses": [
-                        {
-                            "address": get(self.shared_utils.get_peer_facts(node.name), "router_id", required=True),
-                        }
-                        for node in rp_entry.nodes
-                    ],
-                },
-            )
-
-        if rp_addresses:
-            router_pim_sparse_mode = {
-                "ipv4": {
-                    "rp_addresses": rp_addresses,
-                },
-            }
-            if anycast_rps:
-                router_pim_sparse_mode["ipv4"]["anycast_rps"] = anycast_rps
-
-            return router_pim_sparse_mode
-
-        return None
+            for node in rp_entry.nodes:
+                self.structured_config.router_pim_sparse_mode.ipv4.anycast_rps.obtain(rp_entry.rp).other_anycast_rp_addresses.append_new(
+                    address=get(self.shared_utils.get_peer_facts(node.name), "router_id", required=True)
+                )

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
@@ -45,7 +45,7 @@ class RouterPimSparseModeMixin(Protocol):
                 continue
 
             # Anycast-RP using PIM (default)
+            other_anycast_rp_addresses = EosCliConfigGen.RouterPimSparseMode.Ipv4.AnycastRpsItem.OtherAnycastRpAddresses()
             for node in rp_entry.nodes:
-                self.structured_config.router_pim_sparse_mode.ipv4.anycast_rps.obtain(rp_entry.rp).other_anycast_rp_addresses.append_new(
-                    address=get(self.shared_utils.get_peer_facts(node.name), "router_id", required=True)
-                )
+                other_anycast_rp_addresses.append(EosCliConfigGen.RouterPimSparseMode.Ipv4.AnycastRpsItem.OtherAnycastRpAddressesItem(address=get(self.shared_utils.get_peer_facts(node.name), "router_id", required=True)))
+            self.structured_config.router_pim_sparse_mode.ipv4.anycast_rps.append_new(address=rp_entry.rp,other_anycast_rp_addresses=other_anycast_rp_addresses)

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
@@ -36,7 +36,7 @@ class RouterPimSparseModeMixin(Protocol):
                 if rp_entry.access_list_name:
                     rp_address.access_lists.append(rp_entry.access_list_name)
                 else:
-                    rp_address.groups.extend(rp._entry.groups)
+                    rp_address.groups.extend(rp_entry.groups)
 
             self.structured_config.router_pim_sparse_mode.ipv4.rp_addresses.append(rp_address)
 

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
@@ -46,11 +46,7 @@ class RouterPimSparseModeMixin(Protocol):
             # Anycast-RP using PIM (default)
             other_anycast_rp_addresses = EosCliConfigGen.RouterPimSparseMode.Ipv4.AnycastRpsItem.OtherAnycastRpAddresses()
             for node in rp_entry.nodes:
-                other_anycast_rp_addresses.append(
-                    EosCliConfigGen.RouterPimSparseMode.Ipv4.AnycastRpsItem.OtherAnycastRpAddressesItem(
-                        address=get(self.shared_utils.get_peer_facts(node.name), "router_id", required=True)
-                    )
-                )
+                other_anycast_rp_addresses.append_new(address=get(self.shared_utils.get_peer_facts(node.name), "router_id", required=True))
             self.structured_config.router_pim_sparse_mode.ipv4.anycast_rps.append_new(
                 address=rp_entry.rp, other_anycast_rp_addresses=other_anycast_rp_addresses
             )

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
@@ -36,8 +36,7 @@ class RouterPimSparseModeMixin(Protocol):
                 if rp_entry.access_list_name:
                     rp_address.access_lists.append(rp_entry.access_list_name)
                 else:
-                    for group in rp_entry.groups:
-                        rp_address.groups.append(group)
+                    rp_address.groups.extend(rp._entry.groups)
 
             self.structured_config.router_pim_sparse_mode.ipv4.rp_addresses.append(rp_address)
 


### PR DESCRIPTION
## Change Summary

Refactor eos_designs  structured_config for underlay router_pim_sparse_mode

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

## How to test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
