### PR TITLE
Refactor(eos_cli_config_gen, eos_designs): Rename keys `destination_address_prefix` and `gateway` under `static_routes` and `ipv6_static_routes`

### DIFF
--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
@@ -1641,10 +1641,10 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.10.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
@@ -1641,10 +1641,10 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.10.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
@@ -10158,10 +10158,10 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.10.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan10

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
@@ -3240,10 +3240,10 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.10.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
@@ -3240,10 +3240,10 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.10.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
@@ -3150,10 +3150,10 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.10.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan10

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
@@ -3150,10 +3150,10 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.10.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan10

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
@@ -3150,10 +3150,10 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.10.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan10

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
@@ -183,8 +183,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
@@ -183,8 +183,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/inet-cloud.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/inet-cloud.yml
@@ -158,8 +158,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/mpls-cloud.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/mpls-cloud.yml
@@ -160,8 +160,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/pf1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/pf1.yml
@@ -707,12 +707,12 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.18.100.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 100.64.100.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
+- prefix: 172.18.0.0/16
+  next_hop: 172.18.100.1
+- prefix: 0.0.0.0/0
+  next_hop: 100.64.100.1
 stun:
   server:
     local_interfaces:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/pf2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/pf2.yml
@@ -707,12 +707,12 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.18.200.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 100.64.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
+- prefix: 172.18.0.0/16
+  next_hop: 172.18.200.1
+- prefix: 0.0.0.0/0
+  next_hop: 100.64.200.1
 stun:
   server:
     local_interfaces:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border1.yml
@@ -375,8 +375,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border2.yml
@@ -375,8 +375,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan1.yml
@@ -855,12 +855,12 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.18.10.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 100.64.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
+- prefix: 172.18.0.0/16
+  next_hop: 172.18.10.1
+- prefix: 0.0.0.0/0
+  next_hop: 100.64.10.1
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan2.yml
@@ -856,10 +856,10 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.18.11.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
+- prefix: 172.18.0.0/16
+  next_hop: 172.18.11.1
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-leaf1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-leaf1.yml
@@ -324,8 +324,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-leaf2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-leaf2.yml
@@ -324,8 +324,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan1.yml
@@ -693,10 +693,10 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.18.20.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
+- prefix: 172.18.0.0/16
+  next_hop: 172.18.20.1
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan2.yml
@@ -748,8 +748,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site3-leaf1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site3-leaf1.yml
@@ -94,8 +94,8 @@ ntp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site3-wan1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site3-wan1.yml
@@ -603,8 +603,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.17.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.17.1
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -356,8 +356,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -356,8 +356,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -78,8 +78,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -428,8 +428,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -428,8 +428,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -78,8 +78,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -177,8 +177,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -177,8 +177,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1a.yml
@@ -356,8 +356,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1b.yml
@@ -356,8 +356,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf1c.yml
@@ -78,8 +78,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2a.yml
@@ -428,8 +428,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2b.yml
@@ -428,8 +428,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-leaf2c.yml
@@ -78,8 +78,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine1.yml
@@ -177,8 +177,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
+++ b/ansible_collections/arista/avd/examples/dual-dc-l3ls/intended/structured_configs/dc2-spine2.yml
@@ -177,8 +177,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p1.yml
@@ -163,8 +163,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p2.yml
@@ -163,8 +163,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p3.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p3.yml
@@ -138,8 +138,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p4.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/p4.yml
@@ -138,8 +138,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe1.yml
@@ -239,8 +239,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe2.yml
@@ -239,8 +239,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe3.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/pe3.yml
@@ -234,8 +234,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr1.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr1.yml
@@ -204,8 +204,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr2.yml
+++ b/ansible_collections/arista/avd/examples/isis-ldp-ipvpn/intended/structured_configs/rr2.yml
@@ -204,8 +204,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF1.yml
@@ -130,8 +130,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF2.yml
@@ -130,8 +130,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF3.yml
@@ -130,8 +130,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/LEAF4.yml
@@ -130,8 +130,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE1.yml
@@ -164,8 +164,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/intended/structured_configs/SPINE2.yml
@@ -164,8 +164,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.100.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.100.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1a.yml
@@ -377,8 +377,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1b.yml
@@ -377,8 +377,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf1c.yml
@@ -99,8 +99,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2a.yml
@@ -377,8 +377,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2b.yml
@@ -377,8 +377,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-leaf2c.yml
@@ -99,8 +99,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine1.yml
@@ -198,8 +198,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/examples/single-dc-l3ls/intended/structured_configs/dc1-spine2.yml
@@ -198,8 +198,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-L2LEAF1A.yml
@@ -90,8 +90,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-L2LEAF1B.yml
@@ -90,8 +90,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1A.yml
@@ -270,8 +270,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-L3LEAF1B.yml
@@ -267,8 +267,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/CUSTOM-TEMPLATES-SPINE1.yml
@@ -128,8 +128,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF.yml
+++ b/ansible_collections/arista/avd/molecule/ansible_only/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF.yml
@@ -164,8 +164,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan1

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf1a.yml
@@ -455,8 +455,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf1b.yml
@@ -493,8 +493,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf1c.yml
@@ -73,11 +73,11 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.21.110.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.21.110.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4085

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf2a.yml
@@ -447,8 +447,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf2b.yml
@@ -447,8 +447,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-leaf2c.yml
@@ -73,11 +73,11 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.21.110.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.21.110.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4085

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-spine1.yml
@@ -266,8 +266,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-spine2.yml
@@ -248,8 +248,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-svc-leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-svc-leaf1a.yml
@@ -213,8 +213,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-svc-leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-svc-leaf1b.yml
@@ -213,8 +213,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-wan1.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-wan1.yml
@@ -555,12 +555,12 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.18.3.1
-- destination_address_prefix: 100.64.0.0/16
-  gateway: 100.64.3.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
+- prefix: 172.18.0.0/16
+  next_hop: 172.18.3.1
+- prefix: 100.64.0.0/16
+  next_hop: 100.64.3.1
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-wan2.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc1-wan2.yml
@@ -555,12 +555,12 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.18.4.1
-- destination_address_prefix: 100.64.0.0/16
-  gateway: 100.64.4.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
+- prefix: 172.18.0.0/16
+  next_hop: 172.18.4.1
+- prefix: 100.64.0.0/16
+  next_hop: 100.64.4.1
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf1a.yml
@@ -358,8 +358,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf1b.yml
@@ -358,8 +358,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf1c.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf1c.yml
@@ -80,8 +80,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf2a.yml
@@ -430,8 +430,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf2b.yml
@@ -430,8 +430,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf2c.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf2c.yml
@@ -80,8 +80,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf3a.arista.com.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf3a.arista.com.yml
@@ -399,8 +399,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf3b.arista.com.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-leaf3b.arista.com.yml
@@ -347,8 +347,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-spine1.yml
@@ -219,8 +219,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/anta_runner/intended/structured_configs/dc2-spine2.yml
@@ -219,8 +219,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ipv6-static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ipv6-static-routes.yml
@@ -3,44 +3,44 @@
 
 ipv6_static_routes:
   - vrf: default
-    destination_address_prefix: 2a01:cb04:4e6:d300::/64
+    prefix: 2a01:cb04:4e6:d300::/64
     interface: vlan1001
-    gateway: 2a01:cb04:4e6:d100::1
+    next_hop: 2a01:cb04:4e6:d100::1
 
   - vrf: default
-    destination_address_prefix: 2a01:cb04:4e6:d400::/64
+    prefix: 2a01:cb04:4e6:d400::/64
     interface: vlan1001
-    gateway: 2a01:cb04:4e6:d100::1
+    next_hop: 2a01:cb04:4e6:d100::1
     distance: 200
     tag: 666
     name: RT-TO-FAKE-DMZ
 
   - vrf: default
-    destination_address_prefix: 2a01:cb04:4e6:d400::/64
+    prefix: 2a01:cb04:4e6:d400::/64
     interface: vlan1001
-    gateway: 2a01:cb04:4e6:d100::1
+    next_hop: 2a01:cb04:4e6:d100::1
     distance: 200
     tag: 666
     metric: 100
     name: RT-TO-FAKE-DB-ZONE
 
   - vrf: TENANT_A_PROJECT01
-    destination_address_prefix: 2a01:cb04:4e6:a300::/64
+    prefix: 2a01:cb04:4e6:a300::/64
     interface: vlan1001
-    gateway: 2a01:cb04:4e6:100::1
+    next_hop: 2a01:cb04:4e6:100::1
 
   - vrf: TENANT_A_PROJECT01
-    destination_address_prefix: 2a01:cb04:4e6:a400::/64
+    prefix: 2a01:cb04:4e6:a400::/64
     interface: vlan1001
-    gateway: 2a01:cb04:4e6:100::1
+    next_hop: 2a01:cb04:4e6:100::1
     distance: 201
     tag: 667
     name: RT-TO-FAKE-DMZ
 
   - vrf: TENANT_A_PROJECT01
-    destination_address_prefix: 2b01:cb04:4e6:a400::/64
+    prefix: 2b01:cb04:4e6:a400::/64
     interface: vlan102
-    gateway: 2a01:cb04:4e6:102::1
+    next_hop: 2a01:cb04:4e6:102::1
     track_bfd: true
     distance: 201
     tag: 102
@@ -48,7 +48,7 @@ ipv6_static_routes:
     name: Track-BFD
 
   - vrf: TENANT_A_PROJECT01
-    destination_address_prefix: 2c01:cb04:4e6:a400::/64
+    prefix: 2c01:cb04:4e6:a400::/64
     interface: vlan102
     # Negative test case - Tacking should not be enabled
     track_bfd: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/static-routes.yml
@@ -3,55 +3,55 @@
 
 static_routes:
   - vrf: BLUE-C1
-    destination_address_prefix: 193.1.0.0/24
+    prefix: 193.1.0.0/24
     interface: Null0
 
   - vrf: BLUE-C1
