### PR TITLE
Doc(eos_designs): Add `vrf_id` in l2ls-fabric example

### DIFF
--- a/ansible_collections/arista/avd/examples/l2ls-fabric/README.md
+++ b/ansible_collections/arista/avd/examples/l2ls-fabric/README.md
@@ -351,6 +351,7 @@ The updated changes are noted in the tabs below.
       - name: MY_FABRIC
         vrfs:
           - name: default
+            vrf_id: 10
             svis:
               - id: 10
                 name: 'BLUE-NET'


### PR DESCRIPTION
## Change Summary

In L2LS-fabric example, `vrf_id` is missing for the vrf which is causing the failure. This is fixed in the PR.

## Related Issue(s)

Fixes #5348

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
When using the avd example l2ls-fabric and following the instructions for Add Routing to Spines we encounter FAILED messages when building.

## How to test
Use doc https://avd.arista.com/5.2/ansible_collections/arista/avd/examples/l2ls-fabric/index.html. Add `vrf_id` for vrf default while adding routing to spine.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
