### PR TITLE
Test(eos_designs): Add pytest coverage for network_services/loopback_interfaces.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-L2LEAF1A.cfg
@@ -29,13 +29,19 @@ ip name-server vrf MGMT 2001:db8::1
 ip name-server vrf MGMT 2001:db8::2
 !
 snmp-server contact example@example.com
-snmp-server location EOS_DESIGNS_UNIT_TESTS MH-L2LEAF1A
+snmp-server location EOS_DESIGNS_UNIT_TESTS TENANT_NETWORKS_POD MH-L2LEAF1A
 !
 spanning-tree mode mstp
 spanning-tree mst 0 priority 16384
 !
 vlan 310
    name Tenant_X_OP_Zone_1
+!
+vlan 315
+   name Tenant_network_vrf_1
+!
+vlan 316
+   name Tenant_network_vrf_2
 !
 vrf instance MGMT
 !
@@ -50,7 +56,7 @@ management api http-commands
 interface Port-Channel1
    description MH-LEAF2A_Po2
    no shutdown
-   switchport trunk allowed vlan 310
+   switchport trunk allowed vlan 310,315-316
    switchport mode trunk
    switchport
    link tracking group l2leaf-server02 upstream

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -31,14 +31,24 @@ ip name-server vrf MGMT 2001:db8::1
 ip name-server vrf MGMT 2001:db8::2
 !
 snmp-server contact example@example.com
-snmp-server location EOS_DESIGNS_UNIT_TESTS MH-LEAF1A
+snmp-server location EOS_DESIGNS_UNIT_TESTS TENANT_NETWORKS_POD MH-LEAF1A
 !
 vlan 310
    name Tenant_X_OP_Zone_1
 !
+vlan 315
+   name Tenant_network_vrf_1
+!
+vlan 316
+   name Tenant_network_vrf_2
+!
 vrf instance MGMT
 !
 vrf instance Tenant_X_OP_Zone
+!
+vrf instance VRF_with_loopback_ip_pools
+!
+vrf instance VRF_without_loopback_ip_pools
 !
 management api http-commands
    protocol https
@@ -339,6 +349,13 @@ interface Loopback100
    ip address 10.255.1.33/32
    ipv6 address 2001:db8:1::1/128
 !
+interface Loopback200
+   description VRF_with_loopback_ip_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf VRF_with_loopback_ip_pools
+   ip address 10.101.102.33/32
+   ipv6 address 2001:db8:1::1/128
+!
 interface Management1
    description OOB_MANAGEMENT
    no shutdown
@@ -351,21 +368,41 @@ interface Vlan310
    vrf Tenant_X_OP_Zone
    ip address virtual 10.1.10.1/24
 !
+interface Vlan315
+   description Tenant_network_vrf_1
+   no shutdown
+   vrf VRF_with_loopback_ip_pools
+   ip address virtual 10.1.10.2/24
+!
+interface Vlan316
+   description Tenant_network_vrf_2
+   no shutdown
+   vrf VRF_without_loopback_ip_pools
+   ip address virtual 10.1.10.3/24
+!
 interface Vxlan1
    description MH-LEAF1A_VTEP
    vxlan source-interface Loopback1
    vxlan udp-port 4789
    vxlan vlan 310 vni 11310
+   vxlan vlan 315 vni 11315
+   vxlan vlan 316 vni 11316
    vxlan vrf Tenant_X_OP_Zone vni 20
+   vxlan vrf VRF_with_loopback_ip_pools vni 22
+   vxlan vrf VRF_without_loopback_ip_pools vni 23
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
 !
 ip address virtual source-nat vrf Tenant_X_OP_Zone address 10.255.1.33
+ip address virtual source-nat vrf VRF_with_loopback_ip_pools address 10.101.102.33
 ipv6 address virtual source-nat vrf Tenant_X_OP_Zone address 2001:db8:1::1
