### PR TITLE
Test(eos_designs): Improve pytest coverage for overlay/stun.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
@@ -80,6 +80,8 @@ router path-selection
       !
       local interface Ethernet3
       !
+      local interface Port-Channel5
+      !
       peer static router-ip 192.168.144.1
          name cv-pathfinder-pathfinder
          ipv4 address 172.17.7.7
@@ -153,6 +155,12 @@ ip security
       shared-key 7 ABCDEF1234567890
       dpd 10 50 clear
       mode transport
+!
+interface Port-Channel5
+   description Another-ISP_peer2_Port-Channel16
+   no shutdown
+   no switchport
+   ip address 10.7.7.5/31
 !
 interface Dps1
    description DPS Interface
@@ -332,6 +340,7 @@ stun
       local-interface Ethernet1
       local-interface Ethernet2
       local-interface Ethernet3
+      local-interface Port-Channel5
       ssl profile profileA
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
@@ -189,6 +189,12 @@ metadata:
         value: Another-ISP
       - name: Circuit
         value: '999'
+    - interface: Port-Channel5
+      tags:
+      - name: Type
+        value: wan
+      - name: Carrier
+        value: Another-ISP
   cv_pathfinder:
     role: pathfinder
     vtep_ip: 192.168.144.1
@@ -209,6 +215,10 @@ metadata:
       circuit_id: '999'
       pathgroup: INET
       public_ip: 10.9.9.9
+    - name: Port-Channel5
+      carrier: Another-ISP
+      pathgroup: INET
+      public_ip: 10.7.7.5
     pathgroups:
     - name: MPLS
       carriers:
@@ -379,6 +389,16 @@ metadata:
 platform:
   sfe:
     data_plane_cpu_allocation_max: 1
+port_channel_interfaces:
+- name: Port-Channel5
+  description: Another-ISP_peer2_Port-Channel16
+  shutdown: false
+  ip_address: 10.7.7.5/31
+  peer: peer2
+  peer_interface: Port-Channel16
+  peer_type: l3_port_channel
+  switchport:
+    enabled: false
 prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
@@ -592,6 +612,7 @@ router_path_selection:
     local_interfaces:
     - name: Ethernet1
     - name: Ethernet3
+    - name: Port-Channel5
     static_peers:
     - router_ip: 192.168.144.1
       name: cv-pathfinder-pathfinder
@@ -645,6 +666,7 @@ stun:
     - Ethernet1
     - Ethernet2
     - Ethernet3
+    - Port-Channel5
     ssl_profile: profileA
 transceiver_qsfp_default_mode_4x10: false
 vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_CUSTOM_CONTROL_PLANE_POLICY_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_CUSTOM_CONTROL_PLANE_POLICY_TESTS.yml
@@ -83,6 +83,14 @@ wan_rr:
           wan_carrier: Another-ISP
           wan_circuit_id: 999
           ip_address: 10.9.9.9/31
+      # Test for l3_port_channels
+      l3_port_channels:
+        - name: Port-Channel5
+          ip_address: 10.7.7.5/31
+          peer: peer2
+          peer_port_channel: Port-Channel16
+          peer_ip: 10.7.7.8/31
+          wan_carrier: Another-ISP
 
 wan_virtual_topologies:
   vrfs:


### PR DESCRIPTION
## Change Summary

Improve pytest coverage for overlay/stun.py

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Improved test coverage to 100%

## How to test
Tox coverage report

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
