### PR TITLE
Fix(eos_designs): Snmp-settings enable only specific traps

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-2.cfg
@@ -16,6 +16,7 @@ snmp-server host 10.6.75.126 version 3 auth USER-WRITE
 snmp-server host 10.6.75.127 version 2c SNMP-COMMUNITY-2
 snmp-server host 10.6.75.127 vrf SNMPVRF version 2c SNMP-COMMUNITY-2
 snmp-server host 10.6.75.128 version 3 auth USER-WRITE
+snmp-server enable traps foo
 snmp-server vrf default
 snmp-server vrf SNMPVRF
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-2.yml
@@ -40,6 +40,10 @@ snmp_server:
     users:
     - username: USER-WRITE
       authentication_level: auth
+  traps:
+    snmp_traps:
+    - name: foo
+      enabled: true
   vrfs:
   - name: default
     enable: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-2.yml
@@ -42,3 +42,8 @@ snmp_settings:
       users:
         - username: USER-WRITE
           authentication_level: auth
+
+  traps:
+    snmp_traps:
+      - name: foo
+        enabled: true

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
@@ -65,10 +65,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;username</samp>](## "snmp_server.hosts.[].users.[].username") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;authentication_level</samp>](## "snmp_server.hosts.[].users.[].authentication_level") | String |  |  | Valid Values:<br>- <code>auth</code><br>- <code>noauth</code><br>- <code>priv</code> |  |
     | [<samp>&nbsp;&nbsp;traps</samp>](## "snmp_server.traps") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.traps.enable") | Boolean |  | `False` |  | Enable or disable all snmp-traps.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.traps.enable") | Boolean |  |  |  | Enable or disable all snmp-traps.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_traps</samp>](## "snmp_server.traps.snmp_traps") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "snmp_server.traps.snmp_traps.[].name") | String |  |  |  | Enable or disable specific snmp-traps and their sub_traps.<br>Examples:<br>- "bgp"<br>- "bgp established"<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "snmp_server.traps.snmp_traps.[].enabled") | Boolean |  | `True` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "snmp_server.traps.snmp_traps.[].enabled") | Boolean |  |  |  | The trap is enabled unless this is set to false. |
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "snmp_server.vrfs") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "snmp_server.vrfs.[].name") | String | Required, Unique |  |  | VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_server.vrfs.[].enable") | Boolean |  |  |  |  |
@@ -192,7 +192,7 @@
       traps:
 
         # Enable or disable all snmp-traps.
-        enable: <bool; default=False>
+        enable: <bool>
         snmp_traps:
 
             # Enable or disable specific snmp-traps and their sub_traps.
@@ -200,7 +200,9 @@
             # - "bgp"
             # - "bgp established"
           - name: <str>
-            enabled: <bool; default=True>
+
+            # The trap is enabled unless this is set to false.
+            enabled: <bool>
       vrfs:
 
           # VRF name.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
