### PR TITLE
Test(eos_designs): Add pytest coverage for overlay/cvx.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-mgmt-ip-cvx-servers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-mgmt-ip-cvx-servers.yml
@@ -13,7 +13,7 @@ cvxserver:
   nodes:
     - name: missing-mgmt-ip-cvx-servers
       id: 1
-      # no mgmt_ip
+      mgmt_ip: 192.168.201.116/24
 
 expected_error_message: >-
   'mgmt_ip' for CVX Server missing-peer-ip-l3-interface is required.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-mgmt-ip-cvx-servers.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-mgmt-ip-cvx-servers.yml
@@ -1,0 +1,19 @@
+---
+type: cvxserver
+
+overlay_routing_protocol: CVX
+overlay_cvx_servers: [missing-mgmt-ip-cvx-servers, missing-peer-ip-l3-interface]
+
+node_type_keys:
+  - key: cvxserver
+    type: cvxserver
+    underlay_router: false
+
+cvxserver:
+  nodes:
+    - name: missing-mgmt-ip-cvx-servers
+      id: 1
+      # no mgmt_ip
+
+expected_error_message: >-
+  'mgmt_ip' for CVX Server missing-peer-ip-l3-interface is required.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -165,6 +165,7 @@ all:
             missing-internet-exit-policy-zscaler-wan-interface-peer-ip:
             missing-internet-exit-policy-zscaler-wan-interface-tunnels-id:
             missing-peer-ip-l3-interface:
+            missing-mgmt-ip-cvx-servers:
             wan-router-l3-interfaces-unsupported-rxtx-for-subinterface:
             ntp-settings-server-vrf-missing-mgmt-ip:
             ntp-settings-server-vrf-missing-inband-mgmt-interface:


### PR DESCRIPTION
## Change Summary

Improve pytest coverage for overlay/cvx.py [COVERAGE 100%]

Note: The error message is a bit confusing.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added negative tests for cvx_servers

## How to test
Check the tox coverage report

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
