### PR TITLE
Feat(eos_cli_config_gen): Add support for pim ipv4 neighbor filter

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -4262,6 +4262,7 @@ interface Ethernet5
    pim ipv4 hello interval 10
    pim ipv4 hello count 2.5
    pim ipv4 dr-priority 200
+   pim ipv4 neighbor filter Test_Filter_Ethernet
    pim ipv4 bfd
    isis enable ISIS_TEST
    isis bfd
@@ -5562,6 +5563,7 @@ interface Port-Channel99
    pim ipv4 hello interval 15
    pim ipv4 hello count 4.5
    pim ipv4 dr-priority 200
+   pim ipv4 neighbor filter Test_Filter_PortChannel
    pim ipv4 bfd
 !
 interface Port-Channel100
@@ -6675,6 +6677,7 @@ interface Vlan4094
    pim ipv4 hello interval 10
    pim ipv4 hello count 3.5
    pim ipv4 dr-priority 200
+   pim ipv4 neighbor filter Test_Filter_Vlan
    pim ipv4 bfd
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 rx-disabled level-1
@@ -9956,12 +9959,12 @@ router pim sparse-mode
 
 #### PIM Sparse Mode Enabled Interfaces
 
-| Interface Name | VRF Name | IP Version | Border Router | DR Priority | Local Interface |
-| -------------- | -------- | ---------- | ------------- | ----------- | --------------- |
-| Ethernet5 | - | IPv4 | True | 200 | - |
-| Port-Channel99 | - | IPv4 | - | 200 | - |
-| Vlan89 | - | IPv4 | - | - | Loopback0 |
-| Vlan4094 | - | IPv4 | - | 200 | - |
+| Interface Name | VRF Name | IP Version | Border Router | DR Priority | Local Interface | Neighbor Filter |
+| -------------- | -------- | ---------- | ------------- | ----------- | --------------- | --------------- |
+| Ethernet5 | - | IPv4 | True | 200 | - | Test_Filter_Ethernet |
+| Port-Channel99 | - | IPv4 | - | 200 | - | Test_Filter_PortChannel |
+| Vlan89 | - | IPv4 | - | - | Loopback0 | - |
+| Vlan4094 | - | IPv4 | - | 200 | - | Test_Filter_Vlan |
 
 ### Router MSDP
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1988,6 +1988,7 @@ interface Port-Channel99
    pim ipv4 hello interval 15
    pim ipv4 hello count 4.5
    pim ipv4 dr-priority 200
+   pim ipv4 neighbor filter Test_Filter_PortChannel
    pim ipv4 bfd
 !
 interface Port-Channel100
@@ -2595,6 +2596,7 @@ interface Ethernet5
    pim ipv4 hello interval 10
    pim ipv4 hello count 2.5
    pim ipv4 dr-priority 200
+   pim ipv4 neighbor filter Test_Filter_Ethernet
    pim ipv4 bfd
    isis enable ISIS_TEST
    isis bfd
@@ -3944,6 +3946,7 @@ interface Vlan4094
    pim ipv4 hello interval 10
    pim ipv4 hello count 3.5
    pim ipv4 dr-priority 200
+   pim ipv4 neighbor filter Test_Filter_Vlan
    pim ipv4 bfd
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 5 rx-disabled level-1

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ethernet-interfaces.yml
@@ -359,6 +359,7 @@ ethernet_interfaces:
         border_router: true
         bfd: true
         bidirectional: true
+        neighbor_filter: Test_Filter_Ethernet
         hello:
           count: 2.5
           interval: 10

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -556,6 +556,7 @@ port_channel_interfaces:
         sparse_mode: true
         bfd: true
         bidirectional: true
+        neighbor_filter: Test_Filter_PortChannel
         hello:
           count: 4.5
           interval: 15

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlan-interfaces.yml
@@ -239,6 +239,7 @@ vlan_interfaces:
         sparse_mode: true
         bfd: true
         bidirectional: true
