### PR TITLE
Feat(eos_cli_config_gen): Support for configuring dhcp server ipv4 and ipv6 for Vlan interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -6566,6 +6566,8 @@ interface Vlan2002
    no autostate
    vrf Tenant_B
    ip verify unicast source reachable-via rx
+   dhcp server ipv4
+   dhcp server ipv6
    isis enable EVPN_UNDERLAY
    isis bfd
    isis authentication mode md5 rx-disabled

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -1865,6 +1865,7 @@ dhcp server vrf VRF01
 | -------------- | --------- | --------- |
 | Ethernet64 | True | True |
 | Port-Channel112 | True | True |
+| Vlan2002 | True | True |
 
 ## System Boot Settings
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -3878,6 +3878,8 @@ interface Vlan2002
    no autostate
    vrf Tenant_B
    ip verify unicast source reachable-via rx
+   dhcp server ipv4
+   dhcp server ipv6
    isis enable EVPN_UNDERLAY
    isis bfd
    isis authentication mode md5 rx-disabled

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
@@ -19,6 +19,8 @@ vlan_interfaces:
     ip_address_virtual: 10.2.2.1/24
     no_autostate: true
     isis_enable: "EVPN_UNDERLAY"
+    dhcp_server_ipv4: true
+    dhcp_server_ipv6: true
     isis_bfd: true
     ip_verify_unicast_source_reachable_via: rx
     # Test isis authentication both md5 rx
@@ -44,6 +46,8 @@ vlan_interfaces:
     vrf: Tenant_C
     ip_address_virtual: 10.10.81.1/24
     ipv6_enable: true
