### PR TITLE
Test(eos_designs): Improved the pytest coverage for underlay/router_pim_sparse_mode.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-peer-router-id-for-router-pim-sparse-mode.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-peer-router-id-for-router-pim-sparse-mode.yml
@@ -1,0 +1,25 @@
+underlay_multicast: true
+underlay_multicast_rps:
+  - rp: 192.168.200.1
+    groups:
+      - 239.255.1.0/24
+    nodes:
+      - name: missing-peer-router-id-for-router-pim-sparse-mode
+        loopback_number: 4
+      - name: missing-mgmt-ip-cvx-servers
+        loopback_number: 4
+      - name: missing-inband-mgmt-interface
+        loopback_number: 4
+
+type: l3leaf
+l3leaf:
+  defaults:
+    loopback_ipv4_pool: 192.168.0.0/24
+    vtep_loopback_ipv4_pool: 192.168.1.0/24
+  nodes:
+    - name: missing-peer-router-id-for-router-pim-sparse-mode
+      bgp_as: 65001
+      id: 1
+
+expected_error_message: >-
+  'router_id' is required but was not found for missing-mgmt-ip-cvx-servers.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -182,6 +182,7 @@ all:
             missing-mgmt-ip-ipv6-mgmt-ip:
             missing-inband-mgmt-interface:
             missing-mgmt-ip-cvx-servers:
+            missing-peer-router-id-for-router-pim-sparse-mode:
             wan-router-l3-interfaces-unsupported-rxtx-for-subinterface:
             wan-router-policy-unmatched:
             ntp-settings-server-vrf-missing-mgmt-ip:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1A.cfg
@@ -120,9 +120,6 @@ interface Vxlan1
 ip access-list standard RP_ACL_2
    10 permit 239.255.2.0/24
 !
-ip access-list standard RP_ACL_3
-   10 permit 239.255.3.0/24
-!
 ip access-list standard RP_ACL_4
    10 permit 239.255.4.0/24
 !
@@ -216,7 +213,7 @@ router pim sparse-mode
    ipv4
       rp address 192.168.200.1 239.255.1.0/24
       rp address 192.168.200.2 access-list RP_ACL_2
-      rp address 192.168.200.3 access-list RP_ACL_3
+      rp address 192.168.200.3
       rp address 192.168.200.4 access-list RP_ACL_4
       rp address 192.168.200.5 access-list RP_ACL_5
       anycast-rp 192.168.200.4 192.168.255.3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF1B.cfg
@@ -104,9 +104,6 @@ interface Vxlan1
 ip access-list standard RP_ACL_2
    10 permit 239.255.2.0/24
 !
-ip access-list standard RP_ACL_3
-   10 permit 239.255.3.0/24
-!
 ip access-list standard RP_ACL_4
    10 permit 239.255.4.0/24
 !
@@ -199,7 +196,7 @@ router pim sparse-mode
    ipv4
       rp address 192.168.200.1 239.255.1.0/24
       rp address 192.168.200.2 access-list RP_ACL_2
-      rp address 192.168.200.3 access-list RP_ACL_3
+      rp address 192.168.200.3
       rp address 192.168.200.4 access-list RP_ACL_4
       rp address 192.168.200.5 access-list RP_ACL_5
       anycast-rp 192.168.200.4 192.168.255.3

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2A.cfg
@@ -94,9 +94,6 @@ interface Vxlan1
 ip access-list standard RP_ACL_2
    10 permit 239.255.2.0/24
 !
-ip access-list standard RP_ACL_3
-   10 permit 239.255.3.0/24
-!
 ip access-list standard RP_ACL_4
    10 permit 239.255.4.0/24
 !
@@ -189,7 +186,7 @@ router pim sparse-mode
    ipv4
       rp address 192.168.200.1 239.255.1.0/24
       rp address 192.168.200.2 access-list RP_ACL_2
-      rp address 192.168.200.3 access-list RP_ACL_3
+      rp address 192.168.200.3
       rp address 192.168.200.4 access-list RP_ACL_4
       rp address 192.168.200.5 access-list RP_ACL_5
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-L3LEAF2B.cfg
@@ -94,9 +94,6 @@ interface Vxlan1
 ip access-list standard RP_ACL_2
    10 permit 239.255.2.0/24
 !
