### PR TITLE
Feat(eos_cli_config_gen): Add support for spanning_tree_bpduguard `rate-limit count` under ethernet_interfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -4100,9 +4100,9 @@ interface Ethernet2
    storm-control unknown-unicast level 1
    storm-control all level 10
    spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
    spanning-tree bpduguard rate-limit enable
    spanning-tree bpduguard rate-limit count 10 interval 3
-   spanning-tree bpdufilter disable
 !
 interface Ethernet3
    !! testing single line comment
@@ -4138,9 +4138,9 @@ interface Ethernet3
    ptp transport layer2
    ptp vlan 2
    no priority-flow-control
+   spanning-tree guard root
    spanning-tree bpduguard rate-limit disable
    spanning-tree bpduguard rate-limit count 10
-   spanning-tree guard root
    switchport backup-link Ethernet4
    !
    sync-e
@@ -4172,8 +4172,8 @@ interface Ethernet4
    multicast ipv4 static
    switchport port-security violation protect
    priority-flow-control on
-   spanning-tree bpduguard rate-limit count 10 interval 15
    spanning-tree guard none
+   spanning-tree bpduguard rate-limit count 10 interval 15
 !
 interface Ethernet5
    description Molecule Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -4100,6 +4100,8 @@ interface Ethernet2
    storm-control unknown-unicast level 1
    storm-control all level 10
    spanning-tree bpduguard disable
+   spanning-tree bpduguard rate-limit enable
+   spanning-tree bpduguard rate-limit count 10 interval 3
    spanning-tree bpdufilter disable
 !
 interface Ethernet3
@@ -4136,6 +4138,8 @@ interface Ethernet3
    ptp transport layer2
    ptp vlan 2
    no priority-flow-control
+   spanning-tree bpduguard rate-limit disable
+   spanning-tree bpduguard rate-limit count 10
    spanning-tree guard root
    switchport backup-link Ethernet4
    !
@@ -4168,6 +4172,7 @@ interface Ethernet4
    multicast ipv4 static
    switchport port-security violation protect
    priority-flow-control on
+   spanning-tree bpduguard rate-limit count 10 interval 15
    spanning-tree guard none
 !
 interface Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -2472,9 +2472,9 @@ interface Ethernet2
    storm-control unknown-unicast level 1
    storm-control all level 10
    spanning-tree bpduguard disable
+   spanning-tree bpdufilter disable
    spanning-tree bpduguard rate-limit enable
    spanning-tree bpduguard rate-limit count 10 interval 3
-   spanning-tree bpdufilter disable
 !
 interface Ethernet3
    !! testing single line comment
@@ -2510,9 +2510,9 @@ interface Ethernet3
    ptp transport layer2
    ptp vlan 2
    no priority-flow-control
+   spanning-tree guard root
    spanning-tree bpduguard rate-limit disable
    spanning-tree bpduguard rate-limit count 10
-   spanning-tree guard root
    switchport backup-link Ethernet4
    !
    sync-e
@@ -2544,8 +2544,8 @@ interface Ethernet4
    multicast ipv4 static
    switchport port-security violation protect
    priority-flow-control on
-   spanning-tree bpduguard rate-limit count 10 interval 15
    spanning-tree guard none
+   spanning-tree bpduguard rate-limit count 10 interval 15
 !
 interface Ethernet5
    description Molecule Routing

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -2472,6 +2472,8 @@ interface Ethernet2
    storm-control unknown-unicast level 1
    storm-control all level 10
    spanning-tree bpduguard disable
+   spanning-tree bpduguard rate-limit enable
+   spanning-tree bpduguard rate-limit count 10 interval 3
    spanning-tree bpdufilter disable
 !
 interface Ethernet3
@@ -2508,6 +2510,8 @@ interface Ethernet3
    ptp transport layer2
    ptp vlan 2
    no priority-flow-control
+   spanning-tree bpduguard rate-limit disable
+   spanning-tree bpduguard rate-limit count 10
    spanning-tree guard root
    switchport backup-link Ethernet4
    !
@@ -2540,6 +2544,7 @@ interface Ethernet4
    multicast ipv4 static
    switchport port-security violation protect
    priority-flow-control on
+   spanning-tree bpduguard rate-limit count 10 interval 15
    spanning-tree guard none
 !
 interface Ethernet5

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -194,6 +194,10 @@ ethernet_interfaces:
           # no-drop
           no_drop: true
     spanning_tree_bpduguard: disabled
