### PR TITLE
Doc: Fix quotes for new_key in yaml schema docs

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/aaa-accounting.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/aaa-accounting.md
@@ -67,11 +67,11 @@
           # Group Name.
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>methods.group</samp> instead.
+          # Use `methods.group` instead.
           group: <str>
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>methods.method</samp> instead.
+          # Use `methods.method` instead.
           logging: <bool>
           methods: # >=1 items
             - method: <str; "logging" | "group"; required>
@@ -85,11 +85,11 @@
           # Group Name.
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>methods.group</samp> instead.
+          # Use `methods.group` instead.
           group: <str>
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>methods.method</samp> instead.
+          # Use `methods.method` instead.
           logging: <bool>
           methods: # >=1 items
             - method: <str; "logging" | "group"; required>
@@ -104,7 +104,7 @@
           # Group Name.
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>methods.group</samp> instead.
+          # Use `methods.group` instead.
           group: <str>
           methods: # >=1 items
             - method: <str; "logging" | "group"; required>
@@ -119,7 +119,7 @@
           # Group Name.
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>methods.group</samp> instead.
+          # Use `methods.group` instead.
           group: <str>
           methods: # >=1 items
 
@@ -141,11 +141,11 @@
             # Group Name.
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
-            # Use <samp>methods.group</samp> instead.
+            # Use `methods.group` instead.
             group: <str>
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
-            # Use <samp>methods.method</samp> instead.
+            # Use `methods.method` instead.
             logging: <bool>
             methods: # >=1 items
               - method: <str; "logging" | "group"; required>
@@ -162,11 +162,11 @@
             # Group Name.
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
-            # Use <samp>methods.group</samp> instead.
+            # Use `methods.group` instead.
             group: <str>
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
-            # Use <samp>methods.method</samp> instead.
+            # Use `methods.method` instead.
             logging: <bool>
             methods: # >=1 items
               - method: <str; "logging" | "group"; required>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/community-lists.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/community-lists.md
