### PR TITLE
Doc(eos_designs): Add network-services l3_port_channels to input variables

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -1467,6 +1467,12 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vr
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
 --8<--
 
+#### Network services VRF L3 Port-Channels configuration
+
+--8<--
+ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
+--8<--
+
 #### Network services VRF Loopbacks configuration
 
 Loopbacks are usually configured with `vtep_diagnostic` which supports IP pools etc.


### PR DESCRIPTION
## Change Summary

Missed in #5019

## Related Issue(s)

Reported by the field

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Make the documentation complete again

## How to test

Bioutiful doc

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