+ipv6 address virtual source-nat vrf VRF_with_loopback_ip_pools address 2001:db8:1::1
 !
 ip routing
 no ip routing vrf MGMT
 ip routing vrf Tenant_X_OP_Zone
+ip routing vrf VRF_with_loopback_ip_pools
+ip routing vrf VRF_without_loopback_ip_pools
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -413,6 +450,18 @@ router bgp 65151
       redistribute learned
       vlan 310
    !
+   vlan-aware-bundle VRF_with_loopback_ip_pools
+      rd 192.168.255.33:22
+      route-target both 22:22
+      redistribute learned
+      vlan 315
+   !
+   vlan-aware-bundle VRF_without_loopback_ip_pools
+      rd 192.168.255.33:23
+      route-target both 23:23
+      redistribute learned
+      vlan 316
+   !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
       host-flap detection window 180 threshold 5 expiry timeout 10 seconds
@@ -426,6 +475,20 @@ router bgp 65151
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 10.255.1.33
+      redistribute connected
+   !
+   vrf VRF_with_loopback_ip_pools
+      rd 192.168.255.33:22
+      route-target import evpn 22:22
+      route-target export evpn 22:22
+      router-id 10.101.102.33
+      redistribute connected
+   !
+   vrf VRF_without_loopback_ip_pools
+      rd 192.168.255.33:23
+      route-target import evpn 23:23
+      route-target export evpn 23:23
+      router-id 192.168.255.33
       redistribute connected
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -31,14 +31,24 @@ ip name-server vrf MGMT 2001:db8::1
 ip name-server vrf MGMT 2001:db8::2
 !
 snmp-server contact example@example.com
-snmp-server location EOS_DESIGNS_UNIT_TESTS MH-LEAF1B
+snmp-server location EOS_DESIGNS_UNIT_TESTS TENANT_NETWORKS_POD MH-LEAF1B
 !
 vlan 310
    name Tenant_X_OP_Zone_1
 !
+vlan 315
+   name Tenant_network_vrf_1
+!
+vlan 316
+   name Tenant_network_vrf_2
+!
 vrf instance MGMT
 !
 vrf instance Tenant_X_OP_Zone
+!
+vrf instance VRF_with_loopback_ip_pools
+!
+vrf instance VRF_without_loopback_ip_pools
 !
 management api http-commands
    protocol https
@@ -339,6 +349,13 @@ interface Loopback100
    ip address 10.255.1.34/32
    ipv6 address 2001:db8:1::2/128
 !
+interface Loopback200
+   description VRF_with_loopback_ip_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf VRF_with_loopback_ip_pools
+   ip address 10.101.102.34/32
+   ipv6 address 2001:db8:1::2/128
+!
 interface Management1
    description OOB_MANAGEMENT
    no shutdown
@@ -351,21 +368,41 @@ interface Vlan310
    vrf Tenant_X_OP_Zone
    ip address virtual 10.1.10.1/24
 !
+interface Vlan315
+   description Tenant_network_vrf_1
+   no shutdown
+   vrf VRF_with_loopback_ip_pools
+   ip address virtual 10.1.10.2/24
+!
+interface Vlan316
+   description Tenant_network_vrf_2
+   no shutdown
+   vrf VRF_without_loopback_ip_pools
+   ip address virtual 10.1.10.3/24
+!
 interface Vxlan1
    description MH-LEAF1B_VTEP
    vxlan source-interface Loopback1
    vxlan udp-port 4789
    vxlan vlan 310 vni 11310
+   vxlan vlan 315 vni 11315
+   vxlan vlan 316 vni 11316
    vxlan vrf Tenant_X_OP_Zone vni 20
+   vxlan vrf VRF_with_loopback_ip_pools vni 22
+   vxlan vrf VRF_without_loopback_ip_pools vni 23
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
 !
 ip address virtual source-nat vrf Tenant_X_OP_Zone address 10.255.1.34
