### PR TITLE
Feat(eos_cli_config_gen): Add support for dot1x statistics, vlan assignment group and radius av-pair filter_id

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -10300,9 +10300,9 @@ ip as-path access-list mylist2 deny _64517$ igp
 
 #### 802.1X Global
 
-| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization |
-| ------------------- | -------------------- | ----------------------|
-| True | True | True |
+| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization | Dropped Statistics Packets |
+| ------------------- | -------------------- | ----------------------| -------------------------- |
+| True | True | True | True |
 
 #### 802.1X MAC based authentication
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -10300,7 +10300,7 @@ ip as-path access-list mylist2 deny _64517$ igp
 
 #### 802.1X Global
 
-| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization | Dropped Statistics Packets |
+| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization | Dropped Packets Statistics |
 | ------------------- | -------------------- | ----------------------| -------------------------- |
 | True | True | True | True |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -10325,6 +10325,14 @@ ip as-path access-list mylist2 deny _64517$ igp
 | IPv4 Access-list | ACL |
 | Start limit | Infinite |
 
+#### 802.1X VLAN Assignment Groups
+
+| VLAN Group Name | Value |
+| --------------- | ----- |
+| Assignment_1 | 400-407 |
+| Assignment_2 | 55 |
+| Assignment_3 | 1,3,15-20 |
+
 #### 802.1X Supplicant
 
 | Attribute | Value |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -10327,7 +10327,7 @@ ip as-path access-list mylist2 deny _64517$ igp
 
 #### 802.1X VLAN Assignment Groups
 
-| VLAN Group Name | Value |
+| VLAN Group Name | Members |
 | --------------- | ----- |
 | Assignment_1 | 400-407 |
 | Assignment_2 | 55 |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -10328,7 +10328,7 @@ ip as-path access-list mylist2 deny _64517$ igp
 #### 802.1X VLAN Assignment Groups
 
 | VLAN Group Name | Members |
-| --------------- | ----- |
+| --------------- | ------- |
 | Assignment_1 | 400-407 |
 | Assignment_2 | 55 |
 | Assignment_3 | 1,3,15-20 |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1418,7 +1418,7 @@ router pim sparse-mode
 
 #### 802.1X Global
 
-| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization | Dropped Statistics Packets |
+| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization | Dropped Packets Statistics |
 | ------------------- | -------------------- | ----------------------| -------------------------- |
 | True | True | True | - |
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -1418,9 +1418,9 @@ router pim sparse-mode
 
 #### 802.1X Global
 
-| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization |
-| ------------------- | -------------------- | ----------------------|
-| True | True | True |
+| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization | Dropped Statistics Packets |
+| ------------------- | -------------------- | ----------------------| -------------------------- |
+| True | True | True | - |
 
 #### 802.1X Radius AV pair
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1593,6 +1593,9 @@ dot1x
    mac based authentication delay 300 seconds
    mac based authentication hold period 300 seconds
    radius av-pair service-type
+   radius av-pair filter-id multiple
+   radius av-pair filter-id delimiter period
+   radius av-pair filter-id ipv4 ipv6 required
    radius av-pair framed-mtu 1500
    mac-based-auth radius av-pair user-name delimiter colon lowercase
    aaa unresponsive recovery action reauthenticate
@@ -1600,6 +1603,10 @@ dot1x
    captive-portal url http://portal-nacm08/captiveredirect/ ssl profile Profile1
    captive-portal access-list ipv4 ACL
    captive-portal start limit infinite
+   vlan assignment group Assignment_1 members 400-407
+   vlan assignment group Assignment_2 members 55
+   vlan assignment group Assignment_3 members 1,3,15-20
+   statistics packets dropped
    radius av-pair lldp system-name auth-only
    radius av-pair lldp system-description auth-only
    radius av-pair dhcp hostname auth-only

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/dot1x.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/dot1x.yml
@@ -4,12 +4,17 @@ dot1x:
   system_auth_control: true
   protocol_lldp_bypass: true
   dynamic_authorization: true
+  statistics_packets_dropped: true
   mac_based_authentication:
     delay: 300
     hold_period: 300
   radius_av_pair:
     service_type: true
     framed_mtu: 1500
+    filter_id:
+      delimiter_period: true
+      ipv4_ipv6_required: true
+      multiple: true
     lldp:
       system_name:
         enabled: true
@@ -65,3 +70,10 @@ dot1x:
         ssl_profile: PF2
     logging: true
     disconnect_cached_results_timeout: 79
+  vlan_assignment_groups:
+    - name: Assignment_3
+      vlan: 1,3,15-20
+    - name: Assignment_2
+      vlan: 55
+    - name: Assignment_1
+      vlan: 400-407

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/dot1x.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/dot1x.yml
@@ -72,8 +72,8 @@ dot1x:
     disconnect_cached_results_timeout: 79
   vlan_assignment_groups:
     - name: Assignment_3
-      vlan: 1,3,15-20
+      members: 1,3,15-20
     - name: Assignment_2
-      vlan: 55
+      members: 55
     - name: Assignment_1
