### PR TITLE
Feat(eos_cli_config_gen): Added support for 802.1x phone ACL bypass

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3543,7 +3543,7 @@ ip security
 #### Switchport Defaults Summary
 
 - Default Switchport Mode: access
-- Default Switchport bypass phone traffic from configured access-list.
+- Default Switchport Phone Access-list Bypass: True
 - Default Switchport Phone COS: 0
 - Default Switchport Phone Trunk: tagged
 - Default Switchport Phone VLAN: 69

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3543,6 +3543,7 @@ ip security
 #### Switchport Defaults Summary
 
 - Default Switchport Mode: access
+- Default Switchport bypass phone traffic from configured access-list.
 - Default Switchport Phone COS: 0
 - Default Switchport Phone Trunk: tagged
 - Default Switchport Phone VLAN: 69
@@ -3552,6 +3553,8 @@ ip security
 ```eos
 !
 switchport default mode access
+!
+switchport default phone access-list bypass
 !
 switchport default phone cos 0
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -155,6 +155,8 @@ ip dhcp snooping vlan 10,20,500,1000-2000
 !
 switchport default mode access
 !
+switchport default phone access-list bypass
+!
 switchport default phone cos 0
 !
 switchport default phone vlan 69

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/switchport-default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/switchport-default.yml
@@ -7,3 +7,4 @@ switchport_default:
     cos: 0
     trunk: tagged
     vlan: 69
+    access_list_bypass: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/switchport-default.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/switchport-default.md
@@ -13,6 +13,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "switchport_default.phone.cos") | Integer |  |  | Min: 0<br>Max: 7 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk</samp>](## "switchport_default.phone.trunk") | String |  |  | Valid Values:<br>- <code>tagged</code><br>- <code>untagged</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "switchport_default.phone.vlan") | Integer |  |  | Min: 1<br>Max: 4094 | VLAN ID. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;access_list_bypass</samp>](## "switchport_default.phone.access_list_bypass") | Boolean |  |  |  | Bypass phone traffic from configured access-list. |
 
 === "YAML"
 
@@ -25,4 +26,7 @@
 
         # VLAN ID.
         vlan: <int; 1-4094>
+
+        # Bypass phone traffic from configured access-list.
+        access_list_bypass: <bool>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/switchport-default.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/switchport-default.j2
@@ -13,6 +13,9 @@
 {%     if switchport_default.mode is arista.avd.defined %}
 - Default Switchport Mode: {{ switchport_default.mode }}
 {%     endif %}
+{%     if switchport_default.phone.access_list_bypass is arista.avd.defined(true) %}
+- Default Switchport bypass phone traffic from configured access-list.
+{%     endif %}
 {%     if switchport_default.phone.cos is arista.avd.defined %}
 - Default Switchport Phone COS: {{ switchport_default.phone.cos }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/switchport-default.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/switchport-default.j2
@@ -14,7 +14,7 @@
 - Default Switchport Mode: {{ switchport_default.mode }}
 {%     endif %}
 {%     if switchport_default.phone.access_list_bypass is arista.avd.defined(true) %}
-- Default Switchport bypass phone traffic from configured access-list.
+- Default Switchport Phone Access-list Bypass: True
 {%     endif %}
 {%     if switchport_default.phone.cos is arista.avd.defined %}
 - Default Switchport Phone COS: {{ switchport_default.phone.cos }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/switchport-default.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/switchport-default.j2
@@ -12,6 +12,10 @@ switchport default mode routed
 switchport default mode access
 {% endif %}
 {# switchport default phone #}
+{% if switchport_default.phone.access_list_bypass is arista.avd.defined(true) %}
+!
+switchport default phone access-list bypass
+{% endif %}
 {% if switchport_default.phone.cos is arista.avd.defined %}
 !
 switchport default phone cos {{ switchport_default.phone.cos }}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -58301,11 +58301,13 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         class Phone(AvdModel):
             """Subclass of AvdModel."""
 
-            _fields: ClassVar[dict] = {"cos": {"type": int}, "trunk": {"type": str}, "vlan": {"type": int}}
+            _fields: ClassVar[dict] = {"cos": {"type": int}, "trunk": {"type": str}, "vlan": {"type": int}, "access_list_bypass": {"type": bool}}
             cos: int | None
             trunk: Literal["tagged", "untagged"] | None
             vlan: int | None
             """VLAN ID."""
+            access_list_bypass: bool | None
+            """Bypass phone traffic from configured access-list."""
 
             if TYPE_CHECKING:
 
@@ -58315,6 +58317,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     cos: int | None | UndefinedType = Undefined,
                     trunk: Literal["tagged", "untagged"] | None | UndefinedType = Undefined,
                     vlan: int | None | UndefinedType = Undefined,
+                    access_list_bypass: bool | None | UndefinedType = Undefined,
                 ) -> None:
                     """
                     Phone.
@@ -58326,6 +58329,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         cos: cos
                         trunk: trunk
                         vlan: VLAN ID.
+                        access_list_bypass: Bypass phone traffic from configured access-list.
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -21828,6 +21828,9 @@ keys:
             - str
             min: 1
             max: 4094
+          access_list_bypass:
+            description: Bypass phone traffic from configured access-list.
+            type: bool
   switchport_port_security:
     type: dict
     keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/switchport_default.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/switchport_default.schema.yml
@@ -31,3 +31,6 @@ keys:
               - str
             min: 1
             max: 4094
+          access_list_bypass:
+            description: Bypass phone traffic from configured access-list.
+            type: bool


### PR DESCRIPTION
## Change Summary

Added support for 802.1x phone ACL bypass

## Related Issue(s)

Fixes #4809 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added support for 802.1x phone ACL bypass

## How to test
Run Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