+        neighbor_filter: Test_Filter_Vlan
         hello:
           count: 3.5
           interval: 10

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -194,6 +194,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sparse_mode</samp>](## "ethernet_interfaces.[].pim.ipv4.sparse_mode") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "ethernet_interfaces.[].pim.ipv4.bfd") | Boolean |  |  |  | Set the default for whether Bidirectional Forwarding Detection is enabled for PIM. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bidirectional</samp>](## "ethernet_interfaces.[].pim.ipv4.bidirectional") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_filter</samp>](## "ethernet_interfaces.[].pim.ipv4.neighbor_filter") | String |  |  |  | Standard access list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hello</samp>](## "ethernet_interfaces.[].pim.ipv4.hello") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;count</samp>](## "ethernet_interfaces.[].pim.ipv4.hello.count") | String |  |  |  | Number of missed hellos after which the neighbor expires. Range <1.5-65535>. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "ethernet_interfaces.[].pim.ipv4.hello.interval") | Integer |  |  | Min: 1<br>Max: 65535 | PIM hello interval in seconds. |
@@ -1042,6 +1043,9 @@
             # Set the default for whether Bidirectional Forwarding Detection is enabled for PIM.
             bfd: <bool>
             bidirectional: <bool>
+
+            # Standard access list name.
+            neighbor_filter: <str>
             hello:
 
               # Number of missed hellos after which the neighbor expires. Range <1.5-65535>.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -282,6 +282,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;sparse_mode</samp>](## "port_channel_interfaces.[].pim.ipv4.sparse_mode") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "port_channel_interfaces.[].pim.ipv4.bfd") | Boolean |  |  |  | Set the default for whether Bidirectional Forwarding Detection is enabled for PIM. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bidirectional</samp>](## "port_channel_interfaces.[].pim.ipv4.bidirectional") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_filter</samp>](## "port_channel_interfaces.[].pim.ipv4.neighbor_filter") | String |  |  |  | Standard access list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hello</samp>](## "port_channel_interfaces.[].pim.ipv4.hello") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;count</samp>](## "port_channel_interfaces.[].pim.ipv4.hello.count") | String |  |  |  | Number of missed hellos after which the neighbor expires. Range <1.5-65535>. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "port_channel_interfaces.[].pim.ipv4.hello.interval") | Integer |  |  | Min: 1<br>Max: 65535 | PIM hello interval in seconds. |
@@ -1067,6 +1068,9 @@
             # Set the default for whether Bidirectional Forwarding Detection is enabled for PIM.
             bfd: <bool>
             bidirectional: <bool>
+
+            # Standard access list name.
+            neighbor_filter: <str>
             hello:
 
               # Number of missed hellos after which the neighbor expires. Range <1.5-65535>.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlan-interfaces.md
@@ -152,6 +152,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;local_interface</samp>](## "vlan_interfaces.[].pim.ipv4.local_interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bfd</samp>](## "vlan_interfaces.[].pim.ipv4.bfd") | Boolean |  |  |  | Set the default for whether Bidirectional Forwarding Detection is enabled for PIM. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;bidirectional</samp>](## "vlan_interfaces.[].pim.ipv4.bidirectional") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;neighbor_filter</samp>](## "vlan_interfaces.[].pim.ipv4.neighbor_filter") | String |  |  |  | Standard access list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hello</samp>](## "vlan_interfaces.[].pim.ipv4.hello") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;count</samp>](## "vlan_interfaces.[].pim.ipv4.hello.count") | String |  |  |  | Number of missed hellos after which the neighbor expires. Range <1.5-65535>. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interval</samp>](## "vlan_interfaces.[].pim.ipv4.hello.interval") | Integer |  |  | Min: 1<br>Max: 65535 | PIM hello interval in seconds. |
@@ -546,6 +547,9 @@
             # Set the default for whether Bidirectional Forwarding Detection is enabled for PIM.
             bfd: <bool>
             bidirectional: <bool>
+
+            # Standard access list name.
+            neighbor_filter: <str>
             hello:
 
               # Number of missed hellos after which the neighbor expires. Range <1.5-65535>.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/pim-sparse-mode-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/pim-sparse-mode-interfaces.j2
@@ -9,14 +9,15 @@
 
 #### PIM Sparse Mode Enabled Interfaces
 
-| Interface Name | VRF Name | IP Version | Border Router | DR Priority | Local Interface |
-| -------------- | -------- | ---------- | ------------- | ----------- | --------------- |
+| Interface Name | VRF Name | IP Version | Border Router | DR Priority | Local Interface | Neighbor Filter |
+| -------------- | -------- | ---------- | ------------- | ----------- | --------------- | --------------- |
 {%     for interface in pim_interfaces %}
 {%         set vrf = interface.vrf | arista.avd.default('-') %}
 {%         set ip_version = "IPv4" %}
 {%         set border_router = interface.pim.ipv4.border_router | arista.avd.default('-') %}
 {%         set dr_priority = interface.pim.ipv4.dr_priority | arista.avd.default('-') %}
 {%         set local_interface = interface.pim.ipv4.local_interface | arista.avd.default('-') %}
-| {{ interface.name }} | {{ vrf }} | {{ ip_version }} | {{ border_router }} | {{ dr_priority }} | {{ local_interface }} |
+{%         set neighbor_filter = interface.pim.ipv4.neighbor_filter | arista.avd.default('-') %}
+| {{ interface.name }} | {{ vrf }} | {{ ip_version }} | {{ border_router }} | {{ dr_priority }} | {{ local_interface }} | {{ neighbor_filter }} |
 {%     endfor %}
 {% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ethernet-interfaces.j2
@@ -660,6 +660,9 @@ interface {{ ethernet_interface.name }}
 {%     if ethernet_interface.pim.ipv4.dr_priority is arista.avd.defined %}
    pim ipv4 dr-priority {{ ethernet_interface.pim.ipv4.dr_priority }}
 {%     endif %}
+{%     if ethernet_interface.pim.ipv4.neighbor_filter is arista.avd.defined %}
+   pim ipv4 neighbor filter {{ ethernet_interface.pim.ipv4.neighbor_filter }}
+{%     endif %}
 {%     if ethernet_interface.pim.ipv4.bfd is arista.avd.defined(true) %}
    pim ipv4 bfd
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -537,6 +537,9 @@ interface {{ port_channel_interface.name }}
 {%     if port_channel_interface.pim.ipv4.dr_priority is arista.avd.defined %}
    pim ipv4 dr-priority {{ port_channel_interface.pim.ipv4.dr_priority }}
 {%     endif %}
+{%     if port_channel_interface.pim.ipv4.neighbor_filter is arista.avd.defined %}
+   pim ipv4 neighbor filter {{ port_channel_interface.pim.ipv4.neighbor_filter }}
+{%     endif %}
 {%     if port_channel_interface.pim.ipv4.bfd is arista.avd.defined(true) %}
    pim ipv4 bfd
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlan-interfaces.j2
@@ -322,6 +322,9 @@ interface {{ vlan_interface.name }}
 {%     if vlan_interface.pim.ipv4.dr_priority is arista.avd.defined %}
    pim ipv4 dr-priority {{ vlan_interface.pim.ipv4.dr_priority }}
 {%     endif %}
+{%     if vlan_interface.pim.ipv4.neighbor_filter is arista.avd.defined %}
+   pim ipv4 neighbor filter {{ vlan_interface.pim.ipv4.neighbor_filter }}
+{%     endif %}
 {%     if vlan_interface.pim.ipv4.bfd is arista.avd.defined(true) %}
    pim ipv4 bfd
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -6785,6 +6785,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     "sparse_mode": {"type": bool},
                     "bfd": {"type": bool},
                     "bidirectional": {"type": bool},
+                    "neighbor_filter": {"type": str},
                     "hello": {"type": Hello},
                 }
                 border_router: bool | None
@@ -6794,6 +6795,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 bfd: bool | None
                 """Set the default for whether Bidirectional Forwarding Detection is enabled for PIM."""
                 bidirectional: bool | None
+                neighbor_filter: str | None
+                """Standard access list name."""
                 hello: Hello
                 """Subclass of AvdModel."""
 
@@ -6807,6 +6810,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         sparse_mode: bool | None | UndefinedType = Undefined,
                         bfd: bool | None | UndefinedType = Undefined,
                         bidirectional: bool | None | UndefinedType = Undefined,
+                        neighbor_filter: str | None | UndefinedType = Undefined,
                         hello: Hello | UndefinedType = Undefined,
                     ) -> None:
                         """
@@ -6821,6 +6825,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             sparse_mode: sparse_mode
                             bfd: Set the default for whether Bidirectional Forwarding Detection is enabled for PIM.
                             bidirectional: bidirectional
+                            neighbor_filter: Standard access list name.
                             hello: Subclass of AvdModel.
 
                         """
