### PR TITLE
Test(eos_designs): Added pytest coverage for network_services/metadata.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-1.cfg
@@ -194,14 +194,18 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-edge-2.cfg
@@ -274,14 +274,18 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile CUSTOM-CP-APP-PROFILE
       application APP-CONTROL-PLANE
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.cfg
@@ -220,14 +220,18 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    field-set ipv4 prefix CUSTOM-DEST-PREFIX-1
       6.6.6.0/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-wan-use-evpn-on-lan-no-overlay-on-lan.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-wan-use-evpn-on-lan-no-overlay-on-lan.cfg
@@ -230,14 +230,18 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-wan-use-evpn-on-lan.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge-wan-use-evpn-on-lan.cfg
@@ -230,14 +230,18 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge.cfg
@@ -435,16 +435,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -562,14 +562,18 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2A.cfg
@@ -339,16 +339,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge2B.cfg
@@ -324,16 +324,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3A.cfg
@@ -263,16 +263,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge3B.cfg
@@ -263,16 +263,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge4A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge4A.cfg
@@ -274,16 +274,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge4B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge4B.cfg
@@ -274,16 +274,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder.cfg
@@ -316,16 +316,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder1.cfg
@@ -307,16 +307,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-pathfinder2.cfg
@@ -320,16 +320,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1A.cfg
@@ -388,16 +388,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-transit1B.cfg
@@ -369,16 +369,20 @@ application traffic recognition
       application CUSTOM-DSCP-APPLICATION
       application microsoft-teams
    !
+   category VIDEO-WITH-SERVICE
+      application microsoft service chat
+   !
    application-profile APP-PROFILE-CONTROL-PLANE
       application APP-CONTROL-PLANE
    !
    application-profile MPLS-ONLY
    !
    application-profile VIDEO
+      application skype service chat
       application CUSTOM-APPLICATION-1
-      application skype
       application rtp transport
       category VIDEO1
+      category VIDEO-WITH-SERVICE service audio-video
    !
    application-profile VOICE
       application CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
 config_end: true
 dps_interfaces:
 - name: Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
 config_end: true
 dps_interfaces:
 - name: Dps1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
 config_end: true
 dps_interfaces:
 - name: Dps1
@@ -371,16 +378,25 @@ metadata:
       - name: VIDEO
         builtin_applications:
         - name: skype
+          services:
+          - chat
         user_defined_applications:
         - name: CUSTOM-APPLICATION-1
         categories:
         - category: VIDEO1
+        - category: VIDEO-WITH-SERVICE
+          services:
+          - audio-video
         transport_protocols:
         - rtp
       categories:
         builtin_applications:
         - name: microsoft-teams
           category: VIDEO1
+        - name: microsoft
+          category: VIDEO-WITH-SERVICE
+          services:
+          - chat
         user_defined_applications:
         - name: CUSTOM-APPLICATION-2
           category: VIDEO1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-use-evpn-on-lan-no-overlay-on-lan.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-use-evpn-on-lan-no-overlay-on-lan.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-use-evpn-on-lan.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-use-evpn-on-lan.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -60,10 +64,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge3A.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge3B.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4A.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4B.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
@@ -496,10 +503,15 @@ metadata:
       - name: VIDEO
         builtin_applications:
         - name: skype
+          services:
+          - chat
         user_defined_applications:
         - name: CUSTOM-APPLICATION-1
         categories:
         - category: VIDEO1
+        - category: VIDEO-WITH-SERVICE
+          services:
+          - audio-video
         transport_protocols:
         - rtp
       - name: VOICE
@@ -510,6 +522,10 @@ metadata:
         builtin_applications:
         - name: microsoft-teams
           category: VIDEO1
+        - name: microsoft
+          category: VIDEO-WITH-SERVICE
+          services:
+          - chat
         user_defined_applications:
         - name: CUSTOM-APPLICATION-2
           category: VIDEO1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
@@ -459,10 +466,15 @@ metadata:
       - name: VIDEO
         builtin_applications:
         - name: skype
+          services:
+          - chat
         user_defined_applications:
         - name: CUSTOM-APPLICATION-1
         categories:
         - category: VIDEO1
+        - category: VIDEO-WITH-SERVICE
+          services:
+          - audio-video
         transport_protocols:
         - rtp
       - name: VOICE
@@ -473,6 +485,10 @@ metadata:
         builtin_applications:
         - name: microsoft-teams
           category: VIDEO1
+        - name: microsoft
+          category: VIDEO-WITH-SERVICE
+          services:
+          - chat
         user_defined_applications:
         - name: CUSTOM-APPLICATION-2
           category: VIDEO1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION
@@ -477,10 +484,15 @@ metadata:
       - name: VIDEO
         builtin_applications:
         - name: skype
+          services:
+          - chat
         user_defined_applications:
         - name: CUSTOM-APPLICATION-1
         categories:
         - category: VIDEO1
+        - category: VIDEO-WITH-SERVICE
+          services:
+          - audio-video
         transport_protocols:
         - rtp
       - name: VOICE
@@ -491,6 +503,10 @@ metadata:
         builtin_applications:
         - name: microsoft-teams
           category: VIDEO1
+        - name: microsoft
+          category: VIDEO-WITH-SERVICE
+          services:
+          - chat
         user_defined_applications:
         - name: CUSTOM-APPLICATION-2
           category: VIDEO1

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -12,6 +12,10 @@ application_traffic_recognition:
     - name: CUSTOM-APPLICATION-2
     - name: CUSTOM-DSCP-APPLICATION
     - name: microsoft-teams
+  - name: VIDEO-WITH-SERVICE
+    applications:
+    - name: microsoft
+      service: chat
   field_sets:
     l4_ports:
     - name: TCP-SRC-2
@@ -59,10 +63,13 @@ application_traffic_recognition:
     applications:
     - name: CUSTOM-APPLICATION-1
     - name: skype
+      service: chat
     application_transports:
     - rtp
     categories:
     - name: VIDEO1
+    - name: VIDEO-WITH-SERVICE
+      service: audio-video
   - name: VOICE
     applications:
     - name: CUSTOM-VOICE-APPLICATION

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -748,11 +748,14 @@ application_classification:
       # Testing categories filtering
       categories:
         - name: VIDEO1
+        - name: VIDEO-WITH-SERVICE
+          service: audio-video
       applications:
         # Testing applications in application-profiles filtering
         - name: CUSTOM-APPLICATION-1
         # Builtin application that should not raise
         - name: skype
+          service: chat
       # application transport to also be covered by the profile
       application_transports:
         - rtp
@@ -774,6 +777,10 @@ application_classification:
         - name: CUSTOM-DSCP-APPLICATION
         # Builtin application that should not raise
         - name: microsoft-teams
+    - name: VIDEO-WITH-SERVICE
+      applications:
+        - name: microsoft
+          service: chat
   applications:
     ipv4_applications:
       # This should not be rendered in any device


### PR DESCRIPTION

## Change Summary

Added pytest coverage for network_services/metadata.py

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added pytest coverage for network_services/metadata.py. Now coverage is 100%

## How to test
Run tox

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