+    spanning_tree_bpduguard_rate_limit:
+      enabled: true
+      count: 10
+      interval: 3
     spanning_tree_bpdufilter: disabled
     # test for switchport settings
     switchport:
@@ -247,6 +251,9 @@ ethernet_interfaces:
     priority_flow_control:
       enabled: false
     spanning_tree_guard: root
+    spanning_tree_bpduguard_rate_limit:
+      enabled: false
+      count: 10
     tcp_mss_ceiling:
       ipv6_segment_size: 65
     # test for switchport settings
@@ -305,6 +312,9 @@ ethernet_interfaces:
     priority_flow_control:
       enabled: true
     spanning_tree_guard: disabled
+    spanning_tree_bpduguard_rate_limit:
+      count: 10
+      interval: 15
     tcp_mss_ceiling:
       ipv4_segment_size: 65
     multicast:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -385,6 +385,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;cos</samp>](## "ethernet_interfaces.[].qos.cos") | Integer |  |  |  | COS value. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpdufilter</samp>](## "ethernet_interfaces.[].spanning_tree_bpdufilter") | String |  |  | Valid Values:<br>- <code>enabled</code><br>- <code>disabled</code><br>- <code>True</code><br>- <code>False</code><br>- <code>true</code><br>- <code>false</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpduguard</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard") | String |  |  | Valid Values:<br>- <code>enabled</code><br>- <code>disabled</code><br>- <code>True</code><br>- <code>False</code><br>- <code>true</code><br>- <code>false</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_bpduguard_rate_limit</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard_rate_limit") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard_rate_limit.enabled") | Boolean |  |  |  | Enable/Disable rate limiter on this port. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;count</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard_rate_limit.count") | Integer |  |  | Min: 1<br>Max: 20000 | Max number of BPDUs per timer interval. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].spanning_tree_bpduguard_rate_limit.interval") | Integer |  |  | Min: 1<br>Max: 15 | Number of seconds in the BPDU input rate limiter timer. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_guard</samp>](## "ethernet_interfaces.[].spanning_tree_guard") | String |  |  | Valid Values:<br>- <code>loop</code><br>- <code>root</code><br>- <code>disabled</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;spanning_tree_portfast</samp>](## "ethernet_interfaces.[].spanning_tree_portfast") | String |  |  | Valid Values:<br>- <code>edge</code><br>- <code>network</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vmtracer</samp>](## "ethernet_interfaces.[].vmtracer") | Boolean |  |  |  |  |
@@ -1435,6 +1439,16 @@
           cos: <int>
         spanning_tree_bpdufilter: <str; "enabled" | "disabled" | "True" | "False" | "true" | "false">
         spanning_tree_bpduguard: <str; "enabled" | "disabled" | "True" | "False" | "true" | "false">
+        spanning_tree_bpduguard_rate_limit:
+
+          # Enable/Disable rate limiter on this port.
+          enabled: <bool>
+
+          # Max number of BPDUs per timer interval.
+          count: <int; 1-20000>
+
+          # Number of seconds in the BPDU input rate limiter timer.
+          interval: <int; 1-15>
         spanning_tree_guard: <str; "loop" | "root" | "disabled">
         spanning_tree_portfast: <str; "edge" | "network">
         vmtracer: <bool>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -967,6 +967,18 @@ interface {{ ethernet_interface.name }}
 {%     elif ethernet_interface.spanning_tree_bpduguard is arista.avd.defined("disabled") %}
    spanning-tree bpduguard disable
 {%     endif %}
+{%     if ethernet_interface.spanning_tree_bpduguard_rate_limit.enabled is arista.avd.defined(true) %}
+   spanning-tree bpduguard rate-limit enable
+{%     elif ethernet_interface.spanning_tree_bpduguard_rate_limit.enabled is arista.avd.defined(false) %}
+   spanning-tree bpduguard rate-limit disable
+{%     endif %}
+{%     if ethernet_interface.spanning_tree_bpduguard_rate_limit.count is arista.avd.defined %}
+{%         set rate_limit_count = "spanning-tree bpduguard rate-limit count " ~ ethernet_interface.spanning_tree_bpduguard_rate_limit.count %}
+{%         if ethernet_interface.spanning_tree_bpduguard_rate_limit.interval is arista.avd.defined %}
+{%             set rate_limit_count = rate_limit_count ~ " interval " ~ ethernet_interface.spanning_tree_bpduguard_rate_limit.interval %}
+{%         endif %}
+   {{ rate_limit_count }}
+{%     endif %}
 {%     if ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined and ethernet_interface.spanning_tree_bpdufilter in [True, "True", "enabled"] %}
    spanning-tree bpdufilter enable
 {%     elif ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined("disabled") %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -967,18 +967,6 @@ interface {{ ethernet_interface.name }}
 {%     elif ethernet_interface.spanning_tree_bpduguard is arista.avd.defined("disabled") %}
    spanning-tree bpduguard disable
 {%     endif %}
-{%     if ethernet_interface.spanning_tree_bpduguard_rate_limit.enabled is arista.avd.defined(true) %}
-   spanning-tree bpduguard rate-limit enable
-{%     elif ethernet_interface.spanning_tree_bpduguard_rate_limit.enabled is arista.avd.defined(false) %}
-   spanning-tree bpduguard rate-limit disable
-{%     endif %}
-{%     if ethernet_interface.spanning_tree_bpduguard_rate_limit.count is arista.avd.defined %}
-{%         set rate_limit_count = "spanning-tree bpduguard rate-limit count " ~ ethernet_interface.spanning_tree_bpduguard_rate_limit.count %}
-{%         if ethernet_interface.spanning_tree_bpduguard_rate_limit.interval is arista.avd.defined %}
-{%             set rate_limit_count = rate_limit_count ~ " interval " ~ ethernet_interface.spanning_tree_bpduguard_rate_limit.interval %}
-{%         endif %}
-   {{ rate_limit_count }}
-{%     endif %}
 {%     if ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined and ethernet_interface.spanning_tree_bpdufilter in [True, "True", "enabled"] %}
    spanning-tree bpdufilter enable
 {%     elif ethernet_interface.spanning_tree_bpdufilter is arista.avd.defined("disabled") %}
@@ -990,6 +978,18 @@ interface {{ ethernet_interface.name }}
 {%         else %}
    spanning-tree guard {{ ethernet_interface.spanning_tree_guard }}
 {%         endif %}
+{%     endif %}
+{%     if ethernet_interface.spanning_tree_bpduguard_rate_limit.enabled is arista.avd.defined(true) %}
+   spanning-tree bpduguard rate-limit enable
+{%     elif ethernet_interface.spanning_tree_bpduguard_rate_limit.enabled is arista.avd.defined(false) %}
+   spanning-tree bpduguard rate-limit disable
+{%     endif %}
+{%     if ethernet_interface.spanning_tree_bpduguard_rate_limit.count is arista.avd.defined %}
+{%         set rate_limit_count = "spanning-tree bpduguard rate-limit count " ~ ethernet_interface.spanning_tree_bpduguard_rate_limit.count %}
+{%         if ethernet_interface.spanning_tree_bpduguard_rate_limit.interval is arista.avd.defined %}
+{%             set rate_limit_count = rate_limit_count ~ " interval " ~ ethernet_interface.spanning_tree_bpduguard_rate_limit.interval %}
+{%         endif %}
+   {{ rate_limit_count }}
 {%     endif %}
 {%     if ethernet_interface.logging.event.spanning_tree is arista.avd.defined(true) %}
    logging event spanning-tree

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -8633,6 +8633,39 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
+        class SpanningTreeBpduguardRateLimit(AvdModel):
+            """Subclass of AvdModel."""
+
+            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "count": {"type": int}, "interval": {"type": int}}
+            enabled: bool | None
+            """Enable/Disable rate limiter on this port."""
+            count: int | None
+            """Max number of BPDUs per timer interval."""
+            interval: int | None
+            """Number of seconds in the BPDU input rate limiter timer."""
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self,
+                    *,
+                    enabled: bool | None | UndefinedType = Undefined,
+                    count: int | None | UndefinedType = Undefined,
+                    interval: int | None | UndefinedType = Undefined,
+                ) -> None:
+                    """
+                    SpanningTreeBpduguardRateLimit.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        enabled: Enable/Disable rate limiter on this port.
+                        count: Max number of BPDUs per timer interval.
+                        interval: Number of seconds in the BPDU input rate limiter timer.
+
+                    """
+
         class PriorityFlowControl(AvdModel):
             """Subclass of AvdModel."""
 
