### PR TITLE
Feat(eos_designs): Add support for `structured_config` inside `<network_services_keys.name>[].vrfs[].ospf`

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-services-l3-port-channels.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-services-l3-port-channels.cfg
@@ -245,6 +245,7 @@ router bgp 101
 !
 router ospf 2 vrf TESTING
    router-id 192.168.255.109
+   auto-cost reference-bandwidth 10
    passive-interface default
    no passive-interface Port-Channel1111.100
    no passive-interface Port-Channel1111.200

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-l3-port-channels.yml
@@ -358,6 +358,7 @@ router_ospf:
     redistribute:
       bgp:
         enabled: true
+    auto_cost_reference_bandwidth: 10
 service_routing_protocols_model: multi-agent
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/network-services-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/network-services-l3-port-channels.yml
@@ -100,6 +100,8 @@ tenants:
         vrf_id: 2
         ospf:
           enabled: true
+          structured_config:
+            auto_cost_reference_bandwidth: 10
         l3_port_channels:
           - name: Port-Channel1111
             mode: active

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
@@ -25,7 +25,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.redistribute_connected.route_map") | String |  |  |  | Route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.nodes") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.nodes.[]") | String |  |  |  | Hostname. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.structured_config") | Dictionary |  |  |  | Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.structured_config") | Dictionary |  |  |  | Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_ospf</samp>](## "<network_services_keys.name>.[].vrfs.[].redistribute_ospf") | Boolean |  | `True` |  | Non-selectively enabling or disabling redistribute ospf inside the VRF. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;svis</samp>](## "<network_services_keys.name>.[].vrfs.[].svis") | List, items: Dictionary |  |  |  | List of SVIs.<br>This will create both the L3 SVI and L2 VLAN based on filters applied to the node.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].id") | Integer | Required |  | Min: 1<br>Max: 4096 | SVI interface id and VLAN id. |
@@ -134,7 +134,7 @@
                   # Hostname.
                 - <str>
 
-              # Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen.
+              # Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for eos_cli_config_gen.
               structured_config: <dict>
 
             # Non-selectively enabling or disabling redistribute ospf inside the VRF.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
@@ -25,6 +25,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.redistribute_connected.route_map") | String |  |  |  | Route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.nodes") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.nodes.[]") | String |  |  |  | Hostname. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.structured_config") | Dictionary |  |  |  | Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_ospf</samp>](## "<network_services_keys.name>.[].vrfs.[].redistribute_ospf") | Boolean |  | `True` |  | Non-selectively enabling or disabling redistribute ospf inside the VRF. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;svis</samp>](## "<network_services_keys.name>.[].vrfs.[].svis") | List, items: Dictionary |  |  |  | List of SVIs.<br>This will create both the L3 SVI and L2 VLAN based on filters applied to the node.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].id") | Integer | Required |  | Min: 1<br>Max: 4096 | SVI interface id and VLAN id. |
@@ -132,6 +133,9 @@
 
                   # Hostname.
                 - <str>
+
+              # Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen.
+              structured_config: <dict>
 
             # Non-selectively enabling or disabling redistribute ospf inside the VRF.
             redistribute_ospf: <bool; default=True>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
@@ -25,7 +25,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.redistribute_connected.route_map") | String |  |  |  | Route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.nodes") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.nodes.[]") | String |  |  |  | Hostname. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.structured_config") | Dictionary |  |  |  | Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for eos_cli_config_gen. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.structured_config") | Dictionary |  |  |  | Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_ospf</samp>](## "<network_services_keys.name>.[].vrfs.[].redistribute_ospf") | Boolean |  | `True` |  | Non-selectively enabling or disabling redistribute ospf inside the VRF. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;svis</samp>](## "<network_services_keys.name>.[].vrfs.[].svis") | List, items: Dictionary |  |  |  | List of SVIs.<br>This will create both the L3 SVI and L2 VLAN based on filters applied to the node.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].id") | Integer | Required |  | Min: 1<br>Max: 4096 | SVI interface id and VLAN id. |
@@ -134,7 +134,7 @@
                   # Hostname.
                 - <str>
 
-              # Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for eos_cli_config_gen.
+              # Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen.
               structured_config: <dict>
 
             # Non-selectively enabling or disabling redistribute ospf inside the VRF.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