-ip access-list standard RP_ACL_3
-   10 permit 239.255.3.0/24
-!
 ip access-list standard RP_ACL_4
    10 permit 239.255.4.0/24
 !
@@ -189,7 +186,7 @@ router pim sparse-mode
    ipv4
       rp address 192.168.200.1 239.255.1.0/24
       rp address 192.168.200.2 access-list RP_ACL_2
-      rp address 192.168.200.3 access-list RP_ACL_3
+      rp address 192.168.200.3
       rp address 192.168.200.4 access-list RP_ACL_4
       rp address 192.168.200.5 access-list RP_ACL_5
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/UNDERLAY-MULTICAST-SPINE1.cfg
@@ -67,9 +67,6 @@ interface Management1
 ip access-list standard RP_ACL_2
    10 permit 239.255.2.0/24
 !
-ip access-list standard RP_ACL_3
-   10 permit 239.255.3.0/24
-!
 ip access-list standard RP_ACL_4
    10 permit 239.255.4.0/24
 !
@@ -146,7 +143,7 @@ router pim sparse-mode
    ipv4
       rp address 192.168.200.1 239.255.1.0/24
       rp address 192.168.200.2 access-list RP_ACL_2
-      rp address 192.168.200.3 access-list RP_ACL_3
+      rp address 192.168.200.3
       rp address 192.168.200.4 access-list RP_ACL_4
       rp address 192.168.200.5 access-list RP_ACL_5
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1A.yml
@@ -235,8 +235,6 @@ router_pim_sparse_mode:
       access_lists:
       - RP_ACL_2
     - address: 192.168.200.3
-      access_lists:
-      - RP_ACL_3
     - address: 192.168.200.4
       access_lists:
       - RP_ACL_4
@@ -256,10 +254,6 @@ standard_access_lists:
   sequence_numbers:
   - sequence: 10
     action: permit 239.255.2.0/24
-- name: RP_ACL_3
-  sequence_numbers:
-  - sequence: 10
-    action: permit 239.255.3.0/24
 - name: RP_ACL_4
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF1B.yml
@@ -213,8 +213,6 @@ router_pim_sparse_mode:
       access_lists:
       - RP_ACL_2
     - address: 192.168.200.3
-      access_lists:
-      - RP_ACL_3
     - address: 192.168.200.4
       access_lists:
       - RP_ACL_4
@@ -234,10 +232,6 @@ standard_access_lists:
   sequence_numbers:
   - sequence: 10
     action: permit 239.255.2.0/24
-- name: RP_ACL_3
-  sequence_numbers:
-  - sequence: 10
-    action: permit 239.255.3.0/24
 - name: RP_ACL_4
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2A.yml
@@ -221,8 +221,6 @@ router_pim_sparse_mode:
       access_lists:
       - RP_ACL_2
     - address: 192.168.200.3
-      access_lists:
-      - RP_ACL_3
     - address: 192.168.200.4
       access_lists:
       - RP_ACL_4
@@ -237,10 +235,6 @@ standard_access_lists:
   sequence_numbers:
   - sequence: 10
     action: permit 239.255.2.0/24
-- name: RP_ACL_3
-  sequence_numbers:
-  - sequence: 10
-    action: permit 239.255.3.0/24
 - name: RP_ACL_4
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-L3LEAF2B.yml
@@ -221,8 +221,6 @@ router_pim_sparse_mode:
       access_lists:
       - RP_ACL_2
     - address: 192.168.200.3
-      access_lists:
-      - RP_ACL_3
     - address: 192.168.200.4
       access_lists:
       - RP_ACL_4
@@ -237,10 +235,6 @@ standard_access_lists:
   sequence_numbers:
   - sequence: 10
     action: permit 239.255.2.0/24
-- name: RP_ACL_3
-  sequence_numbers:
-  - sequence: 10
-    action: permit 239.255.3.0/24
 - name: RP_ACL_4
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/UNDERLAY-MULTICAST-SPINE1.yml
@@ -188,8 +188,6 @@ router_pim_sparse_mode:
       access_lists:
       - RP_ACL_2
     - address: 192.168.200.3
