### PR TITLE
CI: Refactor test_get_device_structured_config

### DIFF
--- a/python-avd/tests/pyavd/molecule_scenarios/test_get_device_structured_config.py
+++ b/python-avd/tests/pyavd/molecule_scenarios/test_get_device_structured_config.py
@@ -37,8 +37,9 @@ def test_get_device_structured_config(molecule_host: MoleculeHost) -> None:
     validate_inputs(inputs)
 
     expected_structured_config = molecule_host.structured_config
-    avd_facts = molecule_host.scenario.avd_facts
+
     with patch("sys.path", [*sys.path, *molecule_host.scenario.extra_python_paths]):
+        avd_facts = molecule_host.scenario.avd_facts
         structured_config = get_device_structured_config(molecule_host.name, inputs, avd_facts)
 
     assert isinstance(structured_config, dict)


### PR DESCRIPTION
## Change Summary

Right now running:

```
tox -e py312 -- tests/pyavd/molecule_scenarios/test_get_device_structured_config.py
```

fails when

```
tox -e py312 -- tests/pyavd/molecule_scenarios/
```

works.

After tshooting it is because avd_facts is not using the patch path in the first scenario and it is throwing import errors.

## Component(s) name

`ci`

## Proposed changes

Moved getting the facts inside the patched sys context

## How to test

can only be tested locally. Failing tests pass

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
