### PR TITLE
Feat(eos_cli_config_gen): Added support for DLB on ECMP groups

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -6842,6 +6842,8 @@ ip virtual-router mac-address mlag-peer
 !
 ip routing ipv6 interfaces
 ip hardware fib optimize prefixes profile urpf-internet
+ip hardware fib load-balance distribution dynamic
+ip hardware fib load-balance distribution dynamic flow-set-size 4
 no ip routing vrf MGMT
 ip routing vrf TENANT_A_PROJECT01
 ip routing vrf TENANT_A_PROJECT02

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11969,9 +11969,9 @@ ip nat synchronization
 
 ### IP Hardware FIB Summary
 
-IP hardware fib optimize prefixes profile: urpf-internet
-IP hardware fib dynamic load balancing: Enabled
-IP hardware fib dynamic load balancing flow-set-size: 4
+IP hardware FIB optimize prefixes profile: urpf-internet
+IP hardware FIB dynamic load balancing: Enabled
+IP hardware FIB dynamic load balancing flow-set-size: 4
 
 ### IP Hardware FIB Configuration
 

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -250,6 +250,9 @@
   - [NAT Synchronization](#nat-synchronization)
   - [NAT Translation Settings](#nat-translation-settings)
   - [IP NAT Device Configuration](#ip-nat-device-configuration)
+- [IP Hardware FIB](#ip-hardware-fib)
+  - [IP Hardware FIB Summary](#ip-hardware-fib-summary)
+  - [IP Hardware FIB Configuration](#ip-hardware-fib-configuration)
 - [Errdisable](#errdisable)
   - [Errdisable Summary](#errdisable-summary)
 - [MACsec](#macsec)
@@ -11960,6 +11963,22 @@ ip nat synchronization
    local-interface Ethernet1
    port-range 1024 65535
    port-range split disabled
+```
+
+## IP Hardware FIB
+
+### IP Hardware FIB Summary
+
+IP hardware fib optimize prefixes profile: urpf-internet
+IP hardware fib dynamic load balancing: Enabled
+IP hardware fib dynamic load balancing flow-set-size: 4
+
+### IP Hardware FIB Configuration
+
+```eos
+ip hardware fib optimize prefixes profile urpf-internet
+ip hardware fib load-balance distribution dynamic
+ip hardware fib load-balance distribution dynamic flow-set-size 4
 ```
 
 ## Errdisable

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4431,6 +4431,8 @@ ip access-list standard ACL-SSH-VRF
 !
 ip routing ipv6 interfaces
 ip hardware fib optimize prefixes profile urpf-internet
+ip hardware fib load-balance distribution dynamic
+ip hardware fib load-balance distribution dynamic flow-set-size 4
 no ip routing vrf MGMT
 ip routing vrf TENANT_A_PROJECT01
 ip routing vrf TENANT_A_PROJECT02

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ip-hardware.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/ip-hardware.yml
@@ -4,3 +4,7 @@ ip_hardware:
     optimize:
       prefixes:
         profile: urpf-internet
+    load_balance_distribution:
+      dynamic:
+        enabled: true
+        flow_set_size: 4

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-hardware.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-hardware.md
@@ -14,7 +14,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ip_hardware.fib.optimize.prefixes.profile") | String |  |  | Valid Values:<br>- <code>internet</code><br>- <code>urpf-internet</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;load_balance_distribution</samp>](## "ip_hardware.fib.load_balance_distribution") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic.enabled") | Boolean |  |  |  | Enable dynamic load balancing. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic.enabled") | Boolean | Required |  |  | Enable dynamic load balancing. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flow_set_size</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size") | Integer |  |  | Min: 1<br>Max: 7 | Set flow set size. Requires `enabled` key to be set to `true`.<br>1: Allow up to 128 ECMP groups of 256 entries each.<br>2: Allow up to 64 ECMP groups of 512 entries each.<br>3: Allow up to 32 ECMP groups of 1024 entries each.<br>4: Allow up to 16 ECMP groups of 2048 entries each.<br>5: Allow up to 8 ECMP groups of 4096 entries each.<br>6: Allow up to 4 ECMP groups of 8192 entries each.<br>7: Allow up to 2 ECMP groups of 16384 entries each. |
 
 === "YAML"
@@ -29,7 +29,7 @@
           dynamic:
 
             # Enable dynamic load balancing.
-            enabled: <bool>
+            enabled: <bool; required>
 
             # Set flow set size. Requires `enabled` key to be set to `true`.
             # 1: Allow up to 128 ECMP groups of 256 entries each.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-hardware.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-hardware.md
@@ -15,7 +15,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;load_balance_distribution</samp>](## "ip_hardware.fib.load_balance_distribution") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic.enabled") | Boolean |  |  |  | Enable dynamic load balancing. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flow_set_size</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size") | Integer |  |  | Min: 1<br>Max: 7 | Set flow set size. Requires enabled key to be set `true`.<br>1: Allow up to 128 ECMP groups of 256 entries each.<br>2: Allow up to 64 ECMP groups of 512 entries each.<br>3: Allow up to 32 ECMP groups of 1024 entries each.<br>4: Allow up to 16 ECMP groups of 2048 entries each.<br>5: Allow up to 8 ECMP groups of 4096 entries each.<br>6: Allow up to 4 ECMP groups of 8192 entries each.<br>7: Allow up to 2 ECMP groups of 16384 entries each. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flow_set_size</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size") | Integer |  |  | Min: 1<br>Max: 7 | Set flow set size. Requires `enabled` key to be set to `true`.<br>1: Allow up to 128 ECMP groups of 256 entries each.<br>2: Allow up to 64 ECMP groups of 512 entries each.<br>3: Allow up to 32 ECMP groups of 1024 entries each.<br>4: Allow up to 16 ECMP groups of 2048 entries each.<br>5: Allow up to 8 ECMP groups of 4096 entries each.<br>6: Allow up to 4 ECMP groups of 8192 entries each.<br>7: Allow up to 2 ECMP groups of 16384 entries each. |
 
 === "YAML"
 
@@ -31,7 +31,7 @@
             # Enable dynamic load balancing.
             enabled: <bool>
 
-            # Set flow set size. Requires enabled key to be set `true`.
+            # Set flow set size. Requires `enabled` key to be set to `true`.
             # 1: Allow up to 128 ECMP groups of 256 entries each.
             # 2: Allow up to 64 ECMP groups of 512 entries each.
             # 3: Allow up to 32 ECMP groups of 1024 entries each.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-hardware.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-hardware.md
@@ -12,6 +12,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;optimize</samp>](## "ip_hardware.fib.optimize") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefixes</samp>](## "ip_hardware.fib.optimize.prefixes") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;profile</samp>](## "ip_hardware.fib.optimize.prefixes.profile") | String |  |  | Valid Values:<br>- <code>internet</code><br>- <code>urpf-internet</code> |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;load_balance_distribution</samp>](## "ip_hardware.fib.load_balance_distribution") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;dynamic</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic.enabled") | Boolean |  |  |  | Enable dynamic load balancing. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;flow_set_size</samp>](## "ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size") | Integer |  |  | Min: 1<br>Max: 7 | Set flow set size. Requires enabled key to be set `true`.<br>1: Allow up to 128 ECMP groups of 256 entries each.<br>2: Allow up to 64 ECMP groups of 512 entries each.<br>3: Allow up to 32 ECMP groups of 1024 entries each.<br>4: Allow up to 16 ECMP groups of 2048 entries each.<br>5: Allow up to 8 ECMP groups of 4096 entries each.<br>6: Allow up to 4 ECMP groups of 8192 entries each.<br>7: Allow up to 2 ECMP groups of 16384 entries each. |
 
 === "YAML"
 
@@ -21,4 +25,19 @@
         optimize:
           prefixes:
             profile: <str; "internet" | "urpf-internet">
+        load_balance_distribution:
+          dynamic:
+
+            # Enable dynamic load balancing.
+            enabled: <bool>
+
+            # Set flow set size. Requires enabled key to be set `true`.
+            # 1: Allow up to 128 ECMP groups of 256 entries each.
+            # 2: Allow up to 64 ECMP groups of 512 entries each.
+            # 3: Allow up to 32 ECMP groups of 1024 entries each.
+            # 4: Allow up to 16 ECMP groups of 2048 entries each.
+            # 5: Allow up to 8 ECMP groups of 4096 entries each.
+            # 6: Allow up to 4 ECMP groups of 8192 entries each.
+            # 7: Allow up to 2 ECMP groups of 16384 entries each.
+            flow_set_size: <int; 1-7>
     ```

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-hardware.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-hardware.j2
@@ -1,0 +1,28 @@
+{#
+ Copyright (c) 2023-2025 Arista Networks, Inc.
+ Use of this source code is governed by the Apache License 2.0
+ that can be found in the LICENSE file.
+#}
+{# eos - ip hardware #}
+{% if ip_hardware.fib.optimize.prefixes.profile is arista.avd.defined or ip_hardware.fib.load_balance_distribution.dynamic is arista.avd.defined %}
+
+## IP Hardware FIB
+
+### IP Hardware FIB Summary
+
+{%     if ip_hardware.fib.optimize.prefixes.profile is arista.avd.defined %}
+IP hardware fib optimize prefixes profile: {{ ip_hardware.fib.optimize.prefixes.profile }}
+{%     endif %}
+{%     if ip_hardware.fib.load_balance_distribution.dynamic.enabled is arista.avd.defined(true) %}
+IP hardware fib dynamic load balancing: Enabled
+{%     endif %}
+{%     if ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size is arista.avd.defined %}
+IP hardware fib dynamic load balancing flow-set-size: {{ ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size }}
+{%     endif %}
+
+### IP Hardware FIB Configuration
+
+```eos
+{%     include 'eos/ip-hardware.j2' %}
+```
+{% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-hardware.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/ip-hardware.j2
@@ -11,13 +11,13 @@
 ### IP Hardware FIB Summary
 
 {%     if ip_hardware.fib.optimize.prefixes.profile is arista.avd.defined %}
-IP hardware fib optimize prefixes profile: {{ ip_hardware.fib.optimize.prefixes.profile }}
+IP hardware FIB optimize prefixes profile: {{ ip_hardware.fib.optimize.prefixes.profile }}
 {%     endif %}
 {%     if ip_hardware.fib.load_balance_distribution.dynamic.enabled is arista.avd.defined(true) %}
-IP hardware fib dynamic load balancing: Enabled
+IP hardware FIB dynamic load balancing: Enabled
 {%     endif %}
 {%     if ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size is arista.avd.defined %}
-IP hardware fib dynamic load balancing flow-set-size: {{ ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size }}
+IP hardware FIB dynamic load balancing flow-set-size: {{ ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size }}
 {%     endif %}
 
 ### IP Hardware FIB Configuration

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-device-documentation.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos-device-documentation.j2
@@ -115,6 +115,8 @@
 {% include 'documentation/ip-dhcp-snooping.j2' %}
 {# IP NAT #}
 {% include 'documentation/ip-nat.j2' %}
+{# IP Hardware FIB #}
+{% include 'documentation/ip-hardware.j2' %}
 {# Errdisable #}
 {% include 'documentation/errdisable.j2' %}
 {# MACsec #}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-hardware.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/ip-hardware.j2
@@ -7,3 +7,9 @@
 {% if ip_hardware.fib.optimize.prefixes.profile is arista.avd.defined %}
 ip hardware fib optimize prefixes profile {{ ip_hardware.fib.optimize.prefixes.profile }}
 {% endif %}
+{% if ip_hardware.fib.load_balance_distribution.dynamic.enabled is arista.avd.defined(true) %}
+ip hardware fib load-balance distribution dynamic
+{%     if ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size is arista.avd.defined %}
+ip hardware fib load-balance distribution dynamic flow-set-size {{ ip_hardware.fib.load_balance_distribution.dynamic.flow_set_size }}
+{%     endif %}
+{% endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -14331,13 +14331,87 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         """
 
-            _fields: ClassVar[dict] = {"optimize": {"type": Optimize}}
+            class LoadBalanceDistribution(AvdModel):
+                """Subclass of AvdModel."""
+
+                class Dynamic(AvdModel):
+                    """Subclass of AvdModel."""
+
+                    _fields: ClassVar[dict] = {"enabled": {"type": bool}, "flow_set_size": {"type": int}}
+                    enabled: bool | None
+                    """Enable dynamic load balancing."""
+                    flow_set_size: int | None
+                    """
+                    Set flow set size. Requires enabled key to be set `true`.
+                    1: Allow up to 128 ECMP groups of 256
+                    entries each.
+                    2: Allow up to 64 ECMP groups of 512 entries each.
+                    3: Allow up to 32 ECMP groups of
+                    1024 entries each.
+                    4: Allow up to 16 ECMP groups of 2048 entries each.
+                    5: Allow up to 8 ECMP groups
+                    of 4096 entries each.
+                    6: Allow up to 4 ECMP groups of 8192 entries each.
+                    7: Allow up to 2 ECMP
+                    groups of 16384 entries each.
+                    """
+
+                    if TYPE_CHECKING:
+
+                        def __init__(self, *, enabled: bool | None | UndefinedType = Undefined, flow_set_size: int | None | UndefinedType = Undefined) -> None:
+                            """
+                            Dynamic.
+
+
+                            Subclass of AvdModel.
+
+                            Args:
+                                enabled: Enable dynamic load balancing.
+                                flow_set_size:
+                                   Set flow set size. Requires enabled key to be set `true`.
+                                   1: Allow up to 128 ECMP groups of 256
+                                   entries each.
+                                   2: Allow up to 64 ECMP groups of 512 entries each.
+                                   3: Allow up to 32 ECMP groups of
+                                   1024 entries each.
+                                   4: Allow up to 16 ECMP groups of 2048 entries each.
+                                   5: Allow up to 8 ECMP groups
+                                   of 4096 entries each.
+                                   6: Allow up to 4 ECMP groups of 8192 entries each.
+                                   7: Allow up to 2 ECMP
+                                   groups of 16384 entries each.
+
+                            """
+
+                _fields: ClassVar[dict] = {"dynamic": {"type": Dynamic}}
+                dynamic: Dynamic
+                """Subclass of AvdModel."""
+
+                if TYPE_CHECKING:
+
+                    def __init__(self, *, dynamic: Dynamic | UndefinedType = Undefined) -> None:
+                        """
+                        LoadBalanceDistribution.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            dynamic: Subclass of AvdModel.
+
+                        """
+
+            _fields: ClassVar[dict] = {"optimize": {"type": Optimize}, "load_balance_distribution": {"type": LoadBalanceDistribution}}
             optimize: Optimize
+            """Subclass of AvdModel."""
+            load_balance_distribution: LoadBalanceDistribution
             """Subclass of AvdModel."""
 
             if TYPE_CHECKING:
 
-                def __init__(self, *, optimize: Optimize | UndefinedType = Undefined) -> None:
+                def __init__(
+                    self, *, optimize: Optimize | UndefinedType = Undefined, load_balance_distribution: LoadBalanceDistribution | UndefinedType = Undefined
+                ) -> None:
                     """
                     Fib.
 
@@ -14346,6 +14420,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     Args:
                         optimize: Subclass of AvdModel.
+                        load_balance_distribution: Subclass of AvdModel.
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -14342,7 +14342,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     """Enable dynamic load balancing."""
                     flow_set_size: int | None
                     """
-                    Set flow set size. Requires enabled key to be set `true`.
+                    Set flow set size. Requires `enabled` key to be set to `true`.
                     1: Allow up to 128 ECMP groups of 256
                     entries each.
                     2: Allow up to 64 ECMP groups of 512 entries each.
@@ -14368,7 +14368,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                             Args:
                                 enabled: Enable dynamic load balancing.
                                 flow_set_size:
-                                   Set flow set size. Requires enabled key to be set `true`.
+                                   Set flow set size. Requires `enabled` key to be set to `true`.
                                    1: Allow up to 128 ECMP groups of 256
                                    entries each.
                                    2: Allow up to 64 ECMP groups of 512 entries each.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -14338,7 +14338,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     """Subclass of AvdModel."""
 
                     _fields: ClassVar[dict] = {"enabled": {"type": bool}, "flow_set_size": {"type": int}}
-                    enabled: bool | None
+                    enabled: bool
                     """Enable dynamic load balancing."""
                     flow_set_size: int | None
                     """
@@ -14358,7 +14358,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     if TYPE_CHECKING:
 
-                        def __init__(self, *, enabled: bool | None | UndefinedType = Undefined, flow_set_size: int | None | UndefinedType = Undefined) -> None:
+                        def __init__(self, *, enabled: bool | UndefinedType = Undefined, flow_set_size: int | None | UndefinedType = Undefined) -> None:
                             """
                             Dynamic.
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -5673,6 +5673,35 @@ keys:
                     valid_values:
                     - internet
                     - urpf-internet
+          load_balance_distribution:
+            type: dict
+            keys:
+              dynamic:
+                type: dict
+                keys:
+                  enabled:
+                    type: bool
+                    description: Enable dynamic load balancing.
+                  flow_set_size:
+                    description: 'Set flow set size. Requires enabled key to be set
+                      `true`.
+
+                      1: Allow up to 128 ECMP groups of 256 entries each.
+
+                      2: Allow up to 64 ECMP groups of 512 entries each.
+
+                      3: Allow up to 32 ECMP groups of 1024 entries each.
+
+                      4: Allow up to 16 ECMP groups of 2048 entries each.
+
+                      5: Allow up to 8 ECMP groups of 4096 entries each.
+
+                      6: Allow up to 4 ECMP groups of 8192 entries each.
+
+                      7: Allow up to 2 ECMP groups of 16384 entries each.'
+                    type: int
+                    min: 1
+                    max: 7
   ip_http_client_source_interfaces:
     type: list
     items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -5683,8 +5683,8 @@ keys:
                     type: bool
                     description: Enable dynamic load balancing.
                   flow_set_size:
-                    description: 'Set flow set size. Requires enabled key to be set
-                      `true`.
+                    description: 'Set flow set size. Requires `enabled` key to be
+                      set to `true`.
 
                       1: Allow up to 128 ECMP groups of 256 entries each.
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -5682,6 +5682,7 @@ keys:
                   enabled:
                     type: bool
                     description: Enable dynamic load balancing.
+                    required: true
                   flow_set_size:
                     description: 'Set flow set size. Requires `enabled` key to be
                       set to `true`.
@@ -5702,6 +5703,8 @@ keys:
                     type: int
                     min: 1
                     max: 7
+                    convert_types:
+                    - str
   ip_http_client_source_interfaces:
     type: list
     items:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_hardware.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_hardware.schema.yml
@@ -30,6 +30,7 @@ keys:
                   enabled:
                     type: bool
                     description: Enable dynamic load balancing.
+                    required: true
                   flow_set_size:
                     description: |-
                       Set flow set size. Requires `enabled` key to be set to `true`.
@@ -43,3 +44,5 @@ keys:
                     type: int
                     min: 1
                     max: 7
+                    convert_types:
+                      - str

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_hardware.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_hardware.schema.yml
@@ -32,7 +32,7 @@ keys:
                     description: Enable dynamic load balancing.
                   flow_set_size:
                     description: |-
-                      Set flow set size. Requires enabled key to be set `true`.
+                      Set flow set size. Requires `enabled` key to be set to `true`.
                       1: Allow up to 128 ECMP groups of 256 entries each.
                       2: Allow up to 64 ECMP groups of 512 entries each.
                       3: Allow up to 32 ECMP groups of 1024 entries each.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_hardware.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_hardware.schema.yml
@@ -21,3 +21,25 @@ keys:
                   profile:
                     type: str
                     valid_values: ["internet", "urpf-internet"]
+          load_balance_distribution:
+            type: dict
+            keys:
+              dynamic:
+                type: dict
+                keys:
+                  enabled:
+                    type: bool
+                    description: Enable dynamic load balancing.
+                  flow_set_size:
+                    description: |-
+                      Set flow set size. Requires enabled key to be set `true`.
+                      1: Allow up to 128 ECMP groups of 256 entries each.
+                      2: Allow up to 64 ECMP groups of 512 entries each.
+                      3: Allow up to 32 ECMP groups of 1024 entries each.
+                      4: Allow up to 16 ECMP groups of 2048 entries each.
+                      5: Allow up to 8 ECMP groups of 4096 entries each.
+                      6: Allow up to 4 ECMP groups of 8192 entries each.
+                      7: Allow up to 2 ECMP groups of 16384 entries each.
+                    type: int
+                    min: 1
+                    max: 7


### PR DESCRIPTION
## Change Summary

Added support for DLB on ECMP groups. Need to confirm the config order of `ip hardware fib load-balance distribution dynamic` and `ip hardware fib optimize prefixes profile urpf-internet`. 

## Related Issue(s)

Fixes #4920 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Added support for DLB on ECMP groups.

## How to test
Run Molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
