### PR TITLE
Feat(eos_cli_config_gen): Add TWAMP sender profile knob under router TE

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -7176,6 +7176,7 @@ router traffic-engineering
             segment-list label-stack 900002 900010 900011 900012
    router-id ipv4 10.0.0.1
    router-id ipv6 2001:beef:cafe::1
+   twamp-light sender profile test-profile
    !
    flex-algo
       flex-algo 128 test-algo

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -6090,6 +6090,7 @@ router traffic-engineering
             segment-list label-stack 900002 900010 900011 900012
    router-id ipv4 10.0.0.1
    router-id ipv6 2001:beef:cafe::1
+   twamp-light sender profile test-profile
    !
    flex-algo
       flex-algo 128 test-algo

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-traffic-engineering.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/router-traffic-engineering.j2
@@ -61,6 +61,9 @@ router traffic-engineering
 {%     if router_traffic_engineering.router_id.ipv6 is arista.avd.defined %}
    router-id ipv6 {{ router_traffic_engineering.router_id.ipv6 }}
 {%     endif %}
+{%     if router_traffic_engineering.twamp_light_sender_profile is arista.avd.defined %}
+   twamp-light sender profile {{ router_traffic_engineering.twamp_light_sender_profile }}
+{%     endif %}
 {%     if router_traffic_engineering.flex_algos is arista.avd.defined %}
    !
    flex-algo


### PR DESCRIPTION
## Change Summary

Add twamp-light sender profile under router traffic-engineering. This was added in PR #5020 but the template change does not seem to have made it into devel. Molecule test and schema changes already exist for this.

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
