### PR TITLE
Refactor(eos_designs): Refactor eos_designs structured_config code for spanning_tree

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -390,13 +390,11 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
         """spanning_tree set based on spanning_tree_root_super, spanning_tree_mode and spanning_tree_priority."""
         if not self.shared_utils.network_services_l2:
             self.structured_config.spanning_tree.mode = "none"
-
-        spanning_tree_root_super = self.shared_utils.node_config.spanning_tree_root_super
-        spanning_tree_mode = self.shared_utils.node_config.spanning_tree_mode
-        if spanning_tree_root_super is not True and spanning_tree_mode is None:
             return
 
-        if spanning_tree_root_super is True:
+        spanning_tree_mode = self.shared_utils.node_config.spanning_tree_mode
+
+        if self.shared_utils.node_config.spanning_tree_root_super is True:
             self.structured_config.spanning_tree.root_super = True
 
         if spanning_tree_mode is not None:

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -385,31 +385,28 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
             }
         return None
 
-    @cached_property
-    def spanning_tree(self) -> dict | None:
+    @structured_config_contributor
+    def spanning_tree(self) -> None:
         """spanning_tree set based on spanning_tree_root_super, spanning_tree_mode and spanning_tree_priority."""
         if not self.shared_utils.network_services_l2:
-            return {"mode": "none"}
+            self.structured_config.spanning_tree.mode = "none"
 
         spanning_tree_root_super = self.shared_utils.node_config.spanning_tree_root_super
         spanning_tree_mode = self.shared_utils.node_config.spanning_tree_mode
         if spanning_tree_root_super is not True and spanning_tree_mode is None:
-            return None
+            return
 
-        spanning_tree = {}
         if spanning_tree_root_super is True:
-            spanning_tree["root_super"] = True
+            self.structured_config.spanning_tree.root_super = True
 
         if spanning_tree_mode is not None:
-            spanning_tree["mode"] = spanning_tree_mode
+            self.structured_config.spanning_tree.mode = spanning_tree_mode
             priority = self.shared_utils.node_config.spanning_tree_priority
             # "rapid-pvst" is not included below. Per vlan spanning-tree priorities are set under network-services.
             if spanning_tree_mode == "mstp":
-                spanning_tree["mst_instances"] = [{"id": "0", "priority": priority}]
+                self.structured_config.spanning_tree.mst_instances.append_new(id="0", priority=priority)
             elif spanning_tree_mode == "rstp":
-                spanning_tree["rstp_priority"] = priority
-
-        return spanning_tree
+                self.structured_config.spanning_tree.rstp_priority = priority
 
     @cached_property
     def service_unsupported_transceiver(self) -> dict | None:

--- a/python-avd/pyavd/_eos_designs/structured_config/mlag/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/mlag/__init__.py
@@ -19,13 +19,13 @@ class AvdStructuredConfigMlag(StructuredConfigGenerator):
             return super().render()
         return None
 
-    @cached_property
-    def spanning_tree(self) -> dict:
+    @structured_config_contributor
+    def spanning_tree(self) -> None:
         vlans = [self.shared_utils.node_config.mlag_peer_vlan]
         if self.shared_utils.mlag_peer_l3_vlan is not None:
             vlans.append(self.shared_utils.mlag_peer_l3_vlan)
 
-        return {"no_spanning_tree_vlan": list_compress(vlans)}
+        self.structured_config.spanning_tree.no_spanning_tree_vlan = list_compress(vlans)
 
     @structured_config_contributor
     def vlans(self) -> None:


### PR DESCRIPTION
## Change Summary

Refactor eos_designs structured_config code for spanning_tree

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Refactor eos_designs structured_config code for spanning_tree

## How to test
Run Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
