### PR TITLE
Feat(anta_runner): Add strict mode to fail the Ansible task if a test failed or errored

### DIFF
--- a/ansible_collections/arista/avd/plugins/modules/anta_workflow.py
+++ b/ansible_collections/arista/avd/plugins/modules/anta_workflow.py
@@ -174,4 +174,5 @@ EXAMPLES = r"""
           #   hide_statuses:
           #     - success
           #     - skipped
+        strict_mode: true
 """

--- a/ansible_collections/arista/avd/plugins/modules/anta_workflow.py
+++ b/ansible_collections/arista/avd/plugins/modules/anta_workflow.py
@@ -126,8 +126,8 @@ options:
             choices: ["success", "failure", "error", "skipped", "unset"]
   strict_mode:
     description: |-
-      Controls the final status of the Ansible task based on the aggregated ANTA test results.
-      It determines if the plugin reports `failed: true` or `changed: true` back to Ansible when ANTA tests fail or error.
+      When `strict_mode` is `true`, the plugin returns `failed: true` if any ANTA tests fail or error.
+      Otherwise, the plugin returns `changed: true` in such cases.
     type: bool
     default: false
 seealso:

--- a/ansible_collections/arista/avd/plugins/modules/anta_workflow.py
+++ b/ansible_collections/arista/avd/plugins/modules/anta_workflow.py
@@ -124,6 +124,12 @@ options:
             type: list
             elements: str
             choices: ["success", "failure", "error", "skipped", "unset"]
+  strict_mode:
+    description: |-
+      Controls the final status of the Ansible task based on the aggregated ANTA test results.
+      It determines if the plugin reports `failed: true` or `changed: true` back to Ansible when ANTA tests fail or error.
+    type: bool
+    default: false
 seealso:
   - name: ANTA website
     description: Documentation for the ANTA test framework

--- a/ansible_collections/arista/avd/roles/anta_runner/README.md
+++ b/ansible_collections/arista/avd/roles/anta_runner/README.md
@@ -180,8 +180,8 @@ anta_runner_batch_size: 5
 # Run ANTA in dry-run mode. This will generate the tests but not execute them.
 anta_runner_dry_run: false
 
-# Controls the final status of the Ansible task based on the aggregated ANTA test results.
-# It determines if the plugin reports `failed: true` or `changed: true` back to Ansible when ANTA tests fail or error.
+# When `true`, the plugin returns `failed: true` if any ANTA tests fail or error.
+# Otherwise, the plugin returns `changed: true` in such cases.
 anta_strict_mode: false
 ```
 

--- a/ansible_collections/arista/avd/roles/anta_runner/README.md
+++ b/ansible_collections/arista/avd/roles/anta_runner/README.md
@@ -179,6 +179,10 @@ anta_runner_batch_size: 5
 
 # Run ANTA in dry-run mode. This will generate the tests but not execute them.
 anta_runner_dry_run: false
+
+# Controls the final status of the Ansible task based on the aggregated ANTA test results.
+# It determines if the plugin reports `failed: true` or `changed: true` back to Ansible when ANTA tests fail or error.
+anta_strict_mode: false
 ```
 
 !!! tip

--- a/ansible_collections/arista/avd/roles/anta_runner/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/anta_runner/defaults/main/main.yml
@@ -21,5 +21,9 @@ anta_runner_batch_size: 5
 # Run ANTA in dry-run mode. This will generate the tests but not execute them.
 anta_runner_dry_run: false
 
+# Controls the final status of the Ansible task based on the aggregated ANTA test results.
+# It determines if the plugin reports `failed: true` or `changed: true` back to Ansible when ANTA tests fail or error.
+anta_strict_mode: false
+
 # Structured configuration file format. Supported formats: yml, yaml, json.
 avd_structured_config_file_format: "yml"

--- a/ansible_collections/arista/avd/roles/anta_runner/defaults/main/main.yml
+++ b/ansible_collections/arista/avd/roles/anta_runner/defaults/main/main.yml
@@ -21,8 +21,8 @@ anta_runner_batch_size: 5
 # Run ANTA in dry-run mode. This will generate the tests but not execute them.
 anta_runner_dry_run: false
 