-      vlan: 400-407
+      members: 400-407

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
@@ -81,7 +81,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disconnect_cached_results_timeout</samp>](## "dot1x.supplicant.disconnect_cached_results_timeout") | Integer |  |  | Min: 60<br>Max: 65535 | Timeout in seconds for removing a disconnected supplicant. |
     | [<samp>&nbsp;&nbsp;vlan_assignment_groups</samp>](## "dot1x.vlan_assignment_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "dot1x.vlan_assignment_groups.[].name") | String | Required, Unique |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "dot1x.vlan_assignment_groups.[].vlan") | String | Required |  |  | VLAN value(s) or range(s) of VLAN values. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;members</samp>](## "dot1x.vlan_assignment_groups.[].members") | String | Required |  |  | VLAN value(s) or range(s) of VLAN values. |
 
 === "YAML"
 
@@ -248,5 +248,5 @@
         - name: <str; required; unique>
 
           # VLAN value(s) or range(s) of VLAN values.
-          vlan: <str; required>
+          members: <str; required>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
@@ -40,7 +40,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "dot1x.radius_av_pair.dhcp.vendor_class_id.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth_only</samp>](## "dot1x.radius_av_pair.dhcp.vendor_class_id.auth_only") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;filter_id</samp>](## "dot1x.radius_av_pair.filter_id") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delimiter_period</samp>](## "dot1x.radius_av_pair.filter_id.delimiter_period") | Boolean |  |  |  | Delimiter to use, Period as delimiter. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delimiter_period</samp>](## "dot1x.radius_av_pair.filter_id.delimiter_period") | Boolean |  |  |  | Use period as the delimiter. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_ipv6_required</samp>](## "dot1x.radius_av_pair.filter_id.ipv4_ipv6_required") | Boolean |  |  |  | IPv4 filter-id, IPv6 filter-id, Filter-id are required. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiple</samp>](## "dot1x.radius_av_pair.filter_id.multiple") | Boolean |  |  |  | Multiple attribute |
     | [<samp>&nbsp;&nbsp;aaa</samp>](## "dot1x.aaa") | Dictionary |  |  |  | Configure AAA parameters. |
@@ -136,7 +136,7 @@
             auth_only: <bool>
         filter_id:
 
-          # Delimiter to use, Period as delimiter.
+          # Use period as the delimiter.
           delimiter_period: <bool>
 
           # IPv4 filter-id, IPv6 filter-id, Filter-id are required.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;protocol_lldp_bypass</samp>](## "dot1x.protocol_lldp_bypass") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;protocol_bpdu_bypass</samp>](## "dot1x.protocol_bpdu_bypass") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;dynamic_authorization</samp>](## "dot1x.dynamic_authorization") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;statistics_packets_dropped</samp>](## "dot1x.statistics_packets_dropped") | Boolean |  |  |  | Enable the dot1x dropped counters. |
+    | [<samp>&nbsp;&nbsp;statistics_packets_dropped</samp>](## "dot1x.statistics_packets_dropped") | Boolean |  |  |  | Enable the 802.1X port authentication dropped data packet statistics. |
     | [<samp>&nbsp;&nbsp;mac_based_authentication</samp>](## "dot1x.mac_based_authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "dot1x.mac_based_authentication.delay") | Integer |  |  | Min: 0<br>Max: 300 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hold_period</samp>](## "dot1x.mac_based_authentication.hold_period") | Integer |  |  | Min: 1<br>Max: 300 |  |
@@ -92,7 +92,7 @@
       protocol_bpdu_bypass: <bool>
       dynamic_authorization: <bool>
 
-      # Enable the dot1x dropped counters.
+      # Enable the 802.1X port authentication dropped data packet statistics.
       statistics_packets_dropped: <bool>
       mac_based_authentication:
         delay: <int; 0-300>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
@@ -42,7 +42,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;filter_id</samp>](## "dot1x.radius_av_pair.filter_id") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delimiter_period</samp>](## "dot1x.radius_av_pair.filter_id.delimiter_period") | Boolean |  |  |  | Use period as the delimiter. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_ipv6_required</samp>](## "dot1x.radius_av_pair.filter_id.ipv4_ipv6_required") | Boolean |  |  |  | Enable filters for IPv4 and IPv6 traffic. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiple</samp>](## "dot1x.radius_av_pair.filter_id.multiple") | Boolean |  |  |  | Multiple attribute |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiple</samp>](## "dot1x.radius_av_pair.filter_id.multiple") | Boolean |  |  |  | Multiple attribute. |
     | [<samp>&nbsp;&nbsp;aaa</samp>](## "dot1x.aaa") | Dictionary |  |  |  | Configure AAA parameters. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;unresponsive</samp>](## "dot1x.aaa.unresponsive") | Dictionary |  |  |  | Configure AAA timeout options. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eap_response</samp>](## "dot1x.aaa.unresponsive.eap_response") | String |  |  | Valid Values:<br>- <code>success</code><br>- <code>disabled</code> | EAP response to send. |
@@ -144,7 +144,7 @@
           # Enable filters for IPv4 and IPv6 traffic.
           ipv4_ipv6_required: <bool>
 
-          # Multiple attribute
+          # Multiple attribute.
           multiple: <bool>
 
       # Configure AAA parameters.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
@@ -12,6 +12,7 @@
     | [<samp>&nbsp;&nbsp;protocol_lldp_bypass</samp>](## "dot1x.protocol_lldp_bypass") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;protocol_bpdu_bypass</samp>](## "dot1x.protocol_bpdu_bypass") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;dynamic_authorization</samp>](## "dot1x.dynamic_authorization") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;statistics_packets_dropped</samp>](## "dot1x.statistics_packets_dropped") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;mac_based_authentication</samp>](## "dot1x.mac_based_authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "dot1x.mac_based_authentication.delay") | Integer |  |  | Min: 0<br>Max: 300 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hold_period</samp>](## "dot1x.mac_based_authentication.hold_period") | Integer |  |  | Min: 1<br>Max: 300 |  |
@@ -38,6 +39,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vendor_class_id</samp>](## "dot1x.radius_av_pair.dhcp.vendor_class_id") | Dictionary |  |  |  | Vendor class identifier (DHCP Option 60). |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "dot1x.radius_av_pair.dhcp.vendor_class_id.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth_only</samp>](## "dot1x.radius_av_pair.dhcp.vendor_class_id.auth_only") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;filter_id</samp>](## "dot1x.radius_av_pair.filter_id") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delimiter_period</samp>](## "dot1x.radius_av_pair.filter_id.delimiter_period") | Boolean |  |  |  | Delimiter to use, Period as delimiter. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_ipv6_required</samp>](## "dot1x.radius_av_pair.filter_id.ipv4_ipv6_required") | Boolean |  |  |  | IPv4 filter-id, IPv6 filter-id, Filter-id are required. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiple</samp>](## "dot1x.radius_av_pair.filter_id.multiple") | Boolean |  |  |  | Multiple attribute |
     | [<samp>&nbsp;&nbsp;aaa</samp>](## "dot1x.aaa") | Dictionary |  |  |  | Configure AAA parameters. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;unresponsive</samp>](## "dot1x.aaa.unresponsive") | Dictionary |  |  |  | Configure AAA timeout options. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;eap_response</samp>](## "dot1x.aaa.unresponsive.eap_response") | String |  |  | Valid Values:<br>- <code>success</code><br>- <code>disabled</code> | EAP response to send. |
@@ -74,6 +79,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ssl_profile</samp>](## "dot1x.supplicant.profiles.[].ssl_profile") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "dot1x.supplicant.logging") | Boolean |  |  |  | Enable supplicant logging. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;disconnect_cached_results_timeout</samp>](## "dot1x.supplicant.disconnect_cached_results_timeout") | Integer |  |  | Min: 60<br>Max: 65535 | Timeout in seconds for removing a disconnected supplicant. |
+    | [<samp>&nbsp;&nbsp;vlan_assignment_groups</samp>](## "dot1x.vlan_assignment_groups") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "dot1x.vlan_assignment_groups.[].name") | String | Required, Unique |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "dot1x.vlan_assignment_groups.[].vlan") | String | Required |  |  | VLAN value(s) or range(s) of VLAN values. |
 
 === "YAML"
 
@@ -83,6 +91,7 @@
       protocol_lldp_bypass: <bool>
       protocol_bpdu_bypass: <bool>
       dynamic_authorization: <bool>
+      statistics_packets_dropped: <bool>
       mac_based_authentication:
         delay: <int; 0-300>
         hold_period: <int; 1-300>
@@ -125,6 +134,16 @@
           vendor_class_id:
             enabled: <bool; required>
             auth_only: <bool>
+        filter_id:
+
+          # Delimiter to use, Period as delimiter.
+          delimiter_period: <bool>
+
+          # IPv4 filter-id, IPv6 filter-id, Filter-id are required.
+          ipv4_ipv6_required: <bool>
+
+          # Multiple attribute
+          multiple: <bool>
 
       # Configure AAA parameters.
       aaa:
@@ -223,4 +242,9 @@
 
         # Timeout in seconds for removing a disconnected supplicant.
         disconnect_cached_results_timeout: <int; 60-65535>
+      vlan_assignment_groups:
+        - name: <str; required; unique>
+
+          # VLAN value(s) or range(s) of VLAN values.
+          vlan: <str; required>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/dot1x.md
@@ -12,7 +12,7 @@
     | [<samp>&nbsp;&nbsp;protocol_lldp_bypass</samp>](## "dot1x.protocol_lldp_bypass") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;protocol_bpdu_bypass</samp>](## "dot1x.protocol_bpdu_bypass") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;dynamic_authorization</samp>](## "dot1x.dynamic_authorization") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;statistics_packets_dropped</samp>](## "dot1x.statistics_packets_dropped") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;statistics_packets_dropped</samp>](## "dot1x.statistics_packets_dropped") | Boolean |  |  |  | Enable the dot1x dropped counters. |
     | [<samp>&nbsp;&nbsp;mac_based_authentication</samp>](## "dot1x.mac_based_authentication") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;delay</samp>](## "dot1x.mac_based_authentication.delay") | Integer |  |  | Min: 0<br>Max: 300 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hold_period</samp>](## "dot1x.mac_based_authentication.hold_period") | Integer |  |  | Min: 1<br>Max: 300 |  |
@@ -41,7 +41,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;auth_only</samp>](## "dot1x.radius_av_pair.dhcp.vendor_class_id.auth_only") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;filter_id</samp>](## "dot1x.radius_av_pair.filter_id") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;delimiter_period</samp>](## "dot1x.radius_av_pair.filter_id.delimiter_period") | Boolean |  |  |  | Use period as the delimiter. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_ipv6_required</samp>](## "dot1x.radius_av_pair.filter_id.ipv4_ipv6_required") | Boolean |  |  |  | IPv4 filter-id, IPv6 filter-id, Filter-id are required. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_ipv6_required</samp>](## "dot1x.radius_av_pair.filter_id.ipv4_ipv6_required") | Boolean |  |  |  | Enable filters for IPv4 and IPv6 traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multiple</samp>](## "dot1x.radius_av_pair.filter_id.multiple") | Boolean |  |  |  | Multiple attribute |
     | [<samp>&nbsp;&nbsp;aaa</samp>](## "dot1x.aaa") | Dictionary |  |  |  | Configure AAA parameters. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;unresponsive</samp>](## "dot1x.aaa.unresponsive") | Dictionary |  |  |  | Configure AAA timeout options. |
@@ -91,6 +91,8 @@
       protocol_lldp_bypass: <bool>
       protocol_bpdu_bypass: <bool>
       dynamic_authorization: <bool>
+
+      # Enable the dot1x dropped counters.
       statistics_packets_dropped: <bool>
       mac_based_authentication:
         delay: <int; 0-300>
@@ -139,7 +141,7 @@
           # Use period as the delimiter.
           delimiter_period: <bool>
 
-          # IPv4 filter-id, IPv6 filter-id, Filter-id are required.
+          # Enable filters for IPv4 and IPv6 traffic.
           ipv4_ipv6_required: <bool>
 
           # Multiple attribute

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
@@ -19,12 +19,13 @@
 
 #### 802.1X Global
 
-| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization |
-| ------------------- | -------------------- | ----------------------|
+| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization | Dropped Statistics Packets |
+| ------------------- | -------------------- | ----------------------| -------------------------- |
 {%         set system_auth_control = dot1x.system_auth_control | arista.avd.default('-') %}
 {%         set protocol_lldp_bypass = dot1x.protocol_lldp_bypass | arista.avd.default('-') %}
 {%         set dynamic_authorization = dot1x.dynamic_authorization | arista.avd.default('-') %}
-| {{ system_auth_control }} | {{ protocol_lldp_bypass }} | {{ dynamic_authorization }} |
+{%         set statistics_packets_dropped = dot1x.statistics_packets_dropped | arista.avd.default('-') %}
+| {{ system_auth_control }} | {{ protocol_lldp_bypass }} | {{ dynamic_authorization }} | {{ statistics_packets_dropped }} |
 {%         if dot1x.mac_based_authentication is arista.avd.defined %}
 
 #### 802.1X MAC based authentication

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
@@ -69,7 +69,7 @@
 #### 802.1X VLAN Assignment Groups
 
 | VLAN Group Name | Members |
-| --------------- | ----- |
+| --------------- | ------- |
 {%             for vlan_assignment_group in dot1x.vlan_assignment_groups | arista.avd.natural_sort("name") %}
 | {{ vlan_assignment_group.name }} | {{ vlan_assignment_group.members }} |
 {%             endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
@@ -64,6 +64,16 @@
 | Start limit | Infinite |
 {%             endif %}
 {%         endif %}
+{%         if dot1x.vlan_assignment_groups is arista.avd.defined %}
+
+#### 802.1X VLAN Assignment Groups
+
+| VLAN Group Name | Value |
+| --------------- | ----- |
+{%             for vlan_assignment_group in dot1x.vlan_assignment_groups | arista.avd.natural_sort("name") %}
+| {{ vlan_assignment_group.name }} | {{ vlan_assignment_group.vlan }} |
+{%             endfor %}
+{%         endif %}
 {%         if dot1x.supplicant is arista.avd.defined %}
 
 #### 802.1X Supplicant

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
@@ -19,7 +19,7 @@
 
 #### 802.1X Global
 
-| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization | Dropped Statistics Packets |
+| System Auth Control | Protocol LLDP Bypass | Dynamic Authorization | Dropped Packets Statistics |
 | ------------------- | -------------------- | ----------------------| -------------------------- |
 {%         set system_auth_control = dot1x.system_auth_control | arista.avd.default('-') %}
 {%         set protocol_lldp_bypass = dot1x.protocol_lldp_bypass | arista.avd.default('-') %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dot1x.j2
@@ -68,10 +68,10 @@
 
 #### 802.1X VLAN Assignment Groups
 
-| VLAN Group Name | Value |
+| VLAN Group Name | Members |
 | --------------- | ----- |
 {%             for vlan_assignment_group in dot1x.vlan_assignment_groups | arista.avd.natural_sort("name") %}
-| {{ vlan_assignment_group.name }} | {{ vlan_assignment_group.vlan }} |
+| {{ vlan_assignment_group.name }} | {{ vlan_assignment_group.members }} |
 {%             endfor %}
 {%         endif %}
 {%         if dot1x.supplicant is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dot1x.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dot1x.j2
@@ -116,7 +116,7 @@ dot1x
 {%             endif %}
 {%         endif %}
 {%         for vlan_assignment_group in dot1x.vlan_assignment_groups | arista.avd.natural_sort("name") %}
-   vlan assignment group {{ vlan_assignment_group.name }} members {{ vlan_assignment_group.vlan }}
+   vlan assignment group {{ vlan_assignment_group.name }} members {{ vlan_assignment_group.members }}
 {%         endfor %}
 {%         if dot1x.statistics_packets_dropped is arista.avd.defined(true) %}
    statistics packets dropped

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dot1x.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/dot1x.j2
@@ -78,6 +78,15 @@ dot1x
 {%         if dot1x.radius_av_pair.service_type is arista.avd.defined(true) %}
    radius av-pair service-type
 {%         endif %}
+{%         if dot1x.radius_av_pair.filter_id.multiple is arista.avd.defined(true) %}
+   radius av-pair filter-id multiple
+{%         endif %}
+{%         if dot1x.radius_av_pair.filter_id.delimiter_period is arista.avd.defined(true) %}
+   radius av-pair filter-id delimiter period
+{%         endif %}
+{%         if dot1x.radius_av_pair.filter_id.ipv4_ipv6_required is arista.avd.defined(true) %}
+   radius av-pair filter-id ipv4 ipv6 required
+{%         endif %}
 {%         if dot1x.radius_av_pair.framed_mtu is arista.avd.defined %}
    radius av-pair framed-mtu {{ dot1x.radius_av_pair.framed_mtu }}
 {%         endif %}
@@ -105,6 +114,12 @@ dot1x
 {%             if dot1x.captive_portal.start_limit_infinite is arista.avd.defined(true) %}
    captive-portal start limit infinite
 {%             endif %}
+{%         endif %}
+{%         for vlan_assignment_group in dot1x.vlan_assignment_groups | arista.avd.natural_sort("name") %}
+   vlan assignment group {{ vlan_assignment_group.name }} members {{ vlan_assignment_group.vlan }}
+{%         endfor %}
+{%         if dot1x.statistics_packets_dropped is arista.avd.defined(true) %}
+   statistics packets dropped
 {%         endif %}
 {%         if dot1x.radius_av_pair.lldp is arista.avd.defined %}
 {%             if dot1x.radius_av_pair.lldp.system_name.enabled is arista.avd.defined(true) %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -4395,7 +4395,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 delimiter_period: bool | None
                 """Use period as the delimiter."""
                 ipv4_ipv6_required: bool | None
-                """IPv4 filter-id, IPv6 filter-id, Filter-id are required."""
+                """Enable filters for IPv4 and IPv6 traffic."""
                 multiple: bool | None
                 """Multiple attribute"""
 
@@ -4416,7 +4416,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         Args:
                             delimiter_period: Use period as the delimiter.
-                            ipv4_ipv6_required: IPv4 filter-id, IPv6 filter-id, Filter-id are required.
+                            ipv4_ipv6_required: Enable filters for IPv4 and IPv6 traffic.
                             multiple: Multiple attribute
 
                         """
@@ -4944,6 +4944,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         protocol_bpdu_bypass: bool | None
         dynamic_authorization: bool | None
         statistics_packets_dropped: bool | None
+        """Enable the dot1x dropped counters."""
         mac_based_authentication: MacBasedAuthentication
         """Subclass of AvdModel."""
         radius_av_pair_username_format: RadiusAvPairUsernameFormat
@@ -5001,7 +5002,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     protocol_lldp_bypass: protocol_lldp_bypass
                     protocol_bpdu_bypass: protocol_bpdu_bypass
                     dynamic_authorization: dynamic_authorization
-                    statistics_packets_dropped: statistics_packets_dropped
+                    statistics_packets_dropped: Enable the dot1x dropped counters.
                     mac_based_authentication: Subclass of AvdModel.
                     radius_av_pair_username_format:
                        RADIUS AV-pair username settings.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -4944,7 +4944,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         protocol_bpdu_bypass: bool | None
         dynamic_authorization: bool | None
         statistics_packets_dropped: bool | None
-        """Enable the dot1x dropped counters."""
+        """Enable the 802.1X port authentication dropped data packet statistics."""
         mac_based_authentication: MacBasedAuthentication
         """Subclass of AvdModel."""
         radius_av_pair_username_format: RadiusAvPairUsernameFormat
@@ -5002,7 +5002,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     protocol_lldp_bypass: protocol_lldp_bypass
                     protocol_bpdu_bypass: protocol_bpdu_bypass
                     dynamic_authorization: dynamic_authorization
-                    statistics_packets_dropped: Enable the dot1x dropped counters.
+                    statistics_packets_dropped: Enable the 802.1X port authentication dropped data packet statistics.
                     mac_based_authentication: Subclass of AvdModel.
                     radius_av_pair_username_format:
                        RADIUS AV-pair username settings.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -4898,14 +4898,14 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         class VlanAssignmentGroupsItem(AvdModel):
             """Subclass of AvdModel."""
 
-            _fields: ClassVar[dict] = {"name": {"type": str}, "vlan": {"type": str}}
+            _fields: ClassVar[dict] = {"name": {"type": str}, "members": {"type": str}}
             name: str
-            vlan: str
+            members: str
             """VLAN value(s) or range(s) of VLAN values."""
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, name: str | UndefinedType = Undefined, vlan: str | UndefinedType = Undefined) -> None:
+                def __init__(self, *, name: str | UndefinedType = Undefined, members: str | UndefinedType = Undefined) -> None:
                     """
                     VlanAssignmentGroupsItem.
 
@@ -4914,7 +4914,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     Args:
                         name: name
-                        vlan: VLAN value(s) or range(s) of VLAN values.
+                        members: VLAN value(s) or range(s) of VLAN values.
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -4388,12 +4388,53 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         """
 
-            _fields: ClassVar[dict] = {"service_type": {"type": bool}, "framed_mtu": {"type": int}, "lldp": {"type": Lldp}, "dhcp": {"type": Dhcp}}
+            class FilterId(AvdModel):
+                """Subclass of AvdModel."""
+
+                _fields: ClassVar[dict] = {"delimiter_period": {"type": bool}, "ipv4_ipv6_required": {"type": bool}, "multiple": {"type": bool}}
+                delimiter_period: bool | None
+                """Delimiter to use, Period as delimiter."""
+                ipv4_ipv6_required: bool | None
+                """IPv4 filter-id, IPv6 filter-id, Filter-id are required."""
+                multiple: bool | None
+                """Multiple attribute"""
+
+                if TYPE_CHECKING:
+
+                    def __init__(
+                        self,
+                        *,
+                        delimiter_period: bool | None | UndefinedType = Undefined,
+                        ipv4_ipv6_required: bool | None | UndefinedType = Undefined,
+                        multiple: bool | None | UndefinedType = Undefined,
+                    ) -> None:
+                        """
+                        FilterId.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            delimiter_period: Delimiter to use, Period as delimiter.
+                            ipv4_ipv6_required: IPv4 filter-id, IPv6 filter-id, Filter-id are required.
+                            multiple: Multiple attribute
+
+                        """
+
+            _fields: ClassVar[dict] = {
+                "service_type": {"type": bool},
+                "framed_mtu": {"type": int},
+                "lldp": {"type": Lldp},
+                "dhcp": {"type": Dhcp},
+                "filter_id": {"type": FilterId},
+            }
             service_type: bool | None
             framed_mtu: int | None
             lldp: Lldp
             """Subclass of AvdModel."""
             dhcp: Dhcp
+            """Subclass of AvdModel."""
+            filter_id: FilterId
             """Subclass of AvdModel."""
 
             if TYPE_CHECKING:
@@ -4405,6 +4446,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     framed_mtu: int | None | UndefinedType = Undefined,
                     lldp: Lldp | UndefinedType = Undefined,
                     dhcp: Dhcp | UndefinedType = Undefined,
+                    filter_id: FilterId | UndefinedType = Undefined,
                 ) -> None:
                     """
                     RadiusAvPair.
@@ -4417,6 +4459,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         framed_mtu: framed_mtu
                         lldp: Subclass of AvdModel.
                         dhcp: Subclass of AvdModel.
+                        filter_id: Subclass of AvdModel.
 
                     """
 
@@ -4852,22 +4895,55 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
+        class VlanAssignmentGroupsItem(AvdModel):
+            """Subclass of AvdModel."""
+
+            _fields: ClassVar[dict] = {"name": {"type": str}, "vlan": {"type": str}}
+            name: str
+            vlan: str
+            """VLAN value(s) or range(s) of VLAN values."""
+
+            if TYPE_CHECKING:
+
+                def __init__(self, *, name: str | UndefinedType = Undefined, vlan: str | UndefinedType = Undefined) -> None:
+                    """
+                    VlanAssignmentGroupsItem.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        name: name
+                        vlan: VLAN value(s) or range(s) of VLAN values.
+
+                    """
+
+        class VlanAssignmentGroups(AvdIndexedList[str, VlanAssignmentGroupsItem]):
+            """Subclass of AvdIndexedList with `VlanAssignmentGroupsItem` items. Primary key is `name` (`str`)."""
+
+            _primary_key: ClassVar[str] = "name"
+
+        VlanAssignmentGroups._item_type = VlanAssignmentGroupsItem
+
         _fields: ClassVar[dict] = {
             "system_auth_control": {"type": bool},
             "protocol_lldp_bypass": {"type": bool},
             "protocol_bpdu_bypass": {"type": bool},
             "dynamic_authorization": {"type": bool},
+            "statistics_packets_dropped": {"type": bool},
             "mac_based_authentication": {"type": MacBasedAuthentication},
             "radius_av_pair_username_format": {"type": RadiusAvPairUsernameFormat},
             "radius_av_pair": {"type": RadiusAvPair},
             "aaa": {"type": Aaa},
             "captive_portal": {"type": CaptivePortal},
             "supplicant": {"type": Supplicant},
+            "vlan_assignment_groups": {"type": VlanAssignmentGroups},
         }
         system_auth_control: bool | None
         protocol_lldp_bypass: bool | None
         protocol_bpdu_bypass: bool | None
         dynamic_authorization: bool | None
+        statistics_packets_dropped: bool | None
         mac_based_authentication: MacBasedAuthentication
         """Subclass of AvdModel."""
         radius_av_pair_username_format: RadiusAvPairUsernameFormat
@@ -4893,6 +4969,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """
         supplicant: Supplicant
         """Subclass of AvdModel."""
+        vlan_assignment_groups: VlanAssignmentGroups
+        """Subclass of AvdIndexedList with `VlanAssignmentGroupsItem` items. Primary key is `name` (`str`)."""
 
         if TYPE_CHECKING:
 
@@ -4903,12 +4981,14 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 protocol_lldp_bypass: bool | None | UndefinedType = Undefined,
                 protocol_bpdu_bypass: bool | None | UndefinedType = Undefined,
                 dynamic_authorization: bool | None | UndefinedType = Undefined,
+                statistics_packets_dropped: bool | None | UndefinedType = Undefined,
                 mac_based_authentication: MacBasedAuthentication | UndefinedType = Undefined,
                 radius_av_pair_username_format: RadiusAvPairUsernameFormat | UndefinedType = Undefined,
                 radius_av_pair: RadiusAvPair | UndefinedType = Undefined,
                 aaa: Aaa | UndefinedType = Undefined,
                 captive_portal: CaptivePortal | UndefinedType = Undefined,
                 supplicant: Supplicant | UndefinedType = Undefined,
+                vlan_assignment_groups: VlanAssignmentGroups | UndefinedType = Undefined,
             ) -> None:
                 """
                 Dot1x.
@@ -4921,6 +5001,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     protocol_lldp_bypass: protocol_lldp_bypass
                     protocol_bpdu_bypass: protocol_bpdu_bypass
                     dynamic_authorization: dynamic_authorization
+                    statistics_packets_dropped: statistics_packets_dropped
                     mac_based_authentication: Subclass of AvdModel.
                     radius_av_pair_username_format:
                        RADIUS AV-pair username settings.
@@ -4937,6 +5018,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                        Subclass of AvdModel.
                     supplicant: Subclass of AvdModel.
+                    vlan_assignment_groups: Subclass of AvdIndexedList with `VlanAssignmentGroupsItem` items. Primary key is `name` (`str`).
 
                 """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -4397,7 +4397,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 ipv4_ipv6_required: bool | None
                 """Enable filters for IPv4 and IPv6 traffic."""
                 multiple: bool | None
-                """Multiple attribute"""
+                """Multiple attribute."""
 
                 if TYPE_CHECKING:
 
@@ -4417,7 +4417,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         Args:
                             delimiter_period: Use period as the delimiter.
                             ipv4_ipv6_required: Enable filters for IPv4 and IPv6 traffic.
-                            multiple: Multiple attribute
+                            multiple: Multiple attribute.
 
                         """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -4393,7 +4393,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 _fields: ClassVar[dict] = {"delimiter_period": {"type": bool}, "ipv4_ipv6_required": {"type": bool}, "multiple": {"type": bool}}
                 delimiter_period: bool | None
-                """Delimiter to use, Period as delimiter."""
+                """Use period as the delimiter."""
                 ipv4_ipv6_required: bool | None
                 """IPv4 filter-id, IPv6 filter-id, Filter-id are required."""
                 multiple: bool | None
@@ -4415,7 +4415,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         Subclass of AvdModel.
 
                         Args:
-                            delimiter_period: Delimiter to use, Period as delimiter.
+                            delimiter_period: Use period as the delimiter.
                             ipv4_ipv6_required: IPv4 filter-id, IPv6 filter-id, Filter-id are required.
                             multiple: Multiple attribute
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1656,6 +1656,7 @@ keys:
         type: bool
       statistics_packets_dropped:
         type: bool
+        description: Enable the dot1x dropped counters.
       mac_based_authentication:
         type: dict
         keys:
@@ -1761,7 +1762,7 @@ keys:
                 description: Use period as the delimiter.
               ipv4_ipv6_required:
                 type: bool
-                description: IPv4 filter-id, IPv6 filter-id, Filter-id are required.
+                description: Enable filters for IPv4 and IPv6 traffic.
               multiple:
                 type: bool
                 description: Multiple attribute

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1765,7 +1765,7 @@ keys:
                 description: Enable filters for IPv4 and IPv6 traffic.
               multiple:
                 type: bool
-                description: Multiple attribute
+                description: Multiple attribute.
       aaa:
         type: dict
         description: Configure AAA parameters.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1758,7 +1758,7 @@ keys:
             keys:
               delimiter_period:
                 type: bool
-                description: Delimiter to use, Period as delimiter.
+                description: Use period as the delimiter.
               ipv4_ipv6_required:
                 type: bool
                 description: IPv4 filter-id, IPv6 filter-id, Filter-id are required.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1656,7 +1656,7 @@ keys:
         type: bool
       statistics_packets_dropped:
         type: bool
-        description: Enable the dot1x dropped counters.
+        description: Enable the 802.1X port authentication dropped data packet statistics.
       mac_based_authentication:
         type: dict
         keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1654,6 +1654,8 @@ keys:
         type: bool
       dynamic_authorization:
         type: bool
+      statistics_packets_dropped:
+        type: bool
       mac_based_authentication:
         type: dict
         keys:
@@ -1751,6 +1753,18 @@ keys:
                     required: true
                   auth_only:
                     type: bool
+          filter_id:
+            type: dict
+            keys:
+              delimiter_period:
+                type: bool
+                description: Delimiter to use, Period as delimiter.
+              ipv4_ipv6_required:
+                type: bool
+                description: IPv4 filter-id, IPv6 filter-id, Filter-id are required.
+              multiple:
+                type: bool
+                description: Multiple attribute
       aaa:
         type: dict
         description: Configure AAA parameters.
@@ -1931,6 +1945,20 @@ keys:
             min: 60
             max: 65535
             description: Timeout in seconds for removing a disconnected supplicant.
+      vlan_assignment_groups:
+        type: list
+        primary_key: name
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            vlan:
+              type: str
+              required: true
+              convert_types:
+              - int
+              description: VLAN value(s) or range(s) of VLAN values.
   dps_interfaces:
     type: list
     primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -1954,7 +1954,7 @@ keys:
           keys:
             name:
               type: str
-            vlan:
+            members:
               type: str
               required: true
               convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
@@ -310,7 +310,7 @@ keys:
           keys:
             name:
               type: str
-            vlan:
+            members:
               type: str
               required: true
               convert_types:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
@@ -20,7 +20,7 @@ keys:
         type: bool
       statistics_packets_dropped:
         type: bool
-        description: Enable the dot1x dropped counters.
+        description: Enable the 802.1X port authentication dropped data packet statistics.
       mac_based_authentication:
         type: dict
         keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
@@ -18,6 +18,8 @@ keys:
         type: bool
       dynamic_authorization:
         type: bool
+      statistics_packets_dropped:
+        type: bool
       mac_based_authentication:
         type: dict
         keys:
@@ -115,6 +117,18 @@ keys:
                     required: true
                   auth_only:
                     type: bool
+          filter_id:
+            type: dict
+            keys:
+              delimiter_period:
+                type: bool
+                description: Delimiter to use, Period as delimiter.
+              ipv4_ipv6_required:
+                type: bool
+                description: IPv4 filter-id, IPv6 filter-id, Filter-id are required.
+              multiple:
+                type: bool
+                description: Multiple attribute
       aaa:
         type: dict
         description: Configure AAA parameters.
@@ -287,3 +301,17 @@ keys:
             min: 60
             max: 65535
             description: Timeout in seconds for removing a disconnected supplicant.
+      vlan_assignment_groups:
+        type: list
+        primary_key: name
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+            vlan:
+              type: str
+              required: true
+              convert_types:
+                - int
+              description: VLAN value(s) or range(s) of VLAN values.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
@@ -125,7 +125,7 @@ keys:
                 description: Use period as the delimiter.
               ipv4_ipv6_required:
                 type: bool
-                description: IPv4 filter-id, IPv6 filter-id, Filter-id are required.
+                description: Enable filters for IPv4 and IPv6 traffic.
               multiple:
                 type: bool
                 description: Multiple attribute

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
@@ -20,6 +20,7 @@ keys:
         type: bool
       statistics_packets_dropped:
         type: bool
+        description: Enable the dot1x dropped counters.
       mac_based_authentication:
         type: dict
         keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
@@ -122,7 +122,7 @@ keys:
             keys:
               delimiter_period:
                 type: bool
-                description: Delimiter to use, Period as delimiter.
+                description: Use period as the delimiter.
               ipv4_ipv6_required:
                 type: bool
                 description: IPv4 filter-id, IPv6 filter-id, Filter-id are required.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
@@ -129,7 +129,7 @@ keys:
                 description: Enable filters for IPv4 and IPv6 traffic.
               multiple:
                 type: bool
-                description: Multiple attribute
+                description: Multiple attribute.
       aaa:
         type: dict
         description: Configure AAA parameters.


### PR DESCRIPTION
## Change Summary

Configuration of dot1x global settings:
```
   radius av-pair filter-id multiple
   radius av-pair filter-id delimiter period
   radius av-pair filter-id ipv4 ipv6 required
   vlan assignment group <group name> members <vlan_id>
   vlan assignment group <group name> members <vlan_id>
   statistics packets dropped
```

## Related Issue(s)

Fixes #5146 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Adding to cli_config_gen_schema, and its j2 files.

## How to test
CI run

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
