### PR TITLE
Feat(eos_cli_config_gen): Add 'replay protection' support in MacSec profiles

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11881,11 +11881,13 @@ mac security
    profile A2
       key 1234b 7 <removed>
       traffic unprotected allow active-sak
+      replay protection disabled
    !
    profile A3
       cipher aes256-gcm-xpn
       key ab 7 <removed>
       traffic unprotected drop
+      replay protection window 20000
 ```
 
 ### Traffic Policies information

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11837,7 +11837,7 @@ FIPS restrictions enabled.
 
 | Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback | Replay Protection Disabled | Replay Protection Window |
 | ------ | ------------------- | ------------ | --- | ---------------------------- | -------------------------- | ------------------------ |
-| - | - | - | - | allow active-sak | - | - |
+| - | - | - | - | allow active-sak | True | - |
 
 ###### Keys
 
@@ -11851,7 +11851,7 @@ FIPS restrictions enabled.
 
 | Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback | Replay Protection Disabled | Replay Protection Window |
 | ------ | ------------------- | ------------ | --- | ---------------------------- | -------------------------- | ------------------------ |
-| aes256-gcm-xpn | - | - | - | drop | - | - |
+| aes256-gcm-xpn | - | - | - | drop | - | 20000 |
 
 ###### Keys
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11813,9 +11813,9 @@ FIPS restrictions enabled.
 
 ###### Settings
 
-| Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback |
-| ------ | ------------------- | ------------ | --- | ---------------------------- |
-| aes128-gcm | 100 | 30 | True | allow |
+| Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback | Replay Protection Disabled | Replay Protection Window |
+| ------ | ------------------- | ------------ | --- | ---------------------------- | -------------------------- | ------------------------ |
+| aes128-gcm | 100 | 30 | True | allow | - | - |
 
 ###### Keys
 
@@ -11835,9 +11835,9 @@ FIPS restrictions enabled.
 
 ###### Settings
 
-| Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback |
-| ------ | ------------------- | ------------ | --- | ---------------------------- |
-| - | - | - | - | allow active-sak |
+| Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback | Replay Protection Disabled | Replay Protection Window |
+| ------ | ------------------- | ------------ | --- | ---------------------------- | -------------------------- | ------------------------ |
+| - | - | - | - | allow active-sak | - | - |
 
 ###### Keys
 
@@ -11849,9 +11849,9 @@ FIPS restrictions enabled.
 
 ###### Settings
 
-| Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback |
-| ------ | ------------------- | ------------ | --- | ---------------------------- |
-| aes256-gcm-xpn | - | - | - | drop |
+| Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback | Replay Protection Disabled | Replay Protection Window |
+| ------ | ------------------- | ------------ | --- | ---------------------------- | -------------------------- | ------------------------ |
+| aes256-gcm-xpn | - | - | - | drop | - | - |
 
 ###### Keys
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1722,11 +1722,13 @@ mac security
    profile A2
       key 1234b 7 12485744465E5A53
       traffic unprotected allow active-sak
+      replay protection disabled
    !
    profile A3
       cipher aes256-gcm-xpn
       key ab 7 10195F4C5144405A
       traffic unprotected drop
+      replay protection window 20000
 !
 interface Port-Channel3
    description MLAG_PEER_DC1-LEAF1B_Po3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/mac-security-eth-po-entropy.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/mac-security-eth-po-entropy.yml
@@ -32,6 +32,8 @@ mac_security:
       traffic_unprotected:
         action: allow
         allow_active_sak: true
+      replay_protection:
+        disabled: true
     - name: A3
       cipher: aes256-gcm-xpn
       connection_keys:
@@ -40,3 +42,5 @@ mac_security:
           fallback: false
       traffic_unprotected:
         action: drop
+      replay_protection:
+        window: 20000

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-security.md
@@ -33,8 +33,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "mac_security.profiles.[].traffic_unprotected.action") | String | Required |  | Valid Values:<br>- <code>allow</code><br>- <code>drop</code> | Allow/drop the transmit/receive of unprotected traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allow_active_sak</samp>](## "mac_security.profiles.[].traffic_unprotected.allow_active_sak") | Boolean |  |  |  | Allow transmit/receive of encrypted traffic using operational SAK and block otherwise. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;replay_protection</samp>](## "mac_security.profiles.[].replay_protection") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disabled</samp>](## "mac_security.profiles.[].replay_protection.disabled") | Boolean |  |  |  | Disable replay protection |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window</samp>](## "mac_security.profiles.[].replay_protection.window") | Integer |  |  | Min: 0<br>Max: 4294967295 | Set replay protection window size |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disabled</samp>](## "mac_security.profiles.[].replay_protection.disabled") | Boolean |  |  |  | Disable replay protection. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window</samp>](## "mac_security.profiles.[].replay_protection.window") | Integer |  |  | Min: 0<br>Max: 4294967295 | Set replay protection window size. |
 
 === "YAML"
 
@@ -74,9 +74,9 @@
             allow_active_sak: <bool>
           replay_protection:
 
-            # Disable replay protection
+            # Disable replay protection.
             disabled: <bool>
 
-            # Set replay protection window size
+            # Set replay protection window size.
             window: <int; 0-4294967295>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-security.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-security.md
@@ -32,6 +32,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;traffic_unprotected</samp>](## "mac_security.profiles.[].traffic_unprotected") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;action</samp>](## "mac_security.profiles.[].traffic_unprotected.action") | String | Required |  | Valid Values:<br>- <code>allow</code><br>- <code>drop</code> | Allow/drop the transmit/receive of unprotected traffic. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;allow_active_sak</samp>](## "mac_security.profiles.[].traffic_unprotected.allow_active_sak") | Boolean |  |  |  | Allow transmit/receive of encrypted traffic using operational SAK and block otherwise. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;replay_protection</samp>](## "mac_security.profiles.[].replay_protection") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;disabled</samp>](## "mac_security.profiles.[].replay_protection.disabled") | Boolean |  |  |  | Disable replay protection |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window</samp>](## "mac_security.profiles.[].replay_protection.window") | Integer |  |  | Min: 0<br>Max: 4294967295 | Set replay protection window size |
 
 === "YAML"
 
@@ -69,4 +72,11 @@
 
             # Allow transmit/receive of encrypted traffic using operational SAK and block otherwise.
             allow_active_sak: <bool>
+          replay_protection:
+
+            # Disable replay protection
+            disabled: <bool>
+
+            # Set replay protection window size
+            window: <int; 0-4294967295>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mac-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mac-security.j2
@@ -28,8 +28,8 @@ FIPS restrictions enabled.
 
 ###### Settings
 
-| Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback |
-| ------ | ------------------- | ------------ | --- | ---------------------------- |
+| Cipher | Key-Server Priority | Rekey-Period | SCI | Traffic Unprotected Fallback | Replay Protection Disabled | Replay Protection Window |
+| ------ | ------------------- | ------------ | --- | ---------------------------- | -------------------------- | ------------------------ |
 {%             set cipher = profile.cipher | arista.avd.default('-') %}
 {%             set key_server_priority = profile.mka.key_server_priority | arista.avd.default('-') %}
 {%             set rekey_period = profile.mka.session.rekey_period | arista.avd.default('-') %}
@@ -38,7 +38,9 @@ FIPS restrictions enabled.
 {%             if traffic_unprotected == "allow" and profile.traffic_unprotected.allow_active_sak is arista.avd.defined(true) %}
 {%                 set traffic_unprotected = traffic_unprotected ~ " active-sak" %}
 {%             endif %}
-| {{ cipher }} | {{ key_server_priority }} | {{ rekey_period }} | {{ sci }} | {{ traffic_unprotected }} |
+{%             set replace_protection_disabled = profile.replace_protection.disabled | arista.avd.default('-') %}
+{%             set replace_protection_window = profile.replace_protection.window | arista.avd.default('-') %}
+| {{ cipher }} | {{ key_server_priority }} | {{ rekey_period }} | {{ sci }} | {{ traffic_unprotected }} | {{ replace_protection_disabled }} | {{ replace_protection_window }} |
 {%             if profile.connection_keys is arista.avd.defined %}
 
 ###### Keys

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mac-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mac-security.j2
@@ -38,9 +38,9 @@ FIPS restrictions enabled.
 {%             if traffic_unprotected == "allow" and profile.traffic_unprotected.allow_active_sak is arista.avd.defined(true) %}
 {%                 set traffic_unprotected = traffic_unprotected ~ " active-sak" %}
 {%             endif %}
-{%             set replace_protection_disabled = profile.replace_protection.disabled | arista.avd.default('-') %}
-{%             set replace_protection_window = profile.replace_protection.window | arista.avd.default('-') %}
-| {{ cipher }} | {{ key_server_priority }} | {{ rekey_period }} | {{ sci }} | {{ traffic_unprotected }} | {{ replace_protection_disabled }} | {{ replace_protection_window }} |
+{%             set replay_protection_disabled = profile.replay_protection.disabled | arista.avd.default('-') %}
+{%             set replay_protection_window = profile.replay_protection.window | arista.avd.default('-') %}
+| {{ cipher }} | {{ key_server_priority }} | {{ rekey_period }} | {{ sci }} | {{ traffic_unprotected }} | {{ replay_protection_disabled }} | {{ replay_protection_window }} |
 {%             if profile.connection_keys is arista.avd.defined %}
 
 ###### Keys

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/mac-security.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/mac-security.j2
@@ -50,5 +50,11 @@ mac security
 {%         if profile.l2_protocols.lldp.mode is arista.avd.defined %}
       l2-protocol lldp {{ profile.l2_protocols.lldp.mode }}
 {%         endif %}
+{%         if profile.replay_protection.disabled is arista.avd.defined(true) %}
+      replay protection disabled
+{%         endif %}
+{%         if profile.replay_protection.window is arista.avd.defined %}
+      replay protection window {{ profile.replay_protection.window }}
+{%         endif %}
 {%     endfor %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -18061,6 +18061,30 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         """
 
+            class ReplayProtection(AvdModel):
+                """Subclass of AvdModel."""
+
+                _fields: ClassVar[dict] = {"disabled": {"type": bool}, "window": {"type": int}}
+                disabled: bool | None
+                """Disable replay protection"""
+                window: int | None
+                """Set replay protection window size"""
+
+                if TYPE_CHECKING:
+
+                    def __init__(self, *, disabled: bool | None | UndefinedType = Undefined, window: int | None | UndefinedType = Undefined) -> None:
+                        """
+                        ReplayProtection.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            disabled: Disable replay protection
+                            window: Set replay protection window size
+
+                        """
+
             _fields: ClassVar[dict] = {
                 "name": {"type": str},
                 "cipher": {"type": str},
@@ -18069,6 +18093,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 "sci": {"type": bool},
                 "l2_protocols": {"type": L2Protocols},
                 "traffic_unprotected": {"type": TrafficUnprotected},
+                "replay_protection": {"type": ReplayProtection},
             }
             name: str
             """Profile-Name."""
@@ -18081,6 +18106,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             l2_protocols: L2Protocols
             """Subclass of AvdModel."""
             traffic_unprotected: TrafficUnprotected
+            """Subclass of AvdModel."""
+            replay_protection: ReplayProtection
             """Subclass of AvdModel."""
 
             if TYPE_CHECKING:
@@ -18095,6 +18122,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     sci: bool | None | UndefinedType = Undefined,
                     l2_protocols: L2Protocols | UndefinedType = Undefined,
                     traffic_unprotected: TrafficUnprotected | UndefinedType = Undefined,
+                    replay_protection: ReplayProtection | UndefinedType = Undefined,
                 ) -> None:
                     """
                     ProfilesItem.
@@ -18110,6 +18138,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         sci: sci
                         l2_protocols: Subclass of AvdModel.
                         traffic_unprotected: Subclass of AvdModel.
+                        replay_protection: Subclass of AvdModel.
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -18066,9 +18066,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 _fields: ClassVar[dict] = {"disabled": {"type": bool}, "window": {"type": int}}
                 disabled: bool | None
-                """Disable replay protection"""
+                """Disable replay protection."""
                 window: int | None
-                """Set replay protection window size"""
+                """Set replay protection window size."""
 
                 if TYPE_CHECKING:
 
@@ -18080,8 +18080,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         Subclass of AvdModel.
 
                         Args:
-                            disabled: Disable replay protection
-                            window: Set replay protection window size
+                            disabled: Disable replay protection.
+                            window: Set replay protection window size.
 
                         """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7213,14 +7213,14 @@ keys:
               keys:
                 disabled:
                   type: bool
-                  description: Disable replay protection
+                  description: Disable replay protection.
                 window:
                   type: int
                   convert_types:
                   - str
                   min: 0
                   max: 4294967295
-                  description: Set replay protection window size
+                  description: Set replay protection window size.
   maintenance:
     type: dict
     display_name: Maintenance Mode

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7208,6 +7208,19 @@ keys:
                   type: bool
                   description: Allow transmit/receive of encrypted traffic using operational
                     SAK and block otherwise.
+            replay_protection:
+              type: dict
+              keys:
+                disabled:
+                  type: bool
+                  description: Disable replay protection
+                window:
+                  type: int
+                  convert_types:
+                  - str
+                  min: 0
+                  max: 4294967295
+                  description: Set replay protection window size
   maintenance:
     type: dict
     display_name: Maintenance Mode

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_security.schema.yml
@@ -109,11 +109,11 @@ keys:
               keys:
                 disabled:
                   type: bool
-                  description: Disable replay protection
+                  description: Disable replay protection.
                 window:
                   type: int
                   convert_types:
                     - str
                   min: 0
                   max: 4294967295
-                  description: Set replay protection window size
+                  description: Set replay protection window size.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_security.schema.yml
@@ -104,3 +104,16 @@ keys:
                 allow_active_sak:
                   type: bool
                   description: Allow transmit/receive of encrypted traffic using operational SAK and block otherwise.
+            replay_protection:
+              type: dict
+              keys:
+                disabled:
+                  type: bool
+                  description: Disable replay protection
+                window:
+                  type: int
+                  convert_types:
+                    - str
+                  min: 0
+                  max: 4294967295
+                  description: Set replay protection window size


### PR DESCRIPTION
## Change Summary

Add support for "replay protection" CLI syntax, in MacSec profiles:

```
mac security
   profile <PROFILE-NAME>
      replay protection disabled
      replay protection window <0-4294967295>

```
## Related Issue(s)

Fixes #5179 

## Component(s) name

`arista.avd.eos_cli_config_gen`


## Proposed changes

```yaml
mac_security:
  profiles:
      # Profile-Name.
    - name: <str; required; unique>
      replay_protection:
        disabled: <bool>
        window: <int; 0-4294967295>
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
