### PR TITLE
Doc: Updated eos_cli_config_gen contribution guide to use host1 as centric testing

### DIFF
--- a/docs/contribution/authoring_eos_cli_config_gen.md
+++ b/docs/contribution/authoring_eos_cli_config_gen.md
@@ -96,7 +96,7 @@ Run `pre-commit run --all`, this will trigger recompiling the schemas and the te
      - Add the additional test cases to the next host directory, e.g., `host_vars/host2/<key_name>.yml`, `host_vars/host3/<key_name>.yml`, etc.
      - Ensure each file represents unique scenarios or configurations to validate different combinations.
    - Ensure that the new keys are thoroughly tested with various valid values and edge cases.
-   - Ensure `host1` is used for all comprehensive command tests. Utilize other hosts(`host2`, `host2`, etc.) for commands that aren't broadly compatible or to enhance test coverage.
+   - Ensure `host1` is used for all comprehensive command tests. Use other hosts (e.g., `host2`, `host3`, etc.) for commands that aren't broadly compatible or to enhance test coverage.
 3. When marking any key as "deprecated", move the related tests to the `eos_cli_config_gen_deprecated_vars` molecule scenario and add any missing tests if necessary.
 4. Run `molecule converge -s <scenario_name>` from the path `ansible_collections/arista/avd/` to execute the molecule tests locally and generate the new expected configuration and documentation for newly added test-cases.
 5. To execute all the molecule scenarios, run `make refresh-facts` from the path `ansible_collections/arista/avd/molecule` and verify the tests.

--- a/docs/contribution/authoring_eos_cli_config_gen.md
+++ b/docs/contribution/authoring_eos_cli_config_gen.md
@@ -96,6 +96,7 @@ Run `pre-commit run --all`, this will trigger recompiling the schemas and the te
      - Add the additional test cases to the next host directory, e.g., `host_vars/host2/<key_name>.yml`, `host_vars/host3/<key_name>.yml`, etc.
      - Ensure each file represents unique scenarios or configurations to validate different combinations.
    - Ensure that the new keys are thoroughly tested with various valid values and edge cases.
+   - Ensure `host1` is used for all comprehensive command tests. Utilize other hosts(`host2`, `host2`, etc.) for commands that aren't broadly compatible or to enhance test coverage.
 3. When marking any key as "deprecated", move the related tests to the `eos_cli_config_gen_deprecated_vars` molecule scenario and add any missing tests if necessary.
 4. Run `molecule converge -s <scenario_name>` from the path `ansible_collections/arista/avd/` to execute the molecule tests locally and generate the new expected configuration and documentation for newly added test-cases.
 5. To execute all the molecule scenarios, run `make refresh-facts` from the path `ansible_collections/arista/avd/molecule` and verify the tests.

--- a/docs/contribution/authoring_eos_cli_config_gen.md
+++ b/docs/contribution/authoring_eos_cli_config_gen.md
@@ -96,7 +96,7 @@ Run `pre-commit run --all`, this will trigger recompiling the schemas and the te
      - Add the additional test cases to the next host directory, e.g., `host_vars/host2/<key_name>.yml`, `host_vars/host3/<key_name>.yml`, etc.
      - Ensure each file represents unique scenarios or configurations to validate different combinations.
    - Ensure that the new keys are thoroughly tested with various valid values and edge cases.
-   - Ensure `host1` is used for all comprehensive command tests. Use other hosts (e.g., `host2`, `host3`, etc.) for commands that aren't broadly compatible or to enhance test coverage.
+   - Use `host1` for all inputs. Also use other hosts (e.g., `host2`, `host3`, etc.) when you have mutually exclusive inputs or wish to test different values for a single key.
 3. When marking any key as "deprecated", move the related tests to the `eos_cli_config_gen_deprecated_vars` molecule scenario and add any missing tests if necessary.
 4. Run `molecule converge -s <scenario_name>` from the path `ansible_collections/arista/avd/` to execute the molecule tests locally and generate the new expected configuration and documentation for newly added test-cases.
 5. To execute all the molecule scenarios, run `make refresh-facts` from the path `ansible_collections/arista/avd/molecule` and verify the tests.


### PR DESCRIPTION
## Change Summary

Updated eos_cli_config_gen contribution guide to use host1 as centric testing

## Related Issue(s)

Fixes https://github.com/aristanetworks/avd/pull/5465#discussion_r2123072328

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Ensure `host1` is used for all comprehensive command tests. Utilize other hosts(`host2`, `host3`, etc.) for commands that aren't broadly compatible or to enhance test coverage.

## How to test
NA

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