+    dhcp_server_ipv4: false
+    dhcp_server_ipv6: false
     ipv6_address_virtuals:
       - fc00:10:10:81::1/64
       - fc00:10:11:81::1/64

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -85,6 +85,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;protocol</samp>](## "vlan_interfaces.[].ip_nat.source.static.[].protocol") | String |  |  | Valid Values:<br>- <code>udp</code><br>- <code>tcp</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;translated_ip</samp>](## "vlan_interfaces.[].ip_nat.source.static.[].translated_ip") | String | Required |  |  | IPv4 address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;translated_port</samp>](## "vlan_interfaces.[].ip_nat.source.static.[].translated_port") | Integer |  |  | Min: 1<br>Max: 65535 | requires 'original_port'. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv4</samp>](## "vlan_interfaces.[].dhcp_server_ipv4") | Boolean |  |  |  | Enable IPv4 DHCP server. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;dhcp_server_ipv6</samp>](## "vlan_interfaces.[].dhcp_server_ipv6") | Boolean |  |  |  | Enable IPv6 DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_enable</samp>](## "vlan_interfaces.[].ipv6_enable") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address</samp>](## "vlan_interfaces.[].ipv6_address") | String |  |  |  | IPv6_address/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_address_virtuals</samp>](## "vlan_interfaces.[].ipv6_address_virtuals") | List, items: String |  |  |  | The new "ipv6_address_virtuals" key support multiple virtual ipv6 addresses. |
@@ -406,6 +408,12 @@
 
                 # requires 'original_port'.
                 translated_port: <int; 1-65535>
+
+        # Enable IPv4 DHCP server.
+        dhcp_server_ipv4: <bool>
+
+        # Enable IPv6 DHCP server.
+        dhcp_server_ipv6: <bool>
         ipv6_enable: <bool>
 
         # IPv6_address/Mask.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -147,8 +147,8 @@
 {%         for port_channel_interface in port_channel_interfaces_dhcp_server | arista.avd.natural_sort %}
 | {{ port_channel_interface.name }} | {{ port_channel_interface.dhcp_server_ipv4 | arista.avd.default("-") }} | {{ port_channel_interface.dhcp_server_ipv6 | arista.avd.default("-") }} |
 {%         endfor %}
-{%         for vlan_interfaces in vlan_interfaces_dhcp_server | arista.avd.natural_sort %}
-| {{ vlan_interfaces.name }} | {{ vlan_interfaces.dhcp_server_ipv4 | arista.avd.default("-") }} | {{ vlan_interfaces.dhcp_server_ipv6 | arista.avd.default("-") }} |
+{%         for vlan_interface in vlan_interfaces_dhcp_server | arista.avd.natural_sort %}
+| {{ vlan_interface.name }} | {{ vlan_interface.dhcp_server_ipv4 | arista.avd.default("-") }} | {{ vlan_interface.dhcp_server_ipv6 | arista.avd.default("-") }} |
 {%         endfor %}
 {%     endif %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -6,6 +6,7 @@
 {# doc - dhcp server #}
 {% set ethernet_interfaces_dhcp_server = [] %}
 {% set port_channel_interfaces_dhcp_server = [] %}
+{% set vlan_interfaces_dhcp_server = [] %}
 {% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
 {%     if ethernet_interface.dhcp_server_ipv4 is arista.avd.defined(true) or ethernet_interface.dhcp_server_ipv6 is arista.avd.defined(true) %}
 {%         do ethernet_interfaces_dhcp_server.append(ethernet_interface) %}
@@ -14,6 +15,11 @@
 {% for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort('name') %}
 {%     if port_channel_interface.dhcp_server_ipv4 is arista.avd.defined(true) or port_channel_interfaces.dhcp_server_ipv6 is arista.avd.defined(true) %}
 {%         do port_channel_interfaces_dhcp_server.append(port_channel_interface) %}
+{%     endif %}
+{% endfor %}
+{% for vlan_interface in vlan_interfaces | arista.avd.natural_sort('name') %}
+{%     if vlan_interface.dhcp_server_ipv4 is arista.avd.defined(true) or vlan_interface.dhcp_server_ipv6 is arista.avd.defined(true) %}
+{%         do vlan_interfaces_dhcp_server.append(vlan_interface) %}
 {%     endif %}
 {% endfor %}
 {% if (ethernet_interfaces_dhcp_server | length > 0 or port_channel_interfaces_dhcp_server | length > 0 or dhcp_servers is arista.avd.defined) %}
@@ -129,7 +135,7 @@
 {%         include 'eos/dhcp-servers.j2' %}
 ```
 {%     endif %}
-{%     if ethernet_interfaces_dhcp_server | length > 0 or port_channel_interfaces_dhcp_server | length > 0 %}
+{%     if ethernet_interfaces_dhcp_server | length > 0 or port_channel_interfaces_dhcp_server | length > 0 or vlan_interfaces_dhcp_server | length > 0 %}
 
 ### DHCP Server Interfaces
 
@@ -140,6 +146,9 @@
 {%         endfor %}
 {%         for port_channel_interface in port_channel_interfaces_dhcp_server | arista.avd.natural_sort %}
 | {{ port_channel_interface.name }} | {{ port_channel_interface.dhcp_server_ipv4 | arista.avd.default("-") }} | {{ port_channel_interface.dhcp_server_ipv6 | arista.avd.default("-") }} |
+{%         endfor %}
+{%         for vlan_interfaces in vlan_interfaces_dhcp_server | arista.avd.natural_sort %}
+| {{ vlan_interfaces.name }} | {{ vlan_interfaces.dhcp_server_ipv4 | arista.avd.default("-") }} | {{ vlan_interfaces.dhcp_server_ipv6 | arista.avd.default("-") }} |
 {%         endfor %}
 {%     endif %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/dhcp-servers.j2
@@ -7,17 +7,17 @@
 {% set ethernet_interfaces_dhcp_server = [] %}
 {% set port_channel_interfaces_dhcp_server = [] %}
 {% set vlan_interfaces_dhcp_server = [] %}
-{% for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
+{% for ethernet_interface in ethernet_interfaces | arista.avd.default([]) %}
 {%     if ethernet_interface.dhcp_server_ipv4 is arista.avd.defined(true) or ethernet_interface.dhcp_server_ipv6 is arista.avd.defined(true) %}
 {%         do ethernet_interfaces_dhcp_server.append(ethernet_interface) %}
 {%     endif %}
 {% endfor %}
-{% for port_channel_interface in port_channel_interfaces | arista.avd.natural_sort('name') %}
+{% for port_channel_interface in port_channel_interfaces | arista.avd.default([]) %}
 {%     if port_channel_interface.dhcp_server_ipv4 is arista.avd.defined(true) or port_channel_interfaces.dhcp_server_ipv6 is arista.avd.defined(true) %}
 {%         do port_channel_interfaces_dhcp_server.append(port_channel_interface) %}
 {%     endif %}
 {% endfor %}
-{% for vlan_interface in vlan_interfaces | arista.avd.natural_sort('name') %}
+{% for vlan_interface in vlan_interfaces | arista.avd.default([]) %}
 {%     if vlan_interface.dhcp_server_ipv4 is arista.avd.defined(true) or vlan_interface.dhcp_server_ipv6 is arista.avd.defined(true) %}
 {%         do vlan_interfaces_dhcp_server.append(vlan_interface) %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -116,6 +116,12 @@ interface {{ vlan_interface.name }}
 {%         endif %}
    {{ destination_cli }}
 {%     endfor %}
+{%     if vlan_interface.dhcp_server_ipv4 is arista.avd.defined(true) %}
+   dhcp server ipv4
+{%     endif %}
+{%     if vlan_interface.dhcp_server_ipv6 is arista.avd.defined(true) %}
+   dhcp server ipv6
+{%     endif %}
 {%     if vlan_interface.ip_attached_host_route_export.enabled is arista.avd.defined(true) %}
 {%         set ip_attached_host_route_export_cli = "ip attached-host route export" %}
 {%         if vlan_interface.ip_attached_host_route_export.distance is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -62033,6 +62033,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "ip_helpers": {"type": IpHelpers},
             "ip_dhcp_relay_all_subnets": {"type": bool},
             "ip_nat": {"type": IpNat},
+            "dhcp_server_ipv4": {"type": bool},
+            "dhcp_server_ipv6": {"type": bool},
             "ipv6_enable": {"type": bool},
             "ipv6_address": {"type": str},
             "ipv6_address_virtuals": {"type": Ipv6AddressVirtuals},
@@ -62117,6 +62119,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Allow forwarding requests with secondary IP addresses in the gateway address "giaddr" field."""
         ip_nat: IpNat
         """Subclass of AvdModel."""
+        dhcp_server_ipv4: bool | None
+        """Enable IPv4 DHCP server."""
+        dhcp_server_ipv6: bool | None
+        """Enable IPv6 DHCP server."""
         ipv6_enable: bool | None
         ipv6_address: str | None
         """IPv6_address/Mask."""
@@ -62249,6 +62255,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 ip_helpers: IpHelpers | UndefinedType = Undefined,
                 ip_dhcp_relay_all_subnets: bool | None | UndefinedType = Undefined,
                 ip_nat: IpNat | UndefinedType = Undefined,
+                dhcp_server_ipv4: bool | None | UndefinedType = Undefined,
+                dhcp_server_ipv6: bool | None | UndefinedType = Undefined,
                 ipv6_enable: bool | None | UndefinedType = Undefined,
                 ipv6_address: str | None | UndefinedType = Undefined,
                 ipv6_address_virtuals: Ipv6AddressVirtuals | UndefinedType = Undefined,
@@ -62326,6 +62334,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        `ip_helper` (`str`).
                     ip_dhcp_relay_all_subnets: Allow forwarding requests with secondary IP addresses in the gateway address "giaddr" field.
                     ip_nat: Subclass of AvdModel.
+                    dhcp_server_ipv4: Enable IPv4 DHCP server.
+                    dhcp_server_ipv6: Enable IPv6 DHCP server.
                     ipv6_enable: ipv6_enable
                     ipv6_address: IPv6_address/Mask.
                     ipv6_address_virtuals:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -22621,6 +22621,12 @@ keys:
         ip_nat:
           type: dict
           $ref: eos_cli_config_gen#/$defs/interface_ip_nat
+        dhcp_server_ipv4:
+          type: bool
+          description: Enable IPv4 DHCP server.
+        dhcp_server_ipv6:
+          type: bool
+          description: Enable IPv6 DHCP server.
         ipv6_enable:
           type: bool
         ipv6_address:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -166,6 +166,12 @@ keys:
         ip_nat:
           type: dict
           $ref: "eos_cli_config_gen#/$defs/interface_ip_nat"
+        dhcp_server_ipv4:
+          type: bool
+          description: Enable IPv4 DHCP server.
+        dhcp_server_ipv6:
+          type: bool
+          description: Enable IPv6 DHCP server.
         ipv6_enable:
           type: bool
         ipv6_address:


### PR DESCRIPTION
## Change Summary

Adding support for configuring dhcp server ipv4 and dhcp server ipv6 for Vlan interfaces

## Related Issue(s)

Fixes #5086 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
vlan_interfaces:
  - name: <str; required; unique>

    # Enable IPv4 DHCP server.
    dhcp_server_ipv4: <bool>

    # Enable IPv6 DHCP server.
    dhcp_server_ipv6: <bool>

## How to test
CI

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
