### PR TITLE
Refactor(eos_designs): Clean legacy render method for structured config

### DIFF
--- a/python-avd/pyavd/_eos_designs/avdfacts.py
+++ b/python-avd/pyavd/_eos_designs/avdfacts.py
@@ -53,16 +53,6 @@ class AvdFactsProtocol(Protocol):
             return getattr(self, key)
         return default_value
 
-    def render(self) -> dict:
-        """
-        Return a dictionary of all @cached_property values.
-
-        If the value is cached, it will automatically get returned from cache
-        If the value is not cached, it will be resolved by the attribute function first.
-        Empty values are removed from the returned data.
-        """
-        return {key: value for key in self.keys() if (value := getattr(self, key)) is not None}
-
     def clear_cache(self) -> None:
         for key in self.keys() + self.internal_keys():
             self.__dict__.pop(key, None)

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/__init__.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/__init__.py
@@ -12,7 +12,7 @@ from pyavd._utils import remove_cached_property_type
 
 from .mlag import MlagMixin
 from .overlay import OverlayMixin
-from .schema import EosDesignsFactsProtocol
+from .schema import EosDesignsFacts, EosDesignsFactsProtocol
 from .short_esi import ShortEsiMixin
 from .uplinks import UplinksMixin
 from .utils import UtilsMixin