-      access_lists:
-      - RP_ACL_3
     - address: 192.168.200.4
       access_lists:
       - RP_ACL_4
@@ -204,10 +202,6 @@ standard_access_lists:
   sequence_numbers:
   - sequence: 10
     action: permit 239.255.2.0/24
-- name: RP_ACL_3
-  sequence_numbers:
-  - sequence: 10
-    action: permit 239.255.3.0/24
 - name: RP_ACL_4
   sequence_numbers:
   - sequence: 10

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/UNDERLAY_MULTICAST_TESTS.yml
@@ -11,8 +11,6 @@ underlay_multicast_rps:
       - 239.255.2.0/24
     access_list_name: RP_ACL_2
   - rp: 192.168.200.3
-    groups:
-      - 239.255.3.0/24
     access_list_name: RP_ACL_3
     nodes:
       - name: UNDERLAY-MULTICAST-L3LEAF1A

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
@@ -50,6 +50,7 @@ class RouterPimSparseModeMixin(Protocol):
                 if not peer_facts.router_id:
                     msg = f"'router_id' is required but was not found for {node.name}."
                     raise AristaAvdInvalidInputsError(msg)
+
                 other_anycast_rp_addresses.append_new(address=peer_facts.router_id)
             self.structured_config.router_pim_sparse_mode.ipv4.anycast_rps.append_new(
                 address=rp_entry.rp, other_anycast_rp_addresses=other_anycast_rp_addresses

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
@@ -3,10 +3,11 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol, cast
+from typing import TYPE_CHECKING, Protocol
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
+from pyavd._errors import AristaAvdInvalidInputsError
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigUnderlayProtocol
@@ -46,8 +47,10 @@ class RouterPimSparseModeMixin(Protocol):
             other_anycast_rp_addresses = EosCliConfigGen.RouterPimSparseMode.Ipv4.AnycastRpsItem.OtherAnycastRpAddresses()
             for node in rp_entry.nodes:
                 peer_facts = self.shared_utils.get_peer_facts(node.name)
-                router_id = cast("str", peer_facts.router_id)
-                other_anycast_rp_addresses.append_new(address=router_id)
+                if not peer_facts.router_id:
+                    msg = f"'router_id' is required but was not found for {node.name}."
+                    raise AristaAvdInvalidInputsError(msg)
+                other_anycast_rp_addresses.append_new(address=peer_facts.router_id)
             self.structured_config.router_pim_sparse_mode.ipv4.anycast_rps.append_new(
                 address=rp_entry.rp, other_anycast_rp_addresses=other_anycast_rp_addresses
             )

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/router_pim_sparse_mode.py
@@ -3,11 +3,10 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Protocol, cast
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
-from pyavd._errors import AristaAvdInvalidInputsError
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigUnderlayProtocol
@@ -47,11 +46,8 @@ class RouterPimSparseModeMixin(Protocol):
             other_anycast_rp_addresses = EosCliConfigGen.RouterPimSparseMode.Ipv4.AnycastRpsItem.OtherAnycastRpAddresses()
             for node in rp_entry.nodes:
                 peer_facts = self.shared_utils.get_peer_facts(node.name)
-                if not peer_facts.router_id:
-                    msg = f"'router_id' is required but was not found for {node.name}."
-                    raise AristaAvdInvalidInputsError(msg)
-
-                other_anycast_rp_addresses.append_new(address=peer_facts.router_id)
+                router_id = cast("str", peer_facts.router_id)
+                other_anycast_rp_addresses.append_new(address=router_id)
             self.structured_config.router_pim_sparse_mode.ipv4.anycast_rps.append_new(
                 address=rp_entry.rp, other_anycast_rp_addresses=other_anycast_rp_addresses
             )


### PR DESCRIPTION
## Change Summary

Improved the pytest coverage for underlay/router_pim_sparse_mode.py

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Improved the pytest coverage for underlay/router_pim_sparse_mode.py. coverage is 100% now

## How to test
Run tox

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