@@ -29010,6 +29015,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     "sparse_mode": {"type": bool},
                     "bfd": {"type": bool},
                     "bidirectional": {"type": bool},
+                    "neighbor_filter": {"type": str},
                     "hello": {"type": Hello},
                 }
                 border_router: bool | None
@@ -29019,6 +29025,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 bfd: bool | None
                 """Set the default for whether Bidirectional Forwarding Detection is enabled for PIM."""
                 bidirectional: bool | None
+                neighbor_filter: str | None
+                """Standard access list name."""
                 hello: Hello
                 """Subclass of AvdModel."""
 
@@ -29032,6 +29040,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         sparse_mode: bool | None | UndefinedType = Undefined,
                         bfd: bool | None | UndefinedType = Undefined,
                         bidirectional: bool | None | UndefinedType = Undefined,
+                        neighbor_filter: str | None | UndefinedType = Undefined,
                         hello: Hello | UndefinedType = Undefined,
                     ) -> None:
                         """
@@ -29046,6 +29055,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             sparse_mode: sparse_mode
                             bfd: Set the default for whether Bidirectional Forwarding Detection is enabled for PIM.
                             bidirectional: bidirectional
+                            neighbor_filter: Standard access list name.
                             hello: Subclass of AvdModel.
 
                         """