-    destination_address_prefix: 193.1.1.0/24
+    prefix: 193.1.1.0/24
     interface: Null0
 
   - vrf: BLUE-C1
-    destination_address_prefix: 193.1.2.0/24
+    prefix: 193.1.2.0/24
     interface: Null0
 
   - vrf: default
-    destination_address_prefix: 1.1.1.0/24
+    prefix: 1.1.1.0/24
     interface: vlan1001
-    gateway: 10.1.1.1
+    next_hop: 10.1.1.1
 
   - vrf: default
-    destination_address_prefix: 1.1.2.0/24
+    prefix: 1.1.2.0/24
     interface: vlan1001
-    gateway: 10.1.1.1
+    next_hop: 10.1.1.1
     distance: 200
     tag: 666
     name: RT-TO-FAKE-DMZ
 
   - vrf: TENANT_A_PROJECT01
-    destination_address_prefix: 1.2.1.0/24
+    prefix: 1.2.1.0/24
     interface: vlan202
-    gateway: 10.1.2.1
+    next_hop: 10.1.2.1
 
   - vrf: TENANT_A_PROJECT01
-    destination_address_prefix: 1.2.2.0/24
+    prefix: 1.2.2.0/24
     interface: vlan1001
-    gateway: 10.1.2.1
+    next_hop: 10.1.2.1
     distance: 201
     tag: 667
     name: RT-TO-FAKE-DMZ
 
-  - destination_address_prefix: 10.3.4.0/24
-    gateway: 1.2.3.4
+  - prefix: 10.3.4.0/24
+    next_hop: 1.2.3.4
     vrf: TENANT_A_PROJECT02
 
-  - destination_address_prefix: 10.3.5.0/24
+  - prefix: 10.3.5.0/24
     vrf: TENANT_A_PROJECT02
     interface: Null0
 
   - vrf: TENANT_A_PROJECT01
-    destination_address_prefix: 10.3.6.0/24
+    prefix: 10.3.6.0/24
     interface: Ethernet40
-    gateway: 11.2.1.1
+    next_hop: 11.2.1.1
     track_bfd: true
     tag: 1000
     name: Track-BFD
@@ -59,7 +59,7 @@ static_routes:
     metric: 300
 
   - vrf: TENANT_A_PROJECT01
-    destination_address_prefix: 10.3.7.0/24
+    prefix: 10.3.7.0/24
     interface: Ethernet41
     # Negative test case - Tacking should not be enabled
     track_bfd: true

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/intended/configs/host1.cfg
@@ -143,6 +143,10 @@ interface Ethernet12
 ip community-list TEST1 permit 1000:1000
 ip community-list TEST2 permit 2000:3000
 !
+ip route 1.1.2.0/24 Vlan1001 10.1.1.1 200 tag 666 name RT-TO-FAKE-DMZ
+!
+ipv6 route vrf TENANT_A_PROJECT01 2a01:cb04:4e6:a300::/64 Vlan1001 2a01:cb04:4e6:100::1
+!
 router bgp 65101
    router-id 192.168.255.3
    redistribute bgp leaked route-map RM-REDISTRIBUTE-BGP

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/ipv6-static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/ipv6-static-routes.yml
@@ -1,6 +1,6 @@
 ---
 ipv6_static_routes:
   - vrf: TENANT_A_PROJECT01
-    prefix: 2a01:cb04:4e6:a300::/64
+    destination_address_prefix: 2a01:cb04:4e6:a300::/64
     interface: vlan1001
-    next_hop: 2a01:cb04:4e6:100::1
+    gateway: 2a01:cb04:4e6:100::1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/ipv6-static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/ipv6-static-routes.yml
@@ -1,0 +1,6 @@
+---
+ipv6_static_routes:
+  - vrf: TENANT_A_PROJECT01
+    prefix: 2a01:cb04:4e6:a300::/64
+    interface: vlan1001
+    next_hop: 2a01:cb04:4e6:100::1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/static-routes.yml
@@ -1,0 +1,9 @@
+---
+static_routes:
+  - vrf: default
+    prefix: 1.1.2.0/24
+    interface: vlan1001
+    next_hop: 10.1.1.1
+    distance: 200
+    tag: 666
+    name: RT-TO-FAKE-DMZ

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen_deprecated_vars/inventory/host_vars/host1/static-routes.yml
@@ -1,9 +1,9 @@
 ---
 static_routes:
   - vrf: default
-    prefix: 1.1.2.0/24
+    destination_address_prefix: 1.1.2.0/24
     interface: vlan1001
-    next_hop: 10.1.1.1
+    gateway: 10.1.1.1
     distance: 200
     tag: 666
     name: RT-TO-FAKE-DMZ

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1A.yml
@@ -377,8 +377,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-BL1B.yml
@@ -377,8 +377,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -93,8 +93,8 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -129,8 +129,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -129,8 +129,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF1A.yml
@@ -289,8 +289,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan130

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2A.yml
@@ -512,8 +512,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-LEAF2B.yml
@@ -512,8 +512,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE1.yml
@@ -268,8 +268,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE2.yml
@@ -268,8 +268,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE3.yml
@@ -268,8 +268,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SPINE4.yml
@@ -268,8 +268,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3A.yml
@@ -614,8 +614,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_config_deploy_cvp/intended/structured_configs/DC1-SVC3B.yml
@@ -592,8 +592,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
@@ -95,10 +95,10 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.23.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 172.23.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
@@ -61,10 +61,10 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.23.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 172.23.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -161,8 +161,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -163,11 +163,11 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
 - vrf: default
-  destination_address_prefix: 10.0.0.0/8
-  gateway: 10.1.100.100
+  prefix: 10.0.0.0/8
+  next_hop: 10.1.100.100
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
@@ -45,10 +45,10 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.23.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 172.23.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
@@ -74,11 +74,11 @@ router_isis:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
 - vrf: default
-  destination_address_prefix: 10.1.0.0/16
-  gateway: 10.1.100.100
+  prefix: 10.1.0.0/16
+  next_hop: 10.1.100.100
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan110

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
@@ -61,10 +61,10 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.23.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 172.23.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
@@ -61,10 +61,10 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.23.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 172.23.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE1.yml
@@ -92,8 +92,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-SPINE2.yml
@@ -92,8 +92,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
@@ -61,10 +61,10 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.23.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 172.23.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
@@ -61,10 +61,10 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.23.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 172.23.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -124,8 +124,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -126,11 +126,11 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.31.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.31.0.1
 - vrf: default
-  destination_address_prefix: 10.0.0.0/8
-  gateway: 10.1.100.100
+  prefix: 10.0.0.0/8
+  next_hop: 10.1.100.100
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER1.yml
@@ -467,8 +467,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan2020

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LER2.yml
@@ -482,8 +482,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan2020

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR1.yml
@@ -166,8 +166,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-LSR2.yml
@@ -136,8 +136,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
@@ -187,8 +187,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LER1.yml
@@ -562,12 +562,12 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: TENANT_B_INTRA
-  destination_address_prefix: 123.0.10.0/24
+  prefix: 123.0.10.0/24
   interface: Ethernet6.10
-  gateway: 123.1.1.3
+  next_hop: 123.1.1.3
   name: TENANT_B_SITE_5_SUBNET
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR1.yml
@@ -166,8 +166,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-LSR2.yml
@@ -205,8 +205,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
@@ -187,8 +187,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE3-LER1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE3-LER1.yml
@@ -81,8 +81,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -53,10 +53,10 @@ spanning_tree:
     priority: 8192
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.21.110.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
+- prefix: 0.0.0.0/0
+  next_hop: 172.21.110.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4085

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -100,10 +100,10 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.21.110.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
+- prefix: 0.0.0.0/0
+  next_hop: 172.21.110.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -108,10 +108,10 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.21.110.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
+- prefix: 0.0.0.0/0
+  next_hop: 172.21.110.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -240,8 +240,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4085

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -663,8 +663,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: vrf_with_loopbacks_dc1_pod1_only

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE1.yml
@@ -304,8 +304,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-SPINE2.yml
@@ -204,8 +204,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-LEAF1A.yml
@@ -345,8 +345,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: vrf_with_loopbacks_from_overlapping_pool

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE1.yml
@@ -201,8 +201,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD2-SPINE2.yml
@@ -189,8 +189,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS1.yml
@@ -214,8 +214,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-RS2.yml
@@ -212,8 +212,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE1.yml
@@ -185,8 +185,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-SUPER-SPINE2.yml
@@ -188,8 +188,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -626,8 +626,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: vrf_with_loopbacks_dc1_pod1_only

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -62,10 +62,10 @@ spanning_tree:
     priority: 8192
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.21.210.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
+- prefix: 0.0.0.0/0
+  next_hop: 172.21.210.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
@@ -62,10 +62,10 @@ spanning_tree:
     priority: 8192
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 172.21.210.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
+- prefix: 0.0.0.0/0
+  next_hop: 172.21.210.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -318,8 +318,8 @@ spanning_tree:
   rstp_priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: vrf_with_loopbacks_from_overlapping_pool

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -183,8 +183,8 @@ spanning_tree:
   rstp_priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE1.yml