@@ -25,7 +25,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;route_map</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.redistribute_connected.route_map") | String |  |  |  | Route-map name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.nodes") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.nodes.[]") | String |  |  |  | Hostname. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.structured_config") | Dictionary |  |  |  | Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].ospf.structured_config") | Dictionary |  |  |  | Custom structured config added under router_ospf.process_ids.[process_id=<process_id>] for eos_cli_config_gen. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;redistribute_ospf</samp>](## "<network_services_keys.name>.[].vrfs.[].redistribute_ospf") | Boolean |  | `True` |  | Non-selectively enabling or disabling redistribute ospf inside the VRF. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;svis</samp>](## "<network_services_keys.name>.[].vrfs.[].svis") | List, items: Dictionary |  |  |  | List of SVIs.<br>This will create both the L3 SVI and L2 VLAN based on filters applied to the node.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;id</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].id") | Integer | Required |  | Min: 1<br>Max: 4096 | SVI interface id and VLAN id. |
@@ -134,7 +134,7 @@
                   # Hostname.
                 - <str>
 
-              # Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen.
+              # Custom structured config added under router_ospf.process_ids.[process_id=<process_id>] for eos_cli_config_gen.
               structured_config: <dict>
 
             # Non-selectively enabling or disabling redistribute ospf inside the VRF.

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -35402,6 +35402,7 @@ class EosDesigns(EosDesignsRootModel):
                             "redistribute_bgp": {"type": RedistributeBgp},
                             "redistribute_connected": {"type": RedistributeConnected},
                             "nodes": {"type": Nodes},
+                            "structured_config": {"type": EosCliConfigGen.RouterOspf.ProcessIdsItem},
                         }
                         enabled: bool | None
                         process_id: int | None
@@ -35429,6 +35430,11 @@ class EosDesigns(EosDesignsRootModel):
                         """Subclass of AvdModel."""
                         nodes: Nodes
                         """Subclass of AvdList with `str` items."""
+                        structured_config: EosCliConfigGen.RouterOspf.ProcessIdsItem
+                        """
+                        Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for
+                        eos_cli_config_gen.
+                        """
 
                         if TYPE_CHECKING:
 
@@ -35443,6 +35449,7 @@ class EosDesigns(EosDesignsRootModel):
                                 redistribute_bgp: RedistributeBgp | UndefinedType = Undefined,
                                 redistribute_connected: RedistributeConnected | UndefinedType = Undefined,
                                 nodes: Nodes | UndefinedType = Undefined,
+                                structured_config: EosCliConfigGen.RouterOspf.ProcessIdsItem | UndefinedType = Undefined,
                             ) -> None:
                                 """
                                 Ospf.
@@ -35468,6 +35475,9 @@ class EosDesigns(EosDesignsRootModel):
                                     redistribute_bgp: Subclass of AvdModel.
                                     redistribute_connected: Subclass of AvdModel.
                                     nodes: Subclass of AvdList with `str` items.
+                                    structured_config:
+                                       Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for
+                                       eos_cli_config_gen.
 
                                 """
 

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -35432,7 +35432,7 @@ class EosDesigns(EosDesignsRootModel):
                         """Subclass of AvdList with `str` items."""
                         structured_config: EosCliConfigGen.RouterOspf.ProcessIdsItem
                         """
-                        Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for
+                        Custom structured config added under router_ospf.process_ids.[process_id=<process_id>] for
                         eos_cli_config_gen.
                         """
 
@@ -35476,7 +35476,7 @@ class EosDesigns(EosDesignsRootModel):
                                     redistribute_connected: Subclass of AvdModel.
                                     nodes: Subclass of AvdList with `str` items.
                                     structured_config:
-                                       Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for
+                                       Custom structured config added under router_ospf.process_ids.[process_id=<process_id>] for
                                        eos_cli_config_gen.
 
                                 """

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -35432,7 +35432,7 @@ class EosDesigns(EosDesignsRootModel):
                         """Subclass of AvdList with `str` items."""
                         structured_config: EosCliConfigGen.RouterOspf.ProcessIdsItem
                         """
-                        Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for
+                        Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for
                         eos_cli_config_gen.
                         """
 
@@ -35476,7 +35476,7 @@ class EosDesigns(EosDesignsRootModel):
                                     redistribute_connected: Subclass of AvdModel.
                                     nodes: Subclass of AvdList with `str` items.
                                     structured_config:
-                                       Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for
+                                       Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for
                                        eos_cli_config_gen.
 
                                 """

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -35432,7 +35432,7 @@ class EosDesigns(EosDesignsRootModel):
                         """Subclass of AvdList with `str` items."""
                         structured_config: EosCliConfigGen.RouterOspf.ProcessIdsItem
                         """
-                        Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for
+                        Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for
                         eos_cli_config_gen.
                         """
 
@@ -35476,7 +35476,7 @@ class EosDesigns(EosDesignsRootModel):
                                     redistribute_connected: Subclass of AvdModel.
                                     nodes: Subclass of AvdList with `str` items.
                                     structured_config:
-                                       Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for
+                                       Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for
                                        eos_cli_config_gen.
 
                                 """

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -6771,6 +6771,14 @@ $defs:
                     items:
                       type: str
                       description: Hostname.
+                  structured_config:
+                    type: dict
+                    relaxed_validation: true
+                    description: Custom structured config added under router_ospf.process_ids.[process_id=<OSPF
+                      process ID>] for eos_cli_config_gen.
+                    documentation_options:
+                      hide_keys: true
+                    $ref: eos_cli_config_gen#/keys/router_ospf/keys/process_ids/items
               redistribute_ospf:
                 documentation_options:
                   table: network-services-vrfs-ospf-settings

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -6774,8 +6774,8 @@ $defs:
                   structured_config:
                     type: dict
                     relaxed_validation: true
-                    description: Custom structured config added under router_ospf.process_ids.[process_id=<OSPF
-                      process ID>] for eos_cli_config_gen.
+                    description: Custom structured config added under router_ospf.process_ids.[process_id=<process_id>]
+                      for eos_cli_config_gen.
                     documentation_options:
                       hide_keys: true
                     $ref: eos_cli_config_gen#/keys/router_ospf/keys/process_ids/items

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -6774,8 +6774,8 @@ $defs:
                   structured_config:
                     type: dict
                     relaxed_validation: true
-                    description: Custom structured config added under router_ospf.process_ids.[process_id=<OSPF
-                      process ID>] for eos_cli_config_gen.
+                    description: Custom structured config added under router_ospf.process_ids.[process_id=<vrf>]
+                      for eos_cli_config_gen.
                     documentation_options:
                       hide_keys: true
                     $ref: eos_cli_config_gen#/keys/router_ospf/keys/process_ids/items

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -6774,8 +6774,8 @@ $defs:
                   structured_config:
                     type: dict
                     relaxed_validation: true
-                    description: Custom structured config added under router_ospf.process_ids.[process_id=<vrf>]
-                      for eos_cli_config_gen.
+                    description: Custom structured config added under router_ospf.process_ids.[process_id=<OSPF
+                      process ID>] for eos_cli_config_gen.
                     documentation_options:
                       hide_keys: true
                     $ref: eos_cli_config_gen#/keys/router_ospf/keys/process_ids/items

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -553,6 +553,13 @@ $defs:
                     items:
                       type: str
                       description: Hostname.
+                  structured_config:
+                    type: dict
+                    relaxed_validation: true
+                    description: Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen.
+                    documentation_options:
+                      hide_keys: true
+                    $ref: "eos_cli_config_gen#/keys/router_ospf/keys/process_ids/items"
               redistribute_ospf:
                 documentation_options:
                   table: network-services-vrfs-ospf-settings

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -556,7 +556,7 @@ $defs:
                   structured_config:
                     type: dict
                     relaxed_validation: true
-                    description: Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen.
+                    description: Custom structured config added under router_ospf.process_ids.[process_id=<process_id>] for eos_cli_config_gen.
                     documentation_options:
                       hide_keys: true
                     $ref: "eos_cli_config_gen#/keys/router_ospf/keys/process_ids/items"

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -556,7 +556,7 @@ $defs:
                   structured_config:
                     type: dict
                     relaxed_validation: true
-                    description: Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen.
+                    description: Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for eos_cli_config_gen.
                     documentation_options:
                       hide_keys: true
                     $ref: "eos_cli_config_gen#/keys/router_ospf/keys/process_ids/items"

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -556,7 +556,7 @@ $defs:
                   structured_config:
                     type: dict
                     relaxed_validation: true
-                    description: Custom structured config added under router_ospf.process_ids.[process_id=<vrf>] for eos_cli_config_gen.
+                    description: Custom structured config added under router_ospf.process_ids.[process_id=<OSPF process ID>] for eos_cli_config_gen.
                     documentation_options:
                       hide_keys: true
                     $ref: "eos_cli_config_gen#/keys/router_ospf/keys/process_ids/items"

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/router_ospf.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/router_ospf.py
@@ -48,6 +48,11 @@ class RouterOspfMixin(Protocol):
                 )
                 self._update_ospf_interface(process, vrf)
 
+                if vrf.ospf.structured_config:
+                    self.custom_structured_configs.nested.router_ospf.process_ids.obtain(process_id)._deepmerge(
+                        vrf.ospf.structured_config, list_merge=self.custom_structured_configs.list_merge_strategy
+                    )
+
                 if vrf.name != "default":
                     process.vrf = vrf.name
                 if vrf.ospf.bfd:


### PR DESCRIPTION
## Change Summary

Add support for structured_config inside `<network_services_keys.name>.vrfs[].ospf`

## Related Issue(s)

Fixes #4924 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Added `structured_config` key under `<network_services_keys.name>.vrfs[].ospf`

```
<network_services_keys.name>:
        - name: <str>
           vrfs:
             - name: <str>
                ospf:
                   structured_config: <dict>
```

## How to test
Tested in molecule `eos_designs_unit_tests`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