@@ -16,7 +16,7 @@
     ```yaml
     # This key is deprecated.
     # Support will be removed in AVD version 6.0.0.
-    # Use <samp>ip_community_lists</samp> instead.
+    # Use `ip_community_lists` instead.
     community_lists:
 
         # Community-list Name.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ethernet-interfaces.md
@@ -665,25 +665,25 @@
         # For an access port this would be a single vlan "123".
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.access_vlan or switchport.trunk.allowed_vlan</samp> instead.
+        # Use `switchport.access_vlan` or `switchport.trunk.allowed_vlan` instead.
         vlans: <str>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.trunk.native_vlan</samp> instead.
+        # Use `switchport.trunk.native_vlan` instead.
         native_vlan: <int>
 
         # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.trunk.native_vlan_tag</samp> instead.
+        # Use `switchport.trunk.native_vlan_tag` instead.
         native_vlan_tag: <bool>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.mode</samp> instead.
+        # Use `switchport.mode` instead.
         mode: <str; "access" | "dot1q-tunnel" | "trunk" | "trunk phone">
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.phone</samp> instead.
+        # Use `switchport.phone` instead.
         phone:
           trunk: <str; "tagged" | "tagged phone" | "untagged" | "untagged phone">
           vlan: <int; 1-4094>
@@ -701,7 +701,7 @@
         mac_timestamp: <str; "before-fcs" | "replace-fcs" | "header">
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.trunk.groups</samp> instead.
+        # Use `switchport.trunk.groups` instead.
         trunk_groups:
           - <str>
 
@@ -790,7 +790,7 @@
         # VLAN tag to configure on sub-interface.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>encapsulation_dot1q.vlan</samp> instead.
+        # Use `encapsulation_dot1q.vlan` instead.
         encapsulation_dot1q_vlan: <int>
 
         # Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
@@ -1072,12 +1072,12 @@
         tcp_mss_ceiling:
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>ipv4</samp> instead.
+          # Use `ipv4` instead.
           ipv4_segment_size: <int; 64-65475>
           ipv4: <int; 64-65475>
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>ipv6</samp> instead.
+          # Use `ipv6` instead.
           ipv6_segment_size: <int; 64-65475>
           ipv6: <int; 64-65475>
           direction: <str; "egress" | "ingress">
@@ -1097,13 +1097,13 @@
         isis_hello_padding: <bool>
         # This key is deprecated.
         # Support will be removed in AVD version v6.0.0.
-        # Use <samp>isis_authentication.both.mode or isis_authentication.level_1.mode or isis_authentication.level_2.mode</samp> instead.
+        # Use `isis_authentication.both.mode` or `isis_authentication.level_1.mode` or `isis_authentication.level_2.mode` instead.
         isis_authentication_mode: <str; "text" | "md5">
 
         # Type-7 encrypted password.
         # This key is deprecated.
         # Support will be removed in AVD version v6.0.0.
-        # Use <samp>isis_authentication.both.key or isis_authentication.level_1.key or isis_authentication.level_2.key</samp> instead.
+        # Use `isis_authentication.both.key` or `isis_authentication.level_1.key` or `isis_authentication.level_2.key` instead.
         isis_authentication_key: <str>
 
         # This key should not be mixed with ethernet_interfaces[].isis_authentication_mode or ethernet_interfaces[].isis_authentication_key.
@@ -1329,17 +1329,17 @@
           ztp_vlan: <int>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.trunk.private_vlan_secondary</samp> instead.
+        # Use `switchport.trunk.private_vlan_secondary` instead.
         trunk_private_vlan_secondary: <bool>
 
         # List of vlans as string.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.pvlan_mapping</samp> instead.
+        # Use `switchport.pvlan_mapping` instead.
         pvlan_mapping: <str>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.vlan_translations</samp> instead.
+        # Use `switchport.vlan_translations` instead.
         vlan_translations:
 
             # List of vlans as string (only one vlan if direction is "both").
@@ -2019,7 +2019,7 @@
           # SRLG name or number.
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>srlgs</samp> instead.
+          # Use `srlgs` instead.
           srlg: <str>
           metric: <int; 1-16777215>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-name-server-groups.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ip-name-server-groups.md
@@ -38,7 +38,7 @@
         # Set domain names to complete unqualified host names.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>ip_domain_lists</samp> instead.
+        # Use `ip_domain_lists` instead.
         ip_domain_list: <str>
 
         # Set domain names to complete unqualified host names.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ipv6-static-routes.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/ipv6-static-routes.md
@@ -29,7 +29,7 @@
         # IPv6 Network/Mask.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>prefix</samp> instead.
+        # Use `prefix` instead.
         destination_address_prefix: <str>
 
         # IPv6 Network/Mask.
@@ -39,7 +39,7 @@
         # IPv6 Address.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>next_hop</samp> instead.
+        # Use `next_hop` instead.
         gateway: <str>
 
         # IPv6 Address.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -487,7 +487,7 @@
         # For an access port this would be a single vlan "123".
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.access_vlan or switchport.trunk.allowed_vlan</samp> instead.
+        # Use `switchport.access_vlan` or `switchport.trunk.allowed_vlan` instead.
         vlans: <str>
         snmp_trap_link_change: <bool>
 
@@ -501,7 +501,7 @@
         # VLAN tag to configure on sub-interface.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>encapsulation_dot1q.vlan</samp> instead.
+        # Use `encapsulation_dot1q.vlan` instead.
         encapsulation_dot1q_vlan: <int>
 
         # Warning: `encapsulation_dot1q` should not be combined with `ethernet_interfaces[].type: l3dot1q` or `ethernet_interfaces[].type: l2dot1q`.
@@ -584,19 +584,19 @@
         vlan_id: <int; 1-4094>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.mode</samp> instead.
+        # Use `switchport.mode` instead.
         mode: <str; "access" | "dot1q-tunnel" | "trunk" | "trunk phone">
 
         # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.trunk.native_vlan</samp> instead.
+        # Use `switchport.trunk.native_vlan` instead.
         native_vlan: <int>
 
         # If setting both native_vlan and native_vlan_tag, native_vlan_tag takes precedence.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.trunk.native_vlan_tag</samp> instead.
+        # Use `switchport.trunk.native_vlan_tag` instead.
         native_vlan_tag: <bool>
         link_tracking_groups:
 
@@ -613,7 +613,7 @@
             - <str>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.phone</samp> instead.
+        # Use `switchport.phone` instead.
         phone:
           trunk: <str; "tagged" | "untagged">
           vlan: <int; 1-4094>
@@ -630,7 +630,7 @@
         mlag: <int; 1-2000>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.trunk.groups</samp> instead.
+        # Use `switchport.trunk.groups` instead.
         trunk_groups:
           - <str>
 
@@ -683,17 +683,17 @@
         ntp_serve: <bool>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.trunk.private_vlan_secondary</samp> instead.
+        # Use `switchport.trunk.private_vlan_secondary` instead.
         trunk_private_vlan_secondary: <bool>
 
         # List of vlans as string.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.pvlan_mapping</samp> instead.
+        # Use `switchport.pvlan_mapping` instead.
         pvlan_mapping: <str>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>switchport.vlan_translations</samp> instead.
+        # Use `switchport.vlan_translations` instead.
         vlan_translations:
 
             # List of vlans as string (only one vlan if direction is "both").
@@ -754,13 +754,13 @@
         isis_hello_padding: <bool>
         # This key is deprecated.
         # Support will be removed in AVD version v6.0.0.
-        # Use <samp>port_channel_interfaces[].isis_authentication.both.mode or port_channel_interfaces[].isis_authentication.level_1.mode or port_channel_interfaces[].isis_authentication.level_2.mode</samp> instead.
+        # Use `port_channel_interfaces[].isis_authentication.both.mode` or `port_channel_interfaces[].isis_authentication.level_1.mode` or `port_channel_interfaces[].isis_authentication.level_2.mode` instead.
         isis_authentication_mode: <str; "text" | "md5">
 
         # Type-7 encrypted password.
         # This key is deprecated.
         # Support will be removed in AVD version v6.0.0.
-        # Use <samp>port_channel_interfaces[].isis_authentication.both.key or port_channel_interfaces[].isis_authentication.level_1.key or port_channel_interfaces[].isis_authentication.level_2.key</samp> instead.
+        # Use `port_channel_interfaces[].isis_authentication.both.key` or `port_channel_interfaces[].isis_authentication.level_1.key` or `port_channel_interfaces[].isis_authentication.level_2.key` instead.
         isis_authentication_key: <str>
 
         # This key should not be mixed with port_channel_interfaces[].isis_authentication_mode or ethernet_interfaces[].isis_authentication_key.
@@ -1467,7 +1467,7 @@
           # SRLG name or number.
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>srlgs</samp> instead.
+          # Use `srlgs` instead.
           srlg: <str>
           metric: <int; 1-16777215>
 

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/role-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/role-settings.md
@@ -38,6 +38,6 @@
       toc: <bool; default=True>
     # This key is deprecated.
     # Support will be removed in AVD version 6.0.0.
-    # Use <samp>eos_cli_config_gen_documentation.enable</samp> instead.
+    # Use `eos_cli_config_gen_documentation.enable` instead.
     generate_device_documentation: <bool; default=True>
     ```

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-bgp.md
@@ -2160,7 +2160,7 @@
           rcf: <str>
       # This key is deprecated.
       # Support will be removed in AVD version 6.0.0.