@@ -210,8 +210,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-SPINE2.yml
@@ -168,8 +168,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS1.yml
@@ -156,8 +156,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-RS2.yml
@@ -111,8 +111,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE1.yml
@@ -239,8 +239,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-SUPER-SPINE2.yml
@@ -129,8 +129,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1A.yml
@@ -98,8 +98,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF1B.yml
@@ -98,8 +98,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF2.yml
@@ -98,8 +98,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3A.yml
@@ -157,8 +157,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF3B.yml
@@ -157,8 +157,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4A.yml
@@ -157,8 +157,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF4B.yml
@@ -157,8 +157,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF5A.yml
@@ -98,8 +98,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7A.yml
@@ -157,8 +157,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF7B.yml
@@ -157,8 +157,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8A.yml
@@ -98,8 +98,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_ASN_LEAF8B.yml
@@ -98,8 +98,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_BGP_UNGROUPED_LEAF6.yml
@@ -98,8 +98,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.202.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.202.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_LEAF01.yml
@@ -140,8 +140,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.203.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.203.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE01.yml
@@ -130,8 +130,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.203.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.203.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_SPINE02.yml
@@ -130,8 +130,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.203.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.203.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/AUTO_NODE_TYPE_UNGROUPED_LEAF02.yml
@@ -140,8 +140,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.203.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.203.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1A.yml
@@ -258,8 +258,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF1B.yml
@@ -216,8 +216,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-L3LEAF2.yml
@@ -142,8 +142,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan110

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/CUSTOM-PYTHON_MODULES-SPINE1.yml
@@ -128,8 +128,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -687,11 +687,11 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.4.0/24
-  gateway: 1.2.3.4
+  prefix: 10.3.4.0/24
+  next_hop: 1.2.3.4
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -635,11 +635,11 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.4.0/24
-  gateway: 1.2.3.4
+  prefix: 10.3.4.0/24
+  next_hop: 1.2.3.4
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -461,8 +461,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
@@ -463,8 +463,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -399,8 +399,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4090,4092
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4090

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -407,8 +407,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4090,4092
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4090

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -163,8 +163,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -168,8 +168,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -153,8 +153,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -153,8 +153,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -109,8 +109,8 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-L2LEAF4A.yml
@@ -109,8 +109,8 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -424,14 +424,14 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_A_APP_Zone
-  destination_address_prefix: 10.2.32.0/24
+  prefix: 10.2.32.0/24
   interface: Vlan132
   name: VARP
 - vrf: Tenant_A_APP_Zone
-  destination_address_prefix: 10.3.32.0/24
+  prefix: 10.3.32.0/24
   interface: Vlan132
   name: VARP
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -339,12 +339,12 @@ ip_routing: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 ipv6_static_routes:
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: ::/0
-  gateway: 2001:db8:311::4
+  prefix: ::/0
+  next_hop: 2001:db8:311::4
   name: IPv6-test-2
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: 2001:dba::/32
-  gateway: 2001:db8:310::1
+  prefix: 2001:dba::/32
+  next_hop: 2001:db8:310::1
   track_bfd: true
   name: Track-bfd-network-services
 is_deployed: true
@@ -913,18 +913,18 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 10.3.11.4
+  prefix: 0.0.0.0/0
+  next_hop: 10.3.11.4
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: 1.1.1.0/24
-  gateway: 10.3.11.4
+  prefix: 1.1.1.0/24
+  next_hop: 10.3.11.4
   track_bfd: true
   name: Track-bfd-network-services
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: 10.3.11.0/24
+  prefix: 10.3.11.0/24
   interface: Vlan411
   name: VARP
 tcam_profile:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -282,8 +282,8 @@ ip_routing: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 ipv6_static_routes:
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: ::/0
-  gateway: 2001:db8:311::4
+  prefix: ::/0
+  next_hop: 2001:db8:311::4
   name: IPv6-test-2
 is_deployed: true
 local_users:
@@ -851,18 +851,18 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 10.3.11.4
+  prefix: 0.0.0.0/0
+  next_hop: 10.3.11.4
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: 1.1.1.0/24
-  gateway: 10.3.11.4
+  prefix: 1.1.1.0/24
+  next_hop: 10.3.11.4
   track_bfd: true
   name: Track-bfd-network-services
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: 10.3.11.0/24
+  prefix: 10.3.11.0/24
   interface: Vlan411
   name: VARP
 tcam_profile:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
@@ -553,8 +553,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
@@ -452,8 +452,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
@@ -448,8 +448,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
@@ -528,8 +528,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -1328,8 +1328,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4090,4092
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -1274,8 +1274,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4090,4092
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_A_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5A.yml
@@ -145,8 +145,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF5B.yml
@@ -145,8 +145,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6A.yml
@@ -136,8 +136,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1.L2LEAF6B.yml
@@ -136,8 +136,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -652,8 +652,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4090,4092
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -652,8 +652,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4090,4092
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-DISABLED.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-DISABLED.yml
@@ -690,8 +690,8 @@ standard_access_lists:
     action: permit 232.0.136.0/21
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: TEN_C_L3_MULTICAST_DISABLED_330_331

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L2LEAF1A.yml
@@ -53,8 +53,8 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -1004,8 +1004,8 @@ standard_access_lists:
     action: permit 232.0.136.0/21
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: TEN_C_L3_MULTICAST_DISABLED_330_331

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -1004,8 +1004,8 @@ standard_access_lists:
     action: permit 232.0.136.0/21
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: TEN_C_L3_MULTICAST_DISABLED_330_331

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
@@ -819,8 +819,8 @@ standard_access_lists:
     action: permit 232.0.136.0/21
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: TEN_C_L3_MULTICAST_DISABLED_330_331

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
@@ -883,8 +883,8 @@ standard_access_lists:
     action: permit 232.0.136.0/21
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: TEN_C_L3_MULTICAST_DISABLED_330_331

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
@@ -883,8 +883,8 @@ standard_access_lists:
     action: permit 232.0.136.0/21
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: TEN_C_L3_MULTICAST_DISABLED_330_331

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-SPINE1.yml
@@ -229,8 +229,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
@@ -43,8 +43,8 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -368,8 +368,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
@@ -113,8 +113,8 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -566,8 +566,8 @@ snmp_server:
   location: EOS_DESIGNS_UNIT_TESTS MH-LEAF1A
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_X_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -566,8 +566,8 @@ snmp_server:
   location: EOS_DESIGNS_UNIT_TESTS MH-LEAF1B
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_X_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -300,11 +300,11 @@ snmp_server:
   location: EOS_DESIGNS_UNIT_TESTS MH-LEAF2A
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: default
-  destination_address_prefix: 10.0.0.0/8
-  gateway: 10.2.10.100
+  prefix: 10.0.0.0/8
+  next_hop: 10.2.10.100
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_X_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -200,8 +200,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -200,8 +200,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF1.yml
@@ -164,8 +164,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF2.yml
@@ -164,8 +164,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF3.yml
@@ -164,8 +164,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF4.yml
@@ -164,8 +164,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF5.yml
@@ -164,8 +164,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF6.yml
@@ -164,8 +164,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/RD-RT-ADMIN-SUBFIELD-L3LEAF7.yml
@@ -164,8 +164,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_AUTOGEN_ENGINEID.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SNMP_AUTOGEN_ENGINEID.yml
@@ -43,8 +43,8 @@ snmp_server:
     version: v2c
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_1.yml
@@ -259,18 +259,18 @@ router_ospf:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 10.0.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 10.0.0.1
 - vrf: svi_profile_tests_vrf
-  destination_address_prefix: 10.4.10.0/24
+  prefix: 10.4.10.0/24
   interface: Vlan410
   name: VARP
 - vrf: svi_profile_tests_vrf
-  destination_address_prefix: 10.4.11.0/24
+  prefix: 10.4.11.0/24
   interface: Vlan411
   name: VARP
 - vrf: svi_profile_tests_vrf
-  destination_address_prefix: 10.4.12.0/24
+  prefix: 10.4.12.0/24
   interface: Vlan412
   name: VARP
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/SVI_PROFILE_NODE_2.yml
@@ -131,18 +131,18 @@ router_ospf:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 10.0.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 10.0.0.1
 - vrf: svi_profile_tests_vrf
-  destination_address_prefix: 10.4.10.0/24
+  prefix: 10.4.10.0/24
   interface: Vlan410
   name: VARP
 - vrf: svi_profile_tests_vrf
-  destination_address_prefix: 10.4.11.0/24
+  prefix: 10.4.11.0/24
   interface: Vlan411
   name: VARP
 - vrf: svi_profile_tests_vrf
-  destination_address_prefix: 10.4.12.0/24
+  prefix: 10.4.12.0/24
   interface: Vlan412
   name: VARP
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/TEST-MGMT-GATEWAY-IN-NODE-GROUP.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/TEST-MGMT-GATEWAY-IN-NODE-GROUP.yml
@@ -8,8 +8,8 @@ ip_igmp_snooping:
   globally_enabled: true
 ipv6_static_routes:
 - vrf: MGMT
-  destination_address_prefix: ::/0
-  gateway: 2001:db8::2
+  prefix: ::/0
+  next_hop: 2001:db8::2
 is_deployed: true
 management_api_http:
   enable_https: true
@@ -31,8 +31,8 @@ metadata:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.201.254
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.201.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L2LEAF1A.yml
@@ -44,8 +44,8 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -270,8 +270,8 @@ standard_access_lists:
     action: permit 239.255.5.0/24
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -248,8 +248,8 @@ standard_access_lists:
     action: permit 239.255.5.0/24
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -251,8 +251,8 @@ standard_access_lists:
     action: permit 239.255.5.0/24
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -251,8 +251,8 @@ standard_access_lists:
     action: permit 239.255.5.0/24
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
@@ -218,8 +218,8 @@ standard_access_lists:
     action: permit 239.255.5.0/24
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE2.yml
@@ -168,8 +168,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1A.yml
@@ -106,8 +106,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L2LEAF1B.yml
@@ -106,8 +106,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1A.yml
@@ -211,8 +211,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-L3LEAF1B.yml
@@ -211,8 +211,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UPLINK-MLAG-STRUCTURED-CONFIG-SPINE1.yml
@@ -134,8 +134,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/autovpn-rr2.yml
@@ -278,8 +278,8 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.8.8.9
+- prefix: 0.0.0.0/0
+  next_hop: 10.8.8.9
 stun:
   server:
     local_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-from-network-services-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-from-network-services-1.yml
