### PR TITLE
Feat(eos_cli_config_gen): Add cli_config_gen support for E-Tree options

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3411,6 +3411,7 @@ vlan internal order ascending range 10 40
 | 110 | PR01-DMZ | - |
 | 111 | PRIVATE_VLAN_COMMUNITY | - |
 | 112 | PRIVATE_VLAN_ISOLATED | - |
+| 201 | ETREE_LEAF | - |
 | 3010 | MLAG_iBGP_TENANT_A_PROJECT01 | LEAF_PEER_L3 |
 | 3011 | MLAG_iBGP_TENANT_A_PROJECT02 | MY_TRUNK_GROUP |
 | 3012 | MLAG_iBGP_TENANT_A_PROJECT03 | MY_TRUNK_GROUP |
@@ -3421,6 +3422,18 @@ vlan internal order ascending range 10 40
 | --------------- | ----------------- | ----------------- |
 | community | 111 | 110 |
 | isolated | 112 | 110 |
+
+#### E-Tree role
+
+| VLAN ID | VLAN Name | Role | Remote Leaf Host Drop |
+| ------- | --------- | ---- | --------------------- |
+| 110 | PR01-DMZ | Root | - |
+| 111 | PRIVATE_VLAN_COMMUNITY | Root | - |
+| 112 | PRIVATE_VLAN_ISOLATED | Root | - |
+| 201 | ETREE_LEAF | Leaf | True |
+| 3010 | MLAG_iBGP_TENANT_A_PROJECT01 | Root | - |
+| 3011 | MLAG_iBGP_TENANT_A_PROJECT02 | Root | - |
+| 3012 | MLAG_iBGP_TENANT_A_PROJECT03 | Root | - |
 
 ### VLANs Device Configuration
 
@@ -3443,6 +3456,11 @@ vlan 111
 vlan 112
    name PRIVATE_VLAN_ISOLATED
    private-vlan isolated primary vlan 110
+!
+vlan 201
+   name ETREE_LEAF
+   e-tree role leaf
+      remote leaf host drop
 !
 vlan 3010
    name MLAG_iBGP_TENANT_A_PROJECT01

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3418,12 +3418,12 @@ vlan internal order ascending range 10 40
 
 #### Private VLANs
 
-| Primary Vlan ID | Secondary VLAN ID | Private Vlan Type |
+| Primary VLAN ID | Secondary VLAN ID | Private VLAN Type |
 | --------------- | ----------------- | ----------------- |
 | community | 111 | 110 |
 | isolated | 112 | 110 |
 
-#### E-Tree role
+#### E-Tree Role
 
 | VLAN ID | VLAN Name | Role | Remote Leaf Host Drop |
 | ------- | --------- | ---- | --------------------- |

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -3464,6 +3464,7 @@ vlan 112
 !
 vlan 201
    name ETREE_LEAF
+   !
    e-tree role leaf
       remote leaf host drop
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1178,6 +1178,11 @@ vlan 112
    name PRIVATE_VLAN_ISOLATED
    private-vlan isolated primary vlan 110
 !
+vlan 201
+   name ETREE_LEAF
+   e-tree role leaf
+      remote leaf host drop
+!
 vlan 3010
    name MLAG_iBGP_TENANT_A_PROJECT01
    trunk group LEAF_PEER_L3

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1182,6 +1182,7 @@ vlan 112
 !
 vlan 201
    name ETREE_LEAF
+   !
    e-tree role leaf
       remote leaf host drop
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlans.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vlans.yml
@@ -22,6 +22,12 @@ vlans:
     private_vlan:
       type: isolated
       primary_vlan: 110
