### PR TITLE
Fix(eos_designs): Bring back connected endpoints short_esi support on EPVN-MPLS LERs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER1.md
@@ -312,6 +312,10 @@ interface Ethernet8
 | Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
 | --------- | --------------------------- | --------------------------- | ------------ |
 | Port-Channel3 | 0000:0000:0102:0000:0034 | all-active | 01:02:00:00:00:34 |
+| Port-Channel8 | 0000:0000:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
+| Port-Channel8.111 | 0000:0000:0303:0202:0111 | all-active | 03:03:02:02:01:11 |
+| Port-Channel8.222 | 0000:0000:0303:0202:0222 | all-active | 03:03:02:02:02:22 |
+| Port-Channel8.333 | 0000:0000:0303:0202:0333 | all-active | 03:03:02:02:03:33 |
 
 #### Port-Channel Interfaces Device Configuration
 
@@ -360,24 +364,41 @@ interface Port-Channel8
    description CPE_CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0101
+      route-target import 03:03:02:02:01:01
+   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111
    !
    encapsulation vlan
       client dot1q 111 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0111
+      route-target import 03:03:02:02:01:11
 !
 interface Port-Channel8.222
    vlan id 222
    !
    encapsulation vlan
       client dot1q 222 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0222
+      route-target import 03:03:02:02:02:22
 !
 interface Port-Channel8.333
    vlan id 434
    !
    encapsulation vlan
       client dot1q 333 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0333
+      route-target import 03:03:02:02:03:33
 ```
 
 ### Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/documentation/devices/SITE1-LER2.md
@@ -306,6 +306,10 @@ interface Ethernet8
 | Interface | Ethernet Segment Identifier | Multihoming Redundancy Mode | Route Target |
 | --------- | --------------------------- | --------------------------- | ------------ |
 | Port-Channel3 | 0000:0000:0102:0000:0034 | all-active | 01:02:00:00:00:34 |
+| Port-Channel8 | 0000:0000:0303:0202:0101 | all-active | 03:03:02:02:01:01 |
+| Port-Channel8.111 | 0000:0000:0303:0202:0111 | all-active | 03:03:02:02:01:11 |
+| Port-Channel8.222 | 0000:0000:0303:0202:0222 | all-active | 03:03:02:02:02:22 |
+| Port-Channel8.333 | 0000:0000:0303:0202:0333 | all-active | 03:03:02:02:03:33 |
 
 #### Port-Channel Interfaces Device Configuration
 
@@ -354,24 +358,41 @@ interface Port-Channel8
    description CPE_CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0101
+      route-target import 03:03:02:02:01:01
+   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111
    !
    encapsulation vlan
       client dot1q 111 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0111
+      route-target import 03:03:02:02:01:11
 !
 interface Port-Channel8.222
    vlan id 222
    !
    encapsulation vlan
       client dot1q 222 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0222
+      route-target import 03:03:02:02:02:22
 !
 interface Port-Channel8.333
    vlan id 434
    !
    encapsulation vlan
       client dot1q 333 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0333
+      route-target import 03:03:02:02:03:33
 ```
 
 ### Loopback Interfaces

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER1.cfg
@@ -76,24 +76,41 @@ interface Port-Channel8
    description CPE_CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0101
+      route-target import 03:03:02:02:01:01
+   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111
    !
    encapsulation vlan
       client dot1q 111 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0111
+      route-target import 03:03:02:02:01:11
 !
 interface Port-Channel8.222
    vlan id 222
    !
    encapsulation vlan
       client dot1q 222 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0222
+      route-target import 03:03:02:02:02:22
 !
 interface Port-Channel8.333
    vlan id 434
    !
    encapsulation vlan
       client dot1q 333 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0333
+      route-target import 03:03:02:02:03:33
 !
 interface Ethernet1
    description P2P_SITE1-LSR1_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/configs/SITE1-LER2.cfg
@@ -78,24 +78,41 @@ interface Port-Channel8
    description CPE_CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
    no shutdown
    no switchport
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0101
+      route-target import 03:03:02:02:01:01
+   lacp system-id 0303.0202.0101
 !
 interface Port-Channel8.111
    vlan id 111
    !
    encapsulation vlan
       client dot1q 111 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0111
