### PR TITLE
Fix(eos_cli_config_gen): Ethernet interface documentation template to change double ** into single *

### DIFF
--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/inet-cloud.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/inet-cloud.md
@@ -307,8 +307,8 @@ vlan internal order ascending range 1006 1199
 | Ethernet5 | site1-wan1-Ethernet4 | - | 100.64.10.1/24 | default | - | False | - | - |
 | Ethernet6 | site1-wan2-Ethernet4 | - | 100.64.11.1/24 | default | - | False | - | - |
 | Ethernet7 | site2-wan2-Ethernet4 | - | 100.64.21.1/24 | default | - | False | - | - |
-| Ethernet8 | - | 8 | *100.64.30.1/24 | **default | **- | *False | **- | **- |
-| Ethernet9 | - | 8 | *100.64.30.1/24 | **default | **- | *False | **- | **- |
+| Ethernet8 | - | 8 | *100.64.30.1/24 | *default | *- | *False | *- | *- |
+| Ethernet9 | - | 8 | *100.64.30.1/24 | *default | *- | *False | *- | *- |
 
 *Inherited from Port-Channel Interface
 

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site3-wan1.md
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/documentation/devices/site3-wan1.md
@@ -431,8 +431,8 @@ interface Dps1
 | --------- | ----------- | ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet1.42 | RED-TEST | - | 10.42.3.1/24 | RED | - | False | - | - |
 | Ethernet1.666 | BLUE-TEST | - | 10.66.3.1/24 | BLUE | - | False | - | - |
-| Ethernet4 | inet-cloud_Ethernet8 | 4 | *dhcp | **default | **- | *False | *ACL-INTERNET-IN_Port-Channel4 | **- |
-| Ethernet5 | inet-cloud_Ethernet9 | 4 | *dhcp | **default | **- | *False | *ACL-INTERNET-IN_Port-Channel4 | **- |
+| Ethernet4 | inet-cloud_Ethernet8 | 4 | *dhcp | *default | *- | *False | *ACL-INTERNET-IN_Port-Channel4 | *- |
+| Ethernet5 | inet-cloud_Ethernet9 | 4 | *dhcp | *default | *- | *False | *ACL-INTERNET-IN_Port-Channel4 | *- |
 
 *Inherited from Port-Channel Interface
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3822,8 +3822,8 @@ interface Dps1
 | Ethernet64 | DHCP server interface | - | 192.168.42.42/24 | default | - | - | - | - |
 | Ethernet65 | Multiple VRIDs | - | 192.0.2.2/25 | default | - | False | - | - |
 | Ethernet66 | Multiple VRIDs and tracking | - | 192.0.2.2/25 | default | - | False | - | - |
-| Ethernet80 | LAG Member | 17 | *192.0.2.3/31 | **default | **- | **- | **- | **- |
-| Ethernet81/2 | LAG Member LACP fallback LLDP ZTP VLAN | 112 | *dhcp | **default | **- | **- | **- | **- |
+| Ethernet80 | LAG Member | 17 | *192.0.2.3/31 | *default | *- | *- | *- | *- |
+| Ethernet81/2 | LAG Member LACP fallback LLDP ZTP VLAN | 112 | *dhcp | *default | *- | *- | *- | *- |
 | Ethernet81/3 | Traffic Engineering Interface | - | 100.64.127.0/31 | default | - | False | - | - |
 | Ethernet81/4 | Traffic Engineering Interface | - | 100.64.127.0/31 | default | - | False | - | - |
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LER1.md
@@ -197,10 +197,10 @@ vlan 2020
 | Ethernet6.10 | TENANT_B_SITE_5_INTRA_L3VPN | - | 123.1.1.2/31 | TENANT_B_INTRA | - | False | - | - |
 | Ethernet6.100 | TENANT_B_SITE_3_OSPF | - | 192.168.48.4/31 | TENANT_B_WAN | - | False | - | - |
 | Ethernet6.101 | TENANT_B_SITE_5 | - | 192.168.48.2/31 | TENANT_B_WAN | - | False | - | - |