@@ -127,8 +127,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: default
-  destination_address_prefix: 0.0.0.0
-  gateway: 10.10.1.1
+  prefix: 0.0.0.0
+  next_hop: 10.10.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-1.yml
@@ -172,8 +172,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-2.yml
@@ -167,8 +167,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-3.yml
@@ -99,8 +99,8 @@ router_isis:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-1-isis-sr-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-1-isis-sr-ldp.yml
@@ -479,8 +479,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-2-ospf-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-2-ospf-ldp.yml
@@ -334,8 +334,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-3-isis-sr-ldp.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-3-isis-sr-ldp.yml
@@ -65,8 +65,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-4-multicast.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/core-4-multicast.yml
@@ -135,8 +135,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
@@ -597,14 +597,14 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 10.37.121.1/32
-  gateway: 172.16.9.4
+- prefix: 10.37.121.1/32
+  next_hop: 172.16.9.4
   name: IE-ZSCALER-PRI
-- destination_address_prefix: 10.39.77.1/32
-  gateway: 172.16.9.4
+- prefix: 10.39.77.1/32
+  next_hop: 172.16.9.4
   name: IE-ZSCALER-SEC
-- destination_address_prefix: 10.50.9.1/32
-  gateway: 172.16.9.4
+- prefix: 10.50.9.1/32
+  next_hop: 172.16.9.4
   name: IE-ZSCALER-TER
 stun:
   client:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
@@ -549,14 +549,14 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 10.37.121.1/32
-  gateway: 172.16.9.4
+- prefix: 10.37.121.1/32
+  next_hop: 172.16.9.4
   name: IE-ZSCALER-PRI
-- destination_address_prefix: 10.39.77.1/32
-  gateway: 172.16.9.4
+- prefix: 10.39.77.1/32
+  next_hop: 172.16.9.4
   name: IE-ZSCALER-SEC
-- destination_address_prefix: 10.50.9.1/32
-  gateway: 172.16.9.4
+- prefix: 10.50.9.1/32
+  next_hop: 172.16.9.4
   name: IE-ZSCALER-TER
 stun:
   client:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
@@ -637,8 +637,8 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.7.7.6
+- prefix: 0.0.0.0/0
+  next_hop: 10.7.7.6
 stun:
   server:
     local_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-ipsec-for-wan-path-group.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-ipsec-for-wan-path-group.yml
@@ -471,8 +471,8 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 192.168.121.108/32
-  gateway: 192.168.1.104
+- prefix: 192.168.121.108/32
+  next_hop: 192.168.1.104
   name: IE-ZSCALER-PRI
 stun:
   client:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -969,21 +969,21 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 172.16.0.0/16
-  gateway: 172.16.5.4
-- destination_address_prefix: 172.16.0.0/16
-  gateway: 172.16.5.9
+- prefix: 172.16.0.0/16
+  next_hop: 172.16.5.4
+- prefix: 172.16.0.0/16
+  next_hop: 172.16.5.9
 - vrf: default
-  destination_address_prefix: 66.66.66.0/24
-  gateway: 172.17.0.0
-- destination_address_prefix: 10.37.121.1/32
-  gateway: 172.20.20.21
+  prefix: 66.66.66.0/24
+  next_hop: 172.17.0.0
+- prefix: 10.37.121.1/32
+  next_hop: 172.20.20.21
   name: IE-ZSCALER-PRI
-- destination_address_prefix: 10.39.77.1/32
-  gateway: 172.20.20.21
+- prefix: 10.39.77.1/32
+  next_hop: 172.20.20.21
   name: IE-ZSCALER-SEC
-- destination_address_prefix: 10.50.9.1/32
-  gateway: 172.20.20.21
+- prefix: 10.50.9.1/32
+  next_hop: 172.20.20.21
   name: IE-ZSCALER-TER
 stun:
   client:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -1244,20 +1244,20 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 172.16.0.0/16
-  gateway: 172.31.0.1
-- destination_address_prefix: 172.17.0.0/16
-  gateway: 172.31.0.10
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.31.0.11
-- destination_address_prefix: 10.37.121.1/32
-  gateway: 172.31.0.1
+- prefix: 172.16.0.0/16
+  next_hop: 172.31.0.1
+- prefix: 172.17.0.0/16
+  next_hop: 172.31.0.10
+- prefix: 172.18.0.0/16
+  next_hop: 172.31.0.11
+- prefix: 10.37.121.1/32
+  next_hop: 172.31.0.1
   name: IE-ZSCALER-PRI
-- destination_address_prefix: 10.39.77.1/32
-  gateway: 172.31.0.1
+- prefix: 10.39.77.1/32
+  next_hop: 172.31.0.1
   name: IE-ZSCALER-SEC
-- destination_address_prefix: 10.50.9.1/32
-  gateway: 172.31.0.1
+- prefix: 10.50.9.1/32
+  next_hop: 172.31.0.1
   name: IE-ZSCALER-TER
 stun:
   client:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -850,8 +850,8 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.7.7.6
+- prefix: 0.0.0.0/0
+  next_hop: 10.7.7.6
 stun:
   server:
     local_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cvp-instance-ips-cvaas.yml
@@ -87,8 +87,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/device.with.dots.in.hostname.yml
@@ -77,8 +77,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-prevent-readvertise-to-server-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-prevent-readvertise-to-server-1.yml
@@ -127,8 +127,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-prevent-readvertise-to-server-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-prevent-readvertise-to-server-2.yml
@@ -89,8 +89,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-prevent-readvertise-to-server-3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn-prevent-readvertise-to-server-3.yml
@@ -89,8 +89,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -542,10 +542,10 @@ snmp_server:
   location: EOS_DESIGNS_UNIT_TESTS evpn_services_l2_only_false
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_D_OP_Zone
-  destination_address_prefix: 10.3.11.0/24
+  prefix: 10.3.11.0/24
   interface: Vlan411
   name: VARP
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_true.yml
@@ -307,8 +307,8 @@ snmp_server:
   location: EOS_DESIGNS_UNIT_TESTS evpn_services_l2_only_true
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.only_vlans_in_use.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/filter.only_vlans_in_use.yml
@@ -28,8 +28,8 @@ metadata:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 10.0.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 10.0.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf1.yml
@@ -70,10 +70,10 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.254.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.254.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf2.yml
@@ -70,10 +70,10 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.254.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.254.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf1.yml
@@ -270,8 +270,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf2.yml
@@ -267,8 +267,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf3.yml
@@ -370,8 +370,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf4.yml
@@ -370,8 +370,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-spine1.yml
@@ -287,8 +287,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-spine2.yml
@@ -292,8 +292,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-ips.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-ips.yml
@@ -41,8 +41,8 @@ ip_name_servers:
 - ip_address: 8.8.8.8
   vrf: MGMT
 ipv6_static_routes:
-- destination_address_prefix: ::/0
-  gateway: 2a00:105::1
+- prefix: ::/0
+  next_hop: 2a00:105::1
 is_deployed: true
 management_api_http:
   enable_https: true
@@ -66,8 +66,8 @@ port_channel_interfaces:
       allowed_vlan: '105'
 service_routing_protocols_model: multi-agent
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.105.1
+- prefix: 0.0.0.0/0
+  next_hop: 192.168.105.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan105

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-subnets.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-subnets.yml
@@ -41,8 +41,8 @@ ip_name_servers:
 - ip_address: 8.8.8.8
   vrf: MGMT
 ipv6_static_routes:
-- destination_address_prefix: ::/0
-  gateway: 2a00:104::1
+- prefix: ::/0
+  next_hop: 2a00:104::1
 is_deployed: true
 management_api_http:
   enable_https: true
@@ -66,8 +66,8 @@ port_channel_interfaces:
       allowed_vlan: '104'
 service_routing_protocols_model: multi-agent
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.104.1
+- prefix: 0.0.0.0/0
+  next_hop: 192.168.104.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan104

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only-vrf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only-vrf.yml
@@ -42,8 +42,8 @@ ip_name_servers:
   vrf: MGMT
 ipv6_static_routes:
 - vrf: INBANDMGMT
-  destination_address_prefix: ::/0
-  gateway: 2a00:107::1
+  prefix: ::/0
+  next_hop: 2a00:107::1
 is_deployed: true
 management_api_http:
   enable_https: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only.yml
@@ -41,8 +41,8 @@ ip_name_servers:
 - ip_address: 8.8.8.8
   vrf: MGMT
 ipv6_static_routes:
-- destination_address_prefix: ::/0
-  gateway: 2a00:106::1
+- prefix: ::/0
+  next_hop: 2a00:106::1
 is_deployed: true
 management_api_http:
   enable_https: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-a.yml
@@ -214,8 +214,8 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.101.21
+- prefix: 0.0.0.0/0
+  next_hop: 192.168.101.21
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-b.yml
@@ -214,8 +214,8 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.101.21
+- prefix: 0.0.0.0/0
+  next_hop: 192.168.101.21
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet-vrf.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet-vrf.yml
@@ -64,8 +64,8 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: INBANDMGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.102.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.102.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan102

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet.yml
@@ -63,8 +63,8 @@ port_channel_interfaces:
       allowed_vlan: '101'
 service_routing_protocols_model: multi-agent
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.101.1
+- prefix: 0.0.0.0/0
+  next_hop: 192.168.101.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan101

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_default.yml
@@ -76,8 +76,8 @@ snmp_server:
   location: EOS_DESIGNS_UNIT_TESTS mgmt_interface_default
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_description.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_description.yml
@@ -24,8 +24,8 @@ metadata:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.254
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.254
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_dualstack.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_dualstack.yml
@@ -8,11 +8,11 @@ ip_igmp_snooping:
   globally_enabled: true
 ipv6_static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0200:1::/64
-  gateway: 0200::1
+  prefix: 0200:1::/64
+  next_hop: 0200::1
 - vrf: MGMT