-      # Use <samp>redistribute</samp> instead.
+      # Use `redistribute` instead.
       redistribute_routes:
         - source_protocol: <str; "attached-host" | "bgp" | "connected" | "dynamic" | "isis" | "ospf" | "ospfv3" | "rip" | "static" | "user"; required>
           route_map: <str>
@@ -2448,7 +2448,7 @@
         # BGP additional-paths commands.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>bgp.additional_paths</samp> instead.
+        # Use `bgp.additional_paths` instead.
         bgp_additional_paths:
 
           # Receive multiple paths.
@@ -2750,7 +2750,7 @@
             rcf: <str>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>redistribute</samp> instead.
+        # Use `redistribute` instead.
         redistribute_routes:
           - source_protocol: <str; "attached-host" | "bgp" | "connected" | "dynamic" | "isis" | "ospf" | "ospfv3" | "rip" | "static" | "user"; required>
             route_map: <str>
@@ -3131,7 +3131,7 @@
             route_map: <str>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>redistribute</samp> instead.
+        # Use `redistribute` instead.
         redistribute_routes:
           - source_protocol: <str; required>
             route_map: <str>
@@ -3386,7 +3386,7 @@
             rcf: <str>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>redistribute</samp> instead.
+        # Use `redistribute` instead.
         redistribute_routes:
           - source_protocol: <str; required>
             route_map: <str>
