### PR TITLE
Fix(eos_designs): Fix performance regression in port-profile caching

### DIFF
--- a/python-avd/pyavd/_eos_designs/shared_utils/utils.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/utils.py
@@ -3,7 +3,6 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from functools import lru_cache
 from typing import TYPE_CHECKING, Protocol
 
 from pyavd._errors import AristaAvdError, AristaAvdInvalidInputsError
@@ -29,6 +28,9 @@ class UtilsMixin(Protocol):
     Class should only be used as Mixin to the SharedUtils class.
     Using type-hint on self to get proper type-hints on attributes across all Mixins.
     """
+
+    resolved_port_profiles_cache: dict[str, EosDesigns.PortProfilesItem] | None = None
+    """Poor-mans cache to only resolve and deepmerge a port_profile once."""
 
     def get_peer_facts(self: SharedUtilsProtocol, peer_name: str, required: bool = True) -> EosDesignsFacts | dict | None:
         """
@@ -58,9 +60,19 @@ class UtilsMixin(Protocol):
             msg = f"Error during templating of template: {template_file}"
             raise AristaAvdError(msg) from e
 
-    @lru_cache  # noqa: B019
     def get_merged_port_profile(self: SharedUtilsProtocol, profile_name: str, context: str) -> EosDesigns.PortProfilesItem:
-        """Return list of merged "port_profiles" where "parent_profile" has been applied."""
+        """
+        Return list of merged "port_profiles" where "parent_profile" has been applied.
+
+        Leverages a dict of resolved profiles as a cache.
+        """
+        if self.resolved_port_profiles_cache and profile_name in self.resolved_port_profiles_cache:
+            return self.resolved_port_profiles_cache[profile_name]
+
+        return self.resolve_port_profile(profile_name, context)
+
+    def resolve_port_profile(self: SharedUtilsProtocol, profile_name: str, context: str) -> EosDesigns.PortProfilesItem:
+        """Resolve one port-profile and return it. Also updates the cache."""
         if profile_name not in self.inputs.port_profiles:
             msg = f"Profile '{profile_name}' applied under '{context}' does not exist in `port_profiles`."
             raise AristaAvdInvalidInputsError(msg)
@@ -77,6 +89,12 @@ class UtilsMixin(Protocol):
             port_profile = port_profile._deepinherited(parent_profile)
 
         delattr(port_profile, "parent_profile")
+
+        # Update the cache so we don't resolve again next time.
+        if self.resolved_port_profiles_cache is None:
+            self.resolved_port_profiles_cache = {}
+        self.resolved_port_profiles_cache[profile_name] = port_profile
+
         return port_profile
 
     def get_merged_adapter_settings(self: SharedUtilsProtocol, adapter_or_network_port_settings: ADAPTER_SETTINGS) -> ADAPTER_SETTINGS:

--- a/python-avd/pyavd/_eos_designs/shared_utils/utils.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/utils.py
@@ -69,7 +69,14 @@ class UtilsMixin(Protocol):
         if self.resolved_port_profiles_cache and profile_name in self.resolved_port_profiles_cache:
             return self.resolved_port_profiles_cache[profile_name]
 
-        return self.resolve_port_profile(profile_name, context)
+        resolved_profile = self.resolve_port_profile(profile_name, context)
+
+        # Update the cache so we don't resolve again next time.
+        if self.resolved_port_profiles_cache is None:
+            self.resolved_port_profiles_cache = {}
+        self.resolved_port_profiles_cache[profile_name] = resolved_profile
+
+        return resolved_profile
 
     def resolve_port_profile(self: SharedUtilsProtocol, profile_name: str, context: str) -> EosDesigns.PortProfilesItem:
         """Resolve one port-profile and return it. Also updates the cache."""
@@ -89,11 +96,6 @@ class UtilsMixin(Protocol):
             port_profile = port_profile._deepinherited(parent_profile)
 
         delattr(port_profile, "parent_profile")
-
-        # Update the cache so we don't resolve again next time.
-        if self.resolved_port_profiles_cache is None:
-            self.resolved_port_profiles_cache = {}
-        self.resolved_port_profiles_cache[profile_name] = port_profile
 
         return port_profile
 


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix(eos_designs): Fix performance regression in port-profile caching

## Related Issue(s)

Fix slower performance of facts in inventories containing many connected endpoints with port-profiles.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Remove lru_cache on class method
- Implement a manual cache of resolved profiles.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- No changes expected to outputs.
- Will be testing performance manually.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
