### PR TITLE
Feat(anta_runner): Support null directories and paths to disable file generation

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/anta_workflow.py
+++ b/ansible_collections/arista/avd/plugins/action/anta_workflow.py
@@ -195,7 +195,9 @@ class ActionModule(ActionBase):
                 batch_results = executor.map(run_anta, batches)
 
             # Build the ANTA reports
-            build_reports(batch_results, get(PLUGIN_ARGS, "report"))
+            report_settings = get(PLUGIN_ARGS, "report")
+            if report_settings is not None:
+                build_reports(batch_results, report_settings)
 
         except Exception as error:
             # Recast errors as AnsibleActionFail

--- a/ansible_collections/arista/avd/roles/anta_runner/README.md
+++ b/ansible_collections/arista/avd/roles/anta_runner/README.md
@@ -336,7 +336,7 @@ anta_report_csv_path: "{{ anta_reports_dir + '/anta_report.csv' if anta_reports_
 ```
 
 !!! tip
-    You can disable the generation of certain files by setting their corresponding path variables to `null`.
+    You can disable the generation of certain files by setting their corresponding directory or path variables to `null`.
 
     **Examples:**
 

--- a/ansible_collections/arista/avd/roles/anta_runner/README.md
+++ b/ansible_collections/arista/avd/roles/anta_runner/README.md
@@ -331,7 +331,7 @@ anta_reports_dir: "{{ anta_dir }}/{{ anta_reports_dir_name }}"
 
 # Paths for the generated reports. Supports JSON, CSV, and Markdown.
 anta_report_json_path: "{{ anta_reports_dir + '/anta_report.json' if anta_reports_dir else none }}"
-anta_report_md_path: "{{ anta_reports_dir + '/anta_report.md' if anta_reports_dir else none}}"
+anta_report_md_path: "{{ anta_reports_dir + '/anta_report.md' if anta_reports_dir else none }}"
 anta_report_csv_path: "{{ anta_reports_dir + '/anta_report.csv' if anta_reports_dir else none }}"
 ```
 
@@ -340,11 +340,14 @@ anta_report_csv_path: "{{ anta_reports_dir + '/anta_report.csv' if anta_reports_
 
     **Examples:**
 
-    To disable the creation of AVD-generated catalogs and CSV report:
-
     ```yaml
-    avd_catalogs_dir: null
-    anta_report_csv_path: null
+    avd_catalogs_dir: null      # Disable AVD-generated catalogs
+    user_catalogs_dir: null     # Disable user-defined catalogs, if any
+    anta_runner_logs_dir: null  # Disable all ANTA log files
+    anta_reports_dir: null      # Disable all report files
+    anta_report_json_path: null # Disable JSON report
+    anta_report_md_path: null   # Disable Markdown report
+    anta_report_csv_path: null  # Disable CSV Report
     ```
 
 ## AVD-generated Catalog Test Index

--- a/ansible_collections/arista/avd/roles/anta_runner/README.md
+++ b/ansible_collections/arista/avd/roles/anta_runner/README.md
@@ -321,8 +321,7 @@ user_catalogs_dir: "{{ anta_dir }}/{{ user_catalogs_dir_name }}"
 avd_catalogs_dir_name: "avd_catalogs"
 avd_catalogs_dir: "{{ anta_dir }}/{{ avd_catalogs_dir_name }}"
 
-# Directory for the ANTA debug's logs. When running the role with `-vvv`,
-# all ANTA logs will be stored here by batch.
+# Directory for ANTA logs. ANTA logs are stored in per-batch files.
 anta_runner_logs_dir_name: "logs"
 anta_runner_logs_dir: "{{ anta_dir }}/{{ anta_runner_logs_dir_name }}"
 
@@ -331,10 +330,22 @@ anta_reports_dir_name: "reports"
 anta_reports_dir: "{{ anta_dir }}/{{ anta_reports_dir_name }}"
 
 # Paths for the generated reports. Supports JSON, CSV, and Markdown.