+  - id: 201
+    tenant: Tenant_B
+    name: ETREE_LEAF
+    e_tree:
+      leaf_role: true
+      remote_leaf_host_drop: true
   - id: 3010
     tenant: Tenant_A
     name: MLAG_iBGP_TENANT_A_PROJECT01

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlans.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlans.md
@@ -19,7 +19,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "vlans.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "vlans.[].trunk_groups.[]") | String |  |  |  | Trunk Group Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;e_tree</samp>](## "vlans.[].e_tree") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;leaf_role</samp>](## "vlans.[].e_tree.leaf_role") | Boolean |  |  |  | Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;leaf_role</samp>](## "vlans.[].e_tree.leaf_role") | Boolean |  |  |  | Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_leaf_host_drop</samp>](## "vlans.[].e_tree.remote_leaf_host_drop") | Boolean |  |  |  | Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;private_vlan</samp>](## "vlans.[].private_vlan") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "vlans.[].private_vlan.type") | String |  |  | Valid Values:<br>- <code>community</code><br>- <code>isolated</code> |  |
@@ -54,7 +54,7 @@
           - <str>
         e_tree:
 
-          # Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role
+          # Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role.
           leaf_role: <bool>
 
           # Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlans.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlans.md
@@ -20,7 +20,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "vlans.[].trunk_groups.[]") | String |  |  |  | Trunk Group Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;e_tree</samp>](## "vlans.[].e_tree") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;leaf_role</samp>](## "vlans.[].e_tree.leaf_role") | Boolean |  |  |  | Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_leaf_host_drop</samp>](## "vlans.[].e_tree.remote_leaf_host_drop") | Boolean |  |  |  | Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_leaf_host_drop</samp>](## "vlans.[].e_tree.remote_leaf_host_drop") | Boolean |  |  |  | Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB. This is only applicable for VLANs operating in the 'Leaf' role. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;private_vlan</samp>](## "vlans.[].private_vlan") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "vlans.[].private_vlan.type") | String |  |  | Valid Values:<br>- <code>community</code><br>- <code>isolated</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary_vlan</samp>](## "vlans.[].private_vlan.primary_vlan") | Integer |  |  |  | Primary VLAN ID. |
@@ -57,7 +57,7 @@
           # Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role.
           leaf_role: <bool>
 
-          # Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
+          # Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB. This is only applicable for VLANs operating in the 'Leaf' role.
           remote_leaf_host_drop: <bool>
         private_vlan:
           type: <str; "community" | "isolated">

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlans.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlans.md
@@ -18,6 +18,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_enforcement_disabled</samp>](## "vlans.[].address_locking.ipv4_enforcement_disabled") | Boolean |  |  |  | Disable enforcement for IPv4 locked addresses. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;trunk_groups</samp>](## "vlans.[].trunk_groups") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "vlans.[].trunk_groups.[]") | String |  |  |  | Trunk Group Name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;e_tree</samp>](## "vlans.[].e_tree") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;leaf_role</samp>](## "vlans.[].e_tree.leaf_role") | Boolean |  |  |  | Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_host_leaf_drop</samp>](## "vlans.[].e_tree.remote_host_leaf_drop") | Boolean |  |  |  | Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;private_vlan</samp>](## "vlans.[].private_vlan") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "vlans.[].private_vlan.type") | String |  |  | Valid Values:<br>- <code>community</code><br>- <code>isolated</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary_vlan</samp>](## "vlans.[].private_vlan.primary_vlan") | Integer |  |  |  | Primary VLAN ID. |
@@ -49,6 +52,13 @@
 
             # Trunk Group Name.
           - <str>
+        e_tree:
+
+          # Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role
+          leaf_role: <bool>
+
+          # Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
+          remote_host_leaf_drop: <bool>
         private_vlan:
           type: <str; "community" | "isolated">
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlans.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vlans.md
@@ -20,7 +20,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "vlans.[].trunk_groups.[]") | String |  |  |  | Trunk Group Name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;e_tree</samp>](## "vlans.[].e_tree") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;leaf_role</samp>](## "vlans.[].e_tree.leaf_role") | Boolean |  |  |  | Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_host_leaf_drop</samp>](## "vlans.[].e_tree.remote_host_leaf_drop") | Boolean |  |  |  | Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_leaf_host_drop</samp>](## "vlans.[].e_tree.remote_leaf_host_drop") | Boolean |  |  |  | Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;private_vlan</samp>](## "vlans.[].private_vlan") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;type</samp>](## "vlans.[].private_vlan.type") | String |  |  | Valid Values:<br>- <code>community</code><br>- <code>isolated</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;primary_vlan</samp>](## "vlans.[].private_vlan.primary_vlan") | Integer |  |  |  | Primary VLAN ID. |
@@ -58,7 +58,7 @@
           leaf_role: <bool>
 
           # Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
-          remote_host_leaf_drop: <bool>
+          remote_leaf_host_drop: <bool>
         private_vlan:
           type: <str; "community" | "isolated">
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlans.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlans.j2
@@ -32,7 +32,7 @@
 
 #### Private VLANs
 
-| Primary Vlan ID | Secondary VLAN ID | Private Vlan Type |
+| Primary VLAN ID | Secondary VLAN ID | Private VLAN Type |
 | --------------- | ----------------- | ----------------- |
 {%         for vlan in vlans | arista.avd.natural_sort('id') %}
 {%             if vlan.private_vlan.type is arista.avd.defined and
@@ -43,7 +43,7 @@
 {%     endif %}
 {%     if ns.show_e_tree_table %}
 
-#### E-Tree role
+#### E-Tree Role
 
 | VLAN ID | VLAN Name | Role | Remote Leaf Host Drop |
 | ------- | --------- | ---- | --------------------- |

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlans.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlans.j2
@@ -42,6 +42,7 @@
 {%         endfor %}
 {%     endif %}
 {%     if ns.show_e_tree_table %}
+
 #### E-Tree role
 
 | VLAN ID | VLAN Name | Role | Remote Leaf Host Drop |
@@ -53,10 +54,11 @@
 {%             else %}
 {%                 set row_role = 'Root' %}
 {%             endif %}
-{%             set row_host_drop = vlan.e_tree.remote_host_leaf_drop | arista.avd.default('-' ) %}
+{%             set row_host_drop = vlan.e_tree.remote_leaf_host_drop | arista.avd.default('-' ) %}
 | {{ vlan.id }} | {{ row_name }} | {{ row_role }} | {{ row_host_drop }} |
 {%         endfor %}
 {%     endif %}
+
 ### VLANs Device Configuration
 
 ```eos

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlans.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vlans.j2
@@ -5,7 +5,7 @@
 #}
 {# doc - vlans #}
 {% if vlans is arista.avd.defined %}
-{%     set ns = namespace(show_private_vlan_table = false) %}
+{%     set ns = namespace(show_private_vlan_table = false, show_e_tree_table = false) %}
 
 ## VLANs
 
@@ -16,6 +16,9 @@
 {%     for vlan in vlans | arista.avd.natural_sort('id') %}
 {%         if vlan.private_vlan is arista.avd.defined %}
 {%             set ns.show_private_vlan_table = true %}
+{%         endif %}
+{%         if vlan.e_tree.leaf_role is arista.avd.defined %}
+{%             set ns.show_e_tree_table = true %}
 {%         endif %}
 {%         set row_name = vlan.name | arista.avd.default('-') %}
 {%         if vlan.trunk_groups is arista.avd.defined %}
@@ -38,7 +41,22 @@
 {%             endif %}
 {%         endfor %}
 {%     endif %}
+{%     if ns.show_e_tree_table %}
+#### E-Tree role
 
+| VLAN ID | VLAN Name | Role | Remote Leaf Host Drop |
+| ------- | --------- | ---- | --------------------- |
+{%         for vlan in vlans | arista.avd.natural_sort('id') %}
+{%             set row_name = vlan.name | arista.avd.default('-') %}
+{%             if vlan.e_tree.leaf_role is arista.avd.defined(true) %}
+{%                 set row_role = 'Leaf' %}
+{%             else %}
+{%                 set row_role = 'Root' %}
+{%             endif %}
+{%             set row_host_drop = vlan.e_tree.remote_host_leaf_drop | arista.avd.default('-' ) %}
+| {{ vlan.id }} | {{ row_name }} | {{ row_role }} | {{ row_host_drop }} |
+{%         endfor %}
+{%     endif %}
 ### VLANs Device Configuration
 
 ```eos

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlans.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlans.j2
@@ -16,12 +16,6 @@ vlan {{ vlan.id }}
 {%     for trunk_group in vlan.trunk_groups | arista.avd.natural_sort %}
    trunk group {{ trunk_group }}
 {%     endfor %}
-{%     if vlan.e_tree.leaf_role is arista.avd.defined(true) %}
-   e-tree role leaf
-{%         if vlan.e_tree.remote_leaf_host_drop is arista.avd.defined(true) %}
-      remote leaf host drop
-{%         endif %}
-{%     endif %}
 {%     if vlan.private_vlan.type is arista.avd.defined and
           vlan.private_vlan.primary_vlan is arista.avd.defined %}
    private-vlan {{ vlan.private_vlan.type }} primary vlan {{ vlan.private_vlan.primary_vlan }}
@@ -37,6 +31,13 @@ vlan {{ vlan.id }}
 {%         endif %}
 {%         if vlan.address_locking.ipv4_enforcement_disabled is arista.avd.defined(true) %}
       locked-address ipv4 enforcement disabled
+{%         endif %}
+{%     endif %}
+{%     if vlan.e_tree.leaf_role is arista.avd.defined(true) %}
+   !
+   e-tree role leaf
+{%         if vlan.e_tree.remote_leaf_host_drop is arista.avd.defined(true) %}
+      remote leaf host drop
 {%         endif %}
 {%     endif %}
 {% endfor %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlans.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlans.j2
@@ -18,7 +18,7 @@ vlan {{ vlan.id }}
 {%     endfor %}
 {%     if vlan.e_tree is arista.avd.defined and vlan.e_tree.leaf_role is arista.avd.defined(true) %}
    e-tree role leaf
-{%         if vlan.e_tree.remote_host_leaf_drop is arista.avd.defined(true) %}
+{%         if vlan.e_tree.remote_leaf_host_drop is arista.avd.defined(true) %}
       remote leaf host drop
 {%         endif %}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlans.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlans.j2
@@ -16,6 +16,12 @@ vlan {{ vlan.id }}
 {%     for trunk_group in vlan.trunk_groups | arista.avd.natural_sort %}
    trunk group {{ trunk_group }}
 {%     endfor %}
+{%     if vlan.e_tree is arista.avd.defined and vlan.e_tree.leaf_role is arista.avd.defined(true) %}
+   e-tree role leaf
+{%         if vlan.e_tree.remote_host_leaf_drop is arista.avd.defined(true) %}
+      remote leaf host drop
+{%         endif %}
+{%     endif %}
 {%     if vlan.private_vlan.type is arista.avd.defined and
           vlan.private_vlan.primary_vlan is arista.avd.defined %}
    private-vlan {{ vlan.private_vlan.type }} primary vlan {{ vlan.private_vlan.primary_vlan }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlans.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vlans.j2
@@ -16,7 +16,7 @@ vlan {{ vlan.id }}
 {%     for trunk_group in vlan.trunk_groups | arista.avd.natural_sort %}
    trunk group {{ trunk_group }}
 {%     endfor %}
-{%     if vlan.e_tree is arista.avd.defined and vlan.e_tree.leaf_role is arista.avd.defined(true) %}
+{%     if vlan.e_tree.leaf_role is arista.avd.defined(true) %}
    e-tree role leaf
 {%         if vlan.e_tree.remote_leaf_host_drop is arista.avd.defined(true) %}
       remote leaf host drop

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -63514,7 +63514,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
             _fields: ClassVar[dict] = {"leaf_role": {"type": bool}, "remote_leaf_host_drop": {"type": bool}}
             leaf_role: bool | None
-            """Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role"""
+            """Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role."""
             remote_leaf_host_drop: bool | None
             """Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB"""
 
@@ -63530,7 +63530,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Subclass of AvdModel.
 
                     Args:
-                        leaf_role: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role
+                        leaf_role: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role.
                         remote_leaf_host_drop: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
 
                     """

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -63478,16 +63478,16 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         class ETree(AvdModel):
             """Subclass of AvdModel."""
 
-            _fields: ClassVar[dict] = {"leaf_role": {"type": bool}, "remote_host_leaf_drop": {"type": bool}}
+            _fields: ClassVar[dict] = {"leaf_role": {"type": bool}, "remote_leaf_host_drop": {"type": bool}}
             leaf_role: bool | None
             """Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role"""
-            remote_host_leaf_drop: bool | None
+            remote_leaf_host_drop: bool | None
             """Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB"""
 
             if TYPE_CHECKING:
 
                 def __init__(
-                    self, *, leaf_role: bool | None | UndefinedType = Undefined, remote_host_leaf_drop: bool | None | UndefinedType = Undefined
+                    self, *, leaf_role: bool | None | UndefinedType = Undefined, remote_leaf_host_drop: bool | None | UndefinedType = Undefined
                 ) -> None:
                     """
                     ETree.
@@ -63497,7 +63497,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     Args:
                         leaf_role: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role
-                        remote_host_leaf_drop: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
+                        remote_leaf_host_drop: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -63516,7 +63516,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             leaf_role: bool | None
             """Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role."""
             remote_leaf_host_drop: bool | None
-            """Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB"""
+            """
+            Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB. This is
+            only applicable for VLANs operating in the 'Leaf' role.
+            """
 
             if TYPE_CHECKING:
 
@@ -63531,7 +63534,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     Args:
                         leaf_role: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role.
-                        remote_leaf_host_drop: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
+                        remote_leaf_host_drop:
+                           Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB. This is
+                           only applicable for VLANs operating in the 'Leaf' role.
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -63475,6 +63475,32 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
         TrunkGroups._item_type = str
 
+        class ETree(AvdModel):
+            """Subclass of AvdModel."""
+
+            _fields: ClassVar[dict] = {"leaf_role": {"type": bool}, "remote_host_leaf_drop": {"type": bool}}
+            leaf_role: bool | None
+            """Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role"""
+            remote_host_leaf_drop: bool | None
+            """Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB"""
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self, *, leaf_role: bool | None | UndefinedType = Undefined, remote_host_leaf_drop: bool | None | UndefinedType = Undefined
+                ) -> None:
+                    """
+                    ETree.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        leaf_role: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role
+                        remote_host_leaf_drop: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
+
+                    """
+
         class PrivateVlan(AvdModel):
             """Subclass of AvdModel."""
 
@@ -63506,6 +63532,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "state": {"type": str},
             "address_locking": {"type": AddressLocking},
             "trunk_groups": {"type": TrunkGroups},
+            "e_tree": {"type": ETree},
             "private_vlan": {"type": PrivateVlan},
             "tenant": {"type": str},
         }
@@ -63518,6 +63545,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         """Subclass of AvdModel."""
         trunk_groups: TrunkGroups
         """Subclass of AvdList with `str` items."""
+        e_tree: ETree
+        """Subclass of AvdModel."""
         private_vlan: PrivateVlan
         """Subclass of AvdModel."""
         tenant: str | None
@@ -63533,6 +63562,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 state: Literal["active", "suspend"] | None | UndefinedType = Undefined,
                 address_locking: AddressLocking | UndefinedType = Undefined,
                 trunk_groups: TrunkGroups | UndefinedType = Undefined,
+                e_tree: ETree | UndefinedType = Undefined,
                 private_vlan: PrivateVlan | UndefinedType = Undefined,
                 tenant: str | None | UndefinedType = Undefined,
             ) -> None:
@@ -63548,6 +63578,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     state: state
                     address_locking: Subclass of AvdModel.
                     trunk_groups: Subclass of AvdList with `str` items.
+                    e_tree: Subclass of AvdModel.
                     private_vlan: Subclass of AvdModel.
                     tenant: Key only used for documentation or validation purposes.
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -23614,7 +23614,7 @@ keys:
               type: bool
               description: Set the VLAN into the E-Tree leaf role. By default all
                 VLANs are in root role
-            remote_host_leaf_drop:
+            remote_leaf_host_drop:
               type: bool
               description: Enables remote leaf hosts to instead be installed as explicit
                 drop routes in the local FDB

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -23607,6 +23607,17 @@ keys:
           items:
             type: str
             description: Trunk Group Name.
+        e_tree:
+          type: dict
+          keys:
+            leaf_role:
+              type: bool
+              description: Set the VLAN into the E-Tree leaf role. By default all
+                VLANs are in root role
+            remote_host_leaf_drop:
+              type: bool
+              description: Enables remote leaf hosts to instead be installed as explicit
+                drop routes in the local FDB
         private_vlan:
           type: dict
           keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -23626,7 +23626,7 @@ keys:
             leaf_role:
               type: bool
               description: Set the VLAN into the E-Tree leaf role. By default all
-                VLANs are in root role
+                VLANs are in root role.
             remote_leaf_host_drop:
               type: bool
               description: Enables remote leaf hosts to instead be installed as explicit

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -23630,7 +23630,8 @@ keys:
             remote_leaf_host_drop:
               type: bool
               description: Enables remote leaf hosts to instead be installed as explicit
-                drop routes in the local FDB
+                drop routes in the local FDB. This is only applicable for VLANs operating
+                in the 'Leaf' role.
         private_vlan:
           type: dict
           keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
@@ -51,7 +51,7 @@ keys:
               description: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role.
             remote_leaf_host_drop:
               type: bool
-              description: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
+              description: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB. This is only applicable for VLANs operating in the 'Leaf' role.
         private_vlan:
           type: dict
           keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
@@ -49,7 +49,7 @@ keys:
             leaf_role:
               type: bool
               description: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role
-            remote_host_leaf_drop:
+            remote_leaf_host_drop:
               type: bool
               description: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
         private_vlan:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
@@ -48,7 +48,7 @@ keys:
           keys:
             leaf_role:
               type: bool
-              description: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role
+              description: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role.
             remote_leaf_host_drop:
               type: bool
               description: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
@@ -43,6 +43,15 @@ keys:
           items:
             type: str
             description: Trunk Group Name.
+        e_tree:
+          type: dict
+          keys:
+            leaf_role:
+              type: bool
+              description: Set the VLAN into the E-Tree leaf role. By default all VLANs are in root role
+            remote_host_leaf_drop:
+              type: bool
+              description: Enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
         private_vlan:
           type: dict
           keys:


### PR DESCRIPTION
## Change Summary

This PR allows the E-Tree Leaf Role to be set (all VLANs are root role by default). It also allows for the Remote Leaf Host Drop option to be enabled. Both are on a per-VLAN basis.

It also fixes some header inconsistencies in the documentation headers while I was there.

## Related Issue(s)

Fixes #5448 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
This modifies the existing VLAN schema with the new keys:
```yaml
vlans:
  - id: <int; required; unique>
    e_tree:
       # All VLANs by default have the E-Tree root role
       leaf_role: <bool; default: False>
       # enables remote leaf hosts to instead be installed as explicit drop routes in the local FDB
       remote_leaf_host_drop: <bool; default: false>
```

## How to test
Tested on 7280 running 4.33.1F. Note that the option `remote leaf host drop` requires 4.33.0F+.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
