### PR TITLE
Test: Rust avschema crate: Make xz2 support an optional feature

### DIFF
--- a/rust/avdschema/Cargo.toml
+++ b/rust/avdschema/Cargo.toml
@@ -21,4 +21,5 @@ walkdir = { version = "2.5.0", optional = true }
 xz2 = { version = "0.1.7", optional = true }
 
 [features]
-dump_load_files = ["walkdir", "xz2"]
+dump_load_files = ["dep:walkdir"]
+xz2 = ["dump_load_files", "dep:xz2"]

--- a/rust/avdschema/src/utils/dump.rs
+++ b/rust/avdschema/src/utils/dump.rs
@@ -27,6 +27,7 @@ where
             Some(path) => match path.extension().and_then(OsStr::to_str) {
                 Some("yml" | "yaml") => self.to_yaml_file(path),
                 Some("json") => self.to_json_file(path),
+                #[cfg(feature = "xz2")]
                 Some("xz2") => self.to_xz2_file(path),
                 Some("gz") => self.to_gz_file(path),
                 _ => Err(DumpError::InvalidExtension {}),
@@ -45,7 +46,7 @@ where
         let writer = BufWriter::new(file);
         Ok(serde_yaml::to_writer(writer, self)?)
     }
-    #[cfg(feature = "dump_load_files")]
+    #[cfg(feature = "xz2")]
     fn to_xz2_file(&self, path: PathBuf) -> Result<(), DumpError> {
         let file = File::create(path)?;
         let compressor = xz2::write::XzEncoder::new(file, 1);

--- a/rust/avdschema/src/utils/load.rs
+++ b/rust/avdschema/src/utils/load.rs
@@ -29,6 +29,7 @@ where
             Some(path) => match path.extension().and_then(OsStr::to_str) {
                 Some("yml" | "yaml") => Self::from_yaml_file(path),
                 Some("json") => Self::from_json_file(path),
+                #[cfg(feature = "xz2")]
                 Some("xz2") => Self::from_xz2_file(path),
                 Some("gz") => Self::from_gz_file(path),
                 _ => Err(LoadError::InvalidExtension {}),
@@ -47,7 +48,7 @@ where
         let reader = BufReader::new(file);
         Ok(serde_yaml::from_reader(reader)?)
     }
-    #[cfg(feature = "dump_load_files")]
+    #[cfg(feature = "xz2")]
     fn from_xz2_file(path: PathBuf) -> Result<Self, LoadError> {
         let file = File::open(path)?;
         let decompressor = xz2::read::XzDecoder::new(file);
@@ -60,7 +61,7 @@ where
         let reader = BufReader::new(file);
         Ok(serde_json::from_reader(reader)?)
     }
-    #[cfg(feature = "dump_load_files")]
+    #[cfg(feature = "xz2")]
     fn from_xz2_bytes(bytes: &[u8]) -> Result<Self, LoadError> {
         let decompressor = xz2::read::XzDecoder::new(bytes);
         let reader = BufReader::new(decompressor);


### PR DESCRIPTION
Test: Rust avschema crate: Make xz2 support an optional feature

Put all xz2 support behind an exclusive feature toggle, so we don't include it as part of `included_store`