### PR TITLE
Test(eos_designs): Remove reference to the RaisesContext (pytest internal)

### DIFF
--- a/python-avd/tests/pyavd/workflows/test_verify_inputs.py
+++ b/python-avd/tests/pyavd/workflows/test_verify_inputs.py
@@ -7,14 +7,16 @@ import cProfile
 import logging
 import re
 from collections.abc import Callable
+from contextlib import AbstractContextManager
 from contextlib import nullcontext as does_not_raise
 
 import pytest
-from _pytest.python_api import RaisesContext
 
 from pyavd._cv.client.exceptions import CVDuplicatedDevices
 from pyavd._cv.workflows.models import CVDevice
 from pyavd._cv.workflows.verify_inputs import identify_duplicated_devices, verify_device_inputs
+
+ExpectedExceptionContext = AbstractContextManager[pytest.ExceptionInfo | None]
 
 TWO_DUPED_SERIAL_PATTERNS = [
     "\\('Duplicated devices found in inventory.*\\{"
@@ -567,7 +569,7 @@ def test_verify_device_inputs(
     logs_qty: int,
     expected_logs_patterns: list[str],
     expected_exception_patterns: list[str],
-    expected_exception: RaisesContext | does_not_raise,
+    expected_exception: ExpectedExceptionContext,
     *,
     strict_system_mac_address: bool,
 ) -> None:


### PR DESCRIPTION
## Change Summary

Use `AbstractContextManager` instead of `RaisesContext` for type matching of the context manager returned by `pytest.raises()` if exception is expected.

## Related Issue(s)

Fixes #5477 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

## How to test
`tox`

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