@@ -379,3 +379,7 @@ class EosDesignsFactsGenerator(AvdFacts, EosDesignsFactsGeneratorProtocol, EosDe
         self._populate_downlink_switches_on_peers()
         self._populate_evpn_route_server_clients_on_peers()
         self._populate_mpls_route_reflector_clients_on_peers()
+
+    def render(self) -> EosDesignsFacts:
+        """Returns an instance of the EosDesignsFacts schemas class populated by the generator."""
+        return EosDesignsFacts._from_dict({key: value for key in self.keys() if (value := getattr(self, key)) is not None})

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/get_facts.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/get_facts.py
@@ -9,8 +9,6 @@ from pyavd._eos_designs.eos_designs_facts import EosDesignsFactsGenerator
 from pyavd._eos_designs.shared_utils import SharedUtils
 from pyavd._errors import AristaAvdError, AristaAvdMissingVariableError
 
-from .schema import EosDesignsFacts
-
 if TYPE_CHECKING:
     from collections.abc import Mapping
 
@@ -18,6 +16,8 @@ if TYPE_CHECKING:
 
     from pyavd._eos_designs.schema import EosDesigns
     from pyavd.api.pool_manager import PoolManager
+
+    from .schema import EosDesignsFacts
 
 
 def get_facts(
@@ -50,13 +50,12 @@ def get_facts(
 
     for hostname, generator in peer_facts_generators.items():
         try:
-            facts_in_dict = generator.render()
-        except AristaAvdMissingVariableError as e:
+            all_facts[hostname] = generator.render()
+        except AristaAvdMissingVariableError as e:  # noqa: PERF203
             raise AristaAvdMissingVariableError(variable=e.variable, host=hostname) from e
         except AristaAvdError as e:
             msg = f"{str(e).removesuffix('.')} for host '{hostname}'."
             raise type(e)(msg) from e
-        all_facts[hostname] = EosDesignsFacts._from_dict(facts_in_dict)
 
     return all_facts
 

--- a/python-avd/pyavd/_eos_designs/fabric_documentation_facts/__init__.py
+++ b/python-avd/pyavd/_eos_designs/fabric_documentation_facts/__init__.py
@@ -15,7 +15,7 @@ from pyavd.j2filters import natural_sort
 from .topology import Topology
 
 if TYPE_CHECKING:
-    from typing import TypeVar
+    from typing import Any, TypeVar
 
     from pyavd._eos_designs.eos_designs_facts.schema import EosDesignsFacts
 
@@ -48,6 +48,9 @@ class FabricDocumentationFacts(AvdFacts):
         self.structured_configs = structured_configs
         self._include_connected_endpoints = include_connected_endpoints
         self._toc = toc
+
+    def render(self) -> dict[str, Any]:
+        return {key: value for key in self.keys() if (value := getattr(self, key)) is not None}
 
     @cached_property
     def fabric_name(self) -> str:

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -3,7 +3,6 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from functools import cached_property
 from typing import Protocol
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
@@ -408,8 +407,8 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
         if tcam_profile := self.shared_utils.platform_settings.tcam_profile:
             self.structured_config.tcam_profile.system = tcam_profile
 
-    @cached_property
-    def mac_address_table(self) -> dict | None:
+    @structured_config_contributor
+    def mac_address_table(self) -> None:
         """mac_address_table set based on mac_address_table data-model."""
         self.structured_config.mac_address_table.aging_time = self.inputs.mac_address_table.aging_time
 

--- a/python-avd/pyavd/_eos_designs/structured_config/structured_config_generator.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/structured_config_generator.py
@@ -93,13 +93,6 @@ class StructuredConfigGeneratorProtocol(AvdFactsProtocol, Protocol):
         # In-place update self.structured_config by calling all the refactored methods marked with @structured_config_contributor
         self.render_structured_config()
 
-        # The render method on AvdFacts class will only execute methods with @cached_property not starting with _.
-        # These are the legacy methods which will be refactored to use the @structured_config_contributor decorator instead.
-        generated_structured_config_as_dict = super().render()
-        if generated_structured_config_as_dict:
-            generated_structured_config = EosCliConfigGen._from_dict(generated_structured_config_as_dict)
-            self.structured_config._deepmerge(generated_structured_config, list_merge="append_unique")
-
         # If we run with the legacy behavior we now have to restore the original structured config and merge in the things we generated here.
         if not self.inputs.avd_eos_designs_enforce_duplication_checks_across_all_models and not getattr(
             self, "ignore_avd_eos_designs_enforce_duplication_checks_across_all_models", False
@@ -128,8 +121,6 @@ class StructuredConfigGenerator(AvdFacts, StructuredConfigGeneratorProtocol):
     Base class for structured config generators.
 
     This differs from AvdFacts by also taking structured_config and custom_structured_configs as argument
-    and by the render function which updates the structured_config instead of
-    returning a dict.
     """
 
     def __init__(

--- a/python-avd/pyavd/_eos_designs/structured_config/structured_config_generator.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/structured_config_generator.py
@@ -76,21 +76,19 @@ class StructuredConfigGeneratorProtocol(AvdFactsProtocol, Protocol):
 
     def render(self) -> None:
         """
-        In-place update the structured_config by deepmerging the rendered dict over the structured_config object.
+        In-place update self.structured_config.
 
-        This method is bridging the gap between older classes which returns builtin types on all methods,
-        and refactored classes which inplace updates the self.structured_config.
+        If 'avd_eos_designs_enforce_duplication_checks_across_all_models' is `true` (new behavior for AVD 6.0.0 (?)),
+        all code is updating the same instance of self.structured_config.
+        Otherwise a fresh structured_config instance is initialized for each module, and they are deepmerged on top of the final structured_config.
         """
-        # This knob makes us keep the legacy behavior of maintaining a single structured config object per module and merging them.
-        # Without it set, we will just in-place update the same structured_config, which means any duplication checks will be enforced across all modules.
-        # Note that methods that have not been refactored to update structured_config directly will still be merged on top.
         if not self.inputs.avd_eos_designs_enforce_duplication_checks_across_all_models and not getattr(
             self, "ignore_avd_eos_designs_enforce_duplication_checks_across_all_models", False
         ):
             self._complete_structured_config = self.structured_config
             self.structured_config = EosCliConfigGen()
 
-        # In-place update self.structured_config by calling all the refactored methods marked with @structured_config_contributor
+        # In-place update self.structured_config by calling all methods marked with @structured_config_contributor
         self.render_structured_config()
 
         # If we run with the legacy behavior we now have to restore the original structured config and merge in the things we generated here.


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Clean legacy render method for structured config

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- For structured config remove call for dict-based render() based on cached_properties including merge.
- Remove old dict-based render() method on AvdFacts
- Move logic for EosDesignsFactsGenerator to it's own render() method.
- Caught one missing refactor in base.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