-# Controls the final status of the Ansible task based on the aggregated ANTA test results.
-# It determines if the plugin reports `failed: true` or `changed: true` back to Ansible when ANTA tests fail or error.
+# When `true`, the plugin returns `failed: true` if any ANTA tests fail or error.
+# Otherwise, the plugin returns `changed: true` in such cases.
 anta_strict_mode: false
 
 # Structured configuration file format. Supported formats: yml, yaml, json.

--- a/ansible_collections/arista/avd/roles/anta_runner/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/anta_runner/tasks/main.yml
@@ -53,6 +53,7 @@
       json_output: "{{ anta_report_json_path }}"
       filters:
         hide_statuses: "{{ anta_report_hide_statuses | arista.avd.default([]) }}"
+    strict_mode: "{{ anta_strict_mode }}"
   register: anta
   delegate_to: localhost
   run_once: true

--- a/docs/plugins/Modules_and_action_plugins/anta_workflow.md
+++ b/docs/plugins/Modules_and_action_plugins/anta_workflow.md
@@ -110,6 +110,7 @@ The plugin offers the following capabilities:
           #   hide_statuses:
           #     - success
           #     - skipped
+        strict_mode: true
 ```
 
 ## Authors

--- a/docs/plugins/Modules_and_action_plugins/anta_workflow.md
+++ b/docs/plugins/Modules_and_action_plugins/anta_workflow.md
@@ -64,6 +64,7 @@ The plugin offers the following capabilities:
 | <samp>&nbsp;&nbsp;&nbsp;&nbsp;json_output</samp> | str | optional | None |  | Path to the JSON report file. |
 | <samp>&nbsp;&nbsp;&nbsp;&nbsp;filters</samp> | dict | optional | None |  | Filters used to hide specific test statuses from the reports. |
 | <samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hide_statuses</samp> | list | optional | None | Valid values:<br>- <code>success</code><br>- <code>failure</code><br>- <code>error</code><br>- <code>skipped</code><br>- <code>unset</code> | List of test statuses to hide from the reports. |
+| <samp>strict_mode</samp> | bool | optional | False |  | Controls the final status of the Ansible task based on the aggregated ANTA test results.<br>It determines if the plugin reports `failed: true` or `changed: true` back to Ansible when ANTA tests fail or error. |
 
 ## See Also
 

--- a/docs/plugins/Modules_and_action_plugins/anta_workflow.md
+++ b/docs/plugins/Modules_and_action_plugins/anta_workflow.md
@@ -64,7 +64,7 @@ The plugin offers the following capabilities:
 | <samp>&nbsp;&nbsp;&nbsp;&nbsp;json_output</samp> | str | optional | None |  | Path to the JSON report file. |
 | <samp>&nbsp;&nbsp;&nbsp;&nbsp;filters</samp> | dict | optional | None |  | Filters used to hide specific test statuses from the reports. |
 | <samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hide_statuses</samp> | list | optional | None | Valid values:<br>- <code>success</code><br>- <code>failure</code><br>- <code>error</code><br>- <code>skipped</code><br>- <code>unset</code> | List of test statuses to hide from the reports. |
-| <samp>strict_mode</samp> | bool | optional | False |  | Controls the final status of the Ansible task based on the aggregated ANTA test results.<br>It determines if the plugin reports `failed: true` or `changed: true` back to Ansible when ANTA tests fail or error. |
+| <samp>strict_mode</samp> | bool | optional | False |  | When `strict_mode` is `true`, the plugin returns `failed: true` if any ANTA tests fail or error.<br>Otherwise, the plugin returns `changed: true` in such cases. |
 
 ## See Also
 


### PR DESCRIPTION
## Change Summary

See title.

## Component(s) name

`arista.avd.anta_runner`

## Proposed changes
- Add `anta_strict_mode` to fail the Ansible task if a test failed or errored.
- Add `anta_summary` to the Ansible result object to have more information about the overall run.

## How to test

Make sure a test fails and run ANTA in strict mode:
```yaml
---
- name: Run ANTA
  hosts: GLOBAL
  connection: local
  gather_facts: false
  tasks:
    - name: Run ANTA on EOS devices
      import_role:
        name: arista.avd.anta_runner
      vars:
        anta_strict_mode: true
```
The task should fail.

Re-run with `anta_strict_mode: false`, if you have failures the task should be `changed`.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
