### PR TITLE
Feat(cv_deploy): Handle WorkspaceStreamResponse with ResponseStatus.UNSPECIFIED

### DIFF
--- a/python-avd/pyavd/_cv/client/change_control.py
+++ b/python-avd/pyavd/_cv/client/change_control.py
@@ -218,7 +218,6 @@ class ChangeControlMixin(Protocol):
                 if hasattr(response, "value") and response.value.status == CHANGE_CONTROL_STATUS_MAP[state]:
                     LOGGER.info("wait_for_change_control_complete: Got response for request '%s': %s", cc_id, response.value.status)
                     return response.value
-                LOGGER.debug("wait_for_change_control_complete: Status of change control is '%s.'", response)
 
         except Exception as e:
             raise get_cv_client_exception(e, f"CC ID '{cc_id}')") or e

--- a/python-avd/pyavd/_cv/client/workspace.py
+++ b/python-avd/pyavd/_cv/client/workspace.py
@@ -11,6 +11,7 @@ from pyavd._cv.api.arista.workspace.v1 import (
     Request,
     RequestParams,
     Response,
+    ResponseStatus,
     Workspace,
     WorkspaceConfig,
     WorkspaceConfigDeleteRequest,
@@ -246,12 +247,20 @@ class WorkspaceMixin(Protocol):
             responses = client.subscribe(request, metadata=self._metadata, timeout=timeout)
             async for response in responses:
                 if request_id in response.value.responses.values:
-                    LOGGER.info("wait_for_workspace_response: Got response for request '%s': %s", request_id, response.value.responses.values[request_id])
-                    return response.value.responses.values[request_id], response.value
-                LOGGER.debug(
-                    "wait_for_workspace_response: Got workspace update but not for request_id '%s'. Workspace State: %s",
-                    request_id,
-                    response.value.state,
-                )
+                    LOGGER.info(
+                        "wait_for_workspace_response: Got response for request '%s' at '%s' UTC: %s",
+                        request_id,
+                        response.time,
+                        response.value.responses.values[request_id],
+                    )
+                    if response.value.responses.values[request_id].status != ResponseStatus.UNSPECIFIED:
+                        return response.value.responses.values[request_id], response.value
+                else:
+                    LOGGER.debug(
+                        "wait_for_workspace_response: Got workspace update but not for request_id '%s'. Workspace State: %s. Received responses: %s",
+                        request_id,
+                        response.value.state,
+                        response.value.responses.values,
+                    )
         except Exception as e:
             raise get_cv_client_exception(e, f"Workspace ID '{workspace_id}', Request ID '{request_id}") or e

--- a/python-avd/pyavd/_cv/client/workspace.py
+++ b/python-avd/pyavd/_cv/client/workspace.py
@@ -225,10 +225,11 @@ class WorkspaceMixin(Protocol):
         """
         Monitor a Workspace using arista.workspace.v1.WorkspaceService.Subscribe API for a response to the given request_id.
 
-        Blocks until a response is returned or timed out.
+        Blocks until a response in a terminal state (ResponseStatus.SUCCESS or ResponseStatus.FAIL) is returned or timed out.
+        Responses in an intermediate state (ResponseStatus.UNSPECIFIED) are logged only.
 
         Parameters:
-            workspace_id: Unique identifier the Workspace.
+            workspace_id: Unique identifier for the Workspace.
             request_id: Unique identifier for the Request.
             timeout: Timeout in seconds for the Workspace to build.
 
@@ -247,12 +248,7 @@ class WorkspaceMixin(Protocol):
             responses = client.subscribe(request, metadata=self._metadata, timeout=timeout)
             async for response in responses:
                 if request_id in response.value.responses.values:
-                    LOGGER.info(
-                        "wait_for_workspace_response: Got response for request '%s' at '%s' UTC: %s",
-                        request_id,
-                        response.time,
-                        response.value.responses.values[request_id],
-                    )
+                    LOGGER.info("wait_for_workspace_response: Got response for request '%s': %s", request_id, response.value.responses.values[request_id])
                     if response.value.responses.values[request_id].status != ResponseStatus.UNSPECIFIED:
                         return response.value.responses.values[request_id], response.value
                 else:


### PR DESCRIPTION
## Change Summary

Properly handle WorkspaceStreamResponses in an intermediate state.
This addresses new CV behavior where response in an intermediate state is now published once request is picked by the backend.

## Related Issue(s)

- N/A

## Component(s) name

`arista.avd.cv_deploy`

## Proposed changes
- Avoid returning unless response matching request_id reached terminal state (SUCCESS/FAIL)

## How to test
`cv_deploy` CI molecule test

## Checklist

### User Checklist

- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