+ip address virtual source-nat vrf VRF_with_loopback_ip_pools address 10.101.102.34
 ipv6 address virtual source-nat vrf Tenant_X_OP_Zone address 2001:db8:1::2
+ipv6 address virtual source-nat vrf VRF_with_loopback_ip_pools address 2001:db8:1::2
 !
 ip routing
 no ip routing vrf MGMT
 ip routing vrf Tenant_X_OP_Zone
+ip routing vrf VRF_with_loopback_ip_pools
+ip routing vrf VRF_without_loopback_ip_pools
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -413,6 +450,18 @@ router bgp 65152
       redistribute learned
       vlan 310
    !
+   vlan-aware-bundle VRF_with_loopback_ip_pools
+      rd 192.168.255.34:22
+      route-target both 22:22
+      redistribute learned
+      vlan 315
+   !
+   vlan-aware-bundle VRF_without_loopback_ip_pools
+      rd 192.168.255.34:23
+      route-target both 23:23
+      redistribute learned
+      vlan 316
+   !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
       host-flap detection window 180 threshold 5 expiry timeout 10 seconds
@@ -426,6 +475,20 @@ router bgp 65152
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 10.255.1.34
+      redistribute connected
+   !
+   vrf VRF_with_loopback_ip_pools
+      rd 192.168.255.34:22
+      route-target import evpn 22:22
+      route-target export evpn 22:22
+      router-id 10.101.102.34
+      redistribute connected
+   !
+   vrf VRF_without_loopback_ip_pools
+      rd 192.168.255.34:23
+      route-target import evpn 23:23
+      route-target export evpn 23:23
+      router-id 192.168.255.34
       redistribute connected
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
@@ -31,7 +31,7 @@ ip name-server vrf MGMT 2001:db8::1
 ip name-server vrf MGMT 2001:db8::2
 !
 snmp-server contact example@example.com
-snmp-server location EOS_DESIGNS_UNIT_TESTS MH-LEAF2A
+snmp-server location EOS_DESIGNS_UNIT_TESTS TENANT_NETWORKS_POD MH-LEAF2A
 !
 vlan 310
    name Tenant_X_OP_Zone_1
@@ -39,9 +39,19 @@ vlan 310
 vlan 311
    name Tenant_default_vrf
 !
+vlan 315
+   name Tenant_network_vrf_1
+!
+vlan 316
+   name Tenant_network_vrf_2
+!
 vrf instance MGMT
 !
 vrf instance Tenant_X_OP_Zone
+!
+vrf instance VRF_with_loopback_ip_pools
+!
+vrf instance VRF_without_loopback_ip_pools
 !
 management api http-commands
    protocol https
@@ -54,7 +64,7 @@ management api http-commands
 interface Port-Channel2
    description MH-L2LEAF1A_Po1
    no shutdown
-   switchport trunk allowed vlan 310
+   switchport trunk allowed vlan 310,315-316
    switchport mode trunk
    switchport
 !
@@ -97,6 +107,13 @@ interface Loopback100
    ip address 10.255.1.35/32
    ipv6 address 2001:db8:1::3/128
 !
+interface Loopback200
+   description VRF_with_loopback_ip_pools_VTEP_DIAGNOSTICS
+   no shutdown
+   vrf VRF_with_loopback_ip_pools
+   ip address 10.101.102.35/32
+   ipv6 address 2001:db8:1::3/128
+!
 interface Management1
    description OOB_MANAGEMENT
    no shutdown
@@ -114,23 +131,43 @@ interface Vlan311
    no shutdown
    ip address virtual 10.2.10.1/24
 !
