### PR TITLE
Test(eos_designs): Add pytest coverage for shared_utils/mgmt.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-inband-mgmt-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-inband-mgmt-interface.yml
@@ -1,0 +1,16 @@
+---
+# Test for missing "inband_mgmt_interface", when "default_mgmt_method" is "inband"
+default_mgmt_method: inband
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    - name: missing-inband-mgmt-interface
+
+ntp_settings:
+  servers:
+    - name: 10.10.10.1
+    - name: 10.10.10.2
+
+expected_error_message: "'default_mgmt_method: inband' requires 'inband_mgmt_interface' to be set."

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-mgmt-ip-ipv6-mgmt-ip.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-mgmt-ip-ipv6-mgmt-ip.yml
@@ -1,0 +1,16 @@
+---
+# Test for missing "mgmt_ip" and "ipv6_mgmt_ip", when "default_mgmt_method" is "oob"
+default_mgmt_method: oob
+
+type: l2leaf
+l2leaf:
+  defaults:
+  nodes:
+    - name: missing-mgmt-ip-ipv6-mgmt-ip
+
+ntp_settings:
+  servers:
+    - name: 10.10.10.1
+    - name: 10.10.10.2
+
+expected_error_message: "'default_mgmt_method: oob' requires either 'mgmt_ip' or 'ipv6_mgmt_ip' to be set."

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -165,6 +165,8 @@ all:
             missing-internet-exit-policy-zscaler-wan-interface-peer-ip:
             missing-internet-exit-policy-zscaler-wan-interface-tunnels-id:
             missing-peer-ip-l3-interface:
+            missing-mgmt-ip-ipv6-mgmt-ip:
+            missing-inband-mgmt-interface:
             wan-router-l3-interfaces-unsupported-rxtx-for-subinterface:
             ntp-settings-server-vrf-missing-mgmt-ip:
             ntp-settings-server-vrf-missing-inband-mgmt-interface:


### PR DESCRIPTION
## Change Summary

Add pytest coverage for shared_utils/mgmt.py

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Improve pytest coverage for shared_utils/mgmt.py.  **COVERAGE: 100%**

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
