### PR TITLE
Fix(anta_runner): Remove input_dict from TestSpec

### DIFF
--- a/python-avd/pyavd/_anta/factories.py
+++ b/python-avd/pyavd/_anta/factories.py
@@ -71,30 +71,14 @@ def create_test_definitions(test_spec: TestSpec, device_context: DeviceTestConte
         logger.debug(LogMessage.INPUT_NO_DATA_MODEL, caller=", ".join(keys))
         return None
 
-    # Create the AntaTest.Input instance from the input dict if available
-    if test_spec.input_dict is not None:
-        logger.debug(LogMessage.INPUT_RENDERING, caller="input dictionary")
-        rendered_inputs = {}
-        for input_field, structured_config_key in test_spec.input_dict.items():
-            field_value = get_v2(device_context.structured_config, structured_config_key.value)
-            if field_value is not None:
-                rendered_inputs[input_field] = field_value
-            else:
-                logger.debug(LogMessage.INPUT_NO_DATA_MODEL, caller=structured_config_key.value)
-                return None
-        logger.debug(LogMessage.INPUT_RENDERED, inputs=rendered_inputs)
-        inputs = test_spec.test_class.Input(**rendered_inputs)
-        return [AntaTestDefinition(test=test_spec.test_class, inputs=inputs)]
-
-    # Create the AntaTest.Input instance(s) from the input factory if available
+    # Create the test definitions from the input factory if provided
     if test_spec.input_factory is not None:
-        logger.debug(LogMessage.INPUT_RENDERING, caller="input factory")
-        factory = test_spec.input_factory(device_context, logger)  # pylint: disable=not-callable
+        factory = test_spec.input_factory(device_context, logger)
         results = factory.create()
         if results is None:
             logger.debug(LogMessage.INPUT_NONE_FOUND)
             return None
         return [AntaTestDefinition(test=test_spec.test_class, inputs=inputs) for inputs in results]
 
-    # Otherwise AntaTestDefinition takes `inputs=None` if the test does not require any input
+    # Otherwise AntaTestDefinition takes `inputs=None` if the test does not require any inputs
     return [AntaTestDefinition(test=test_spec.test_class, inputs=None)]

--- a/python-avd/pyavd/_anta/index.py
+++ b/python-avd/pyavd/_anta/index.py
@@ -18,7 +18,7 @@ AVD_TEST_INDEX: list[TestSpec] = [
     TestSpec(
         test_class=VerifyAPIHttpsSSL,
         conditional_keys=[StructuredConfigKey.HTTPS_SSL_PROFILE],
-        input_dict={"profile": StructuredConfigKey.HTTPS_SSL_PROFILE},
+        input_factory=VerifyAPIHttpsSSLInputFactory,
     ),
     TestSpec(
         test_class=VerifyAVTPathHealth,
@@ -100,10 +100,7 @@ AVD_TEST_INDEX: list[TestSpec] = [
     TestSpec(
         test_class=VerifyMlagReloadDelay,
         conditional_keys=[StructuredConfigKey.RELOAD_DELAY_MLAG, StructuredConfigKey.RELOAD_DELAY_NON_MLAG],
-        input_dict={
-            "reload_delay": StructuredConfigKey.RELOAD_DELAY_MLAG,
-            "reload_delay_non_mlag": StructuredConfigKey.RELOAD_DELAY_NON_MLAG,
-        },
+        input_factory=VerifyMlagReloadDelayInputFactory,
     ),
     TestSpec(
         test_class=VerifyMlagStatus,
@@ -127,7 +124,7 @@ AVD_TEST_INDEX: list[TestSpec] = [
     TestSpec(
         test_class=VerifyRoutingProtocolModel,
         conditional_keys=[StructuredConfigKey.SERVICE_ROUTING_PROTOCOLS_MODEL],
-        input_dict={"model": StructuredConfigKey.SERVICE_ROUTING_PROTOCOLS_MODEL},
+        input_factory=VerifyRoutingProtocolModelInputFactory,
     ),
     TestSpec(
         test_class=VerifySpecificIPSecConn,

--- a/python-avd/pyavd/_anta/input_factories/__init__.py
+++ b/python-avd/pyavd/_anta/input_factories/__init__.py
@@ -8,20 +8,24 @@ from __future__ import annotations
 from .avt import VerifyAVTRoleInputFactory
 from .connectivity import VerifyLLDPNeighborsInputFactory, VerifyReachabilityInputFactory
 from .interfaces import VerifyInterfacesStatusInputFactory
-from .mlag import VerifyMlagDualPrimaryInputFactory
+from .mlag import VerifyMlagDualPrimaryInputFactory, VerifyMlagReloadDelayInputFactory
 from .routing_bgp import VerifyBGPPeerSessionInputFactory
-from .security import VerifySpecificIPSecConnInputFactory
+from .routing_generic import VerifyRoutingProtocolModelInputFactory
+from .security import VerifyAPIHttpsSSLInputFactory, VerifySpecificIPSecConnInputFactory
 from .stun import VerifyStunClientTranslationInputFactory
 from .system import VerifyReloadCauseInputFactory
 
 __all__ = [
+    "VerifyAPIHttpsSSLInputFactory",
     "VerifyAVTRoleInputFactory",
     "VerifyBGPPeerSessionInputFactory",
     "VerifyInterfacesStatusInputFactory",
     "VerifyLLDPNeighborsInputFactory",
     "VerifyMlagDualPrimaryInputFactory",
+    "VerifyMlagReloadDelayInputFactory",
     "VerifyReachabilityInputFactory",
     "VerifyReloadCauseInputFactory",
+    "VerifyRoutingProtocolModelInputFactory",
     "VerifySpecificIPSecConnInputFactory",
     "VerifyStunClientTranslationInputFactory",
 ]

--- a/python-avd/pyavd/_anta/input_factories/mlag.py
+++ b/python-avd/pyavd/_anta/input_factories/mlag.py
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from anta.tests.mlag import VerifyMlagDualPrimary
+from anta.tests.mlag import VerifyMlagDualPrimary, VerifyMlagReloadDelay
 
 from ._base_classes import AntaTestInputFactory
 
@@ -22,5 +22,27 @@ class VerifyMlagDualPrimaryInputFactory(AntaTestInputFactory):
                 errdisabled=True,
                 recovery_delay=self.structured_config.mlag_configuration.dual_primary_recovery_delay_mlag or 0,
                 recovery_delay_non_mlag=self.structured_config.mlag_configuration.dual_primary_recovery_delay_non_mlag or 0,
+            )
+        ]
+
+
+class VerifyMlagReloadDelayInputFactory(AntaTestInputFactory):
+    """
+    Input factory class for the `VerifyMlagReloadDelay` test.
+
+    The test inputs `reload_delay` and `reload_delay_non_mlag` are collected from
+    the values of `mlag_configuration.reload_delay_mlag` and `mlag_configuration.reload_delay_non_mlag`
+    of the device structured config.
+    """
+
+    def create(self) -> list[VerifyMlagReloadDelay.Input] | None:
+        """Create a list of inputs for the `VerifyMlagReloadDelay` test."""
+        if self.structured_config.mlag_configuration.reload_delay_mlag is None or self.structured_config.mlag_configuration.reload_delay_non_mlag is None:
+            return None
+
+        return [
+            VerifyMlagReloadDelay.Input(
+                reload_delay=self.structured_config.mlag_configuration.reload_delay_mlag,
+                reload_delay_non_mlag=self.structured_config.mlag_configuration.reload_delay_non_mlag,
             )
         ]

--- a/python-avd/pyavd/_anta/input_factories/routing_generic.py
+++ b/python-avd/pyavd/_anta/input_factories/routing_generic.py
@@ -1,0 +1,22 @@
+# Copyright (c) 2023-2025 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+from __future__ import annotations
+
+from anta.tests.routing.generic import VerifyRoutingProtocolModel
+
+from ._base_classes import AntaTestInputFactory
+
+
+class VerifyRoutingProtocolModelInputFactory(AntaTestInputFactory):
+    """
+    Input factory class for the `VerifyRoutingProtocolModel` test.
+
+    The test input `model` is collected from the value of `service_routing_protocols_model`
+    of the device structured config.
+    """
+
+    def create(self) -> list[VerifyRoutingProtocolModel.Input] | None:
+        """Create a list of inputs for the `VerifyRoutingProtocolModel` test."""
+        model = self.structured_config.service_routing_protocols_model
+        return [VerifyRoutingProtocolModel.Input(model=model)] if model else None

--- a/python-avd/pyavd/_anta/input_factories/security.py
+++ b/python-avd/pyavd/_anta/input_factories/security.py
@@ -6,12 +6,26 @@ from __future__ import annotations
 from ipaddress import ip_interface
 
 from anta.input_models.security import IPSecPeer
-from anta.tests.security import VerifySpecificIPSecConn
+from anta.tests.security import VerifyAPIHttpsSSL, VerifySpecificIPSecConn
 
 from pyavd._anta.logs import LogMessage
 from pyavd.j2filters import natural_sort
 
 from ._base_classes import AntaTestInputFactory
+
+
+class VerifyAPIHttpsSSLInputFactory(AntaTestInputFactory):
+    """
+    Input factory class for the `VerifyAPIHttpsSSL` test.
+
+    The test input `profile` is collected from the value of
+    `management_api_http.https_ssl_profile` of the device structured config.
+    """
+
+    def create(self) -> list[VerifyAPIHttpsSSL] | None:
+        """Create a list of inputs for the `VerifyAPIHttpsSSL test."""
+        profile = self.structured_config.management_api_http.https_ssl_profile
+        return [VerifyAPIHttpsSSL.Input(profile=profile)] if profile else None
 
 
 class VerifySpecificIPSecConnInputFactory(AntaTestInputFactory):

--- a/python-avd/pyavd/_anta/logs.py
+++ b/python-avd/pyavd/_anta/logs.py
@@ -118,5 +118,3 @@ class LogMessage(Enum):
     INPUT_NONE_FOUND = "skipped - no inputs available"
     INPUT_NO_DATA_MODEL = "skipped - data model {caller} not found"
     INPUT_MISSING_FIELDS = "{caller} skipped - missing required fields: {fields}"
-    INPUT_RENDERING = "rendering inputs with {caller}"
-    INPUT_RENDERED = "rendered input dict: {inputs}"

--- a/python-avd/pyavd/api/_anta/avd_catalog_generation_settings.py
+++ b/python-avd/pyavd/api/_anta/avd_catalog_generation_settings.py
@@ -27,7 +27,7 @@ class AvdCatalogGenerationSettings(BaseModel):
     """
     Model defining settings for the AVD-generated ANTA catalog.
 
-    Used in `pyavd.get_device_anta_catalog` to customize the AVD test catalog generation.
+    Used in `pyavd.get_device_test_catalog` to customize the AVD test catalog generation.
 
     Attributes:
     ----------

--- a/python-avd/pyavd/api/_anta/minimal_structured_config.py
+++ b/python-avd/pyavd/api/_anta/minimal_structured_config.py
@@ -30,7 +30,7 @@ def get_minimal_structured_configs(structured_configs: dict[str, dict]) -> dict[
     """
     Get a minimal version of structured configurations for all devices to generate tests.
 
-    Loaded in dataclasses and used in `pyavd.get_device_anta_catalog` to generate ANTA catalogs.
+    Loaded in dataclasses and used in `pyavd.get_device_test_catalog` to generate ANTA catalogs.
 
     Parameters
     ----------

--- a/python-avd/pyavd/api/_anta/test_spec.py
+++ b/python-avd/pyavd/api/_anta/test_spec.py
@@ -20,9 +20,7 @@ class TestSpec(BaseModel):
     TestSpec model used to define an ANTA test specification in PyAVD.
 
     Primarily used in the `AVD_TEST_INDEX` list to define the ANTA tests to be run
-    but can also be provided in the `get_device_anta_catalog` PyAVD function to add custom tests.
-
-    If the ANTA test requires input, either `input_factory` or `input_dict` attributes should be provided, but not both.
+    but can also be provided in the `get_device_test_catalog` PyAVD function to add custom tests.
 
     Attributes:
     ----------
@@ -31,33 +29,26 @@ class TestSpec(BaseModel):
     conditional_keys : list[StructuredConfigKey] | None
         Optional structured config keys that are required to run the test.
     input_factory : type[AntaTestInputFactory] | None
-        Optional input factory class that generates the `AntaTest.Input` model (inputs) for the test.
-    input_dict : dict[str, StructuredConfigKey] | None
-        Optional dictionary that maps the input fields to structured config keys.
-        The structured config keys values will be extracted to generate the `AntaTest.Input` model (inputs) for the test.
+        Optional input factory class that generates the `AntaTest.Input` models (inputs) for the test.
+        Required field if the ANTA test needs inputs.
     """
 
     test_class: type[AntaTest]
     conditional_keys: list[StructuredConfigKey] | None = None
     input_factory: type[AntaTestInputFactory] | None = None
-    input_dict: dict[str, StructuredConfigKey] | None = None
 
     @model_validator(mode="after")
     def check_inputs(self) -> Self:
-        """Check that the TestSpec has either an input factory or an input dict if the test requires input. Cannot have both."""
-        if self.input_factory and self.input_dict:
-            msg = f"TestSpec {self.test_class.name} cannot have both `input_factory` and `input_dict`"
-            raise ValueError(msg)
-
+        """Check if `input_factory` is provided when the ANTA test requires inputs."""
         # Check if the test class has an `Input` model and if it has required fields
         if "Input" in self.test_class.__dict__ and isinstance((input_class := self.test_class.__dict__["Input"]), AntaTest.Input):
             for f_name, f_info in input_class.model_fields.items():
                 # No need to check the base class fields
                 if f_name in {"result_overwrite", "filters"}:
                     continue
-                # If a required field is present, an input factory or input dict must be provided
-                if f_info.is_required() and not self.input_factory and not self.input_dict:
-                    msg = f"TestSpec {self.test_class.name} must have `input_factory or `input_dict`"
+                # If a required field is present, an input factory must be provided
+                if f_info.is_required() and self.input_factory is None:
+                    msg = f"TestSpec for {self.test_class.name} must have `input_factory`"
                     raise ValueError(msg)
 
         return self


### PR DESCRIPTION
## Change Summary

Removing `input_dict` field from TestSpec to use `input_factory` instead to simplify logic and avoid confusion.

## Related Issue(s)

Fixes #https://github.com/aristanetworks/avd-internal/issues/261

## Component(s) name

`arista.avd.anta_runner`

## Proposed changes
See Change Summary.

## How to test
Running anta_runner molecule must not change any device catalogs.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