+interface Vlan315
+   description Tenant_network_vrf_1
+   no shutdown
+   vrf VRF_with_loopback_ip_pools
+   ip address virtual 10.1.10.2/24
+!
+interface Vlan316
+   description Tenant_network_vrf_2
+   no shutdown
+   vrf VRF_without_loopback_ip_pools
+   ip address virtual 10.1.10.3/24
+!
 interface Vxlan1
    description MH-LEAF2A_VTEP
    vxlan source-interface Loopback1
    vxlan udp-port 4789
    vxlan vlan 310 vni 11310
    vxlan vlan 311 vni 11311
+   vxlan vlan 315 vni 11315
+   vxlan vlan 316 vni 11316
    vxlan vrf default vni 21
    vxlan vrf Tenant_X_OP_Zone vni 20
+   vxlan vrf VRF_with_loopback_ip_pools vni 22
+   vxlan vrf VRF_without_loopback_ip_pools vni 23
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
 !
 ip address virtual source-nat vrf Tenant_X_OP_Zone address 10.255.1.35
+ip address virtual source-nat vrf VRF_with_loopback_ip_pools address 10.101.102.35
 ipv6 address virtual source-nat vrf Tenant_X_OP_Zone address 2001:db8:1::3
+ipv6 address virtual source-nat vrf VRF_with_loopback_ip_pools address 2001:db8:1::3
 !
 ip routing
 no ip routing vrf MGMT
 ip routing vrf Tenant_X_OP_Zone
+ip routing vrf VRF_with_loopback_ip_pools
+ip routing vrf VRF_without_loopback_ip_pools
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
@@ -210,6 +247,18 @@ router bgp 65153
       redistribute learned
       vlan 310
    !
+   vlan-aware-bundle VRF_with_loopback_ip_pools
+      rd 192.168.255.35:22
+      route-target both 22:22
+      redistribute learned
+      vlan 315
+   !
+   vlan-aware-bundle VRF_without_loopback_ip_pools
+      rd 192.168.255.35:23
+      route-target both 23:23
+      redistribute learned
+      vlan 316
+   !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate
       host-flap detection window 180 threshold 5 expiry timeout 10 seconds
@@ -229,6 +278,20 @@ router bgp 65153
       route-target import evpn 20:20
       route-target export evpn 20:20
       router-id 10.255.1.35
+      redistribute connected
+   !
+   vrf VRF_with_loopback_ip_pools
+      rd 192.168.255.35:22
+      route-target import evpn 22:22
+      route-target export evpn 22:22
+      router-id 10.101.102.35
+      redistribute connected
+   !
+   vrf VRF_without_loopback_ip_pools
+      rd 192.168.255.35:23
+      route-target import evpn 23:23
+      route-target export evpn 23:23
+      router-id 192.168.255.35
       redistribute connected
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-L2LEAF1A.yml
@@ -79,6 +79,7 @@ management_interfaces:
   gateway: 192.168.200.5
 metadata:
   platform: vEOS-LAB
+  pod_name: TENANT_NETWORKS_POD
   fabric_name: EOS_DESIGNS_UNIT_TESTS
 ntp:
   local_interface:
@@ -101,11 +102,11 @@ port_channel_interfaces:
     enabled: true
     mode: trunk
     trunk:
-      allowed_vlan: '310'
+      allowed_vlan: 310,315-316
 service_routing_protocols_model: multi-agent
 snmp_server:
   contact: example@example.com
-  location: EOS_DESIGNS_UNIT_TESTS MH-L2LEAF1A
+  location: EOS_DESIGNS_UNIT_TESTS TENANT_NETWORKS_POD MH-L2LEAF1A
 spanning_tree:
   mode: mstp
   mst_instances:
@@ -124,6 +125,12 @@ vlan_internal_order:
 vlans:
 - id: 310
   name: Tenant_X_OP_Zone_1
+  tenant: Tenant_X
+- id: 315
+  name: Tenant_network_vrf_1
+  tenant: Tenant_X
+- id: 316
+  name: Tenant_network_vrf_2
   tenant: Tenant_X
 vrfs:
 - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -263,6 +263,12 @@ loopback_interfaces:
   vrf: Tenant_X_OP_Zone
   ip_address: 10.255.1.33/32
   ipv6_address: 2001:db8:1::1/128
