### PR TITLE
Doc: Update porting guide for routed ports

### DIFF
--- a/docs/porting-guides/5.x.x.md
+++ b/docs/porting-guides/5.x.x.md
@@ -1537,6 +1537,28 @@ port_channel_interfaces:
 +       encapsulation: unmatched
 ```
 
+#### routed ports configuration
+
+In AVD 4.0.0, the configuration for routed ports `no switchport` in ethernet interfaces and port-channel interfaces was rendered if `ethernet_interfaces[].type` or `port_channel_interfaces[].type` was set to `routed`.
+
+With AVD 5.0.0, the dependency on the `type` key for rendering the configuration of `vlan_id` in ethernet and port-channel interfaces has been removed. Instead the following should be used:
+
+```diff
+ ethernet_interfaces:
+   - name: Ethernet42
+-    type: routed
++    switchport:
++      enabled: false
+     ip_address: 192.168.42.1/24
+!
+ port_channel_interfaces:
+   - name: Port-Channel42
+-    type: routed
++    switchport:
++      enabled: false
+     ip_address: 192.168.42.1/24
+```
+
 ### Data models for BGP additional-paths under `router_bgp` has been changed
 
 In AVD 5.0.0, the following data models have been changed and will require updates to the inventory:

--- a/docs/porting-guides/5.x.x.md
+++ b/docs/porting-guides/5.x.x.md
@@ -1537,7 +1537,7 @@ port_channel_interfaces:
 +       encapsulation: unmatched
 ```
 
-#### routed ports configuration
+#### Routed ports configuration
 
 In AVD 4.0.0, the configuration for routed ports `no switchport` in ethernet interfaces and port-channel interfaces was rendered if `ethernet_interfaces[].type` or `port_channel_interfaces[].type` was set to `routed`.
 

--- a/docs/porting-guides/5.x.x.md
+++ b/docs/porting-guides/5.x.x.md
@@ -1541,7 +1541,7 @@ port_channel_interfaces:
 
 In AVD 4.0.0, the configuration for routed ports `no switchport` in ethernet interfaces and port-channel interfaces was rendered if `ethernet_interfaces[].type` or `port_channel_interfaces[].type` was set to `routed`.
 
-With AVD 5.0.0, the dependency on the `type` key for rendering the configuration of `vlan_id` in ethernet and port-channel interfaces has been removed. Instead the following should be used:
+With AVD 5.0.0, the dependency on the `type` key for rendering `no switchport` in Ethernet and Port-Channel interfaces has been removed. Instead the following should be used:
 
 ```diff
  ethernet_interfaces:

--- a/docs/porting-guides/5.x.x.md
+++ b/docs/porting-guides/5.x.x.md
@@ -1539,7 +1539,7 @@ port_channel_interfaces:
 
 #### Routed ports configuration
 
-In AVD 4.0.0, the configuration for routed ports `no switchport` in ethernet interfaces and port-channel interfaces was rendered if `ethernet_interfaces[].type` or `port_channel_interfaces[].type` was set to `routed`.
+In AVD 4.x, the `no switchport` command was rendered for Ethernet and Port-Channel interfaces when `ethernet_interfaces[].type` or `port_channel_interfaces[].type` was set to `routed`.
 
 With AVD 5.0.0, the dependency on the `type` key for rendering `no switchport` in Ethernet and Port-Channel interfaces has been removed. Instead the following should be used:
 


### PR DESCRIPTION
## Change Summary

For users migrating from AVD 4.x to 5.x using custom_structured_configuration, the porting guide does not indicate how to migrate the routed ports and it requires to investigate more in depth what should be done looking at the new model. This PR updates the porting guide with clearer information

## Related Issue(s)

Reported from the field

## Component(s) name

`documentation`

## Proposed changes

Example

## How to test

Read the change

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
