### PR TITLE
Test(eos_designs): Improve pytest coverage for overlay/router_bfd.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
@@ -216,9 +216,6 @@ ntp server vrf MGMT 2001:db8::3
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
 !
-router bfd
-   multihop interval 1200 min-rx 1200 multiplier 3
-!
 router bgp 65001
    update wait-install
    no bgp default ipv4-unicast

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
@@ -290,11 +290,6 @@ route_maps:
     type: permit
     match:
     - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
-router_bfd:
-  multihop:
-    interval: 1200
-    min_rx: 1200
-    multiplier: 3
 router_bgp:
   as: '65001'
   maximum_paths:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-SPINE4.yml
@@ -22,4 +22,4 @@ custom_platform_settings:
       mlag: 900
       non_mlag: 1020
 
-bfd_multihop: null
+bfd_multihop:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/DC1-SPINE4.yml
@@ -21,3 +21,5 @@ custom_platform_settings:
     reload_delay:
       mlag: 900
       non_mlag: 1020
+
+bfd_multihop: null


### PR DESCRIPTION
## Change Summary

 Improve pytest coverage for overlay/router_bfd.py to 100%

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Added tests for bfd_multihop

## How to test
Check coverage in tox report

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