+- name: Loopback200
+  description: VRF_with_loopback_ip_pools_VTEP_DIAGNOSTICS
+  shutdown: false
+  vrf: VRF_with_loopback_ip_pools
+  ip_address: 10.101.102.33/32
+  ipv6_address: 2001:db8:1::1/128
 management_api_http:
   enable_https: true
   default_services: false
@@ -278,6 +284,7 @@ management_interfaces:
   gateway: 192.168.200.5
 metadata:
   platform: vEOS-LAB
+  pod_name: TENANT_NETWORKS_POD
   fabric_name: EOS_DESIGNS_UNIT_TESTS
 ntp:
   local_interface:
@@ -529,6 +536,22 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: '310'
+  - name: VRF_with_loopback_ip_pools
+    rd: 192.168.255.33:22
+    route_targets:
+      both:
+      - '22:22'
+    redistribute_routes:
+    - learned
+    vlan: '315'
+  - name: VRF_without_loopback_ip_pools
+    rd: 192.168.255.33:23
+    route_targets:
+      both:
+      - '23:23'
+    redistribute_routes:
+    - learned
+    vlan: '316'
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -560,10 +583,40 @@ router_bgp:
     redistribute:
       connected:
         enabled: true
+  - name: VRF_with_loopback_ip_pools
+    rd: 192.168.255.33:22
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '22:22'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '22:22'
+    router_id: 10.101.102.33
+    redistribute:
+      connected:
+        enabled: true
+  - name: VRF_without_loopback_ip_pools
+    rd: 192.168.255.33:23
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '23:23'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '23:23'
+    router_id: 192.168.255.33
+    redistribute:
+      connected:
+        enabled: true
 service_routing_protocols_model: multi-agent
 snmp_server:
   contact: example@example.com
-  location: EOS_DESIGNS_UNIT_TESTS MH-LEAF1A
+  location: EOS_DESIGNS_UNIT_TESTS TENANT_NETWORKS_POD MH-LEAF1A
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -573,12 +626,31 @@ virtual_source_nat_vrfs:
 - name: Tenant_X_OP_Zone
   ip_address: 10.255.1.33
   ipv6_address: 2001:db8:1::1
+- name: VRF_with_loopback_ip_pools
+  ip_address: 10.101.102.33
+  ipv6_address: 2001:db8:1::1
 vlan_interfaces:
 - name: Vlan310
   description: Tenant_X_OP_Zone_1
   shutdown: false
   vrf: Tenant_X_OP_Zone
   ip_address_virtual: 10.1.10.1/24
+  tenant: Tenant_X
+  tags:
+  - opzone
+- name: Vlan315
+  description: Tenant_network_vrf_1
+  shutdown: false
+  vrf: VRF_with_loopback_ip_pools
+  ip_address_virtual: 10.1.10.2/24
+  tenant: Tenant_X
+  tags:
+  - opzone
+- name: Vlan316
+  description: Tenant_network_vrf_2
+  shutdown: false
+  vrf: VRF_without_loopback_ip_pools
+  ip_address_virtual: 10.1.10.3/24
   tenant: Tenant_X
   tags:
   - opzone
@@ -591,10 +663,22 @@ vlans:
 - id: 310
   name: Tenant_X_OP_Zone_1
   tenant: Tenant_X
+- id: 315
+  name: Tenant_network_vrf_1
+  tenant: Tenant_X
+- id: 316
+  name: Tenant_network_vrf_2
+  tenant: Tenant_X
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: Tenant_X_OP_Zone
+  ip_routing: true
+  tenant: Tenant_X
+- name: VRF_with_loopback_ip_pools
+  ip_routing: true
+  tenant: Tenant_X
+- name: VRF_without_loopback_ip_pools
   ip_routing: true
   tenant: Tenant_X
 vxlan_interface:
@@ -606,6 +690,14 @@ vxlan_interface:
       vlans:
       - id: 310
         vni: 11310
+      - id: 315
+        vni: 11315
+      - id: 316
+        vni: 11316
       vrfs:
       - name: Tenant_X_OP_Zone
         vni: 20
+      - name: VRF_with_loopback_ip_pools
+        vni: 22
+      - name: VRF_without_loopback_ip_pools
+        vni: 23

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -263,6 +263,12 @@ loopback_interfaces:
   vrf: Tenant_X_OP_Zone
   ip_address: 10.255.1.34/32
   ipv6_address: 2001:db8:1::2/128
+- name: Loopback200
+  description: VRF_with_loopback_ip_pools_VTEP_DIAGNOSTICS
+  shutdown: false
+  vrf: VRF_with_loopback_ip_pools
+  ip_address: 10.101.102.34/32
+  ipv6_address: 2001:db8:1::2/128
 management_api_http:
   enable_https: true
   default_services: false
@@ -278,6 +284,7 @@ management_interfaces:
   gateway: 192.168.200.5
 metadata:
   platform: vEOS-LAB
+  pod_name: TENANT_NETWORKS_POD
   fabric_name: EOS_DESIGNS_UNIT_TESTS
 ntp:
   local_interface:
@@ -529,6 +536,22 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: '310'
+  - name: VRF_with_loopback_ip_pools
+    rd: 192.168.255.34:22
+    route_targets:
+      both:
+      - '22:22'
+    redistribute_routes:
+    - learned
+    vlan: '315'
+  - name: VRF_without_loopback_ip_pools
+    rd: 192.168.255.34:23
+    route_targets:
+      both:
+      - '23:23'
+    redistribute_routes:
+    - learned
+    vlan: '316'
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -560,10 +583,40 @@ router_bgp:
     redistribute:
       connected:
         enabled: true
+  - name: VRF_with_loopback_ip_pools
+    rd: 192.168.255.34:22
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '22:22'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '22:22'
+    router_id: 10.101.102.34
+    redistribute:
+      connected:
+        enabled: true
+  - name: VRF_without_loopback_ip_pools
+    rd: 192.168.255.34:23
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '23:23'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '23:23'
+    router_id: 192.168.255.34
+    redistribute:
+      connected:
+        enabled: true
 service_routing_protocols_model: multi-agent
 snmp_server:
   contact: example@example.com
-  location: EOS_DESIGNS_UNIT_TESTS MH-LEAF1B
+  location: EOS_DESIGNS_UNIT_TESTS TENANT_NETWORKS_POD MH-LEAF1B
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -573,12 +626,31 @@ virtual_source_nat_vrfs:
 - name: Tenant_X_OP_Zone
   ip_address: 10.255.1.34
   ipv6_address: 2001:db8:1::2
+- name: VRF_with_loopback_ip_pools
+  ip_address: 10.101.102.34
+  ipv6_address: 2001:db8:1::2
 vlan_interfaces:
 - name: Vlan310
   description: Tenant_X_OP_Zone_1
   shutdown: false
   vrf: Tenant_X_OP_Zone
   ip_address_virtual: 10.1.10.1/24
+  tenant: Tenant_X
+  tags:
+  - opzone
+- name: Vlan315
+  description: Tenant_network_vrf_1
+  shutdown: false
+  vrf: VRF_with_loopback_ip_pools
+  ip_address_virtual: 10.1.10.2/24
+  tenant: Tenant_X
+  tags:
+  - opzone
+- name: Vlan316
+  description: Tenant_network_vrf_2
+  shutdown: false
+  vrf: VRF_without_loopback_ip_pools
+  ip_address_virtual: 10.1.10.3/24
   tenant: Tenant_X
   tags:
   - opzone
