### PR TITLE
Test(eos_designs): Add pytest coverage for underlay/static_routes

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-peer-ip-l3-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-peer-ip-l3-interface.yml
@@ -1,0 +1,20 @@
+---
+type: spine
+spine:
+  nodes:
+    - name: missing-peer-ip-l3-interface
+      id: 1
+      evpn_role: none
+      loopback_ipv4_pool: 1.2.3.4/24
+      bgp_as: 65000
+      l3_interfaces:
+        - # Settings set via profile
+          name: Ethernet1
+          ip_address: 192.168.1.2/31
+          peer: peer1
+          peer_interface: eth1
+          # peer_ip: 192.168.1.3
+          static_routes:
+            - prefix: 0.0.0.0/0
+
+expected_error_message: "Cannot set a static_route route for interface Ethernet1 because 'peer_ip' is missing."

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-peer-ip-l3-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-peer-ip-l3-interface.yml
@@ -8,12 +8,11 @@ spine:
       loopback_ipv4_pool: 1.2.3.4/24
       bgp_as: 65000
       l3_interfaces:
-        - # Settings set via profile
-          name: Ethernet1
+        - name: Ethernet1
           ip_address: 192.168.1.2/31
           peer: peer1
           peer_interface: eth1
-          # peer_ip: 192.168.1.3
+          # peer_ip: 192.168.1.3 # No peer_ip
           static_routes:
             - prefix: 0.0.0.0/0
 

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -142,6 +142,7 @@ all:
             missing-internet-exit-policy-direct-wan-interface-peer-ip:
             missing-internet-exit-policy-zscaler-wan-interface-peer-ip:
             missing-internet-exit-policy-zscaler-wan-interface-tunnels-id:
+            missing-peer-ip-l3-interface:
             wan-router-l3-interfaces-unsupported-rxtx-for-subinterface:
             ntp-settings-server-vrf-missing-mgmt-ip:
             ntp-settings-server-vrf-missing-inband-mgmt-interface:


### PR DESCRIPTION
## Change Summary

Add pytest coverage for underlay/static_routes

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added negative tests to improve test coverge.
COVERAGE: 100%

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
