### PR TITLE
Feat(eos_cli_config_gen): Hardware forwarding id knob for loopbacks

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -5950,6 +5950,7 @@ interface Loopback100
    description TENANT_A_PROJECT02_VTEP_DIAGNOSTICS
    vrf TENANT_A_PROJECT02
    ip address 10.1.255.3/32
+   hardware forwarding id
 ```
 
 ### Tunnel Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -3455,6 +3455,7 @@ interface Loopback100
    description TENANT_A_PROJECT02_VTEP_DIAGNOSTICS
    vrf TENANT_A_PROJECT02
    ip address 10.1.255.3/32
+   hardware forwarding id
 !
 interface Management0
    mac-address 00:1c:73:00:00:aa

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/loopbacks-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/loopbacks-interfaces.yml
@@ -22,6 +22,7 @@ loopback_interfaces:
     description: TENANT_A_PROJECT02_VTEP_DIAGNOSTICS
     vrf: TENANT_A_PROJECT02
     ip_address: 10.1.255.3/32
+    hardware_forwarding_id: true
 
   - name: Loopback99
     description: TENANT_A_PROJECT02_VTEP_DIAGNOSTICS

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/loopback-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/loopback-interfaces.md
@@ -30,7 +30,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;node_segment</samp>](## "loopback_interfaces.[].node_segment") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_index</samp>](## "loopback_interfaces.[].node_segment.ipv4_index") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_index</samp>](## "loopback_interfaces.[].node_segment.ipv6_index") | Integer |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_forwarding_id</samp>](## "loopback_interfaces.[].hardware_forwarding_id") | Boolean |  |  |  | Enable hardware forwarding for the VRF where this loopback inteface belongs. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_forwarding_id</samp>](## "loopback_interfaces.[].hardware_forwarding_id") | Boolean |  |  |  | Enable hardware forwarding for the VRF where this loopback interface belongs. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "loopback_interfaces.[].eos_cli") | String |  |  |  | EOS CLI rendered directly on the loopback interface in the final EOS configuration. |
 
 === "YAML"
@@ -74,7 +74,7 @@
           ipv4_index: <int>
           ipv6_index: <int>
 
-        # Enable hardware forwarding for the VRF where this loopback inteface belongs.
+        # Enable hardware forwarding for the VRF where this loopback interface belongs.
         hardware_forwarding_id: <bool>
 
         # EOS CLI rendered directly on the loopback interface in the final EOS configuration.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/loopback-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/loopback-interfaces.md
@@ -30,6 +30,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;node_segment</samp>](## "loopback_interfaces.[].node_segment") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_index</samp>](## "loopback_interfaces.[].node_segment.ipv4_index") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_index</samp>](## "loopback_interfaces.[].node_segment.ipv6_index") | Integer |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_forwarding_id</samp>](## "loopback_interfaces.[].hardware_forwarding_id") | Boolean |  |  |  | Enable hardware forwarding for the interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "loopback_interfaces.[].eos_cli") | String |  |  |  | EOS CLI rendered directly on the loopback interface in the final EOS configuration. |
 
 === "YAML"
@@ -72,6 +73,9 @@
         node_segment:
           ipv4_index: <int>
           ipv6_index: <int>
+
+        # Enable hardware forwarding for the interface.
+        hardware_forwarding_id: <bool>
 
         # EOS CLI rendered directly on the loopback interface in the final EOS configuration.
         eos_cli: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/loopback-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/loopback-interfaces.md
@@ -30,7 +30,6 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;node_segment</samp>](## "loopback_interfaces.[].node_segment") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_index</samp>](## "loopback_interfaces.[].node_segment.ipv4_index") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_index</samp>](## "loopback_interfaces.[].node_segment.ipv6_index") | Integer |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_forwarding_id</samp>](## "loopback_interfaces.[].hardware_forwarding_id") | Boolean |  |  |  | Enable hardware forwarding for the interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "loopback_interfaces.[].eos_cli") | String |  |  |  | EOS CLI rendered directly on the loopback interface in the final EOS configuration. |
 
 === "YAML"
@@ -73,9 +72,6 @@
         node_segment:
           ipv4_index: <int>
           ipv6_index: <int>
-
-        # Enable hardware forwarding for the interface.
-        hardware_forwarding_id: <bool>
 
         # EOS CLI rendered directly on the loopback interface in the final EOS configuration.
         eos_cli: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/loopback-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/loopback-interfaces.md
@@ -30,7 +30,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;node_segment</samp>](## "loopback_interfaces.[].node_segment") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_index</samp>](## "loopback_interfaces.[].node_segment.ipv4_index") | Integer |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_index</samp>](## "loopback_interfaces.[].node_segment.ipv6_index") | Integer |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_forwarding_id</samp>](## "loopback_interfaces.[].hardware_forwarding_id") | Boolean |  |  |  | Enable hardware forwarding for the interface. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;hardware_forwarding_id</samp>](## "loopback_interfaces.[].hardware_forwarding_id") | Boolean |  |  |  | Enable hardware forwarding for the VRF where this loopback inteface belongs. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;eos_cli</samp>](## "loopback_interfaces.[].eos_cli") | String |  |  |  | EOS CLI rendered directly on the loopback interface in the final EOS configuration. |
 
 === "YAML"
@@ -74,7 +74,7 @@
           ipv4_index: <int>
           ipv6_index: <int>
 
-        # Enable hardware forwarding for the interface.
+        # Enable hardware forwarding for the VRF where this loopback inteface belongs.
         hardware_forwarding_id: <bool>
 
         # EOS CLI rendered directly on the loopback interface in the final EOS configuration.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/loopback-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/loopback-interfaces.j2
@@ -38,6 +38,9 @@ interface {{ loopback_interface.name }}
 {%     elif loopback_interface.mpls.ldp.interface is arista.avd.defined(false) %}
    no mpls ldp interface
 {%     endif %}
+{%     if loopback_interface.hardware_forwarding_id is arista.avd.defined(true) %}
+   hardware forwarding id
+{%     endif %}
 {%     if loopback_interface.ospf_area is arista.avd.defined %}
    ip ospf area {{ loopback_interface.ospf_area }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -17633,6 +17633,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "isis_metric": {"type": int},
             "isis_network_point_to_point": {"type": bool},
             "node_segment": {"type": NodeSegment},
+            "hardware_forwarding_id": {"type": bool},
             "eos_cli": {"type": str},
         }
         name: str
@@ -17661,6 +17662,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         isis_network_point_to_point: bool | None
         node_segment: NodeSegment
         """Subclass of AvdModel."""
+        hardware_forwarding_id: bool | None
+        """Enable hardware forwarding for the interface."""
         eos_cli: str | None
         """EOS CLI rendered directly on the loopback interface in the final EOS configuration."""
 
@@ -17686,6 +17689,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 isis_metric: int | None | UndefinedType = Undefined,
                 isis_network_point_to_point: bool | None | UndefinedType = Undefined,
                 node_segment: NodeSegment | UndefinedType = Undefined,
+                hardware_forwarding_id: bool | None | UndefinedType = Undefined,
                 eos_cli: str | None | UndefinedType = Undefined,
             ) -> None:
                 """
@@ -17712,6 +17716,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     isis_metric: isis_metric
                     isis_network_point_to_point: isis_network_point_to_point
                     node_segment: Subclass of AvdModel.
+                    hardware_forwarding_id: Enable hardware forwarding for the interface.
                     eos_cli: EOS CLI rendered directly on the loopback interface in the final EOS configuration.
 
                 """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -17663,7 +17663,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         node_segment: NodeSegment
         """Subclass of AvdModel."""
         hardware_forwarding_id: bool | None
-        """Enable hardware forwarding for the VRF where this loopback inteface belongs."""
+        """Enable hardware forwarding for the VRF where this loopback interface belongs."""
         eos_cli: str | None
         """EOS CLI rendered directly on the loopback interface in the final EOS configuration."""
 
@@ -17716,7 +17716,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     isis_metric: isis_metric
                     isis_network_point_to_point: isis_network_point_to_point
                     node_segment: Subclass of AvdModel.
-                    hardware_forwarding_id: Enable hardware forwarding for the VRF where this loopback inteface belongs.
+                    hardware_forwarding_id: Enable hardware forwarding for the VRF where this loopback interface belongs.
                     eos_cli: EOS CLI rendered directly on the loopback interface in the final EOS configuration.
 
                 """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -17663,7 +17663,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         node_segment: NodeSegment
         """Subclass of AvdModel."""
         hardware_forwarding_id: bool | None
-        """Enable hardware forwarding for the interface."""
+        """Enable hardware forwarding for the VRF where this loopback inteface belongs."""
         eos_cli: str | None
         """EOS CLI rendered directly on the loopback interface in the final EOS configuration."""
 
@@ -17716,7 +17716,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     isis_metric: isis_metric
                     isis_network_point_to_point: isis_network_point_to_point
                     node_segment: Subclass of AvdModel.
-                    hardware_forwarding_id: Enable hardware forwarding for the interface.
+                    hardware_forwarding_id: Enable hardware forwarding for the VRF where this loopback inteface belongs.
                     eos_cli: EOS CLI rendered directly on the loopback interface in the final EOS configuration.
 
                 """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7056,7 +7056,7 @@ keys:
         hardware_forwarding_id:
           type: bool
           description: Enable hardware forwarding for the VRF where this loopback
-            inteface belongs.
+            interface belongs.
         eos_cli:
           type: str
           description: EOS CLI rendered directly on the loopback interface in the

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7053,6 +7053,9 @@ keys:
               type: int
               convert_types:
               - str
+        hardware_forwarding_id:
+          type: bool
+          description: Enable hardware forwarding for the interface.
         eos_cli:
           type: str
           description: EOS CLI rendered directly on the loopback interface in the

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7055,7 +7055,8 @@ keys:
               - str
         hardware_forwarding_id:
           type: bool
-          description: Enable hardware forwarding for the interface.
+          description: Enable hardware forwarding for the VRF where this loopback
+            inteface belongs.
         eos_cli:
           type: str
           description: EOS CLI rendered directly on the loopback interface in the

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/loopback_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/loopback_interfaces.schema.yml
@@ -78,7 +78,7 @@ keys:
                 - str
         hardware_forwarding_id:
           type: bool
-          description: Enable hardware forwarding for the interface.
+          description: Enable hardware forwarding for the VRF where this loopback inteface belongs.
         eos_cli:
           type: str
           description: EOS CLI rendered directly on the loopback interface in the final EOS configuration.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/loopback_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/loopback_interfaces.schema.yml
@@ -78,7 +78,7 @@ keys:
                 - str
         hardware_forwarding_id:
           type: bool
-          description: Enable hardware forwarding for the VRF where this loopback inteface belongs.
+          description: Enable hardware forwarding for the VRF where this loopback interface belongs.
         eos_cli:
           type: str
           description: EOS CLI rendered directly on the loopback interface in the final EOS configuration.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/loopback_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/loopback_interfaces.schema.yml
@@ -76,6 +76,9 @@ keys:
               type: int
               convert_types:
                 - str
+        hardware_forwarding_id:
+          type: bool
+          description: Enable hardware forwarding for the interface.
         eos_cli:
           type: str
           description: EOS CLI rendered directly on the loopback interface in the final EOS configuration.


### PR DESCRIPTION
## Change Summary

Adds hardware forwarding id knob for loopbacks. Loopbacks in VRFs that don't have any physical interfaces do not properly forward frames unless this config is present.

## Related Issue(s)

SP Enhancements

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```yaml
loopback_interfaces:
  - name: loopback0
    ...
    hardware_forwarding_id: true
```

## How to test
Tested with molecule, checked config order on device.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