@@ -591,10 +663,22 @@ vlans:
 - id: 310
   name: Tenant_X_OP_Zone_1
   tenant: Tenant_X
+- id: 315
+  name: Tenant_network_vrf_1
+  tenant: Tenant_X
+- id: 316
+  name: Tenant_network_vrf_2
+  tenant: Tenant_X
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: Tenant_X_OP_Zone
+  ip_routing: true
+  tenant: Tenant_X
+- name: VRF_with_loopback_ip_pools
+  ip_routing: true
+  tenant: Tenant_X
+- name: VRF_without_loopback_ip_pools
   ip_routing: true
   tenant: Tenant_X
 vxlan_interface:
@@ -606,6 +690,14 @@ vxlan_interface:
       vlans:
       - id: 310
         vni: 11310
+      - id: 315
+        vni: 11315
+      - id: 316
+        vni: 11316
       vrfs:
       - name: Tenant_X_OP_Zone
         vni: 20
+      - name: VRF_with_loopback_ip_pools
+        vni: 22
+      - name: VRF_without_loopback_ip_pools
+        vni: 23

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -103,6 +103,12 @@ loopback_interfaces:
   vrf: Tenant_X_OP_Zone
   ip_address: 10.255.1.35/32
   ipv6_address: 2001:db8:1::3/128
+- name: Loopback200
+  description: VRF_with_loopback_ip_pools_VTEP_DIAGNOSTICS
+  shutdown: false
+  vrf: VRF_with_loopback_ip_pools
+  ip_address: 10.101.102.35/32
+  ipv6_address: 2001:db8:1::3/128
 management_api_http:
   enable_https: true
   default_services: false
@@ -118,6 +124,7 @@ management_interfaces:
   gateway: 192.168.200.5
 metadata:
   platform: vEOS-LAB
+  pod_name: TENANT_NETWORKS_POD
   fabric_name: EOS_DESIGNS_UNIT_TESTS
 ntp:
   local_interface:
@@ -137,7 +144,7 @@ port_channel_interfaces:
     enabled: true
     mode: trunk
     trunk:
-      allowed_vlan: '310'
+      allowed_vlan: 310,315-316
 prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
@@ -251,6 +258,22 @@ router_bgp:
     redistribute_routes:
     - learned
     vlan: '310'
+  - name: VRF_with_loopback_ip_pools
+    rd: 192.168.255.35:22
+    route_targets:
+      both:
+      - '22:22'
+    redistribute_routes:
+    - learned
+    vlan: '315'
+  - name: VRF_without_loopback_ip_pools
+    rd: 192.168.255.35:23
+    route_targets:
+      both:
+      - '23:23'
+    redistribute_routes:
+    - learned
+    vlan: '316'
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -294,10 +317,40 @@ router_bgp:
     redistribute:
       connected:
         enabled: true
+  - name: VRF_with_loopback_ip_pools
+    rd: 192.168.255.35:22
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '22:22'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '22:22'
+    router_id: 10.101.102.35
+    redistribute:
+      connected:
+        enabled: true
+  - name: VRF_without_loopback_ip_pools
+    rd: 192.168.255.35:23
+    route_targets:
+      import:
+      - address_family: evpn
+        route_targets:
+        - '23:23'
+      export:
+      - address_family: evpn
+        route_targets:
+        - '23:23'
+    router_id: 192.168.255.35
+    redistribute:
+      connected:
+        enabled: true
 service_routing_protocols_model: multi-agent
 snmp_server:
   contact: example@example.com
-  location: EOS_DESIGNS_UNIT_TESTS MH-LEAF2A
+  location: EOS_DESIGNS_UNIT_TESTS TENANT_NETWORKS_POD MH-LEAF2A
 static_routes:
 - vrf: MGMT
   destination_address_prefix: 0.0.0.0/0
@@ -309,6 +362,9 @@ transceiver_qsfp_default_mode_4x10: true
 virtual_source_nat_vrfs:
 - name: Tenant_X_OP_Zone
   ip_address: 10.255.1.35
