### PR TITLE
Test(eos_designs): Add pytest coverage for structured_config/mlag/__init__

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-1.cfg
@@ -48,7 +48,7 @@ interface Loopback1
    ip address 192.168.254.111/32
 !
 interface Vlan4094
-   description Applying structured config from l3_vlan only when not set on the main vlan.
+   description Description from mlag_peer_l3_vlan_structured_config.
    no shutdown
    mtu 9214
    no autostate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-1.cfg
@@ -48,7 +48,7 @@ interface Loopback1
    ip address 192.168.254.111/32
 !
 interface Vlan4094
-   description MLAG
+   description Applying structured config from l3_vlan only when not set on the main vlan.
    no shutdown
    mtu 9214
    no autostate

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-1.yml
@@ -177,7 +177,7 @@ static_routes:
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094
-  description: Applying structured config from l3_vlan only when not set on the main vlan.
+  description: Description from mlag_peer_l3_vlan_structured_config.
   shutdown: false
   ip_address: 192.168.253.204/31
   mtu: 9214

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-1.yml
@@ -177,7 +177,7 @@ static_routes:
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
 - name: Vlan4094
-  description: MLAG
+  description: Applying structured config from l3_vlan only when not set on the main vlan.
   shutdown: false
   ip_address: 192.168.253.204/31
   mtu: 9214

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS.yml
@@ -93,7 +93,7 @@ l3leaf:
           mpls_route_reflectors: [ bgp-peer-groups-2 ]
           mpls_overlay_role: client
           mlag_peer_l3_vlan_structured_config:
-            description: "Applying structured config from l3_vlan only when not set on the main vlan."
+            description: "Description from mlag_peer_l3_vlan_structured_config."
           evpn_gateway:
             evpn_l3:
               enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS.yml
@@ -92,6 +92,8 @@ l3leaf:
           evpn_route_servers: [ bgp-peer-groups-2 ]
           mpls_route_reflectors: [ bgp-peer-groups-2 ]
           mpls_overlay_role: client
+          mlag_peer_l3_vlan_structured_config:
+            description: "Applying structured config from l3_vlan only when not set on the main vlan."
           evpn_gateway:
             evpn_l3:
               enabled: true


### PR DESCRIPTION
## Change Summary

Add pytest coverage for structured_config/mlag/__init__ (Coverage: 100%)

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added a test to improve coverage

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
