### PR TITLE
Fix(eos_designs): Avoid setting cv_tag "lan" for port-channel members

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4A.yml
@@ -210,14 +210,6 @@ metadata:
       tags:
       - name: Type
         value: lan
-    - interface: Ethernet42
-      tags:
-      - name: Type
-        value: lan
-    - interface: Ethernet43
-      tags:
-      - name: Type
-        value: lan
     - interface: Port-Channel666
       tags:
       - name: Type

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4B.yml
@@ -210,14 +210,6 @@ metadata:
       tags:
       - name: Type
         value: lan
-    - interface: Ethernet42
-      tags:
-      - name: Type
-        value: lan
-    - interface: Ethernet43
-      tags:
-      - name: Type
-        value: lan
     - interface: Port-Channel666
       tags:
       - name: Type

--- a/python-avd/pyavd/_eos_designs/shared_utils/wan.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/wan.py
@@ -89,15 +89,6 @@ class WanMixin(Protocol):
         )
 
     @cached_property
-    def _wan_port_channel_member_interfaces(self: SharedUtilsProtocol) -> dict:
-        """Dictionary with mapping of member ethernet interface to wan port_channel for a device."""
-        member_intfs = {}
-        for port_channel_intf in self.wan_port_channels:
-            for member_eth_intf in port_channel_intf.member_interfaces:
-                member_intfs[member_eth_intf.name] = port_channel_intf.name
-        return member_intfs
-
-    @cached_property
     def wan_local_carriers(self: SharedUtilsProtocol) -> list:
         """
         List of carriers present on this router based on the wan_interfaces and wan_port_channels with the associated WAN interfaces.

--- a/python-avd/pyavd/_eos_designs/structured_config/metadata/cv_tags.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/metadata/cv_tags.py
@@ -203,14 +203,11 @@ class CvTagsMixin(Protocol):
         if generic_interface.name in self.shared_utils.wan_port_channels:
             wan_port_channel_intf = self.shared_utils.wan_port_channels[generic_interface.name]
             return self._get_cv_pathfinder_wan_interface_tags(wan_port_channel_intf)
-        # Check if input eth interface is member of any L3 Port-Channel wan interface
-        # if so, skip generation of interface tags for such member interface.
-        # TODO: Consider if we should skip this for all port-channel members,
-        # since we would now set it on the port-channel instead.
-        if generic_interface.name in self.shared_utils._wan_port_channel_member_interfaces:
-            return EosCliConfigGen.Metadata.CvTags.InterfaceTagsItem.Tags()
+
         tags = EosCliConfigGen.Metadata.CvTags.InterfaceTagsItem.Tags()
-        tags.append_new(name="Type", value="lan")
+        # Set Type lan for all other interfaces except port-channel members.
+        if not (isinstance(generic_interface, EosCliConfigGen.EthernetInterfacesItem) and generic_interface.channel_group.id):
+            tags.append_new(name="Type", value="lan")
         return tags
 
     # Generate wan interface tags while accounting for wan interface to be either L3 interface or L3 Port-Channel type


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Avoid setting cv_tag "lan" for port-channel members

The cv_tag is set on the port-channel itself, so we should not set it on members as well.

Fixes #5225

## Component(s) name

`arista.avd.eos_designs`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing tests correctly shows that WAN HA port-channel members are no longer getting the tag assigned, which is exactly what was reported.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
