### PR TITLE
Test(eos_designs): Add pytest coverage for network_services/router_ospf.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/group_vars/VRF_OSPF_MISSING_PROCESS_ID.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/group_vars/VRF_OSPF_MISSING_PROCESS_ID.yml
@@ -1,0 +1,35 @@
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 10.42.0.0/24
+    vtep_loopback_ipv4_pool: 10.43.0.0/24
+    mlag_interfaces: [ Ethernet5, Ethernet6 ]
+    mlag_peer_ipv4_pool: 10.255.252.0/24
+    mlag_peer_l3_ipv4_pool: 10.255.251.0/24
+
+  node_groups:
+    - group: vrf-missing-id
+      nodes:
+        - name: vrf-ospf-missing-process-id
+          bgp_as: 42
+          id: 42
+
+type: l3leaf
+
+tenants:
+  # Tenant A Specific Information - VRFs / VLANs
+  - name: Tenant_X
+    mac_vrf_vni_base: 11000
+    vrfs:
+      - name: Tenant_X_OP_Zone
+        vrf_vni: 20
+        svis:
+          - id: 310
+            name: Tenant_X_OP_Zone_1
+            tags: [opzone]
+            enabled: true
+        ospf:
+          enabled: true
+          router_id: none
+
+expected_error_message: >-
+  Missing or invalid 'ospf.process_id' or 'vrf_id' under vrf 'Tenant_X_OP_Zone

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -208,6 +208,9 @@ all:
             VRF_OSPF_VTEP_ROUTER_ID:
               hosts:
                 vrf-ospf-vtep-router-id:
+            VRF_OSPF_MISSING_PROCESS_ID:
+              hosts:
+                vrf-ospf-missing-process-id:
 
         EOS_DESIGNS_FAILURES_EXCLUDED:
           # These hosts are included in the vars and facts, but will not be included in the structured config run,

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -519,7 +519,7 @@ router ospf 14 vrf Tenant_A_WAN_Zone
    passive-interface default
    no passive-interface Ethernet7
    no passive-interface Vlan150
-   redistribute bgp
+   redistribute bgp route-map Tenant_ospf_redistribute_bgp_route_map
    redistribute connected route-map RM_TEST
    max-lsa 15000
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -485,7 +485,7 @@ router bgp 65105
 router ospf 14 vrf Tenant_A_WAN_Zone
    passive-interface default
    no passive-interface Vlan150
-   redistribute bgp
+   redistribute bgp route-map Tenant_ospf_redistribute_bgp_route_map
    redistribute connected route-map RM_TEST
    max-lsa 15000
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -889,5 +889,6 @@ router ospf 16 vrf Tenant_A_OSPF
    no passive-interface Ethernet22
    no passive-interface Ethernet23
    redistribute bgp
+   redistribute connected
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -888,7 +888,6 @@ router ospf 16 vrf Tenant_A_OSPF
    passive-interface default
    no passive-interface Ethernet22
    no passive-interface Ethernet23
-   redistribute bgp
    redistribute connected
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -851,5 +851,6 @@ router ospf 16 vrf Tenant_A_OSPF
    passive-interface default
    no passive-interface Ethernet24
    redistribute bgp
+   redistribute connected
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -850,7 +850,6 @@ router ospf 16 vrf Tenant_A_OSPF
    router-id 10.255.11.11
    passive-interface default
    no passive-interface Ethernet24
-   redistribute bgp
    redistribute connected
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/evpn_services_l2_only_false.cfg
@@ -756,6 +756,7 @@ router bgp 101
 !
 router ospf 123
    router-id 192.168.255.109
+   bfd default
    passive-interface default
    no passive-interface Vlan1234
    redistribute bgp

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -665,6 +665,7 @@ router_ospf:
         route_map: RM_TEST
       bgp:
         enabled: true
+        route_map: Tenant_ospf_redistribute_bgp_route_map
 service_routing_protocols_model: multi-agent
 service_unsupported_transceiver:
   license_name: key1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -616,6 +616,7 @@ router_ospf:
         route_map: RM_TEST
       bgp:
         enabled: true
+        route_map: Tenant_ospf_redistribute_bgp_route_map
 service_routing_protocols_model: multi-agent
 sflow:
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -899,6 +899,8 @@ router_ospf:
     - Ethernet22
     - Ethernet23
     redistribute:
+      connected:
+        enabled: true
       bgp:
         enabled: true
 service_routing_protocols_model: multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -901,8 +901,6 @@ router_ospf:
     redistribute:
       connected:
         enabled: true
-      bgp:
-        enabled: true
 service_routing_protocols_model: multi-agent
 snmp_server:
   contact: example@example.com

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -837,6 +837,8 @@ router_ospf:
     no_passive_interfaces:
     - Ethernet24
     redistribute:
+      connected:
+        enabled: true
       bgp:
         enabled: true
 service_routing_protocols_model: multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -839,8 +839,6 @@ router_ospf:
     redistribute:
       connected:
         enabled: true
-      bgp:
-        enabled: true
 service_routing_protocols_model: multi-agent
 snmp_server:
   contact: example@example.com

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_services_l2_only_false.yml
@@ -531,6 +531,7 @@ router_ospf:
   - id: 123
     passive_interface_default: true
     router_id: 192.168.255.109
+    bfd_enable: true
     no_passive_interfaces:
     - Vlan1234
     redistribute:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -139,6 +139,7 @@ tenant_a:
           max_lsa: 15000
           redistribute_bgp:
             enabled: true
+            route_map: Tenant_ospf_redistribute_bgp_route_map
           redistribute_connected:
             enabled: true
             route_map: RM_TEST
@@ -294,6 +295,8 @@ tenant_a:
         ospf:
           enabled: true
           router_id: diagnostic_loopback
+          redistribute_connected:
+            enabled: true
         l3_interfaces:
           - interfaces:
               - Ethernet22

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_A.yml
@@ -297,6 +297,8 @@ tenant_a:
           router_id: diagnostic_loopback
           redistribute_connected:
             enabled: true
+          redistribute_bgp:
+            enabled: false
         l3_interfaces:
           - interfaces:
               - Ethernet22

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/DC1_TENANTS_NETWORKS/Tenant_D.yml
@@ -115,6 +115,9 @@ tenant_d:
         ospf:
           enabled: true
           process_id: 123
+          bfd: true
+          redistribute_bgp:
+            enabled: true
         svis:
           - id: 1234
             name: VRF_DEFAULT_SVI_WITH_OSPF


### PR DESCRIPTION

## Change Summary

Add pytest coverage for network_services/router_ospf.py

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Add pytest coverage for network_services/router_ospf.py

## How to test
Run tox

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
