### PR TITLE
Test(eos_designs): Add pytest coverage for structured_config/core_interfaces_and_l3_edge/router_bgp.py

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/p2p_links_missing_ip_subnet_ip_pool.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/p2p_links_missing_ip_subnet_ip_pool.yml
@@ -17,4 +17,4 @@ l3_edge:
       as: [65000, 65002]
 
 expected_error_message: >-
-  l3_edge.p2p_links.[].ip, .subnet or .ip_pool
+  'l3_edge.p2p_links.[].ip, .subnet or .ip_pool' is required but was not found.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/p2p_links_missing_ip_subnet_ip_pool.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/p2p_links_missing_ip_subnet_ip_pool.yml
@@ -1,0 +1,20 @@
+type: spine
+spine:
+  nodes:
+    - name: p2p_links_missing_ip_subnet_ip_pool
+      id: 1
+      evpn_role: "none"
+      loopback_ipv4_pool: 1.2.3.4/24
+      bgp_as: 65000
+
+l3_edge:
+  p2p_links_profiles:
+    - name: profile1
+
+  p2p_links:
+    - nodes: [p2p_links_missing_ip_subnet_ip_pool, peer2]
+      interfaces: [ethernet2, ethernet2]
+      as: [65000, 65002]
+
+expected_error_message: >-
+  l3_edge.p2p_links.[].ip, .subnet or .ip_pool

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -219,6 +219,7 @@ all:
             missing-wan-control-load-balance-policy:
             missing-default-policy-wan-control-load-balance-policy:
             missing-wan-policy-in-traffic-vrfs:
+            p2p_links_missing_ip_subnet_ip_pool:
 
           children:
             DUPLICATE_VLANS_MLAG:

--- a/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_bgp.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/core_interfaces_and_l3_edge/router_bgp.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
-from pyavd._errors import AristaAvdInvalidInputsError
+from pyavd._errors import AristaAvdInvalidInputsError, AristaAvdMissingVariableError
 from pyavd._utils import Undefined, get_ip_from_ip_prefix
 
 if TYPE_CHECKING:
@@ -49,7 +49,7 @@ class RouterBgpMixin(Protocol):
             # Regular BGP Neighbors
             if p2p_link_data["ip"] is None or p2p_link_data["peer_ip"] is None:
                 msg = f"{self.data_model}.p2p_links.[].ip, .subnet or .ip_pool"
-                raise AristaAvdInvalidInputsError(msg)
+                raise AristaAvdMissingVariableError(msg)
 
             self.structured_config.router_bgp.neighbors.append_new(
                 ip_address=get_ip_from_ip_prefix(p2p_link_data["peer_ip"]),


### PR DESCRIPTION
## Change Summary

Add pytest coverage for structured_config/core_interfaces_and_l3_edge/router_bgp.py (Coverage: 100%)

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_designs_unit_tests`

## Proposed changes
Added a testcase in negative_unit_tests

## How to test
CI

## Checklist
### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