+  ipv6_address: 2001:db8:1::3
+- name: VRF_with_loopback_ip_pools
+  ip_address: 10.101.102.35
   ipv6_address: 2001:db8:1::3
 vlan_interfaces:
 - name: Vlan311
@@ -326,6 +382,22 @@ vlan_interfaces:
   tenant: Tenant_X
   tags:
   - opzone
+- name: Vlan315
+  description: Tenant_network_vrf_1
+  shutdown: false
+  vrf: VRF_with_loopback_ip_pools
+  ip_address_virtual: 10.1.10.2/24
+  tenant: Tenant_X
+  tags:
+  - opzone
+- name: Vlan316
+  description: Tenant_network_vrf_2
+  shutdown: false
+  vrf: VRF_without_loopback_ip_pools
+  ip_address_virtual: 10.1.10.3/24
+  tenant: Tenant_X
+  tags:
+  - opzone
 vlan_internal_order:
   allocation: ascending
   range:
@@ -338,10 +410,22 @@ vlans:
 - id: 310
   name: Tenant_X_OP_Zone_1
   tenant: Tenant_X
+- id: 315
+  name: Tenant_network_vrf_1
+  tenant: Tenant_X
+- id: 316
+  name: Tenant_network_vrf_2
+  tenant: Tenant_X
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: Tenant_X_OP_Zone
+  ip_routing: true
+  tenant: Tenant_X
+- name: VRF_with_loopback_ip_pools
+  ip_routing: true
+  tenant: Tenant_X
+- name: VRF_without_loopback_ip_pools
   ip_routing: true
   tenant: Tenant_X
 vxlan_interface:
@@ -355,8 +439,16 @@ vxlan_interface:
         vni: 11311
       - id: 310
         vni: 11310
+      - id: 315
+        vni: 11315
+      - id: 316
+        vni: 11316
       vrfs:
       - name: default
         vni: 21
       - name: Tenant_X_OP_Zone
         vni: 20
+      - name: VRF_with_loopback_ip_pools
+        vni: 22
+      - name: VRF_without_loopback_ip_pools
+        vni: 23

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_TENANT_NETWORKS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/MH_TENANT_NETWORKS.yml
@@ -1,5 +1,6 @@
 ---
 # AVD_LAB Tenants Networks
+pod_name: TENANT_NETWORKS_POD
 tenants:
   # Tenant A Specific Information - VRFs / VLANs
   - name: Tenant_X
@@ -30,3 +31,29 @@ tenants:
         static_routes:
           - destination_address_prefix: 10.0.0.0/8
             gateway: 10.2.10.100
+      - name: VRF_with_loopback_ip_pools
+        vrf_id: 22
+        vtep_diagnostic:
+          loopback: 200
+          loopback_ip_pools:
+            - pod: TENANT_NETWORKS_POD
+              ipv4_pool: 10.101.102.0/24
+              ipv6_pool: 2001:db8:1::-2001:db8:1:7fff::, 2001:db8:1:8000::/49
+        svis:
+          - id: 315
+            name: Tenant_network_vrf_1
+            tags: [opzone]
+            enabled: true
+            ip_address_virtual: 10.1.10.2/24
+        bgp:
+          router_id: diagnostic_loopback
+      - name: VRF_without_loopback_ip_pools
+        vrf_id: 23
+        vtep_diagnostic:
+          loopback: 300
+        svis:
+          - id: 316
+            name: Tenant_network_vrf_2
+            tags: [opzone]
+            enabled: true
+            ip_address_virtual: 10.1.10.3/24


### PR DESCRIPTION
## Change Summary

Add pytest coverage for network_services/loopback_interfaces.py

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Add pytest coverage for network_services/loopback_interfaces.py
COVERAGE: 100%

## How to test
Tox coverage report

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
