### PR TITLE
Feat(eos_cli_config_gen): Add support for command hardware access-list update default-result permit

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -2528,6 +2528,8 @@ hardware access-list mechanism tcam
 hardware speed-group 1 serdes 10g
 hardware speed-group 2 serdes 25g
 hardware speed-group 3/1 serdes 25g
+!
+hardware access-list update default-result permit
 ```
 
 ### VM Tracer Sessions

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -254,6 +254,8 @@ flow tracking sampled
          collector dead:beef::cafe
    no shutdown
 !
+hardware access-list update default-result permit
+!
 ip igmp snooping robustness-variable 2
 ip igmp snooping restart query-interval 30
 ip igmp snooping interface-restart-query 500

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/hardware.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/hardware.yml
@@ -3,6 +3,7 @@
 hardware:
   access_list:
     mechanism: tcam
+    update_default_result_permit: true
   speed_groups:
     - speed_group: 1
       serdes: 10g

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/hardware.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/hardware.md
@@ -10,6 +10,7 @@
     | [<samp>hardware</samp>](## "hardware") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;access_list</samp>](## "hardware.access_list") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mechanism</samp>](## "hardware.access_list.mechanism") | String |  |  | Valid Values:<br>- <code>algomatch</code><br>- <code>none</code><br>- <code>tcam</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;update_default_result_permit</samp>](## "hardware.access_list.update_default_result_permit") | Boolean |  |  |  | Accept the packets when access-list is being updated. |
     | [<samp>&nbsp;&nbsp;speed_groups</samp>](## "hardware.speed_groups") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;speed_group</samp>](## "hardware.speed_groups.[].speed_group") | String | Required, Unique |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;serdes</samp>](## "hardware.speed_groups.[].serdes") | String |  |  |  | Serdes speed like "10g" or "25g". |
@@ -23,6 +24,9 @@
     hardware:
       access_list:
         mechanism: <str; "algomatch" | "none" | "tcam">
+
+        # Accept the packets when access-list is being updated.
+        update_default_result_permit: <bool>
       speed_groups:
         - speed_group: <str; required; unique>
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/hardware.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/hardware.j2
@@ -37,5 +37,6 @@
 ```eos
 {%     include 'eos/hardware.j2' %}
 {%     include 'eos/hardware-speed-groups.j2' %}
+{%     include 'eos/hardware-access-list-update-default-result-permit.j2' %}
 ```
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-intended-config.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-intended-config.j2
@@ -56,6 +56,8 @@
 {% include 'eos/event-monitor.j2' %}
 {# flow tracking #}
 {% include 'eos/flow-tracking.j2' %}
+{# hardware access list default update default result permit #}
+{% include 'eos/hardware-access-list-update-default-result-permit.j2' %}
 {# ip igmp snooping #}
 {% include 'eos/ip-igmp-snooping.j2' %}
 {# logging event congestion-drops #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/hardware-access-list-update-default-result-permit.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/hardware-access-list-update-default-result-permit.j2
@@ -1,0 +1,10 @@
+{#
+ Copyright (c) 2023-2025 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# eos - hardware access list update default result permit #}
+{% if hardware.access_list.update_default_result_permit is arista.avd.defined(true) %}
+!
+hardware access-list update default-result permit
+{% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -13064,12 +13064,19 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         class AccessList(AvdModel):
             """Subclass of AvdModel."""
 
-            _fields: ClassVar[dict] = {"mechanism": {"type": str}}
+            _fields: ClassVar[dict] = {"mechanism": {"type": str}, "update_default_result_permit": {"type": bool}}
             mechanism: Literal["algomatch", "none", "tcam"] | None
+            update_default_result_permit: bool | None
+            """Accept the packets when access-list is being updated."""
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, mechanism: Literal["algomatch", "none", "tcam"] | None | UndefinedType = Undefined) -> None:
+                def __init__(
+                    self,
+                    *,
+                    mechanism: Literal["algomatch", "none", "tcam"] | None | UndefinedType = Undefined,
+                    update_default_result_permit: bool | None | UndefinedType = Undefined,
+                ) -> None:
                     """
                     AccessList.
 
@@ -13078,6 +13085,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     Args:
                         mechanism: mechanism
+                        update_default_result_permit: Accept the packets when access-list is being updated.
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -5098,6 +5098,9 @@ keys:
             - algomatch
             - none
             - tcam
+          update_default_result_permit:
+            type: bool
+            description: Accept the packets when access-list is being updated.
       speed_groups:
         type: list
         primary_key: speed_group

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/hardware.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/hardware.schema.yml
@@ -15,6 +15,9 @@ keys:
           mechanism:
             type: str
             valid_values: ["algomatch", "none", "tcam"]
+          update_default_result_permit:
+            type: bool
+            description: Accept the packets when access-list is being updated.
       speed_groups:
         type: list
         primary_key: speed_group


### PR DESCRIPTION
## Change Summary

Added support for command hardware access-list update default-result permit

## Related Issue(s)

Fixes #5267

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added support for command hardware access-list update default-result permit

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