-anta_report_json_path: "{{ anta_reports_dir }}/anta_report.json"
-anta_report_md_path: "{{ anta_reports_dir }}/anta_report.md"
-anta_report_csv_path: "{{ anta_reports_dir }}/anta_report.csv"
+anta_report_json_path: "{{ anta_reports_dir + '/anta_report.json' if anta_reports_dir else none }}"
+anta_report_md_path: "{{ anta_reports_dir + '/anta_report.md' if anta_reports_dir else none}}"
+anta_report_csv_path: "{{ anta_reports_dir + '/anta_report.csv' if anta_reports_dir else none }}"
 ```
+
+!!! tip
+    You can disable the generation of certain files by setting their corresponding path variables to `null`.
+
+    **Examples:**
+
+    To disable the creation of AVD-generated catalogs and CSV report:
+
+    ```yaml
+    avd_catalogs_dir: null
+    anta_report_csv_path: null
+    ```
 
 ## AVD-generated Catalog Test Index
 

--- a/ansible_collections/arista/avd/roles/anta_runner/defaults/main/directories.yml
+++ b/ansible_collections/arista/avd/roles/anta_runner/defaults/main/directories.yml
@@ -33,6 +33,6 @@ anta_reports_dir_name: "reports"
 anta_reports_dir: "{{ anta_dir }}/{{ anta_reports_dir_name }}"
 
 # ANTA report paths.
-anta_report_json_path: "{{ anta_reports_dir }}/anta_report.json"
-anta_report_md_path: "{{ anta_reports_dir }}/anta_report.md"
-anta_report_csv_path: "{{ anta_reports_dir }}/anta_report.csv"
+anta_report_json_path: "{{ anta_reports_dir + '/anta_report.json' if anta_reports_dir else none }}"
+anta_report_md_path: "{{ anta_reports_dir + '/anta_report.md' if anta_reports_dir else none}}"
+anta_report_csv_path: "{{ anta_reports_dir + '/anta_report.csv' if anta_reports_dir else none }}"

--- a/ansible_collections/arista/avd/roles/anta_runner/defaults/main/directories.yml
+++ b/ansible_collections/arista/avd/roles/anta_runner/defaults/main/directories.yml
@@ -34,5 +34,5 @@ anta_reports_dir: "{{ anta_dir }}/{{ anta_reports_dir_name }}"
 
 # ANTA report paths.
 anta_report_json_path: "{{ anta_reports_dir + '/anta_report.json' if anta_reports_dir else none }}"
-anta_report_md_path: "{{ anta_reports_dir + '/anta_report.md' if anta_reports_dir else none}}"
+anta_report_md_path: "{{ anta_reports_dir + '/anta_report.md' if anta_reports_dir else none }}"
 anta_report_csv_path: "{{ anta_reports_dir + '/anta_report.csv' if anta_reports_dir else none }}"

--- a/ansible_collections/arista/avd/roles/anta_runner/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/anta_runner/tasks/main.yml
@@ -13,8 +13,10 @@
   run_once: true
   register: avd_requirements
 
-- name: Create required output directories if not present
-  when: avd_create_directories | arista.avd.default(true)
+- name: Create ANTA directories if needed
+  when:
+    - avd_create_directories | arista.avd.default(true)
+    - item is arista.avd.defined
   ansible.builtin.file:
     path: "{{ item }}"
     state: directory


### PR DESCRIPTION
## Change Summary

The role now supports setting the ANTA directories and paths to `null` to disable file generation.

## Component(s) name

`arista.avd.anta_runner`

## Proposed changes
The following variables can be set to `null`:
```yaml
avd_catalogs_dir: null  # Disable AVD-generated catalog files
anta_reports_dir: null  # Disable all report files
anta_runner_logs_dir: null  # Disable all log files
user_catalogs_dir: null  # Disable user catalogs
```

## How to test
```
---
- name: Run ANTA
  hosts: GLOBAL
  connection: local
  gather_facts: false
  tasks:
    - name: Run ANTA on EOS devices
      import_role:
        name: arista.avd.anta_runner
      vars:
        avd_catalogs_dir: null
```
With `avd_catalogs_dir` set to `null`, no AVD catalogs will be generated in the `anta` base directory.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