-  destination_address_prefix: 0200:2::/64
-  gateway: 0200::1
+  prefix: 0200:2::/64
+  next_hop: 0200::1
 is_deployed: true
 management_api_http:
   enable_https: true
@@ -34,11 +34,11 @@ metadata:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 10.0.10.0/24
-  gateway: 192.168.200.5
+  prefix: 10.0.10.0/24
+  next_hop: 192.168.200.5
 - vrf: MGMT
-  destination_address_prefix: 172.16.254.0/23
-  gateway: 192.168.200.5
+  prefix: 172.16.254.0/23
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_fabric.yml
@@ -76,8 +76,8 @@ snmp_server:
   location: EOS_DESIGNS_UNIT_TESTS mgmt_interface_fabric
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_host.yml
@@ -81,8 +81,8 @@ snmp_server:
   location: EOS_DESIGNS_UNIT_TESTS mgmt_interface_host
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_ipv6.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_ipv6.yml
@@ -8,8 +8,8 @@ ip_igmp_snooping:
   globally_enabled: true
 ipv6_static_routes:
 - vrf: MGMT
-  destination_address_prefix: ::/0
-  gateway: 0200::2
+  prefix: ::/0
+  next_hop: 0200::2
 is_deployed: true
 management_api_http:
   enable_https: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/mgmt_interface_platform.yml
@@ -81,8 +81,8 @@ snmp_server:
   location: EOS_DESIGNS_UNIT_TESTS mgmt_interface_platform
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests-2.yml
@@ -814,8 +814,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-ports-tests.1.yml
@@ -772,8 +772,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-interfaces.yml
@@ -114,8 +114,8 @@ sflow:
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.3
+- prefix: 0.0.0.0/0
+  next_hop: 192.168.1.3
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-port-channels.yml
@@ -504,8 +504,8 @@ service_routing_protocols_model: multi-agent
 spanning_tree:
   mode: none
 static_routes:
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.1.103
+- prefix: 0.0.0.0/0
+  next_hop: 192.168.1.103
 transceiver_qsfp_default_mode_4x10: false
 vrfs:
 - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf1-ptp-disabled.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf1-ptp-disabled.yml
@@ -50,8 +50,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf2-ptp-enabled-uplink-disabled.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf2-ptp-enabled-uplink-disabled.yml
@@ -68,8 +68,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf2-ptp-enabled.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-l2leaf2-ptp-enabled.yml
@@ -77,8 +77,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf1.yml
@@ -428,8 +428,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf2.yml
@@ -401,8 +401,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf3.yml
@@ -185,8 +185,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf4.yml
@@ -149,8 +149,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf5.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-leaf5.yml
@@ -176,8 +176,8 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine1.yml
@@ -364,8 +364,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine2.yml
@@ -261,8 +261,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ptp-tests-spine3.yml
@@ -104,8 +104,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
@@ -68,10 +68,10 @@ sflow:
   run: true
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.254.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.254.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
@@ -68,10 +68,10 @@ sflow:
   run: true
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
-- destination_address_prefix: 0.0.0.0/0
-  gateway: 10.254.254.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
+- prefix: 0.0.0.0/0
+  next_hop: 10.254.254.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf1.yml
@@ -210,8 +210,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf2.yml
@@ -174,8 +174,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf3.yml
@@ -343,8 +343,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf4.yml
@@ -343,8 +343,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-spine1.yml
@@ -323,8 +323,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-spine2.yml
@@ -166,8 +166,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.0.1
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-1.yml
@@ -116,8 +116,8 @@ snmp_server:
     enable: true
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 10.10.10.1
+  prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces.yml
@@ -49,8 +49,8 @@ snmp_server:
     vrf: INBANDMGMT
 static_routes:
 - vrf: INBANDMGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 10.20.30.1
+  prefix: 0.0.0.0/0
+  next_hop: 10.20.30.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4092

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1a.yml
@@ -103,8 +103,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf1b.yml
@@ -116,8 +116,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf3.yml
@@ -59,8 +59,8 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l2leaf4.yml
@@ -59,8 +59,8 @@ port_channel_interfaces:
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1a.yml
@@ -384,8 +384,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf1b.yml
@@ -372,8 +372,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2a.yml
@@ -215,8 +215,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/trunk-group-tests-l3leaf2b.yml
@@ -215,8 +215,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 1.1.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 1.1.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1a.yml
@@ -450,8 +450,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1b.yml
@@ -488,8 +488,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf1c.yml
@@ -72,11 +72,11 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.21.110.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.21.110.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4085

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2a.yml
@@ -440,8 +440,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2b.yml
@@ -440,8 +440,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-leaf2c.yml
@@ -72,11 +72,11 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.21.110.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.21.110.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4085

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-spine1.yml
@@ -265,8 +265,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-spine2.yml
@@ -247,8 +247,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-svc-leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-svc-leaf1a.yml
@@ -208,8 +208,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-svc-leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-svc-leaf1b.yml
@@ -208,8 +208,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan1.yml
@@ -555,12 +555,12 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.18.3.1
-- destination_address_prefix: 100.64.0.0/16
-  gateway: 100.64.3.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
+- prefix: 172.18.0.0/16
+  next_hop: 172.18.3.1
+- prefix: 100.64.0.0/16
+  next_hop: 100.64.3.1
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc1-wan2.yml
@@ -556,12 +556,12 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
-- destination_address_prefix: 172.18.0.0/16
-  gateway: 172.18.4.1
-- destination_address_prefix: 100.64.0.0/16
-  gateway: 100.64.4.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
+- prefix: 172.18.0.0/16
+  next_hop: 172.18.4.1
+- prefix: 100.64.0.0/16
+  next_hop: 100.64.4.1
 stun:
   client:
     server_profiles:

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1a.yml
@@ -357,8 +357,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1b.yml
@@ -357,8 +357,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1c.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf1c.yml
@@ -79,8 +79,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2a.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2a.yml
@@ -429,8 +429,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2b.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2b.yml
@@ -429,8 +429,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2c.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf2c.yml
@@ -79,8 +79,8 @@ spanning_tree:
     priority: 32768
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf3a.arista.com.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf3a.arista.com.yml
@@ -396,8 +396,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf3b.arista.com.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-leaf3b.arista.com.yml
@@ -344,8 +344,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: VRF10

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-spine1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-spine1.yml
@@ -218,8 +218,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-spine2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_validate_state/intended/structured_configs/dc2-spine2.yml
@@ -218,8 +218,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 172.16.1.1
+  prefix: 0.0.0.0/0
+  next_hop: 172.16.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -463,24 +463,24 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.4.0/24
-  gateway: 1.2.3.4
+  prefix: 10.3.4.0/24
+  next_hop: 1.2.3.4
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 1.1.1.0/24
+  prefix: 1.1.1.0/24
   interface: vlan101
-  gateway: 10.1.1.1
+  next_hop: 10.1.1.1
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 1.1.2.0/24
+  prefix: 1.1.2.0/24
   interface: vlan101
-  gateway: 10.1.1.1
+  next_hop: 10.1.1.1
   distance: 200
   tag: 666
   name: RT-TO-FAKE-DMZ
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.5.0/24
+  prefix: 10.3.5.0/24
   interface: Null0
 tcam_profile:
   system: vxlan-routing

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -461,24 +461,24 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.4.0/24
-  gateway: 1.2.3.4
+  prefix: 10.3.4.0/24
+  next_hop: 1.2.3.4
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 1.1.1.0/24
+  prefix: 1.1.1.0/24
   interface: vlan101
-  gateway: 10.1.1.1
+  next_hop: 10.1.1.1
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 1.1.2.0/24
+  prefix: 1.1.2.0/24
   interface: vlan101
-  gateway: 10.1.1.1
+  next_hop: 10.1.1.1
   distance: 200
   tag: 666
   name: RT-TO-FAKE-DMZ
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.5.0/24
+  prefix: 10.3.5.0/24
   interface: Null0
 tcam_profile:
   system: vxlan-routing

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -140,8 +140,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1B.yml
@@ -140,8 +140,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -144,8 +144,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -144,8 +144,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4091'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4091

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-L2LEAF3A.yml
@@ -104,8 +104,8 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -316,8 +316,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan130

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -566,8 +566,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -566,8 +566,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -277,8 +277,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -277,8 +277,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -277,8 +277,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -277,8 +277,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -993,10 +993,10 @@ spanning_tree:
   no_spanning_tree_vlan: '4092'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.5.0/24
+  prefix: 10.3.5.0/24
   interface: Null0
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ebgp_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -993,10 +993,10 @@ spanning_tree:
   no_spanning_tree_vlan: '4092'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.5.0/24
+  prefix: 10.3.5.0/24
   interface: Null0
 transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1A.yml
