### PR TITLE
Feat(eos_designs): Enable graceful-restart for underlay OSPF

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_multicast.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/l3_edge_multicast.cfg
@@ -59,5 +59,6 @@ router ospf 100
    no passive-interface ethernet1
    no passive-interface ethernet2
    max-lsa 12000
+   graceful-restart
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/l3_edge_multicast.yml
@@ -59,6 +59,8 @@ router_ospf:
     - ethernet1
     - ethernet2
     max_lsa: 12000
+    graceful_restart:
+      enabled: true
 service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/l3_edge_multicast.yml
@@ -1,5 +1,6 @@
 underlay_routing_protocol: ospf
 underlay_multicast: true
+underlay_ospf_graceful_restart: true
 
 type: spine
 spine:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/underlay-ospf-graceful-restart.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/underlay-ospf-graceful-restart.md
@@ -1,0 +1,17 @@
+<!--
+  ~ Copyright (c) 2025 Arista Networks, Inc.
+  ~ Use of this source code is governed by the Apache License 2.0
+  ~ that can be found in the LICENSE file.
+  -->
+=== "Table"
+
+    | Variable | Type | Required | Default | Value Restrictions | Description |
+    | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>underlay_ospf_graceful_restart</samp>](## "underlay_ospf_graceful_restart") | Boolean |  | `False` |  | Set graceful restart when the underlay_routing_protocol is OSPF. |
+
+=== "YAML"
+
+    ```yaml
+    # Set graceful restart when the underlay_routing_protocol is OSPF.
+    underlay_ospf_graceful_restart: <bool; default=False>
+    ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/underlay-ospf-graceful-restart.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/underlay-ospf-graceful-restart.md
@@ -7,11 +7,11 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>underlay_ospf_graceful_restart</samp>](## "underlay_ospf_graceful_restart") | Boolean |  | `False` |  | Set graceful restart when the underlay_routing_protocol is OSPF. |
+    | [<samp>underlay_ospf_graceful_restart</samp>](## "underlay_ospf_graceful_restart") | Boolean |  | `False` |  | Enable graceful restart for OSPF underlay. |
 
 === "YAML"
 
     ```yaml
-    # Set graceful restart when the underlay_routing_protocol is OSPF.
+    # Enable graceful restart for OSPF underlay.
     underlay_ospf_graceful_restart: <bool; default=False>
     ```

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -58631,7 +58631,7 @@ class EosDesigns(EosDesignsRootModel):
     """Default value: `False`"""
     underlay_ospf_graceful_restart: bool
     """
-    Set graceful restart when the underlay_routing_protocol is OSPF.
+    Enable graceful restart for OSPF underlay.
 
     Default value: `False`
     """
@@ -60183,7 +60183,7 @@ class EosDesigns(EosDesignsRootModel):
                 underlay_ospf_area: underlay_ospf_area
                 underlay_ospf_authentication: Subclass of AvdModel.
                 underlay_ospf_bfd_enable: underlay_ospf_bfd_enable
-                underlay_ospf_graceful_restart: Set graceful restart when the underlay_routing_protocol is OSPF.
+                underlay_ospf_graceful_restart: Enable graceful restart for OSPF underlay.
                 underlay_ospf_max_lsa: underlay_ospf_max_lsa
                 underlay_ospf_process_id: underlay_ospf_process_id
                 underlay_rfc5549:

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -56980,6 +56980,7 @@ class EosDesigns(EosDesignsRootModel):
         "underlay_ospf_area": {"type": str, "default": "0.0.0.0"},
         "underlay_ospf_authentication": {"type": UnderlayOspfAuthentication},
         "underlay_ospf_bfd_enable": {"type": bool, "default": False},
+        "underlay_ospf_graceful_restart": {"type": bool, "default": False},
         "underlay_ospf_max_lsa": {"type": int, "default": 12000},
         "underlay_ospf_process_id": {"type": int, "default": 100},
         "underlay_rfc5549": {"type": bool, "default": False},
@@ -58628,6 +58629,12 @@ class EosDesigns(EosDesignsRootModel):
     """Subclass of AvdModel."""
     underlay_ospf_bfd_enable: bool
     """Default value: `False`"""
+    underlay_ospf_graceful_restart: bool
+    """
+    Set graceful restart when the underlay_routing_protocol is OSPF.
+
+    Default value: `False`
+    """
     underlay_ospf_max_lsa: int
     """Default value: `12000`"""
     underlay_ospf_process_id: int
@@ -58974,6 +58981,7 @@ class EosDesigns(EosDesignsRootModel):
             underlay_ospf_area: str | UndefinedType = Undefined,
             underlay_ospf_authentication: UnderlayOspfAuthentication | UndefinedType = Undefined,
             underlay_ospf_bfd_enable: bool | UndefinedType = Undefined,
+            underlay_ospf_graceful_restart: bool | UndefinedType = Undefined,
             underlay_ospf_max_lsa: int | UndefinedType = Undefined,
             underlay_ospf_process_id: int | UndefinedType = Undefined,
             underlay_rfc5549: bool | UndefinedType = Undefined,
@@ -60175,6 +60183,7 @@ class EosDesigns(EosDesignsRootModel):
                 underlay_ospf_area: underlay_ospf_area
                 underlay_ospf_authentication: Subclass of AvdModel.
                 underlay_ospf_bfd_enable: underlay_ospf_bfd_enable
+                underlay_ospf_graceful_restart: Set graceful restart when the underlay_routing_protocol is OSPF.
                 underlay_ospf_max_lsa: underlay_ospf_max_lsa
                 underlay_ospf_process_id: underlay_ospf_process_id
                 underlay_rfc5549:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -4671,7 +4671,7 @@ keys:
   underlay_ospf_graceful_restart:
     type: bool
     default: false
-    description: Set graceful restart when the underlay_routing_protocol is OSPF.
+    description: Enable graceful restart for OSPF underlay.
   underlay_ospf_max_lsa:
     documentation_options:
       table: ospf-settings

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -4668,6 +4668,10 @@ keys:
       table: ospf-settings
     type: bool
     default: false
+  underlay_ospf_graceful_restart:
+    type: bool
+    default: false
+    description: Set graceful restart when the underlay_routing_protocol is OSPF.
   underlay_ospf_max_lsa:
     documentation_options:
       table: ospf-settings

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_graceful_restart.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_graceful_restart.schema.yml
@@ -9,4 +9,4 @@ keys:
   underlay_ospf_graceful_restart:
     type: bool
     default: false
-    description: Set graceful restart when the underlay_routing_protocol is OSPF.
+    description: Enable graceful restart for OSPF underlay.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_graceful_restart.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_graceful_restart.schema.yml
@@ -8,5 +8,6 @@ type: dict
 keys:
   underlay_ospf_graceful_restart:
     type: bool
+    # TODO AVD 6.0 : Flip the default to true
     default: false
     description: Enable graceful restart for OSPF underlay.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_graceful_restart.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_graceful_restart.schema.yml
@@ -1,0 +1,12 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../_schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  underlay_ospf_graceful_restart:
+    type: bool
+    default: false
+    description: Set graceful restart when the underlay_routing_protocol is OSPF.

--- a/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_ospf.py
@@ -25,10 +25,13 @@ class RouterOspfMixin(Protocol):
         if not self.shared_utils.underlay_ospf:
             return
 
-        process = EosCliConfigGen.RouterOspf.ProcessIdsItem(id=self.inputs.underlay_ospf_process_id)
-
+        no_passive_interfaces = EosCliConfigGen.RouterOspf.ProcessIdsItem.NoPassiveInterfaces()
         for p2p_link, p2p_link_data in self._filtered_p2p_links:
             if p2p_link.include_in_underlay_protocol:
-                process.no_passive_interfaces.append(p2p_link_data["interface"])
+                no_passive_interfaces.append(p2p_link_data["interface"])
 
-        self.structured_config.router_ospf.process_ids.append(process)
+        if no_passive_interfaces:
+            self.structured_config.router_ospf.process_ids.append_new(
+                id=self.inputs.underlay_ospf_process_id,
+                no_passive_interfaces=no_passive_interfaces,
+            )

--- a/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_ospf.py
@@ -25,16 +25,13 @@ class RouterOspfMixin(Protocol):
         if not self.shared_utils.underlay_ospf:
             return
 
-        no_passive_interfaces = EosCliConfigGen.RouterOspf.ProcessIdsItem.NoPassiveInterfaces()
+        process = EosCliConfigGen.RouterOspf.ProcessIdsItem(id=self.inputs.underlay_ospf_process_id)
+
         for p2p_link, p2p_link_data in self._filtered_p2p_links:
             if p2p_link.include_in_underlay_protocol:
-                no_passive_interfaces.append(p2p_link_data["interface"])
-
-        if no_passive_interfaces:
-            self.structured_config.router_ospf.process_ids.append_new(
-                id=self.inputs.underlay_ospf_process_id,
-                no_passive_interfaces=EosCliConfigGen.RouterOspf.ProcessIdsItem.NoPassiveInterfaces(no_passive_interfaces),
-            )
+                process.no_passive_interfaces.append(p2p_link_data["interface"])
 
         if self.inputs.underlay_ospf_graceful_restart:
-            self.structured_config.router_ospf.process_ids.obtain(self.inputs.underlay_ospf_process_id).graceful_restart.enabled = True
+            process.graceful_restart.enabled = self.inputs.underlay_ospf_graceful_restart
+
+        self.structured_config.router_ospf.process_ids.append(process)

--- a/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_ospf.py
@@ -31,7 +31,4 @@ class RouterOspfMixin(Protocol):
             if p2p_link.include_in_underlay_protocol:
                 process.no_passive_interfaces.append(p2p_link_data["interface"])
 
-        if self.inputs.underlay_ospf_graceful_restart:
-            process.graceful_restart.enabled = self.inputs.underlay_ospf_graceful_restart
-
         self.structured_config.router_ospf.process_ids.append(process)

--- a/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_ospf.py
@@ -35,3 +35,6 @@ class RouterOspfMixin(Protocol):
                 id=self.inputs.underlay_ospf_process_id,
                 no_passive_interfaces=EosCliConfigGen.RouterOspf.ProcessIdsItem.NoPassiveInterfaces(no_passive_interfaces),
             )
+
+        if self.inputs.underlay_ospf_graceful_restart:
+            self.structured_config.router_ospf.process_ids.obtain(self.inputs.underlay_ospf_process_id).graceful_restart.enabled = True

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/router_ospf.py
@@ -48,8 +48,6 @@ class RouterOspfMixin(Protocol):
                 )
                 self._update_ospf_interface(process, vrf)
 
-                if self.inputs.underlay_ospf_graceful_restart:
-                    process.graceful_restart.enabled = True
                 if vrf.name != "default":
                     process.vrf = vrf.name
                 if vrf.ospf.bfd:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/router_ospf.py
@@ -48,6 +48,8 @@ class RouterOspfMixin(Protocol):
                 )
                 self._update_ospf_interface(process, vrf)
 
+                if self.inputs.underlay_ospf_graceful_restart:
+                    process.graceful_restart.enabled = True
                 if vrf.name != "default":
                     process.vrf = vrf.name
                 if vrf.ospf.bfd:

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_ospf.py
@@ -43,4 +43,8 @@ class RouterOspfMixin(Protocol):
 
         if self.shared_utils.overlay_routing_protocol == "none":
             process.redistribute.connected.enabled = True
+
+        if self.inputs.underlay_ospf_graceful_restart:
+            process.graceful_restart.enabled = True
+
         self.structured_config.router_ospf.process_ids.append(process)


### PR DESCRIPTION
## Change Summary

Enable underlay graceful-restart in OSPF configs via eos_designs

## Related Issue(s)

Fixes #4862 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Adding new knob for `underlay_ospf_graceful_restart: <bool>`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
