### PR TITLE
Feat(eos_designs): Added the support of notification_host_flap in mac address table

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -312,6 +312,10 @@ ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 90 permit 192.168.255.255/32
 ipv6 unicast-routing vrf TENANT_D_WAN_ZONE
 !
+mac address-table notification host-flap logging
+mac address-table notification host-flap detection window 10
+mac address-table notification host-flap detection moves 2
+!
 ip route vrf MGMT 0.0.0.0/0 192.168.200.5
 ip route vrf Tenant_A_WAN_Zone 10.3.4.0/24 1.2.3.4
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -249,6 +249,11 @@ loopback_interfaces:
   - 192.168.255.255/32
 mac_address_table:
   aging_time: 42
+  notification_host_flap:
+    logging: true
+    detection:
+      window: 10
+      moves: 2
 management_api_http:
   enable_http: false
   enable_https: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-BL1A.yml
@@ -55,6 +55,11 @@ event_handlers:
 # Test Mac address table variables
 mac_address_table:
   aging_time: 42
+  notification_host_flap:
+    logging: true
+    detection:
+      window: 10
+      moves: 2
 
 # Test that we can enable CloudVision Tag generation
 # for a single device in a Fabric. The structured config for this node

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-address-table.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/mac-address-table.md
@@ -8,7 +8,7 @@
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>mac_address_table</samp>](## "mac_address_table") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;aging_time</samp>](## "mac_address_table.aging_time") | Integer |  |  |  | Aging time in seconds. |
+    | [<samp>&nbsp;&nbsp;aging_time</samp>](## "mac_address_table.aging_time") | Integer |  |  | Min: 0<br>Max: 1000000 | Aging time in seconds 10-1000000.<br>Enter 0 to disable aging.<br> |
     | [<samp>&nbsp;&nbsp;notification_host_flap</samp>](## "mac_address_table.notification_host_flap") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "mac_address_table.notification_host_flap.logging") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;detection</samp>](## "mac_address_table.notification_host_flap.detection") | Dictionary |  |  |  |  |
@@ -20,8 +20,9 @@
     ```yaml
     mac_address_table:
 
-      # Aging time in seconds.
-      aging_time: <int>
+      # Aging time in seconds 10-1000000.
+      # Enter 0 to disable aging.
+      aging_time: <int; 0-1000000>
       notification_host_flap:
         logging: <bool>
         detection:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/system-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/system-settings.md
@@ -35,8 +35,13 @@
     | [<samp>&nbsp;&nbsp;range</samp>](## "internal_vlan_order.range") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;beginning</samp>](## "internal_vlan_order.range.beginning") | Integer | Required |  | Min: 2<br>Max: 4094 | First VLAN ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ending</samp>](## "internal_vlan_order.range.ending") | Integer | Required |  | Min: 2<br>Max: 4094 | Last VLAN ID. |
-    | [<samp>mac_address_table</samp>](## "mac_address_table") | Dictionary |  |  |  | MAC address-table aging time.<br>Use to change the EOS default of 300.<br> |
+    | [<samp>mac_address_table</samp>](## "mac_address_table") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;aging_time</samp>](## "mac_address_table.aging_time") | Integer |  |  | Min: 0<br>Max: 1000000 | Aging time in seconds 10-1000000.<br>Enter 0 to disable aging.<br> |
+    | [<samp>&nbsp;&nbsp;notification_host_flap</samp>](## "mac_address_table.notification_host_flap") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;logging</samp>](## "mac_address_table.notification_host_flap.logging") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;detection</samp>](## "mac_address_table.notification_host_flap.detection") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;window</samp>](## "mac_address_table.notification_host_flap.detection.window") | Integer |  |  | Min: 2<br>Max: 300 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;moves</samp>](## "mac_address_table.notification_host_flap.detection.moves") | Integer |  |  | Min: 2<br>Max: 10 |  |
     | [<samp>queue_monitor_length</samp>](## "queue_monitor_length") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;enabled</samp>](## "queue_monitor_length.enabled") | Boolean | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;notifying</samp>](## "queue_monitor_length.notifying") | Boolean |  |  |  | If True, `eos_designs` will configure `queue-monitor length notifying` according to the<br>`platform_settings.[].feature_support.queue_monitor_length_notify` setting.<br> |
@@ -184,14 +189,16 @@
 
         # Last VLAN ID.
         ending: <int; 2-4094; required>
-
-    # MAC address-table aging time.
-    # Use to change the EOS default of 300.
     mac_address_table:
 
       # Aging time in seconds 10-1000000.
       # Enter 0 to disable aging.
       aging_time: <int; 0-1000000>
+      notification_host_flap:
+        logging: <bool>
+        detection:
+          window: <int; 2-300>
+          moves: <int; 2-10>
     queue_monitor_length:
       enabled: <bool; required>
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -18466,7 +18466,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
         _fields: ClassVar[dict] = {"aging_time": {"type": int}, "notification_host_flap": {"type": NotificationHostFlap}}
         aging_time: int | None
-        """Aging time in seconds."""
+        """
+        Aging time in seconds 10-1000000.
+        Enter 0 to disable aging.
+        """
         notification_host_flap: NotificationHostFlap
         """Subclass of AvdModel."""
 
@@ -18482,7 +18485,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 Subclass of AvdModel.
 
                 Args:
-                    aging_time: Aging time in seconds.
+                    aging_time:
+                       Aging time in seconds 10-1000000.
+                       Enter 0 to disable aging.
                     notification_host_flap: Subclass of AvdModel.
 
                 """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -7309,7 +7309,13 @@ keys:
     keys:
       aging_time:
         type: int
-        description: Aging time in seconds.
+        description: 'Aging time in seconds 10-1000000.
+
+          Enter 0 to disable aging.
+
+          '
+        min: 0
+        max: 1000000
         convert_types:
         - str
       notification_host_flap:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_address_table.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_address_table.schema.yml
@@ -11,7 +11,11 @@ keys:
     keys:
       aging_time:
         type: int
-        description: Aging time in seconds.
+        description: |
+          Aging time in seconds 10-1000000.
+          Enter 0 to disable aging.
+        min: 0
+        max: 1000000
         convert_types:
         - str
       notification_host_flap:

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -6481,32 +6481,6 @@ class EosDesigns(EosDesignsRootModel):
 
     L3InterfaceProfiles._item_type = L3InterfaceProfilesItem
 
-    class MacAddressTable(AvdModel):
-        """Subclass of AvdModel."""
-
-        _fields: ClassVar[dict] = {"aging_time": {"type": int}}
-        aging_time: int | None
-        """
-        Aging time in seconds 10-1000000.
-        Enter 0 to disable aging.
-        """
-
-        if TYPE_CHECKING:
-
-            def __init__(self, *, aging_time: int | None | UndefinedType = Undefined) -> None:
-                """
-                MacAddressTable.
-
-
-                Subclass of AvdModel.
-
-                Args:
-                    aging_time:
-                       Aging time in seconds 10-1000000.
-                       Enter 0 to disable aging.
-
-                """
-
     class ManagementEapi(AvdModel):
         """Subclass of AvdModel."""
 
@@ -56861,7 +56835,7 @@ class EosDesigns(EosDesignsRootModel):
         "l3_interface_profiles": {"type": L3InterfaceProfiles},
         "load_interval": {"type": EosCliConfigGen.LoadInterval},
         "local_users": {"type": EosCliConfigGen.LocalUsers},
-        "mac_address_table": {"type": MacAddressTable},
+        "mac_address_table": {"type": EosCliConfigGen.MacAddressTable},
         "management_eapi": {"type": ManagementEapi},
         "mgmt_destination_networks": {"type": MgmtDestinationNetworks},
         "mgmt_gateway": {"type": str},
@@ -57945,14 +57919,7 @@ class EosDesigns(EosDesignsRootModel):
     """
     load_interval: EosCliConfigGen.LoadInterval
     local_users: EosCliConfigGen.LocalUsers
-    mac_address_table: MacAddressTable
-    """
-    MAC address-table aging time.
-    Use to change the EOS default of 300.
-
-
-    Subclass of AvdModel.
-    """
+    mac_address_table: EosCliConfigGen.MacAddressTable
     management_eapi: ManagementEapi
     """
     Default is HTTPS management eAPI enabled.
@@ -59022,7 +58989,7 @@ class EosDesigns(EosDesignsRootModel):
             l3_interface_profiles: L3InterfaceProfiles | UndefinedType = Undefined,
             load_interval: EosCliConfigGen.LoadInterval | UndefinedType = Undefined,
             local_users: EosCliConfigGen.LocalUsers | UndefinedType = Undefined,
-            mac_address_table: MacAddressTable | UndefinedType = Undefined,
+            mac_address_table: EosCliConfigGen.MacAddressTable | UndefinedType = Undefined,
             management_eapi: ManagementEapi | UndefinedType = Undefined,
             mgmt_destination_networks: MgmtDestinationNetworks | UndefinedType = Undefined,
             mgmt_gateway: str | None | UndefinedType = Undefined,
@@ -59726,12 +59693,7 @@ class EosDesigns(EosDesignsRootModel):
                    `L3InterfaceProfilesItem` items. Primary key is `profile` (`str`).
                 load_interval: load_interval
                 local_users: local_users
-                mac_address_table:
-                   MAC address-table aging time.
-                   Use to change the EOS default of 300.
-
-
-                   Subclass of AvdModel.
+                mac_address_table: mac_address_table
                 management_eapi:
                    Default is HTTPS management eAPI enabled.
                    The VRF is set to < mgmt_interface_vrf >.

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -2185,23 +2185,7 @@ keys:
     documentation_options:
       table: system-settings
     type: dict
-    description: 'MAC address-table aging time.
-
-      Use to change the EOS default of 300.
-
-      '
-    keys:
-      aging_time:
-        type: int
-        convert_types:
-        - str
-        description: 'Aging time in seconds 10-1000000.
-
-          Enter 0 to disable aging.
-
-          '
-        min: 0
-        max: 1000000
+    $ref: eos_cli_config_gen#/keys/mac_address_table
   management_eapi:
     documentation_options:
       table: management-settings

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mac_address_table.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mac_address_table.schema.yml
@@ -10,16 +10,4 @@ keys:
     documentation_options:
       table: system-settings
     type: dict
-    description: |
-      MAC address-table aging time.
-      Use to change the EOS default of 300.
-    keys:
-      aging_time:
-        type: int
-        convert_types:
-          - str
-        description: |
-          Aging time in seconds 10-1000000.
-          Enter 0 to disable aging.
-        min: 0
-        max: 1000000
+    $ref: "eos_cli_config_gen#/keys/mac_address_table"

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -411,7 +411,7 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
     @cached_property
     def mac_address_table(self) -> dict | None:
         """mac_address_table set based on mac_address_table data-model."""
-        self.structured_config.mac_address_table.aging_time = self.inputs.mac_address_table.aging_time
+        self.structured_config.mac_address_table = self.inputs.mac_address_table
 
     @structured_config_contributor
     def queue_monitor_streaming(self) -> None:


### PR DESCRIPTION
## Change Summary

Added the support of notification_host_flap in mac address table

## Related Issue(s)

Fixes #5263 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
eos_designs only knows about mac_address_table.aging, but brings a error for mac_address_table.notification.
So added the support of notification_host_flap in mac address table.

## How to test
Run Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
