### PR TITLE
CI(containers): fix universal build workflow

### DIFF
--- a/.github/workflows/container_build_base.yml
+++ b/.github/workflows/container_build_base.yml
@@ -3,6 +3,8 @@ name: Build base container
 
 "on":
   push:
+    branches:
+      - devel
     paths:
       - containers/base/**
       - .github/workflows/container_build_template.yml
@@ -13,7 +15,7 @@ name: Build base container
 
 jobs:
   build_base:
-    if: ( github.repository == 'aristanetworks/avd' && github.ref == 'refs/heads/devel' ) || vars.DEBUG_CONTAINER_ACTIONS == 'true'
+    if: github.repository == 'aristanetworks/avd'
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:

--- a/.github/workflows/container_build_dev.yml
+++ b/.github/workflows/container_build_dev.yml
@@ -3,6 +3,8 @@ name: Build dev container
 
 "on":
   push:
+    branches:
+      - devel
     paths:
       - containers/dev/**
       - .github/workflows/container_build_template.yml
@@ -13,7 +15,7 @@ name: Build dev container
 
 jobs:
   build_dev_container:
-    if: ( github.repository == 'aristanetworks/avd' && github.ref == 'refs/heads/devel' ) || vars.DEBUG_CONTAINER_ACTIONS == 'true'
+    if: github.repository == 'aristanetworks/avd'
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:

--- a/.github/workflows/container_build_fix.yml
+++ b/.github/workflows/container_build_fix.yml
@@ -1,7 +1,7 @@
 # this workflow can be triggered manually to initiate any build if it fails
 name: fix container build
 
-on:
+"on":
   workflow_dispatch:
     inputs:
       container_name:

--- a/.github/workflows/container_build_fix.yml
+++ b/.github/workflows/container_build_fix.yml
@@ -1,5 +1,5 @@
 # this workflow can be triggered manually to initiate any build if it fails
-name: fix container build
+name: Manual container build
 
 "on":
   workflow_dispatch:
@@ -7,14 +7,14 @@ name: fix container build
       container_name:
         type: choice
         required: true
-        description: "select image name to build"
+        description: "select image type to build"
         options: [universal]
         default: "universal"
       container_tags:
         type: string
         required: false
         description: "container image tags"
-        default: "fix"  # this is a special tag that can be used for testing
+        default: "test"  # this is a special tag that can be used for testing
       python_version:
         type: choice
         required: true
@@ -24,10 +24,10 @@ name: fix container build
       github_tag:
         type: string
         required: true
-        description: "Github tag/branch that will be used to build the image"
+        description: "Github tag/branch that will be used to build the image. For example: devel, v5.3.0"
 
 jobs:
-  fix_container_build:
+  manual_container_build:
     uses: ./.github/workflows/container_build_template.yml
     with:
       container_name: ${{ inputs.container_name }}

--- a/.github/workflows/container_build_fix.yml
+++ b/.github/workflows/container_build_fix.yml
@@ -1,0 +1,36 @@
+# this workflow can be triggered manually to initiate any build if it fails
+name: fix container build
+
+on:
+  workflow_dispatch:
+    inputs:
+      container_name:
+        type: choice
+        required: true
+        description: "select image name to build"
+        options: [universal]
+        default: "universal"
+      container_tags:
+        type: string
+        required: false
+        description: "container image tags"
+        default: "fix"  # this is a special tag that can be used for testing
+      python_version:
+        type: choice
+        required: true
+        description: "select Python version"
+        options: ["3.10", "3.11", "3.12", "3.13"]
+        default: "3.11"
+      github_tag:
+        type: string
+        required: true
+        description: "Github tag/branch that will be used to build the image"
+
+jobs:
+  fix_container_build:
+    uses: ./.github/workflows/container_build_template.yml
+    with:
+      container_name: ${{ inputs.container_name }}
+      container_tags: ${{ inputs.container_tags }}
+      python_version: ${{ inputs.python_version }}
+      github_tag: ${{ inputs.github_tag }}

--- a/.github/workflows/container_build_template.yml
+++ b/.github/workflows/container_build_template.yml
@@ -54,6 +54,11 @@ env:
       python_version:
         required: true
         type: string
+      # github_tag is only required for manual container build
+      github_tag:
+        required: false
+        type: string
+        default: ""
 
 jobs:
   build_image:
@@ -131,10 +136,17 @@ jobs:
       - name: Find ansible and pyavd install location
         id: find-install-locations
         run: |
-          PYAVD_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git@${{ github.ref_name }}#subdirectory=python-avd"
-          ANSIBLE_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git#/ansible_collections/arista/avd/,${{ github.ref_name }}"
-          echo "ansible_install_location=$ANSIBLE_INSTALL_LOCATION" >> $GITHUB_OUTPUT
-          echo "pyavd_install_location=$PYAVD_INSTALL_LOCATION" >> $GITHUB_OUTPUT
+          if [ -z "${{ inputs.container_tags }}" ]; then
+            PYAVD_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git@${{ github.ref_name }}#subdirectory=python-avd"
+            ANSIBLE_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git#/ansible_collections/arista/avd/,${{ github.ref_name }}"
+            echo "ansible_install_location=$ANSIBLE_INSTALL_LOCATION" >> $GITHUB_OUTPUT
+            echo "pyavd_install_location=$PYAVD_INSTALL_LOCATION" >> $GITHUB_OUTPUT
+          else
+            PYAVD_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git@${{ inputs.container_tags }}#subdirectory=python-avd"
+            ANSIBLE_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git#/ansible_collections/arista/avd/,${{ inputs.container_tags }}"
+            echo "ansible_install_location=$ANSIBLE_INSTALL_LOCATION" >> $GITHUB_OUTPUT
+            echo "pyavd_install_location=$PYAVD_INSTALL_LOCATION" >> $GITHUB_OUTPUT
+          fi
 
       # This check is temporarily deactivated, will be rewised in later PRs
       #

--- a/.github/workflows/container_build_template.yml
+++ b/.github/workflows/container_build_template.yml
@@ -136,14 +136,14 @@ jobs:
       - name: Find ansible and pyavd install location
         id: find-install-locations
         run: |
-          if [ -z "${{ inputs.container_tags }}" ]; then
+          if [ -z "${{ inputs.github_tag }}" ]; then
             PYAVD_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git@${{ github.ref_name }}#subdirectory=python-avd"
             ANSIBLE_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git#/ansible_collections/arista/avd/,${{ github.ref_name }}"
             echo "ansible_install_location=$ANSIBLE_INSTALL_LOCATION" >> $GITHUB_OUTPUT
             echo "pyavd_install_location=$PYAVD_INSTALL_LOCATION" >> $GITHUB_OUTPUT
           else
-            PYAVD_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git@${{ inputs.container_tags }}#subdirectory=python-avd"
-            ANSIBLE_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git#/ansible_collections/arista/avd/,${{ inputs.container_tags }}"
+            PYAVD_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git@${{ inputs.github_tag }}#subdirectory=python-avd"
+            ANSIBLE_INSTALL_LOCATION="git+https://github.com/${{ github.repository }}.git#/ansible_collections/arista/avd/,${{ inputs.github_tag }}"
             echo "ansible_install_location=$ANSIBLE_INSTALL_LOCATION" >> $GITHUB_OUTPUT
             echo "pyavd_install_location=$PYAVD_INSTALL_LOCATION" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -16,7 +16,7 @@ name: Build universal container
 
 jobs:
   build_universal_container:
-    if: ( github.repository == 'aristanetworks/avd' && github.ref == 'refs/heads/devel' ) || vars.DEBUG_CONTAINER_ACTIONS == 'true'
+    if: ( github.repository == 'aristanetworks/avd' && ( github.ref == 'refs/heads/devel' || github.event.action == 'published' ) ) || vars.DEBUG_CONTAINER_ACTIONS == 'true'
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:

--- a/.github/workflows/container_build_universal.yml
+++ b/.github/workflows/container_build_universal.yml
@@ -3,6 +3,8 @@ name: Build universal container
 
 "on":
   push:
+    branches:
+      - devel
     paths:
       - containers/universal/**
       - .github/workflows/container_build_template.yml
@@ -16,7 +18,7 @@ name: Build universal container
 
 jobs:
   build_universal_container:
-    if: ( github.repository == 'aristanetworks/avd' && ( github.ref == 'refs/heads/devel' || github.event.action == 'published' ) ) || vars.DEBUG_CONTAINER_ACTIONS == 'true'
+    if: github.repository == 'aristanetworks/avd'
     uses: ./.github/workflows/container_build_template.yml
     strategy:
       matrix:


### PR DESCRIPTION
## Change Summary

fix if condition in universal build workflow
add a workflow to trigger builds manually in case of failure

The manual build workflow with some modifications was tested [here](https://github.com/ankudinov/test-gh-ci-with-devcontainer/actions/runs/14639198212/job/41078063652).

Test the image:
```shell
podman run --rm -it -w /home/avd ghcr.io/ankudinov/test-gh-ci-with-devcontainer/universal:my_test_fix zsh -c "cp -r /home/avd/.ansible/collections/ansible_collections/arista/avd/examples/single-dc-l3ls/* .; ansible-playbook build.yml; ansible-galaxy collection list"
```