@@ -265,8 +265,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-BL1B.yml
@@ -249,8 +249,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -90,8 +90,8 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -126,8 +126,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -126,8 +126,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -207,8 +207,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -267,8 +267,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -267,8 +267,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE1.yml
@@ -246,8 +246,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE2.yml
@@ -180,8 +180,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE3.yml
@@ -180,8 +180,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SPINE4.yml
@@ -246,8 +246,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3A.yml
@@ -276,8 +276,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_isis_overlay_ibgp/intended/structured_configs/DC1-SVC3B.yml
@@ -276,8 +276,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -253,8 +253,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -253,8 +253,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -90,8 +90,8 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -126,8 +126,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -126,8 +126,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -216,8 +216,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -335,8 +335,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -335,8 +335,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4093

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -271,8 +271,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -271,8 +271,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -271,8 +271,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -271,8 +271,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -344,8 +344,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_ospf_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -344,8 +344,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1A.yml
@@ -407,11 +407,11 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.4.0/24
-  gateway: 1.2.3.4
+  prefix: 10.3.4.0/24
+  next_hop: 1.2.3.4
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-BL1B.yml
@@ -400,11 +400,11 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 - vrf: Tenant_A_WAN_Zone
-  destination_address_prefix: 10.3.4.0/24
-  gateway: 1.2.3.4
+  prefix: 10.3.4.0/24
+  next_hop: 1.2.3.4
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF1A.yml
@@ -93,8 +93,8 @@ spanning_tree:
     priority: 16384
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2A.yml
@@ -133,8 +133,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-L2LEAF2B.yml
@@ -133,8 +133,8 @@ spanning_tree:
   no_spanning_tree_vlan: '4094'
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF1A.yml
@@ -319,8 +319,8 @@ spanning_tree:
     priority: 4096
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2A.yml
@@ -620,8 +620,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF2B.yml
@@ -620,8 +620,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3A.yml
@@ -493,8 +493,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF3B.yml
@@ -493,8 +493,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4A.yml
@@ -464,8 +464,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-LEAF4B.yml
@@ -464,8 +464,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE1.yml
@@ -270,8 +270,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE2.yml
@@ -270,8 +270,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE3.yml
@@ -270,8 +270,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE4.yml
@@ -270,8 +270,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE5.yml
@@ -216,8 +216,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SPINE6.yml
@@ -184,8 +184,8 @@ spanning_tree:
   mode: none
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3A.yml
@@ -822,8 +822,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/molecule/evpn_underlay_rfc5549_overlay_ebgp/intended/structured_configs/DC1-SVC3B.yml
@@ -800,8 +800,8 @@ spanning_tree:
   no_spanning_tree_vlan: 4093-4094
 static_routes:
 - vrf: MGMT
