### PR TITLE
Test(eos_designs): Clean up converge file by removing obsolete test cases

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/converge.yml
@@ -118,23 +118,6 @@
               - ansible_failed_result is defined
               - ansible_failed_result.msg == expected_error_message
 
-- name: Converge Negative tests for 'eos_designs_facts' - mlag_same_subnet_1
-  hosts: mlag_same_subnet_1
-  gather_facts: false
-  connection: local
-  tasks:
-    - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg == expected_error_message
-
 - name: Converge Negative tests for 'eos_designs_facts' - missing-mlag-peer-ipv4-pool
   hosts: missing-mlag-peer-ipv4-pool1
   gather_facts: false
@@ -567,23 +550,6 @@
 
 - name: Converge Negative tests for 'eos_designs_structured_config'
   hosts: missing-wan-carriers
-  gather_facts: false
-  connection: local
-  tasks:
-    - name: Run failure scenario Test
-      block:
-        - name: Trigger Error
-          ansible.builtin.import_role:
-            name: arista.avd.eos_designs
-      rescue:
-        - name: Assert eos_designs failed with the expected error message
-          ansible.builtin.assert:
-            that:
-              - ansible_failed_result is defined
-              - ansible_failed_result.msg == expected_error_message
-
-- name: Converge Negative tests for 'eos_designs_structured_config'
-  hosts: missing-wan-pathgroup-in-wan-carriers
   gather_facts: false
   connection: local
   tasks:


### PR DESCRIPTION
## Change Summary

Tests `mlag_same_subnet_1 ` and `missing-wan-pathgroup-in-wan-carriers` were already removed from invetory/hosts.yml  of eos_designs_negative_unit_tests and missed to remove from converge.yml file. Hence removed from converge.yml to overcome from warning while running the molecule eos_designs_negative_unit_tests.
```
INFO     Running eos_designs_negative_unit_tests > syntax
[WARNING]: Could not match supplied host pattern, ignoring: mlag_same_subnet_1
[WARNING]: Could not match supplied host pattern, ignoring: missing-wan-
pathgroup-in-wan-carriers
```

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Fix the below warnings
```
INFO     Running eos_designs_negative_unit_tests > syntax
[WARNING]: Could not match supplied host pattern, ignoring: mlag_same_subnet_1
[WARNING]: Could not match supplied host pattern, ignoring: missing-wan-
pathgroup-in-wan-carriers
```

## How to test
Run eos_designs_negative_unit_tests molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