-| Ethernet11 | P2P_SITE2-LSR2_Ethernet12 | 11 | *100.64.49.2/30 | **default | *9178 | *False | **- | **- |
-| Ethernet12 | P2P_SITE2-LSR2_Ethernet13 | 11 | *100.64.49.2/30 | **default | *9178 | *False | **- | **- |
-| Ethernet13 | P2P_SITE2-LSR2_Ethernet14 | 220 | *100.64.49.6/30 | **default | *9178 | *False | **- | **- |
-| Ethernet14 | P2P_SITE2-LSR2_Ethernet15 | 220 | *100.64.49.6/30 | **default | *9178 | *False | **- | **- |
+| Ethernet11 | P2P_SITE2-LSR2_Ethernet12 | 11 | *100.64.49.2/30 | *default | *9178 | *False | *- | *- |
+| Ethernet12 | P2P_SITE2-LSR2_Ethernet13 | 11 | *100.64.49.2/30 | *default | *9178 | *False | *- | *- |
+| Ethernet13 | P2P_SITE2-LSR2_Ethernet14 | 220 | *100.64.49.6/30 | *default | *9178 | *False | *- | *- |
+| Ethernet14 | P2P_SITE2-LSR2_Ethernet15 | 220 | *100.64.49.6/30 | *default | *9178 | *False | *- | *- |
 
 *Inherited from Port-Channel Interface
 

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE2-LSR2.md
@@ -139,10 +139,10 @@ vlan internal order ascending range 1006 1199
 | Interface | Description | Channel Group | IP Address | VRF |  MTU | Shutdown | ACL In | ACL Out |
 | --------- | ----------- | ------------- | ---------- | ----| ---- | -------- | ------ | ------- |
 | Ethernet3 | P2P_SITE1-LSR2_Ethernet3 | - | 100.64.48.11/31 | default | 9178 | False | - | - |
-| Ethernet12 | P2P_SITE2-LER1_Ethernet11 | 12 | *100.64.49.1/30 | **default | *9178 | *False | **- | **- |
-| Ethernet13 | P2P_SITE2-LER1_Ethernet12 | 12 | *100.64.49.1/30 | **default | *9178 | *False | **- | **- |
-| Ethernet14 | P2P_SITE2-LER1_Ethernet13 | 110 | *100.64.49.5/30 | **default | *9178 | *False | **- | **- |
-| Ethernet15 | P2P_SITE2-LER1_Ethernet14 | 110 | *100.64.49.5/30 | **default | *9178 | *False | **- | **- |
+| Ethernet12 | P2P_SITE2-LER1_Ethernet11 | 12 | *100.64.49.1/30 | *default | *9178 | *False | *- | *- |
+| Ethernet13 | P2P_SITE2-LER1_Ethernet12 | 12 | *100.64.49.1/30 | *default | *9178 | *False | *- | *- |
+| Ethernet14 | P2P_SITE2-LER1_Ethernet13 | 110 | *100.64.49.5/30 | *default | *9178 | *False | *- | *- |
+| Ethernet15 | P2P_SITE2-LER1_Ethernet14 | 110 | *100.64.49.5/30 | *default | *9178 | *False | *- | *- |
 
 *Inherited from Port-Channel Interface
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ethernet-interfaces.j2
@@ -431,11 +431,11 @@
 {%                     set description = ethernet_interface.description | arista.avd.default("-") %}
 {%                     set channel_group = ethernet_interface.channel_group.id | arista.avd.default("-") %}
 {%                     set ip_address = port_channel_interface.ip_address | arista.avd.default("-") %}
-{%                     set vrf = port_channel_interface.vrf | arista.avd.default("*default") %}
-{%                     set mtu = port_channel_interface.mtu | arista.avd.default("*-") %}
-{%                     set shutdown = port_channel_interface.shutdown | arista.avd.default("*-") %}
-{%                     set acl_in = port_channel_interface.access_group_in | arista.avd.default("*-") %}
-{%                     set acl_out = port_channel_interface.access_group_out | arista.avd.default("*-") %}
+{%                     set vrf = port_channel_interface.vrf | arista.avd.default("default") %}
+{%                     set mtu = port_channel_interface.mtu | arista.avd.default("-") %}
+{%                     set shutdown = port_channel_interface.shutdown | arista.avd.default("-") %}
+{%                     set acl_in = port_channel_interface.access_group_in | arista.avd.default("-") %}
+{%                     set acl_out = port_channel_interface.access_group_out | arista.avd.default("-") %}
 | {{ ethernet_interface.name }} | {{ description }} | {{ channel_group }} | *{{ ip_address }} | *{{ vrf }} | *{{ mtu }} | *{{ shutdown }} | *{{ acl_in }} | *{{ acl_out }} |
 {%                 endif %}
 {%             else %}


### PR DESCRIPTION
## Change Summary

Fixing ethernet interface documentation template to change double ** into single *

## Related Issue(s)

Fixes #4771 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