-  destination_address_prefix: 0.0.0.0/0
-  gateway: 192.168.200.5
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.200.5
 tcam_profile:
   system: vxlan-routing
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ipv6-static-routes.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ipv6-static-routes.md
@@ -9,9 +9,11 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>ipv6_static_routes</samp>](## "ipv6_static_routes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;vrf</samp>](## "ipv6_static_routes.[].vrf") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "ipv6_static_routes.[].destination_address_prefix") | String |  |  |  | IPv6 Network/Mask. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "ipv6_static_routes.[].destination_address_prefix") <span style="color:red">deprecated</span> | String |  |  |  | IPv6 Network/Mask.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>prefix</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix</samp>](## "ipv6_static_routes.[].prefix") | String |  |  |  | IPv6 Network/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "ipv6_static_routes.[].interface") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "ipv6_static_routes.[].gateway") | String |  |  |  | IPv6 Address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "ipv6_static_routes.[].gateway") <span style="color:red">deprecated</span> | String |  |  |  | IPv6 Address.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>next_hop</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "ipv6_static_routes.[].next_hop") | String |  |  |  | IPv6 Address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tag</samp>](## "ipv6_static_routes.[].tag") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
@@ -25,11 +27,23 @@
       - vrf: <str>
 
         # IPv6 Network/Mask.
+        # This key is deprecated.
+        # Support will be removed in AVD version 6.0.0.
+        # Use <samp>prefix</samp> instead.
         destination_address_prefix: <str>
+
+        # IPv6 Network/Mask.
+        prefix: <str>
         interface: <str>
 
         # IPv6 Address.
+        # This key is deprecated.
+        # Support will be removed in AVD version 6.0.0.
+        # Use <samp>next_hop</samp> instead.
         gateway: <str>
+
+        # IPv6 Address.
+        next_hop: <str>
 
         # Track next-hop using BFD.
         track_bfd: <bool>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/static-routes.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/static-routes.md
@@ -9,9 +9,11 @@
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
     | [<samp>static_routes</samp>](## "static_routes") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;-&nbsp;vrf</samp>](## "static_routes.[].vrf") | String |  |  |  | VRF Name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "static_routes.[].destination_address_prefix") | String |  |  |  | IPv4_network/Mask. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "static_routes.[].destination_address_prefix") <span style="color:red">deprecated</span> | String |  |  |  | IPv4_network/Mask.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>prefix</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;prefix</samp>](## "static_routes.[].prefix") | String |  |  |  | IPv4_network/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "static_routes.[].interface") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "static_routes.[].gateway") | String |  |  |  | IPv4 Address. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "static_routes.[].gateway") <span style="color:red">deprecated</span> | String |  |  |  | IPv4 Address.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>next_hop</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "static_routes.[].next_hop") | String |  |  |  | IPv4 Address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;tag</samp>](## "static_routes.[].tag") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
@@ -27,11 +29,23 @@
       - vrf: <str>
 
         # IPv4_network/Mask.
+        # This key is deprecated.
+        # Support will be removed in AVD version 6.0.0.
+        # Use <samp>prefix</samp> instead.
         destination_address_prefix: <str>
+
+        # IPv4_network/Mask.
+        prefix: <str>
         interface: <str>
 
         # IPv4 Address.
+        # This key is deprecated.
+        # Support will be removed in AVD version 6.0.0.
+        # Use <samp>next_hop</samp> instead.
         gateway: <str>
+
+        # IPv4 Address.
+        next_hop: <str>
 
         # Track next-hop using BFD.
         track_bfd: <bool>

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ipv6-static-routes.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ipv6-static-routes.j2
@@ -14,20 +14,30 @@
 | --- | ------------------ | ----------------------- | ------------------- | ----------------------------- | ----------------- | ----------------------------- | -------------- |
 {%     for static_route in ipv6_static_routes %}
 {%         set vrf = static_route.vrf | arista.avd.default('default') %}
-{%         if static_route.gateway is arista.avd.defined %}
-{%             set gateway = static_route.gateway %}
+{%         if static_route.next_hop is arista.avd.defined %}
+{%             set next_hop = static_route.next_hop %}
 {%             if static_route.track_bfd is arista.avd.defined(true) %}
-{%                 set gateway = gateway ~ " (tracked with BFD)" %}
+{%                 set next_hop = next_hop ~ " (tracked with BFD)" %}
+{%             endif %}
+{%         elif static_route.gateway is arista.avd.defined %}
+{%             set next_hop = static_route.gateway %}
+{%             if static_route.track_bfd is arista.avd.defined(true) %}
+{%                 set next_hop = next_hop ~ " (tracked with BFD)" %}
 {%             endif %}
 {%         else %}
-{%             set gateway = "-" %}
+{%             set next_hop = "-" %}
 {%         endif %}
 {%         set interface = static_route.interface | arista.avd.default('-') %}
 {%         set distance = static_route.distance | arista.avd.default('1') %}
 {%         set tag = static_route.tag | arista.avd.default('-') %}
 {%         set name = static_route.name | arista.avd.default('-') %}
 {%         set metric = static_route.metric | arista.avd.default('-') %}
-| {{ vrf }} | {{ static_route.destination_address_prefix }} | {{ gateway }} | {{ interface }} | {{ distance }} | {{ tag }} | {{ name }} | {{ metric }} |
+{%         if static_route.prefix is arista.avd.defined %}
+{%             set prefix = static_route.prefix %}
+{%         elif static_route.destination_address_prefix is arista.avd.defined %}
+{%             set prefix = static_route.destination_address_prefix %}
+{%         endif %}
+| {{ vrf }} | {{ prefix }} | {{ next_hop }} | {{ interface }} | {{ distance }} | {{ tag }} | {{ name }} | {{ metric }} |
 {%     endfor %}
 
 #### Static Routes Device Configuration

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/static-routes.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/static-routes.j2
@@ -14,20 +14,30 @@
 | --- | ------------------ | ----------- | -------------- | ----------------------- | --- | ---------- | ------ |
 {%     for static_route in static_routes %}
 {%         set vrf = static_route.vrf | arista.avd.default('default') %}
-{%         if static_route.gateway is arista.avd.defined %}
-{%             set gateway = static_route.gateway %}
+{%         if static_route.next_hop is arista.avd.defined %}
+{%             set next_hop = static_route.next_hop %}
 {%             if static_route.track_bfd is arista.avd.defined(true) %}
-{%                 set gateway = gateway ~ " (tracked with BFD)" %}
+{%                 set next_hop = next_hop ~ " (tracked with BFD)" %}
+{%             endif %}
+{%         elif static_route.gateway is arista.avd.defined %}
+{%             set next_hop = static_route.gateway %}
+{%             if static_route.track_bfd is arista.avd.defined(true) %}
+{%                 set next_hop = next_hop ~ " (tracked with BFD)" %}
 {%             endif %}
 {%         else %}
-{%             set gateway = "-" %}
+{%             set next_hop = "-" %}
 {%         endif %}
 {%         set interface = static_route.interface | arista.avd.default('-') %}
 {%         set distance = static_route.distance | arista.avd.default('1') %}
 {%         set tag = static_route.tag | arista.avd.default('-') %}
 {%         set name =  static_route.name | arista.avd.default('-') %}
 {%         set metric = static_route.metric | arista.avd.default('-') %}
-| {{ vrf }} | {{ static_route.destination_address_prefix }} | {{ gateway }} | {{ interface }} | {{ distance }} | {{ tag }} | {{ name }} | {{ metric }} |
+{%         if static_route.prefix is arista.avd.defined %}
+{%             set prefix = static_route.prefix %}
+{%         elif static_route.destination_address_prefix is arista.avd.defined %}
+{%             set prefix = static_route.destination_address_prefix %}
+{%         endif %}
+| {{ vrf }} | {{ prefix }} | {{ next_hop }} | {{ interface }} | {{ distance }} | {{ tag }} | {{ name }} | {{ metric }} |
 {%     endfor %}
 
 #### Static Routes Device Configuration

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ipv6-static-routes.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ipv6-static-routes.j2
@@ -13,13 +13,20 @@
 {%                 set ipv6_static_route_cli = ipv6_static_route_cli ~ " vrf " ~ ipv6_static_route.vrf %}
 {%             endif %}
 {%         endif %}
-{%         if ipv6_static_route.destination_address_prefix is arista.avd.defined %}
+{%         if ipv6_static_route.prefix is arista.avd.defined %}
+{%             set ipv6_static_route_cli = ipv6_static_route_cli ~ " " ~ ipv6_static_route.prefix %}
+{%         elif ipv6_static_route.destination_address_prefix is arista.avd.defined %}
 {%             set ipv6_static_route_cli = ipv6_static_route_cli ~ " " ~ ipv6_static_route.destination_address_prefix %}
 {%         endif %}
 {%         if ipv6_static_route.interface is arista.avd.defined %}
 {%             set ipv6_static_route_cli = ipv6_static_route_cli ~ " " ~ ipv6_static_route.interface | capitalize %}
 {%         endif %}
-{%         if ipv6_static_route.gateway is arista.avd.defined %}
+{%         if ipv6_static_route.next_hop is arista.avd.defined %}
+{%             set ipv6_static_route_cli = ipv6_static_route_cli ~ " " ~ ipv6_static_route.next_hop %}
+{%             if ipv6_static_route.track_bfd is arista.avd.defined(true) %}
+{%                 set ipv6_static_route_cli = ipv6_static_route_cli ~ " track bfd" %}
+{%             endif %}
+{%         elif ipv6_static_route.gateway is arista.avd.defined %}
 {%             set ipv6_static_route_cli = ipv6_static_route_cli ~ " " ~ ipv6_static_route.gateway %}
 {%             if ipv6_static_route.track_bfd is arista.avd.defined(true) %}
 {%                 set ipv6_static_route_cli = ipv6_static_route_cli ~ " track bfd" %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/static-routes.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/static-routes.j2
@@ -17,10 +17,10 @@
 {%         if static_route.vrf is arista.avd.defined and static_route.vrf != 'default' %}
 {%             set static_route_cli = static_route_cli ~ " vrf " ~ static_route.vrf %}
 {%         endif %}
-{%         if static_route.destination_address_prefix is arista.avd.defined %}
-{%             set static_route_cli = static_route_cli ~ " " ~ static_route.destination_address_prefix %}
-{%         elif static_route.prefix is arista.avd.defined %}
+{%         if static_route.prefix is arista.avd.defined %}
 {%             set static_route_cli = static_route_cli ~ " " ~ static_route.prefix %}
+{%         elif static_route.destination_address_prefix is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " " ~ static_route.destination_address_prefix %}
 {%         endif %}
 {%         if  static_route.interface is arista.avd.defined %}
 {%             set static_route_cli = static_route_cli ~ " " ~ static_route.interface | capitalize %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/static-routes.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/static-routes.j2
@@ -19,11 +19,18 @@
 {%         endif %}
 {%         if static_route.destination_address_prefix is arista.avd.defined %}
 {%             set static_route_cli = static_route_cli ~ " " ~ static_route.destination_address_prefix %}
+{%         elif static_route.prefix is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " " ~ static_route.prefix %}
 {%         endif %}
 {%         if  static_route.interface is arista.avd.defined %}
 {%             set static_route_cli = static_route_cli ~ " " ~ static_route.interface | capitalize %}
 {%         endif %}
-{%         if static_route.gateway is arista.avd.defined %}
+{%         if static_route.next_hop is arista.avd.defined %}
+{%             set static_route_cli = static_route_cli ~ " " ~ static_route.next_hop %}
+{%             if static_route.track_bfd is arista.avd.defined(true) %}
+{%                 set static_route_cli = static_route_cli ~ " track bfd" %}
+{%             endif %}
+{%         elif static_route.gateway is arista.avd.defined %}
 {%             set static_route_cli = static_route_cli ~ " " ~ static_route.gateway %}
 {%             if static_route.track_bfd is arista.avd.defined(true) %}
 {%                 set static_route_cli = static_route_cli ~ " track bfd" %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -17009,8 +17009,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         _fields: ClassVar[dict] = {
             "vrf": {"type": str},
             "destination_address_prefix": {"type": str},
+            "prefix": {"type": str},
             "interface": {"type": str},
             "gateway": {"type": str},
+            "next_hop": {"type": str},
             "track_bfd": {"type": bool},
             "distance": {"type": int},
             "tag": {"type": int},
@@ -17020,8 +17022,12 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         vrf: str | None
         destination_address_prefix: str | None
         """IPv6 Network/Mask."""
+        prefix: str | None
+        """IPv6 Network/Mask."""
         interface: str | None
         gateway: str | None
+        """IPv6 Address."""
+        next_hop: str | None
         """IPv6 Address."""
         track_bfd: bool | None
         """Track next-hop using BFD."""
@@ -17038,8 +17044,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 *,
                 vrf: str | None | UndefinedType = Undefined,
                 destination_address_prefix: str | None | UndefinedType = Undefined,
+                prefix: str | None | UndefinedType = Undefined,
                 interface: str | None | UndefinedType = Undefined,
                 gateway: str | None | UndefinedType = Undefined,
+                next_hop: str | None | UndefinedType = Undefined,
                 track_bfd: bool | None | UndefinedType = Undefined,
                 distance: int | None | UndefinedType = Undefined,
                 tag: int | None | UndefinedType = Undefined,
@@ -17055,8 +17063,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 Args:
                     vrf: vrf
                     destination_address_prefix: IPv6 Network/Mask.
+                    prefix: IPv6 Network/Mask.
                     interface: interface
                     gateway: IPv6 Address.
+                    next_hop: IPv6 Address.
                     track_bfd: Track next-hop using BFD.
                     distance: distance
                     tag: tag
@@ -58851,8 +58861,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         _fields: ClassVar[dict] = {
             "vrf": {"type": str},
             "destination_address_prefix": {"type": str},
+            "prefix": {"type": str},
             "interface": {"type": str},
             "gateway": {"type": str},
+            "next_hop": {"type": str},
             "track_bfd": {"type": bool},
             "distance": {"type": int},
             "tag": {"type": int},
@@ -58863,8 +58875,12 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """VRF Name."""
         destination_address_prefix: str | None
         """IPv4_network/Mask."""
+        prefix: str | None
+        """IPv4_network/Mask."""
         interface: str | None
         gateway: str | None
+        """IPv4 Address."""
+        next_hop: str | None
         """IPv4 Address."""
         track_bfd: bool | None
         """Track next-hop using BFD."""
@@ -58881,8 +58897,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 *,
                 vrf: str | None | UndefinedType = Undefined,
                 destination_address_prefix: str | None | UndefinedType = Undefined,
+                prefix: str | None | UndefinedType = Undefined,
                 interface: str | None | UndefinedType = Undefined,
                 gateway: str | None | UndefinedType = Undefined,
+                next_hop: str | None | UndefinedType = Undefined,
                 track_bfd: bool | None | UndefinedType = Undefined,
                 distance: int | None | UndefinedType = Undefined,
                 tag: int | None | UndefinedType = Undefined,
@@ -58898,8 +58916,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 Args:
                     vrf: VRF Name.
                     destination_address_prefix: IPv4_network/Mask.
+                    prefix: IPv4_network/Mask.
                     interface: interface
                     gateway: IPv4 Address.
+                    next_hop: IPv4 Address.
                     track_bfd: Track next-hop using BFD.
                     distance: distance
                     tag: tag

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -6695,9 +6695,23 @@ keys:
         destination_address_prefix:
           type: str
           description: IPv6 Network/Mask.
+          deprecation:
+            warning: true
+            remove_in_version: 6.0.0
+            new_key: prefix
+        prefix:
+          type: str
+          description: IPv6 Network/Mask.
         interface:
           type: str
         gateway:
+          type: str
+          description: IPv6 Address.
+          deprecation:
+            warning: true
+            remove_in_version: 6.0.0
+            new_key: next_hop
+        next_hop:
           type: str
           description: IPv6 Address.
         track_bfd:
@@ -22002,9 +22016,23 @@ keys:
         destination_address_prefix:
           type: str
           description: IPv4_network/Mask.
+          deprecation:
+            warning: true
+            remove_in_version: 6.0.0
+            new_key: prefix
+        prefix:
+          type: str
+          description: IPv4_network/Mask.
         interface:
           type: str
         gateway:
+          type: str
+          description: IPv4 Address.
+          deprecation:
+            warning: true
+            remove_in_version: 6.0.0
+            new_key: next_hop
+        next_hop:
           type: str
           description: IPv4 Address.
         track_bfd:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_static_routes.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_static_routes.schema.yml
@@ -18,9 +18,23 @@ keys:
         destination_address_prefix:
           type: str
           description: IPv6 Network/Mask.
+          deprecation:
+            warning: true
+            remove_in_version: 6.0.0
+            new_key: prefix
+        prefix:
+          type: str
+          description: IPv6 Network/Mask.
         interface:
           type: str
         gateway:
+          type: str
+          description: IPv6 Address.
+          deprecation:
+            warning: true
+            remove_in_version: 6.0.0
+            new_key: next_hop
+        next_hop:
           type: str
           description: IPv6 Address.
         track_bfd:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/static_routes.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/static_routes.schema.yml
@@ -19,9 +19,23 @@ keys:
         destination_address_prefix:
           type: str
           description: IPv4_network/Mask.
+          deprecation:
+            warning: true
+            remove_in_version: 6.0.0
+            new_key: prefix
+        prefix:
+          type: str
+          description: IPv4_network/Mask.
         interface:
           type: str
         gateway:
+          type: str
+          description: IPv4 Address.
+          deprecation:
+            warning: true
+            remove_in_version: 6.0.0
+            new_key: next_hop
+        next_hop:
           type: str
           description: IPv4 Address.
         track_bfd:

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -116,9 +116,7 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
                     vrf=self.inputs.mgmt_interface_vrf, prefix=mgmt_destination_network, next_hop=self.shared_utils.mgmt_gateway
                 )
         else:
-            self.structured_config.static_routes.append_new(
-                vrf=self.inputs.mgmt_interface_vrf, prefix="0.0.0.0/0", next_hop=self.shared_utils.mgmt_gateway
-            )
+            self.structured_config.static_routes.append_new(vrf=self.inputs.mgmt_interface_vrf, prefix="0.0.0.0/0", next_hop=self.shared_utils.mgmt_gateway)
 
     @structured_config_contributor
     def ipv6_static_routes(self) -> None:
@@ -133,9 +131,7 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
                 )
             return
 
-        self.structured_config.ipv6_static_routes.append_new(
-            vrf=self.inputs.mgmt_interface_vrf, prefix="::/0", next_hop=self.shared_utils.ipv6_mgmt_gateway
-        )
+        self.structured_config.ipv6_static_routes.append_new(vrf=self.inputs.mgmt_interface_vrf, prefix="::/0", next_hop=self.shared_utils.ipv6_mgmt_gateway)
 
     @structured_config_contributor
     def service_routing_protocols_model(self) -> None:

--- a/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/__init__.py
@@ -113,11 +113,11 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
         if self.inputs.mgmt_destination_networks:
             for mgmt_destination_network in self.inputs.mgmt_destination_networks:
                 self.structured_config.static_routes.append_new(
-                    vrf=self.inputs.mgmt_interface_vrf, destination_address_prefix=mgmt_destination_network, gateway=self.shared_utils.mgmt_gateway
+                    vrf=self.inputs.mgmt_interface_vrf, prefix=mgmt_destination_network, next_hop=self.shared_utils.mgmt_gateway
                 )
         else:
             self.structured_config.static_routes.append_new(
-                vrf=self.inputs.mgmt_interface_vrf, destination_address_prefix="0.0.0.0/0", gateway=self.shared_utils.mgmt_gateway
+                vrf=self.inputs.mgmt_interface_vrf, prefix="0.0.0.0/0", next_hop=self.shared_utils.mgmt_gateway
             )
 
     @structured_config_contributor
@@ -129,12 +129,12 @@ class AvdStructuredConfigBaseProtocol(NtpMixin, SnmpServerMixin, RouterGeneralMi
         if self.inputs.ipv6_mgmt_destination_networks:
             for mgmt_destination_network in self.inputs.ipv6_mgmt_destination_networks:
                 self.structured_config.ipv6_static_routes.append_new(
-                    vrf=self.inputs.mgmt_interface_vrf, destination_address_prefix=mgmt_destination_network, gateway=self.shared_utils.ipv6_mgmt_gateway
+                    vrf=self.inputs.mgmt_interface_vrf, prefix=mgmt_destination_network, next_hop=self.shared_utils.ipv6_mgmt_gateway
                 )
             return
 
         self.structured_config.ipv6_static_routes.append_new(
-            vrf=self.inputs.mgmt_interface_vrf, destination_address_prefix="::/0", gateway=self.shared_utils.ipv6_mgmt_gateway
+            vrf=self.inputs.mgmt_interface_vrf, prefix="::/0", next_hop=self.shared_utils.ipv6_mgmt_gateway
         )
 
     @structured_config_contributor

--- a/python-avd/pyavd/_eos_designs/structured_config/inband_management/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/inband_management/__init__.py
@@ -73,7 +73,7 @@ class AvdStructuredConfigInbandManagement(StructuredConfigGenerator):
             return
 
         self.structured_config.static_routes.append_new(
-            destination_address_prefix="0.0.0.0/0", gateway=self.shared_utils.inband_mgmt_gateway, vrf=self.shared_utils.inband_mgmt_vrf
+            prefix="0.0.0.0/0", next_hop=self.shared_utils.inband_mgmt_gateway, vrf=self.shared_utils.inband_mgmt_vrf
         )
 
     @structured_config_contributor
@@ -82,7 +82,7 @@ class AvdStructuredConfigInbandManagement(StructuredConfigGenerator):
             return
 
         self.structured_config.ipv6_static_routes.append_new(
-            destination_address_prefix="::/0", gateway=self.shared_utils.inband_mgmt_ipv6_gateway, vrf=self.shared_utils.inband_mgmt_vrf
+            prefix="::/0",  next_hop=self.shared_utils.inband_mgmt_ipv6_gateway, vrf=self.shared_utils.inband_mgmt_vrf
         )
 
     @structured_config_contributor

--- a/python-avd/pyavd/_eos_designs/structured_config/inband_management/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/inband_management/__init__.py
@@ -82,7 +82,7 @@ class AvdStructuredConfigInbandManagement(StructuredConfigGenerator):
             return
 
         self.structured_config.ipv6_static_routes.append_new(
-            prefix="::/0",  next_hop=self.shared_utils.inband_mgmt_ipv6_gateway, vrf=self.shared_utils.inband_mgmt_vrf
+            prefix="::/0", next_hop=self.shared_utils.inband_mgmt_ipv6_gateway, vrf=self.shared_utils.inband_mgmt_vrf
         )
 
     @structured_config_contributor

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
@@ -34,6 +34,16 @@ class Ipv6StaticRoutesMixin(Protocol):
         for tenant in self.shared_utils.filtered_tenants:
             for vrf in tenant.vrfs:
                 for static_route in vrf.ipv6_static_routes:
-                    static_route_item = static_route._cast_as(EosCliConfigGen.Ipv6StaticRoutesItem, ignore_extra_keys=True)
-                    static_route_item.vrf = vrf.name
+                    static_route_item = EosCliConfigGen.Ipv6StaticRoutesItem()
+                    static_route_item._update(
+                        vrf=vrf.name,
+                        prefix=static_route.destination_address_prefix,
+                        interface=static_route.interface,
+                        next_hop=static_route.gateway,
+                        track_bfd=static_route.track_bfd,
+                        distance=static_route.distance,
+                        tag=static_route.tag,
+                        metric=static_route.metric,
+                        name=static_route.name,
+                    )
                     self.structured_config.ipv6_static_routes.append_unique(static_route_item)

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/static_routes.py
@@ -36,8 +36,18 @@ class StaticRoutesMixin(Protocol):
             for vrf in tenant.vrfs:
                 # Static routes are already filtered inside filtered_tenants
                 for static_route in vrf.static_routes:
-                    static_route_item = static_route._cast_as(EosCliConfigGen.StaticRoutesItem, ignore_extra_keys=True)
-                    static_route_item.vrf = vrf.name
+                    static_route_item = EosCliConfigGen.StaticRoutesItem()
+                    static_route_item._update(
+                        vrf=vrf.name,
+                        prefix=static_route.destination_address_prefix,
+                        interface=static_route.interface,
+                        next_hop=static_route.gateway,
+                        track_bfd=static_route.track_bfd,
+                        distance=static_route.distance,
+                        tag=static_route.tag,
+                        metric=static_route.metric,
+                        name=static_route.name,
+                    )
                     self.structured_config.static_routes.append_unique(static_route_item)
 
                 for svi in vrf.svis:
@@ -51,7 +61,7 @@ class StaticRoutesMixin(Protocol):
                             continue
 
                         static_route_item = EosCliConfigGen.StaticRoutesItem(
-                            destination_address_prefix=str(ipaddress.ip_network(virtual_router_address, strict=False)),
+                            prefix=str(ipaddress.ip_network(virtual_router_address, strict=False)),
                             vrf=vrf.name,
                             name="VARP",
                             interface=f"Vlan{svi.id}",
@@ -62,7 +72,7 @@ class StaticRoutesMixin(Protocol):
     def set_zscaler_ie_connection_static_route(self: AvdStructuredConfigNetworkServicesProtocol, destination_ip: str, name: str, next_hop: str) -> None:
         """Set the static route for one Zscaler Internet Exit connection."""
         self.structured_config.static_routes.append_new(
-            destination_address_prefix=f"{destination_ip}/32",
+            prefix=f"{destination_ip}/32",
             name=name,
-            gateway=next_hop,
+            next_hop=next_hop,
         )

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/static_routes.py
@@ -36,8 +36,7 @@ class StaticRoutesMixin(Protocol):
             for vrf in tenant.vrfs:
                 # Static routes are already filtered inside filtered_tenants
                 for static_route in vrf.static_routes:
-                    static_route_item = EosCliConfigGen.StaticRoutesItem()
-                    static_route_item._update(
+                    static_route_item = EosCliConfigGen.StaticRoutesItem(
                         vrf=vrf.name,
                         prefix=static_route.destination_address_prefix,
                         interface=static_route.interface,

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/static_routes.py
@@ -40,7 +40,5 @@ class StaticRoutesMixin(Protocol):
                 raise AristaAvdInvalidInputsError(msg)
 
             for l3_generic_interface_static_route in l3_generic_interface.static_routes:
-                static_route = EosCliConfigGen.StaticRoutesItem(
-                    prefix=l3_generic_interface_static_route.prefix, next_hop=l3_generic_interface.peer_ip
-                )
+                static_route = EosCliConfigGen.StaticRoutesItem(prefix=l3_generic_interface_static_route.prefix, next_hop=l3_generic_interface.peer_ip)
                 self.structured_config.static_routes.append_unique(static_route)

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/static_routes.py
@@ -41,6 +41,6 @@ class StaticRoutesMixin(Protocol):
 
             for l3_generic_interface_static_route in l3_generic_interface.static_routes:
                 static_route = EosCliConfigGen.StaticRoutesItem(
-                    destination_address_prefix=l3_generic_interface_static_route.prefix, gateway=l3_generic_interface.peer_ip
+                    prefix=l3_generic_interface_static_route.prefix, next_hop=l3_generic_interface.peer_ip
                 )
                 self.structured_config.static_routes.append_unique(static_route)


### PR DESCRIPTION
## Change Summary

Rename keys `destination_address_prefix` and `gateway` under `static_routes` and `ipv6_static_routes`.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen/eos_designs`

## Proposed changes
Rename keys `destination_address_prefix` and `gateway` under `static_routes` and `ipv6_static_routes`
## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