+      route-target import 03:03:02:02:01:11
 !
 interface Port-Channel8.222
    vlan id 222
    !
    encapsulation vlan
       client dot1q 222 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0222
+      route-target import 03:03:02:02:02:22
 !
 interface Port-Channel8.333
    vlan id 434
    !
    encapsulation vlan
       client dot1q 333 network client
+   !
+   evpn ethernet-segment
+      identifier 0000:0000:0303:0202:0333
+      route-target import 03:03:02:02:03:33
 !
 interface Ethernet1
    description P2P_SITE1-LSR2_Ethernet1

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -263,6 +263,10 @@ port_channel_interfaces:
 - name: Port-Channel8
   description: CPE_CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
   shutdown: false
+  evpn_ethernet_segment:
+    identifier: 0000:0000:0303:0202:0101
+    route_target: 03:03:02:02:01:01
+  lacp_id: 0303.0202.0101
   switchport:
     enabled: false
 - name: Port-Channel8.111
@@ -273,6 +277,9 @@ port_channel_interfaces:
     network:
       encapsulation: client
   vlan_id: 111
+  evpn_ethernet_segment:
+    identifier: 0000:0000:0303:0202:0111
+    route_target: 03:03:02:02:01:11
 - name: Port-Channel8.222
   encapsulation_vlan:
     client:
@@ -281,6 +288,9 @@ port_channel_interfaces:
     network:
       encapsulation: client
   vlan_id: 222
+  evpn_ethernet_segment:
+    identifier: 0000:0000:0303:0202:0222
+    route_target: 03:03:02:02:02:22
 - name: Port-Channel8.333
   encapsulation_vlan:
     client:
@@ -289,6 +299,9 @@ port_channel_interfaces:
     network:
       encapsulation: client
   vlan_id: 434
+  evpn_ethernet_segment:
+    identifier: 0000:0000:0303:0202:0333
+    route_target: 03:03:02:02:03:33
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -248,6 +248,10 @@ port_channel_interfaces:
 - name: Port-Channel8
   description: CPE_CPE_TENANT_A_SITE1_EVPN-A-A-PortChannel
   shutdown: false
+  evpn_ethernet_segment:
+    identifier: 0000:0000:0303:0202:0101
+    route_target: 03:03:02:02:01:01
+  lacp_id: 0303.0202.0101
   switchport:
     enabled: false
 - name: Port-Channel8.111
@@ -258,6 +262,9 @@ port_channel_interfaces:
     network:
       encapsulation: client
   vlan_id: 111
+  evpn_ethernet_segment:
+    identifier: 0000:0000:0303:0202:0111
+    route_target: 03:03:02:02:01:11
 - name: Port-Channel8.222
   encapsulation_vlan:
     client:
@@ -266,6 +273,9 @@ port_channel_interfaces:
     network:
       encapsulation: client
   vlan_id: 222
+  evpn_ethernet_segment:
+    identifier: 0000:0000:0303:0202:0222
+    route_target: 03:03:02:02:02:22
 - name: Port-Channel8.333
   encapsulation_vlan:
     client:
@@ -274,6 +284,9 @@ port_channel_interfaces:
     network:
       encapsulation: client
   vlan_id: 434
+  evpn_ethernet_segment:
+    identifier: 0000:0000:0303:0202:0333
+    route_target: 03:03:02:02:03:33
 router_bfd:
   multihop:
     interval: 300

--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/utils.py
@@ -118,8 +118,8 @@ class UtilsMixin(Protocol):
         hash_extra_value: str = "",
     ) -> str | None:
         """Return short_esi for one adapter."""
-        if len(set(adapter.switches)) < 2 or not self.shared_utils.overlay_evpn or not self.shared_utils.overlay_vtep:
-            # Only configure ESI for multi-homing.
+        if len(set(adapter.switches)) < 2 or not self.shared_utils.overlay_evpn or not (self.shared_utils.overlay_vtep or self.shared_utils.overlay_ler):
+            # Only configure ESI for EVPN multi-homing.
             return None
 
         # short_esi is only set when called from sub-interface port-channels.


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Bring back connected endpoints short_esi support on EPVN-MPLS LERs

Fixes regression introduced in #4020.

## Related Issue(s)

Fixes #5227 

## Component(s) name

`arista.avd.eos_designs`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing molecule tests updated correctly with this change. Reverting the missed regressions in #4020.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