@@ -61898,6 +61908,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     "local_interface": {"type": str},
                     "bfd": {"type": bool},
                     "bidirectional": {"type": bool},
+                    "neighbor_filter": {"type": str},
                     "hello": {"type": Hello},
                 }
                 border_router: bool | None
@@ -61908,6 +61919,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 bfd: bool | None
                 """Set the default for whether Bidirectional Forwarding Detection is enabled for PIM."""
                 bidirectional: bool | None
+                neighbor_filter: str | None
+                """Standard access list name."""
                 hello: Hello
                 """Subclass of AvdModel."""
 
@@ -61922,6 +61935,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         local_interface: str | None | UndefinedType = Undefined,
                         bfd: bool | None | UndefinedType = Undefined,
                         bidirectional: bool | None | UndefinedType = Undefined,
+                        neighbor_filter: str | None | UndefinedType = Undefined,
                         hello: Hello | UndefinedType = Undefined,
                     ) -> None:
                         """
@@ -61937,6 +61951,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             local_interface: local_interface
                             bfd: Set the default for whether Bidirectional Forwarding Detection is enabled for PIM.
                             bidirectional: bidirectional
+                            neighbor_filter: Standard access list name.
                             hello: Subclass of AvdModel.
 
                         """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -2896,6 +2896,9 @@ keys:
                     Detection is enabled for PIM.
                 bidirectional:
                   type: bool
+                neighbor_filter:
+                  type: str
+                  description: Standard access list name.
                 hello:
                   type: dict
                   keys:
@@ -11504,6 +11507,9 @@ keys:
                     Detection is enabled for PIM.
                 bidirectional:
                   type: bool
+                neighbor_filter:
+                  type: str
+                  description: Standard access list name.
                 hello:
                   type: dict
                   keys:
@@ -23257,6 +23263,9 @@ keys:
                     Detection is enabled for PIM.
                 bidirectional:
                   type: bool
+                neighbor_filter:
+                  type: str
+                  description: Standard access list name.
                 hello:
                   type: dict
                   keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -2898,6 +2898,8 @@ keys:
                   type: bool
                 neighbor_filter:
                   type: str
+                  convert_types:
+                  - int
                   description: Standard access list name.
                 hello:
                   type: dict
@@ -11509,6 +11511,8 @@ keys:
                   type: bool
                 neighbor_filter:
                   type: str
+                  convert_types:
+                  - int
                   description: Standard access list name.
                 hello:
                   type: dict

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -677,6 +677,9 @@ keys:
                   description: Set the default for whether Bidirectional Forwarding Detection is enabled for PIM.
                 bidirectional:
                   type: bool
+                neighbor_filter:
+                  type: str
+                  description: Standard access list name.
                 hello:
                   type: dict
                   keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -679,6 +679,8 @@ keys:
                   type: bool
                 neighbor_filter:
                   type: str
+                  convert_types:
+                    - int
                   description: Standard access list name.
                 hello:
                   type: dict

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -912,6 +912,8 @@ keys:
                   type: bool
                 neighbor_filter:
                   type: str
+                  convert_types:
+                    - int
                   description: Standard access list name.
                 hello:
                   type: dict

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -910,6 +910,9 @@ keys:
                   description: Set the default for whether Bidirectional Forwarding Detection is enabled for PIM.
                 bidirectional:
                   type: bool
+                neighbor_filter:
+                  type: str
+                  description: Standard access list name.
                 hello:
                   type: dict
                   keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -416,6 +416,9 @@ keys:
                   description: Set the default for whether Bidirectional Forwarding Detection is enabled for PIM.
                 bidirectional:
                   type: bool
+                neighbor_filter:
+                  type: str
+                  description: Standard access list name.
                 hello:
                   type: dict
                   keys:


### PR DESCRIPTION
## Change Summary

Add support for pim ipv4 neighbor filter for Ethernet, Vlans and Portchannel-Interfaces

## Related Issue(s)

Fixes #4622 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added the model and testcase

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
