### PR TITLE
Bump: Restore support for ansible-core 2.15

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -144,7 +144,7 @@ jobs:
         # Also test minimum ansible version for one scenario.
         include:
           - avd_scenario: "eos_cli_config_gen"
-            ansible_version: "ansible-core==2.16.0"
+            ansible_version: "ansible-core==2.15.0"
     needs: [file-changes]
     if: needs.file-changes.outputs.config_gen == 'true'
     steps:
@@ -225,7 +225,10 @@ jobs:
         # Also test minimum ansible version for one scenario.
         include:
           - avd_scenario: "eos_designs_unit_tests"
-            ansible_version: "ansible-core==2.16.0"
+            ansible_version: "ansible-core==2.15.0"
+            pip_requirements: ".github/requirements-ci-dev.txt"
+          - avd_scenario: "eos_designs_unit_tests"
+            ansible_version: "ansible-core<2.17.0"
             pip_requirements: ".github/requirements-ci-dev.txt"
           - avd_scenario: "eos_designs_unit_tests"
             ansible_version: "ansible-core<2.18.0"
@@ -270,7 +273,7 @@ jobs:
           - "ansible-core<2.19.0"
         include:
           - avd_scenario: "eos_config_deploy_cvp"
-            ansible_version: "ansible-core==2.16.0"
+            ansible_version: "ansible-core==2.15.0"
     needs: [file-changes]
     if: needs.file-changes.outputs.cloudvision == 'true' || needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.config_gen == 'true'
 
@@ -304,7 +307,7 @@ jobs:
           - 'ansible-core<2.19.0'
         include:
           - avd_scenario: 'anta_runner'
-            ansible_version: 'ansible-core==2.16.0'
+            ansible_version: 'ansible-core==2.15.0'
     needs: [ file-changes ]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.anta_runner == 'true'
     steps:
@@ -333,7 +336,7 @@ jobs:
           - "ansible-core<2.19.0"
         include:
           - avd_scenario: "eos_validate_state"
-            ansible_version: "ansible-core==2.16.0"
+            ansible_version: "ansible-core==2.15.0"
     needs: [file-changes]
     if: needs.file-changes.outputs.eos_design == 'true' || needs.file-changes.outputs.validate_state == 'true'
     steps:
@@ -476,7 +479,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Install Python & Ansible requirements"
         run: |
-          pip install "ansible-core==2.16.0"
+          pip install "ansible-core==2.15.0"
       - name: Download collection
         uses: actions/download-artifact@v4
         with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -157,7 +157,7 @@ repos:
           --markdown "docs/plugins/Modules_and_action_plugins/"
         language: python
         types: [python]
-        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.16.0,<2.19.0']
+        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.15.0,<2.19.0']
         files: ansible_collections/arista/avd/plugins/modules/
 
       - id: docs-plugin-filter
@@ -167,7 +167,7 @@ repos:
           --markdown "docs/plugins/Filter_plugins/"
         language: python
         types_or: [python, yaml]
-        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.16.0,<2.19.0']
+        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.15.0,<2.19.0']
         files: ansible_collections/arista/avd/plugins/filter/
         exclude: ^(ansible_collections/arista/avd/plugins/filter/deprecated_filters.py)$
 
@@ -178,7 +178,7 @@ repos:
           --markdown "docs/plugins/Lookup_plugins/"
         language: python
         types: [python]
-        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.16.0,<2.19.0']
+        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.15.0,<2.19.0']
         files: ansible_collections/arista/avd/plugins/lookup/
 
       - id: docs-plugin-test
@@ -188,7 +188,7 @@ repos:
           --markdown "docs/plugins/Test_plugins/"
         language: python
         types: [python]
-        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.16.0,<2.19.0']
+        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.15.0,<2.19.0']
         files: ansible_collections/arista/avd/plugins/test/
 
       - id: docs-plugin-vars
@@ -198,7 +198,7 @@ repos:
           --markdown "docs/plugins/Vars_plugins/"
         language: python
         types: [python]
-        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.16.0,<2.19.0']
+        additional_dependencies: ['ansible-doc-extractor>=0.1.10', 'ansible-core>=2.15.0,<2.19.0']
         files: ansible_collections/arista/avd/plugins/vars/
 
       - id: schemas

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -22,7 +22,7 @@ AVD Documentation:
 The AVD collection has the following requirements:
 
 - Python 3.10 or above
-- Ansible Core 2.16.0 to 2.18.x
+- Ansible Core 2.15.0 to 2.18.x
 - the Python package `pyavd[ansible-collection]` matching the collection version
 - Modify the `ansible.cfg` file to support additional Jinja2 extensions
 

--- a/ansible_collections/arista/avd/meta/runtime.yml
+++ b/ansible_collections/arista/avd/meta/runtime.yml
@@ -1,5 +1,5 @@
 ---
-requires_ansible: '>=2.16.0,<2.19.0'
+requires_ansible: '>=2.15.0,<2.19.0'
 plugin_routing:
   filter:
     convert_dicts:

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -8,7 +8,7 @@ PyYAML>=6.0.0
 treelib>=1.5.5
 jsonschema>=3.2.0
 # dev requirements
-ansible-core>=2.16.0,<2.19.0
+ansible-core>=2.15.0,<2.19.0
 ansible-doc-extractor>=0.1.10
 ansible-lint>=25.1.3
 aristaproto[compiler]>=0.1.1

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -18,6 +18,9 @@ title: Release Notes for AVD 5.x.x
 
 - The file `ansible_collections/arista/avd/collections.yml` has been renamed `ansible_collections/arista/avd/requirements.yml` to work well with ansible-lint. A symlink has been kept and will be removed in AVD 6.0.0.
 - `distlib` has been added to the pyavd extras `ansible-collection` to enable installing the collection from source after adding manifest directives to galaxy.yml https://docs.ansible.com/ansible/latest/dev_guide/developing_collections_distributing.html#manifest-directives
+- Python requirements:
+  - AVD now requires ansible-core from **2.15.0** to **2.18.x**.
+    Support for ansible-core 2.15 has been restored because this version remains supported within Ansible Automation Platform 2.4.
 
 ## Release 5.2.3
 

--- a/python-avd/pyproject.toml
+++ b/python-avd/pyproject.toml
@@ -33,7 +33,7 @@ repository = "https://github.com/aristanetworks/avd"
 
 [dependency-groups]
 pytest = [
-    "ansible-core>=2.16.0,<2.19.0",
+    "ansible-core>=2.15.0,<2.19.0",
     "anta>=1.3.0",
     "pytest",
     "pytest-asyncio",
@@ -47,7 +47,7 @@ coverage = [
 
 [project.optional-dependencies]
 ansible = [
-    "ansible-core>=2.16.0,<2.19.0",
+    "ansible-core>=2.15.0,<2.19.0",
     "pyavd[ansible-collection]",
 ]
 ansible-collection = [


### PR DESCRIPTION
## Change Summary

Restore support for ansible-core 2.15 because this version remains supported within Ansible Automation Platform 2.4.