@@ -3502,7 +3502,7 @@
             route_map: <str>
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>redistribute</samp> instead.
+        # Use `redistribute` instead.
         redistribute_routes:
           - source_protocol: <str; "connected" | "isis" | "ospf" | "ospfv3" | "static"; required>
 
@@ -4154,7 +4154,7 @@
               rcf: <str>
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>redistribute</samp> instead.
+          # Use `redistribute` instead.
           redistribute_routes:
             - source_protocol: <str; required>
               route_map: <str>
@@ -4389,7 +4389,7 @@
                 rcf: <str>
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
-            # Use <samp>redistribute</samp> instead.
+            # Use `redistribute` instead.
             redistribute_routes:
               - source_protocol: <str; "attached-host" | "bgp" | "connected" | "dynamic" | "isis" | "ospf" | "ospfv3" | "rip" | "static" | "user"; required>
                 route_map: <str>
@@ -4576,7 +4576,7 @@
                 rcf: <str>
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
-            # Use <samp>redistribute</samp> instead.
+            # Use `redistribute` instead.
             redistribute_routes:
               - source_protocol: <str; "attached-host" | "bgp" | "connected" | "dhcp" | "dynamic" | "isis" | "ospfv3" | "static" | "user"; required>
                 route_map: <str>
@@ -4700,7 +4700,7 @@
                 route_map: <str>
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
-            # Use <samp>redistribute</samp> instead.
+            # Use `redistribute` instead.
             redistribute_routes:
               - source_protocol: <str; "attached-host" | "connected" | "isis" | "ospf" | "ospfv3" | "static"; required>
                 route_map: <str>
@@ -4811,7 +4811,7 @@
                 route_map: <str>
             # This key is deprecated.
             # Support will be removed in AVD version 6.0.0.
-            # Use <samp>redistribute</samp> instead.
+            # Use `redistribute` instead.
             redistribute_routes:
               - source_protocol: <str; "connected" | "isis" | "ospf" | "ospfv3" | "static"; required>
                 route_map: <str>

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/router-path-selection.md
@@ -203,7 +203,7 @@
         # and multi-hop path MTU towards a remote VTEP (minus 40bytes to account for IP + TCP header).
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>ipv4</samp> instead.
+        # Use `ipv4` instead.
         ipv4_segment_size: <str>
 
         # Segment Size for IPv4.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/static-routes.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/static-routes.md
@@ -31,7 +31,7 @@
         # IPv4_network/Mask.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>prefix</samp> instead.
+        # Use `prefix` instead.
         destination_address_prefix: <str>
 
         # IPv4_network/Mask.
@@ -41,7 +41,7 @@
         # IPv4 Address.
         # This key is deprecated.
         # Support will be removed in AVD version 6.0.0.
-        # Use <samp>next_hop</samp> instead.
+        # Use `next_hop` instead.
         gateway: <str>
 
         # IPv4 Address.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vxlan-interface.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vxlan-interface.md
@@ -175,7 +175,7 @@
         eos_cli: <str>
       # This key is deprecated.
       # Support will be removed in AVD version 6.0.0.
