### PR TITLE
Feat(eos_cli_config_gen): Support microsecond unit for qos_profiles threshold

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/qos-profiles.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/qos-profiles.md
@@ -29,7 +29,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ecn</samp>](## "qos_profiles.[].tx_queues.[].random_detect.ecn") | Dictionary |  |  |  | Explicit Congestion Notification. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;count</samp>](## "qos_profiles.[].tx_queues.[].random_detect.ecn.count") | Boolean |  |  |  | Enable counter for random-detect ECNs. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;threshold</samp>](## "qos_profiles.[].tx_queues.[].random_detect.ecn.threshold") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;units</samp>](## "qos_profiles.[].tx_queues.[].random_detect.ecn.threshold.units") | String | Required |  | Valid Values:<br>- <code>segments</code><br>- <code>bytes</code><br>- <code>kbytes</code><br>- <code>mbytes</code><br>- <code>milliseconds</code> | Units to be used for the threshold values.<br>This should be one of segments, byte, kbytes, mbytes. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;units</samp>](## "qos_profiles.[].tx_queues.[].random_detect.ecn.threshold.units") | String | Required |  | Valid Values:<br>- <code>segments</code><br>- <code>bytes</code><br>- <code>kbytes</code><br>- <code>mbytes</code><br>- <code>milliseconds</code><br>- <code>microseconds</code> | Units to be used for the threshold values. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;min</samp>](## "qos_profiles.[].tx_queues.[].random_detect.ecn.threshold.min") | Integer | Required |  | Min: 1 | Random-detect ECN minimum-threshold. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;max</samp>](## "qos_profiles.[].tx_queues.[].random_detect.ecn.threshold.max") | Integer | Required |  | Min: 1 | Random-detect ECN maximum-threshold. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;max_probability</samp>](## "qos_profiles.[].tx_queues.[].random_detect.ecn.threshold.max_probability") | Integer |  |  | Min: 1<br>Max: 100 | Random-detect ECN maximum mark probability. |
@@ -134,8 +134,7 @@
                 threshold:
 
                   # Units to be used for the threshold values.
-                  # This should be one of segments, byte, kbytes, mbytes.
-                  units: <str; "segments" | "bytes" | "kbytes" | "mbytes" | "milliseconds"; required>
+                  units: <str; "segments" | "bytes" | "kbytes" | "mbytes" | "milliseconds" | "microseconds"; required>
 
                   # Random-detect ECN minimum-threshold.
                   min: <int; >=1; required>

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -31525,11 +31525,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             "max_probability": {"type": int},
                             "weight": {"type": int},
                         }
-                        units: Literal["segments", "bytes", "kbytes", "mbytes", "milliseconds"]
-                        """
-                        Units to be used for the threshold values.
-                        This should be one of segments, byte, kbytes, mbytes.
-                        """
+                        units: Literal["segments", "bytes", "kbytes", "mbytes", "milliseconds", "microseconds"]
+                        """Units to be used for the threshold values."""
                         min: int
                         """Random-detect ECN minimum-threshold."""
                         max: int
@@ -31544,7 +31541,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             def __init__(
                                 self,
                                 *,
-                                units: Literal["segments", "bytes", "kbytes", "mbytes", "milliseconds"] | UndefinedType = Undefined,
+                                units: Literal["segments", "bytes", "kbytes", "mbytes", "milliseconds", "microseconds"] | UndefinedType = Undefined,
                                 min: int | UndefinedType = Undefined,
                                 max: int | UndefinedType = Undefined,
                                 max_probability: int | None | UndefinedType = Undefined,
@@ -31557,9 +31554,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    units:
-                                       Units to be used for the threshold values.
-                                       This should be one of segments, byte, kbytes, mbytes.
+                                    units: Units to be used for the threshold values.
                                     min: Random-detect ECN minimum-threshold.
                                     max: Random-detect ECN maximum-threshold.
                                     max_probability: Random-detect ECN maximum mark probability.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -12236,9 +12236,8 @@ keys:
                             - kbytes
                             - mbytes
                             - milliseconds
-                            description: 'Units to be used for the threshold values.
-
-                              This should be one of segments, byte, kbytes, mbytes.'
+                            - microseconds
+                            description: Units to be used for the threshold values.
                           min:
                             type: int
                             required: true

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/qos_profiles.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/qos_profiles.schema.yml
@@ -92,10 +92,8 @@ keys:
                           units:
                             required: true
                             type: str
-                            valid_values: ["segments", "bytes", "kbytes", "mbytes", "milliseconds"]
-                            description: |-
-                              Units to be used for the threshold values.
-                              This should be one of segments, byte, kbytes, mbytes.
+                            valid_values: ["segments", "bytes", "kbytes", "mbytes", "milliseconds", "microseconds"]
+                            description: Units to be used for the threshold values.
                           min:
                             type: int
                             required: true


### PR DESCRIPTION
## Change Summary

Support microsecond unit for qos_profiles threshold

## Related Issue(s)

Fixes #4900

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Support microsecond unit for qos_profiles:tx_queues:random_detect_:ecn:thresholds:units. This is required for AI designs

AVD currently only support below:
threshold:

```
          # Units to be used for the threshold values.
          # This should be one of segments, byte, kbytes, mbytes.
          units: <str; "segments" | "bytes" | "kbytes" | "mbytes" | "milliseconds"; required>
```
On DCS-7280SRA-48C6 running 4.30.3M (Jericho)
PS-VAN1-Spine-2(config-qos-profile-RDMA-QOS-PROFILE-txq-3)#random-detect ecn minimum-threshold 10 ?
bytes Set threshold in bytes
kbytes Set threshold in kbytes
mbytes Set threshold in mbytes
microseconds Set threshold in microseconds
milliseconds Set threshold in milliseconds

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