@@ -63,10 +63,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;write</samp>](## "snmp_settings.groups.[].write") | String |  |  |  | Write view. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;notify</samp>](## "snmp_settings.groups.[].notify") | String |  |  |  | Notify view. |
     | [<samp>&nbsp;&nbsp;traps</samp>](## "snmp_settings.traps") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_settings.traps.enable") | Boolean |  | `False` |  | Enable or disable all snmp-traps.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_settings.traps.enable") | Boolean |  |  |  | Enable or disable all snmp-traps.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_traps</samp>](## "snmp_settings.traps.snmp_traps") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "snmp_settings.traps.snmp_traps.[].name") | String |  |  |  | Enable or disable specific snmp-traps and their sub_traps.<br>Examples:<br>- "bgp"<br>- "bgp established"<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "snmp_settings.traps.snmp_traps.[].enabled") | Boolean |  | `True` |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "snmp_settings.traps.snmp_traps.[].enabled") | Boolean |  |  |  | The trap is enabled unless this is set to false. |
 
 === "YAML"
 
@@ -204,7 +204,7 @@
       traps:
 
         # Enable or disable all snmp-traps.
-        enable: <bool; default=False>
+        enable: <bool>
         snmp_traps:
 
             # Enable or disable specific snmp-traps and their sub_traps.
@@ -212,5 +212,7 @@
             # - "bgp"
             # - "bgp established"
           - name: <str>
-            enabled: <bool; default=True>
+
+            # The trap is enabled unless this is set to false.
+            enabled: <bool>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -58351,7 +58351,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             class SnmpTrapsItem(AvdModel):
                 """Subclass of AvdModel."""
 
-                _fields: ClassVar[dict] = {"name": {"type": str}, "enabled": {"type": bool, "default": True}}
+                _fields: ClassVar[dict] = {"name": {"type": str}, "enabled": {"type": bool}}
                 name: str | None
                 """
                 Enable or disable specific snmp-traps and their sub_traps.
@@ -58359,12 +58359,12 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 - "bgp"
                 - "bgp established"
                 """
-                enabled: bool
-                """Default value: `True`"""
+                enabled: bool | None
+                """The trap is enabled unless this is set to false."""
 
                 if TYPE_CHECKING:
 
-                    def __init__(self, *, name: str | None | UndefinedType = Undefined, enabled: bool | UndefinedType = Undefined) -> None:
+                    def __init__(self, *, name: str | None | UndefinedType = Undefined, enabled: bool | None | UndefinedType = Undefined) -> None:
                         """
                         SnmpTrapsItem.
 
@@ -58377,7 +58377,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                                Examples:  # fmt: skip
                                - "bgp"
                                - "bgp established"
-                            enabled: enabled
+                            enabled: The trap is enabled unless this is set to false.
 
                         """
 
@@ -58386,19 +58386,15 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
             SnmpTraps._item_type = SnmpTrapsItem
 
-            _fields: ClassVar[dict] = {"enable": {"type": bool, "default": False}, "snmp_traps": {"type": SnmpTraps}}
-            enable: bool
-            """
-            Enable or disable all snmp-traps.
-
-            Default value: `False`
-            """
+            _fields: ClassVar[dict] = {"enable": {"type": bool}, "snmp_traps": {"type": SnmpTraps}}
+            enable: bool | None
+            """Enable or disable all snmp-traps."""
             snmp_traps: SnmpTraps
             """Subclass of AvdList with `SnmpTrapsItem` items."""
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, enable: bool | UndefinedType = Undefined, snmp_traps: SnmpTraps | UndefinedType = Undefined) -> None:
+                def __init__(self, *, enable: bool | None | UndefinedType = Undefined, snmp_traps: SnmpTraps | UndefinedType = Undefined) -> None:
                     """
                     Traps.
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -21829,7 +21829,6 @@ keys:
         keys:
           enable:
             type: bool
-            default: false
             description: 'Enable or disable all snmp-traps.
 
               '
@@ -21851,7 +21850,7 @@ keys:
                     '
                 enabled:
                   type: bool
-                  default: true
+                  description: The trap is enabled unless this is set to false.
       vrfs:
         type: list
         primary_key: name

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
@@ -231,7 +231,6 @@ keys:
         keys:
           enable:
             type: bool
-            default: false
             description: |
               Enable or disable all snmp-traps.
           snmp_traps:
@@ -248,7 +247,7 @@ keys:
                     - "bgp established"
                 enabled:
                   type: bool
-                  default: true
+                  description: The trap is enabled unless this is set to false.
       vrfs:
         type: list
         primary_key: name

--- a/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
@@ -56,9 +56,8 @@ class SnmpServerMixin(Protocol):
             ipv6_acls=snmp_settings.ipv6_acls._cast_as(EosCliConfigGen.SnmpServer.Ipv6Acls),
             views=snmp_settings.views._cast_as(EosCliConfigGen.SnmpServer.Views),
             groups=snmp_settings.groups._cast_as(EosCliConfigGen.SnmpServer.Groups),
+            traps=snmp_settings.traps,
         )
-        if snmp_settings.traps.enable:
-            self.structured_config.snmp_server._update(traps=snmp_settings.traps)
 
     def _snmp_engine_ids(self: AvdStructuredConfigBaseProtocol, snmp_settings: EosDesigns.SnmpSettings) -> None:
         """Set dict of engine ids if "snmp_settings.compute_local_engineid" is True."""


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Fix(eos_designs): Snmp-settings enable only specific traps

## Related Issue(s)

Fixes #5368 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Avoid depending on all traps being enabled in eos_designs (bug)
- Remove default values from eos_cli_config_gen schema, since they are not really implemented like that, and it will affect the behavior of eos_designs if set.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Added molecule test for only enabling one trap and not all.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
