### PR TITLE
Refactor: Address ansible-sanity failure from ansible devel

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/eos_validate_state_runner.py
+++ b/ansible_collections/arista/avd/plugins/action/eos_validate_state_runner.py
@@ -9,7 +9,6 @@ from json import dump
 from typing import TYPE_CHECKING, Any
 
 from ansible.errors import AnsibleActionFail
-from ansible.parsing.yaml.dumper import AnsibleDumper
 from ansible.plugins.action import ActionBase, display
 
 from ansible_collections.arista.avd.plugins.plugin_utils.eos_validate_state_utils import AnsibleEOSDevice, ConfigManager, get_anta_results
@@ -19,6 +18,12 @@ from ansible_collections.arista.avd.plugins.plugin_utils.utils import (
     get_validated_path,
     get_validated_value,
 )
+
+# AnsibleDumper moved in the devel version of Ansible and it makes sanity sad.
+try:
+    from ansible._internal._yaml._dumper import AnsibleDumper
+except ImportError:
+    from ansible.parsing.yaml.dumper import AnsibleDumper
 
 if TYPE_CHECKING:
     from collections.abc import Mapping


### PR DESCRIPTION
## Change Summary

PR 84621 in Ansible repo moved `AnsibleDumper` to new `ansible._internal` module. There is a key for backward compatibility but this is not of the right type so the ansible-sanity is sad

## Component(s) name

`ci`

## Proposed changes

try/except import _internal

## How to test

CI is green again 🍏 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