@@ -11425,6 +11458,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "qos": {"type": Qos},
             "spanning_tree_bpdufilter": {"type": str},
             "spanning_tree_bpduguard": {"type": str},
+            "spanning_tree_bpduguard_rate_limit": {"type": SpanningTreeBpduguardRateLimit},
             "spanning_tree_guard": {"type": str},
             "spanning_tree_portfast": {"type": str},
             "vmtracer": {"type": bool},
@@ -11659,6 +11693,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Subclass of AvdModel."""
         spanning_tree_bpdufilter: Literal["enabled", "disabled", "True", "False", "true", "false"] | None
         spanning_tree_bpduguard: Literal["enabled", "disabled", "True", "False", "true", "false"] | None
+        spanning_tree_bpduguard_rate_limit: SpanningTreeBpduguardRateLimit
+        """Subclass of AvdModel."""
         spanning_tree_guard: Literal["loop", "root", "disabled"] | None
         spanning_tree_portfast: Literal["edge", "network"] | None
         vmtracer: bool | None
@@ -11816,6 +11852,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 qos: Qos | UndefinedType = Undefined,
                 spanning_tree_bpdufilter: Literal["enabled", "disabled", "True", "False", "true", "false"] | None | UndefinedType = Undefined,
                 spanning_tree_bpduguard: Literal["enabled", "disabled", "True", "False", "true", "false"] | None | UndefinedType = Undefined,
+                spanning_tree_bpduguard_rate_limit: SpanningTreeBpduguardRateLimit | UndefinedType = Undefined,
                 spanning_tree_guard: Literal["loop", "root", "disabled"] | None | UndefinedType = Undefined,
                 spanning_tree_portfast: Literal["edge", "network"] | None | UndefinedType = Undefined,
                 vmtracer: bool | None | UndefinedType = Undefined,
@@ -11982,6 +12019,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     qos: Subclass of AvdModel.
                     spanning_tree_bpdufilter: spanning_tree_bpdufilter
                     spanning_tree_bpduguard: spanning_tree_bpduguard
+                    spanning_tree_bpduguard_rate_limit: Subclass of AvdModel.
                     spanning_tree_guard: spanning_tree_guard
                     spanning_tree_portfast: spanning_tree_portfast
                     vmtracer: vmtracer

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -3437,6 +3437,26 @@ keys:
           - 'False'
           - 'true'
           - 'false'
+        spanning_tree_bpduguard_rate_limit:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+              description: Enable/Disable rate limiter on this port.
+            count:
+              type: int
+              convert_types:
+              - str
+              description: Max number of BPDUs per timer interval.
+              min: 1
+              max: 20000
+            interval:
+              type: int
+              convert_types:
+              - str
+              description: Number of seconds in the BPDU input rate limiter timer.
+              min: 1
+              max: 15
         spanning_tree_guard:
           type: str
           valid_values:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -1188,6 +1188,26 @@ keys:
           convert_types:
             - bool
           valid_values: ["enabled", "disabled", "True", "False", "true", "false"]
+        spanning_tree_bpduguard_rate_limit:
+          type: dict
+          keys:
+            enabled:
+              type: bool
+              description: Enable/Disable rate limiter on this port.
+            count:
+              type: int
+              convert_types:
+                - str
+              description: Max number of BPDUs per timer interval.
+              min: 1
+              max: 20000
+            interval:
+              type: int
+              convert_types:
+                - str
+              description: Number of seconds in the BPDU input rate limiter timer.
+              min: 1
+              max: 15
         spanning_tree_guard:
           type: str
           valid_values: ["loop", "root", "disabled"]


### PR DESCRIPTION
## Change Summary

Add support for spanning_tree_bpduguard `rate-limit count` under ethernet_interfaces

## Related Issue(s)

Fixes #4884 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added schema and template for `spanning_tree_bpduguard_rate_limit` under `ethernet_interfaces`-
```
ethernet_interfaces:
     spanning_tree_bpduguard_rate_limit:

          # Enable/Disable rate limiter on this port.
          enabled: <bool>

          # Max number of BPDUs per timer interval.
          count: <int; 1-20000>

          # Number of seconds in the BPDU input rate limiter timer.
          interval: <int; 1-15>
```
## How to test
Molecule test

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
