### PR TITLE
Refactor(eos_designs): Improve pytest coverage for overlay/ip_security 

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles.yml
@@ -1,6 +1,5 @@
 ---
 # Testing missing wan_ipsec_profiles
-
 wan_mode: cv-pathfinder
 # Disabling underlay for tests
 underlay_routing_protocol: none
@@ -79,4 +78,3 @@ application_classification:
     - name: TEST
 
 expected_error_message: "'wan_ipsec_profiles' is required but was not found."
-  

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles.yml
@@ -1,0 +1,82 @@
+---
+# Testing missing wan_ipsec_profiles
+
+wan_mode: cv-pathfinder
+# Disabling underlay for tests
+underlay_routing_protocol: none
+
+type: wan_router
+
+bgp_as: 65000
+
+cv_pathfinder_regions:
+  - name: AVD_Land_West
+    id: 42
+    description: AVD Region
+    sites:
+      - name: Site422
+        id: 422
+        location: Somewhere
+
+bgp_peer_groups:
+  wan_overlay_peers:
+    password: "htm4AZe9mIQOO1uiMuGgYQ=="
+    listen_range_prefixes:
+      - 192.168.255.0/24
+
+wan_router:
+  defaults:
+    loopback_ipv4_pool: 192.168.42.0/24
+    vtep_loopback_ipv4_pool: 192.168.255.0/24
+    filter:
+      always_include_vrfs_in_tenants: [TenantA]
+  nodes:
+    - name: missing-wan-ipsec-profiles
+      cv_pathfinder_region: AVD_Land_West
+      cv_pathfinder_site: Site422
+      id: 1
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: ATT
+          wan_circuit_id: 666
+          peer_ip: 1.1.1.1
+          ip_address: dhcp
+          dhcp_ip: 10.0.0.145
+
+wan_path_groups:
+  - name: INET
+    id: 101
+
+wan_carriers:
+  - name: ATT
+    path_group: INET
+    trusted: true
+
+tenants:
+  - name: TenantA
+    vrfs:
+      - name: default
+        vrf_id: 1
+      - name: PROD
+        vrf_id: 42
+
+wan_virtual_topologies:
+  vrfs:
+    - name: PROD
+      wan_vni: 42
+  policies:
+    - name: DEFAULT-POLICY
+      default_virtual_topology:
+        drop_unmatched: true
+      application_virtual_topologies:
+        - application_profile: TEST
+          id: 42
+          path_groups:
+            - names: [INET]
+
+application_classification:
+  application_profiles:
+    - name: TEST
+
+expected_error_message: "'wan_ipsec_profiles' is required but was not found."
+  

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles.yml
@@ -51,30 +51,4 @@ wan_carriers:
     path_group: INET
     trusted: true
 
-tenants:
-  - name: TenantA
-    vrfs:
-      - name: default
-        vrf_id: 1
-      - name: PROD
-        vrf_id: 42
-
-wan_virtual_topologies:
-  vrfs:
-    - name: PROD
-      wan_vni: 42
-  policies:
-    - name: DEFAULT-POLICY
-      default_virtual_topology:
-        drop_unmatched: true
-      application_virtual_topologies:
-        - application_profile: TEST
-          id: 42
-          path_groups:
-            - names: [INET]
-
-application_classification:
-  application_profiles:
-    - name: TEST
-
 expected_error_message: "'wan_ipsec_profiles' is required but was not found."

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -165,6 +165,7 @@ all:
             missing-internet-exit-policy-zscaler-wan-interface-peer-ip:
             missing-internet-exit-policy-zscaler-wan-interface-tunnels-id:
             missing-peer-ip-l3-interface:
+            missing-wan-ipsec-profiles:
             wan-router-l3-interfaces-unsupported-rxtx-for-subinterface:
             ntp-settings-server-vrf-missing-mgmt-ip:
             ntp-settings-server-vrf-missing-inband-mgmt-interface:

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/ip_security.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/ip_security.py
@@ -102,16 +102,15 @@ class IpSecurityMixin(Protocol):
         as suggested would prevent Pathfinders to establish IPsec tunnels between themselves
         which is undesirable.
         """
-        if self.shared_utils.wan_role is not None:
-            self.structured_config.ip_security.profiles.append_new(
-                name=profile_name,
-                ike_policy=ike_policy_name,
-                sa_policy=sa_policy_name,
-                connection="start",
-                shared_key=key,
-                mode="transport",
-                dpd=EosCliConfigGen.IpSecurity.ProfilesItem.Dpd(interval=10, time=50, action="clear"),
-            )
+        self.structured_config.ip_security.profiles.append_new(
+            name=profile_name,
+            ike_policy=ike_policy_name,
+            sa_policy=sa_policy_name,
+            connection="start",
+            shared_key=key,
+            mode="transport",
+            dpd=EosCliConfigGen.IpSecurity.ProfilesItem.Dpd(interval=10, time=50, action="clear"),
+        )
 
     def _set_key_controller(self: AvdStructuredConfigOverlayProtocol, profile_name: str) -> None:
         """Set the key_controller structure if the device is not a RR or pathfinder."""

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/ip_security.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/ip_security.py
@@ -36,9 +36,6 @@ class IpSecurityMixin(Protocol):
         if not self.inputs.wan_ipsec_profiles:
             msg = "wan_ipsec_profiles"
             raise AristaAvdMissingVariableError(msg)
-        if not self.inputs.wan_ipsec_profiles.control_plane:
-            msg = "wan_ipsec_profiles.control_plane"
-            raise AristaAvdMissingVariableError(msg)
 
         if self.shared_utils.is_wan_client and self.inputs.wan_ipsec_profiles.data_plane:
             self._set_data_plane()


### PR DESCRIPTION
## Change Summary

Improve pytest coverage for overlay/ip_security

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added negative tests to improve coverage
COVERAGE: 100%

## How to test
Tox coverage

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
