### PR TITLE
Refactor(eos_designs): Improve connected_endpoints/monitor_sessions

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/monitor_sessions.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/connected_endpoints/monitor_sessions.py
@@ -39,7 +39,7 @@ class MonitorSessionsMixin(Protocol):
             for session_config in session_configs_list[1:]:
                 merged_settings._deepmerge(session_config)
 
-            if merged_settings.session_settings.access_group:
+            if merged_settings.session_settings._get("access_group"):
                 for session in session_configs_list:
                     if session.source_settings.access_group:
                         msg = (


### PR DESCRIPTION
## Change Summary

Add pytest coverage for network_services/ip_access_lists (Coverage: 100%)

## Related Issue(s)

Fixes 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Test was already added just fixed the `if` condition

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
