### PR TITLE
CI: Tweak Sonar config - attempt 1 of ?

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,6 +19,9 @@ sonar.exclusions=\
     python/**/tests/**,\
     ansible_collections/arista/avd/plugins/action/anta_workflow.py
 
+# disable SCM exclusions to get the compiled templates
+sonar.scm.exclusions.disabled=true
+
 # Path to tests
 sonar.tests=\
     python-avd/tests/,\


### PR DESCRIPTION
## Change Summary

~Right now because the compiled templates are not checked-in (with reason) in Github, we don't get the coverage view of compiled templates line in Sonar (which we get locally). This PR attempts to solve this by saving the compiled templates and injecting them back in sonar.yml workflow.~

They are checked in but ignore because of scm exlucsion (.gitignore)

setting this in sonar config file:

```
sonar.scm.exclusions.disabled=true
```

## Related Issue(s)

Reported by maintainer

## Component(s) name

`ci`

## Proposed changes

cf summary

## How to test

Sonar is showing compiled templates line

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