-      # Use <samp>vxlan1</samp> instead.
+      # Use `vxlan1` instead.
       Vxlan1:
         description: <str>
         vxlan:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -274,7 +274,7 @@
     # List of DNS servers. The VRF is set to < mgmt_interface_vrf >.
     # This key is deprecated.
     # Support will be removed in AVD version 6.0.0.
-    # Use <samp>dns_settings.servers</samp> instead.
+    # Use `dns_settings.servers` instead.
     name_servers:
 
         # IPv4 or IPv6 address.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-source-interfaces-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-source-interfaces-settings.md
@@ -39,7 +39,7 @@
       # IP Domain Lookup source-interfaces.
       # This key is deprecated.
       # Support will be removed in AVD version 6.0.0.
-      # Use <samp>dns_settings</samp> instead.
+      # Use `dns_settings` instead.
       domain_lookup:
 
         # Configure an IP Domain Lookup source-interface with the interface set by `mgmt_interface` for the VRF set by `mgmt_interface_vrf`.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
@@ -240,13 +240,13 @@
                 # IPv4_address.
                 # This key is deprecated.
                 # Support will be removed in AVD version 6.0.0.
-                # Use <samp>prefix</samp> instead.
+                # Use `prefix` instead.
               - destination_address_prefix: <str>
 
                 # IPv4_address.
                 # This key is deprecated.
                 # Support will be removed in AVD version 6.0.0.
-                # Use <samp>next_hop</samp> instead.
+                # Use `next_hop` instead.
                 gateway: <str>
                 nodes:
                   - <str>
@@ -267,11 +267,11 @@
                 # IPv6_address.
                 # This key is deprecated.
                 # Support will be removed in AVD version 6.0.0.
-                # Use <samp>prefix</samp> instead.
+                # Use `prefix` instead.
               - destination_address_prefix: <str>
                 # This key is deprecated.
                 # Support will be removed in AVD version 6.0.0.
-                # Use <samp>next_hop</samp> instead.
+                # Use `next_hop` instead.
                 gateway: <str>
                 nodes:
                   - <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/node-type-keys.md
@@ -283,7 +283,7 @@
           # Path to Custom J2 template.
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>router_id_loopback_interface</samp> instead.
+          # Use `router_id_loopback_interface` instead.
           overlay_loopback_interface: <str>
 
     # Define Node Type Keys, to specify the properties of each node type in the fabric.
@@ -461,6 +461,6 @@
           # Path to Custom J2 template.
           # This key is deprecated.
           # Support will be removed in AVD version 6.0.0.
-          # Use <samp>router_id_loopback_interface</samp> instead.
+          # Use `router_id_loopback_interface` instead.
           overlay_loopback_interface: <str>
     ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/overlay-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/overlay-settings.md
@@ -70,7 +70,7 @@
     # Customize the description on overlay interface Loopback0.
     # This key is deprecated.
     # Support will be removed in AVD version 6.0.0.
-    # Use <samp>router_id_loopback_description</samp> instead.
+    # Use `router_id_loopback_description` instead.
     overlay_loopback_description: <str>
 
     # IPv6 Unnumbered for MLAG iBGP connections.

--- a/python-avd/schema_tools/generate_docs/yamllinegen.py
+++ b/python-avd/schema_tools/generate_docs/yamllinegen.py
@@ -157,7 +157,10 @@ class YamlLineGenBase:
             descriptions.append(f"Support will be removed in the first major AVD version released after {self.schema.deprecation.remove_after_date}.")
 
         if self.schema.deprecation.new_key:
-            descriptions.append(f"Use <samp>{self.schema.deprecation.new_key}</samp> instead.")
+            # Enclose each new key in backticks
+            new_keys = self.schema.deprecation.new_key.split(" or ")
+            new_keys = [f"`{new_key}`" for new_key in new_keys]
+            descriptions.append(f"Use {' or '.join(new_keys)} instead.")
 
         if self.schema.deprecation.url:
             descriptions.append(f"See [here]({self.schema.deprecation.url}) for details.")


### PR DESCRIPTION
Update YAML styled schema docs so the deprecation.new_key is enclosed in backticks instead of HTML tags.