### PR TITLE
Feat(eos_designs): VRF assignment improvements for snmp_settings

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
@@ -14,6 +14,17 @@ ip domain lookup vrf INBANDMGMT source-interface Vlan10
 ip name-server vrf default 8.8.8.8
 ip name-server vrf default 192.168.200.5
 !
+snmp-server ipv4 access-list SNMP-MGMT vrf MGMT
+snmp-server ipv4 access-list onur
+snmp-server ipv6 access-list SNMP-MGMT vrf MGMT
+snmp-server ipv6 access-list onur_v6
+snmp-server local-interface Management1
+snmp-server vrf INBANDMGMT local-interface Vlan10
+snmp-server host 10.6.75.127 version 2c SNMP-COMMUNITY-2
+snmp-server host 10.6.75.127 vrf INBANDMGMT version 2c SNMP-COMMUNITY-2
+snmp-server vrf default
+snmp-server vrf INBANDMGMT
+!
 management api http-commands
    protocol https
    no shutdown

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host2.cfg
@@ -10,6 +10,9 @@ service routing protocols model multi-agent
 !
 hostname host2
 !
+snmp-server host 10.6.75.127 vrf MGMT version 2c SNMP-COMMUNITY-2
+snmp-server vrf MGMT
+!
 vrf instance MGMT
 !
 management api http-commands
@@ -26,6 +29,12 @@ interface Loopback0
    node-segment ipv4 index 102
    isis enable CORE
    isis passive
+!
+interface Management1
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 192.168.100.123/24
 !
 ip virtual-router mac-address 00:1c:73:00:dc:01
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
@@ -144,6 +144,32 @@ router_bgp:
     - name: EVPN-OVERLAY-PEERS
       activate: false
 service_routing_protocols_model: multi-agent
+snmp_server:
+  ipv4_acls:
+  - name: SNMP-MGMT
+    vrf: MGMT
+  - name: onur
+  ipv6_acls:
+  - name: SNMP-MGMT
+    vrf: MGMT
+  - name: onur_v6
+  local_interfaces:
+  - name: Management1
+  - name: Vlan10
+    vrf: INBANDMGMT
+  hosts:
+  - host: 10.6.75.127
+    version: 2c
+    community: SNMP-COMMUNITY-2
+  - host: 10.6.75.127
+    vrf: INBANDMGMT
+    version: 2c
+    community: SNMP-COMMUNITY-2
+  vrfs:
+  - name: default
+    enable: true
+  - name: INBANDMGMT
+    enable: true
 static_routes:
 - vrf: default
   prefix: 0.0.0.0

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host2.yml
@@ -22,6 +22,13 @@ management_api_http:
   enable_https: true
   enable_vrfs:
   - name: MGMT
+management_interfaces:
+- name: Management1
+  description: OOB_MANAGEMENT
+  shutdown: false
+  vrf: MGMT
+  ip_address: 192.168.100.123/24
+  type: oob
 metadata:
   fabric_name: EOS_DESIGNS_DEPRECATED_VARS
 mpls:
@@ -75,6 +82,15 @@ router_isis:
     enabled: true
     router_id: 10.42.0.102
 service_routing_protocols_model: multi-agent
+snmp_server:
+  hosts:
+  - host: 10.6.75.127
+    vrf: MGMT
+    version: 2c
+    community: SNMP-COMMUNITY-2
+  vrfs:
+  - name: MGMT
+    enable: true
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/snmp-settings.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/snmp-settings.yml
@@ -1,0 +1,27 @@
+---
+# This tests the VRFs and SNMP hosts only using inband management VRF.
+snmp_settings:
+  # Deprecated. To be removed in 6.0.0
+  enable_inband_mgmt_vrf: true # This one *should* be in the output, since this host *has* inband mgmt
+  # Deprecated. To be removed in 6.0.0
+  enable_mgmt_interface_vrf: true # This one should not be in the output, since this host has no oob mgmt
+  hosts:
+    - host: 10.6.75.127
+      # Deprecated. To be removed in 6.0.0
+      use_inband_mgmt_vrf: true # This one *should* be in the output, since this host *has* inband mgmt
+      # Deprecated. To be removed in 6.0.0
+      use_mgmt_interface_vrf: true # This one should not be in the output, since this host has no oob mgmt
+      version: 2c
+      community: SNMP-COMMUNITY-2
+
+  # Deprecated. To be removed in 6.0.0
+  ipv4_acls: # Copied from eos_cli_config_gen, since we pass this through 1:1
+    - name: SNMP-MGMT
+      vrf: MGMT
+    - name: onur
+
+  # Deprecated. To be removed in 6.0.0
+  ipv6_acls: # Copied from eos_cli_config_gen, since we pass this through 1:1
+    - name: SNMP-MGMT
+      vrf: MGMT
+    - name: onur_v6

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/source-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/source-interfaces.yml
@@ -1,5 +1,9 @@
-# source_interfaces.domain_lookup is deprecated. To be removed in 6.0.0
 source_interfaces:
+  # source_interfaces.domain_lookup is deprecated. To be removed in 6.0.0
   domain_lookup:
+    mgmt_interface: true
+    inband_mgmt_interface: true
+  # source_interfaces.snmp is deprecated. To be removed in 6.0.0
+  snmp:
     mgmt_interface: true
     inband_mgmt_interface: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host2/node_type.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host2/node_type.yml
@@ -14,3 +14,4 @@ pe:
       id: 102
       bgp_as: 102
       virtual_router_mac_address: 00:1c:73:00:dc:01
+      mgmt_ip: 192.168.100.123/24

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host2/snmp-settings.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host2/snmp-settings.yml
@@ -1,0 +1,15 @@
+---
+# This tests the VRFs and SNMP hosts only using oob management VRF.
+snmp_settings:
+  # Deprecated. To be removed in 6.0.0
+  enable_inband_mgmt_vrf: true # This one should not be in the output, since this host has no inband mgmt
+  # Deprecated. To be removed in 6.0.0
+  enable_mgmt_interface_vrf: true # This one *should* be in the output, since this host *has* oob mgmt
+  hosts:
+    - host: 10.6.75.127
+      # Deprecated. To be removed in 6.0.0
+      use_inband_mgmt_vrf: true # This one should not be in the output, since this host has no inband mgmt
+      # Deprecated. To be removed in 6.0.0
+      use_mgmt_interface_vrf: true # This one *should* be in the output, since this host *has* oob mgmt
+      version: 2c
+      community: SNMP-COMMUNITY-2

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-1.cfg
@@ -10,11 +10,12 @@ service routing protocols model multi-agent
 !
 hostname snmp-settings-1
 !
-snmp-server ipv4 access-list SNMP-MGMT vrf MGMT
-snmp-server ipv4 access-list onur
-snmp-server ipv6 access-list SNMP-MGMT vrf MGMT
-snmp-server ipv6 access-list onur_v6
+snmp-server ipv4 access-list acl-for-vrf-default
+snmp-server ipv4 access-list acl-for-vrf-MGMT vrf MGMT
+snmp-server ipv6 access-list acl-for-vrf-default
+snmp-server ipv6 access-list acl-for-vrf-MGMT vrf MGMT
 snmp-server contact example@example.com
+snmp-server vrf MGMT local-interface Management1
 snmp-server view VW-READ iso included
 snmp-server view VW-WRITE iso included
 snmp-server community SNMP-COMMUNITY-1 ro onur
@@ -24,13 +25,10 @@ snmp-server group GRP-READ-ONLY v3 priv read v3read
 snmp-server group GRP-READ-WRITE v3 auth read v3read write v3write
 snmp-server user usertest-auth-priv usergroup v3 auth sha clearauth priv aes192 clearpriv
 snmp-server host 10.6.75.121 vrf SNMPVRF version 1 SNMP-COMMUNITY-1
-snmp-server host 10.6.75.123 vrf MGMT version 2c SNMP-COMMUNITY-2
-snmp-server host 10.6.75.123 vrf SNMPVRF version 2c SNMP-COMMUNITY-2
-snmp-server host 10.6.75.124 vrf MGMT version 3 auth USER-WRITE
+snmp-server host 10.6.75.124 version 3 auth USER-WRITE
 snmp-server host 10.6.75.125 vrf SNMPVRF version 2c SNMP-COMMUNITY-2
-snmp-server host 10.6.75.127 vrf MGMT version 2c SNMP-COMMUNITY-2
-snmp-server host 10.6.75.127 vrf SNMPVRF version 2c SNMP-COMMUNITY-2
-snmp-server host 10.6.75.128 vrf MGMT version 3 auth USER-WRITE
+snmp-server host 10.6.75.129 vrf MGMT version 2c SNMP-COMMUNITY-2
+snmp-server host 10.6.75.130 vrf MGMT version 2c SNMP-COMMUNITY-2
 snmp-server enable traps
 no snmp-server vrf default
 snmp-server vrf MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-2.cfg
@@ -10,12 +10,14 @@ service routing protocols model multi-agent
 !
 hostname snmp-settings-2
 !
-snmp-server host 10.6.75.125 version 2c SNMP-COMMUNITY-2
+snmp-server ipv4 access-list acl-for-vrf-default
+snmp-server ipv6 access-list acl-for-vrf-default
+snmp-server local-interface Vlan123
 snmp-server host 10.6.75.125 vrf SNMPVRF version 2c SNMP-COMMUNITY-2
 snmp-server host 10.6.75.126 version 3 auth USER-WRITE
-snmp-server host 10.6.75.127 version 2c SNMP-COMMUNITY-2
 snmp-server host 10.6.75.127 vrf SNMPVRF version 2c SNMP-COMMUNITY-2
-snmp-server host 10.6.75.128 version 3 auth USER-WRITE
+snmp-server host 10.6.75.129 version 2c SNMP-COMMUNITY-2
+snmp-server host 10.6.75.130 version 2c SNMP-COMMUNITY-2
 snmp-server enable traps foo
 snmp-server vrf default
 snmp-server vrf SNMPVRF

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-avd-6-behavior.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/snmp-settings-avd-6-behavior.cfg
@@ -1,0 +1,40 @@
+!
+no enable password
+no aaa root
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname snmp-settings-avd-6-behavior
+!
+snmp-server ipv4 access-list acl-for-vrf-MGMT
+snmp-server ipv4 access-list acl-for-vrf-default vrf default
+snmp-server ipv6 access-list acl-for-vrf-MGMT
+snmp-server ipv6 access-list acl-for-vrf-default vrf default
+snmp-server vrf MGMT local-interface Management1
+snmp-server host 10.6.75.124 version 3 auth USER-WRITE
+snmp-server host 10.6.75.130 vrf MGMT version 2c SNMP-COMMUNITY-2
+no snmp-server vrf default
+!
+vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+interface Management1
+   description OOB_MANAGEMENT
+   no shutdown
+   vrf MGMT
+   ip address 10.10.10.43/26
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 10.10.10.1
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/source-interfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/source-interfaces.cfg
@@ -10,9 +10,6 @@ service routing protocols model multi-agent
 !
 hostname source-interfaces
 !
-snmp-server local-interface Management1
-snmp-server vrf INBANDMGMT local-interface Vlan4092
-!
 vlan 4092
    name INBAND_MGMT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-1.yml
@@ -38,13 +38,16 @@ snmp_server:
     view: VW-READ
   - name: SNMP-COMMUNITY-3
   ipv4_acls:
-  - name: SNMP-MGMT
+  - name: acl-for-vrf-default
+  - name: acl-for-vrf-MGMT
     vrf: MGMT
-  - name: onur
   ipv6_acls:
-  - name: SNMP-MGMT
+  - name: acl-for-vrf-default
+  - name: acl-for-vrf-MGMT
     vrf: MGMT
-  - name: onur_v6
+  local_interfaces:
+  - name: Management1
+    vrf: MGMT
   views:
   - name: VW-WRITE
     mib_family_name: iso
@@ -75,16 +78,7 @@ snmp_server:
     vrf: SNMPVRF
     version: '1'
     community: SNMP-COMMUNITY-1
-  - host: 10.6.75.123
-    vrf: MGMT
-    version: 2c
-    community: SNMP-COMMUNITY-2
-  - host: 10.6.75.123
-    vrf: SNMPVRF
-    version: 2c
-    community: SNMP-COMMUNITY-2
   - host: 10.6.75.124
-    vrf: MGMT
     version: '3'
     users:
     - username: USER-WRITE
@@ -93,20 +87,14 @@ snmp_server:
     vrf: SNMPVRF
     version: 2c
     community: SNMP-COMMUNITY-2
-  - host: 10.6.75.127
+  - host: 10.6.75.129
     vrf: MGMT
     version: 2c
     community: SNMP-COMMUNITY-2
-  - host: 10.6.75.127
-    vrf: SNMPVRF
+  - host: 10.6.75.130
+    vrf: MGMT
     version: 2c
     community: SNMP-COMMUNITY-2
-  - host: 10.6.75.128
-    vrf: MGMT
-    version: '3'
-    users:
-    - username: USER-WRITE
-      authentication_level: auth
   traps:
     enable: true
   vrfs:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-avd-6-behavior.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-avd-6-behavior.yml
@@ -3,7 +3,7 @@ aaa_root:
 config_end: true
 enable_password:
   disabled: true
-hostname: snmp-settings-2
+hostname: snmp-settings-avd-6-behavior
 ip_igmp_snooping:
   globally_enabled: true
 is_deployed: true
@@ -11,62 +11,52 @@ management_api_http:
   enable_https: true
   enable_vrfs:
   - name: MGMT
+management_interfaces:
+- name: Management1
+  description: OOB_MANAGEMENT
+  shutdown: false
+  vrf: MGMT
+  ip_address: 10.10.10.43/26
+  type: oob
+  gateway: 10.10.10.1
 metadata:
   fabric_name: EOS_DESIGNS_UNIT_TESTS
 service_routing_protocols_model: multi-agent
 snmp_server:
   ipv4_acls:
+  - name: acl-for-vrf-MGMT
   - name: acl-for-vrf-default
+    vrf: default
   ipv6_acls:
+  - name: acl-for-vrf-MGMT
   - name: acl-for-vrf-default
+    vrf: default
   local_interfaces:
-  - name: Vlan123
+  - name: Management1
+    vrf: MGMT
   hosts:
-  - host: 10.6.75.125
-    vrf: SNMPVRF
-    version: 2c
-    community: SNMP-COMMUNITY-2
-  - host: 10.6.75.126
+  - host: 10.6.75.124
     version: '3'
     users:
     - username: USER-WRITE
       authentication_level: auth
-  - host: 10.6.75.127
-    vrf: SNMPVRF
-    version: 2c
-    community: SNMP-COMMUNITY-2
-  - host: 10.6.75.129
-    version: 2c
-    community: SNMP-COMMUNITY-2
   - host: 10.6.75.130
+    vrf: MGMT
     version: 2c
     community: SNMP-COMMUNITY-2
-  traps:
-    snmp_traps:
-    - name: foo
-      enabled: true
   vrfs:
   - name: default
-    enable: true
-  - name: SNMPVRF
-    enable: true
+    enable: false
+static_routes:
+- vrf: MGMT
+  prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
 transceiver_qsfp_default_mode_4x10: true
-vlan_interfaces:
-- name: Vlan123
-  description: Inband Management
-  shutdown: false
-  ip_address: 192.168.0.1/24
-  mtu: 1500
-  type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
   range:
     beginning: 1006
     ending: 1199
-vlans:
-- id: 4092
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces.yml
@@ -37,11 +37,6 @@ management_interfaces:
 metadata:
   fabric_name: EOS_DESIGNS_UNIT_TESTS
 service_routing_protocols_model: multi-agent
-snmp_server:
-  local_interfaces:
-  - name: Management1
-  - name: Vlan4092
-    vrf: INBANDMGMT
 static_routes:
 - vrf: INBANDMGMT
   prefix: 0.0.0.0/0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-1.yml
@@ -17,11 +17,17 @@ snmp_settings:
   contact: example@example.com
   location: false
 
-  enable_inband_mgmt_vrf: true # This one should not be in the output, since this host has no inband mgmt
-  enable_mgmt_interface_vrf: true
   vrfs:
     - name: default
       enable: false
+      ipv4_acl: acl-for-vrf-default
+      ipv6_acl: acl-for-vrf-default
+    # Testing automatically picking up the oob VRF with the 'use_default_mgmt_method_vrf' keyword.
+    # This errors if mgmt_ip is missing.
+    - name: use_default_mgmt_method_vrf
+      enable: true
+      ipv4_acl: acl-for-vrf-MGMT
+      ipv6_acl: acl-for-vrf-MGMT
   users:
     - name: usertest-auth-priv
       group: usergroup
@@ -36,41 +42,27 @@ snmp_settings:
       vrf: SNMPVRF
       version: 1
       community: SNMP-COMMUNITY-1
-    - host: 10.6.75.123
-      vrf: SNMPVRF
-      use_mgmt_interface_vrf: true
-      version: 2c
-      community: SNMP-COMMUNITY-2
     - host: 10.6.75.124
-      use_mgmt_interface_vrf: true
       version: 3
       users:
         - username: USER-WRITE
           authentication_level: auth
     - host: 10.6.75.125
       vrf: SNMPVRF
-      use_inband_mgmt_vrf: true
       version: 2c
       community: SNMP-COMMUNITY-2
-    - host: 10.6.75.126 # This one should not be in the output, since this host has no inband mgmt
-      use_inband_mgmt_vrf: true
-      version: 3
-      users:
-        - username: USER-WRITE
-          authentication_level: auth
-    - host: 10.6.75.127
-      vrf: SNMPVRF
-      use_inband_mgmt_vrf: true
-      use_mgmt_interface_vrf: true
+    # Testing automatically picking up the oob VRF with the 'use_mgmt_interface_vrf' keyword.
+    # This errors if mgmt_ip is missing.
+    - host: 10.6.75.129
+      vrf: use_mgmt_interface_vrf
       version: 2c
       community: SNMP-COMMUNITY-2
-    - host: 10.6.75.128
-      use_inband_mgmt_vrf: true
-      use_mgmt_interface_vrf: true
-      version: 3
-      users:
-        - username: USER-WRITE
-          authentication_level: auth
+    # Testing automatically picking up the oob VRF with the 'use_default_mgmt_method_vrf' keyword.
+    # This errors if mgmt_ip is missing.
+    - host: 10.6.75.130
+      vrf: use_default_mgmt_method_vrf
+      version: 2c
+      community: SNMP-COMMUNITY-2
 
   communities: # Copied from eos_cli_config_gen, since we pass this through 1:1
     - name: SNMP-COMMUNITY-1
@@ -85,16 +77,6 @@ snmp_settings:
         name: SNMP-MGMT
       view: VW-READ
     - name: SNMP-COMMUNITY-3
-
-  ipv4_acls: # Copied from eos_cli_config_gen, since we pass this through 1:1
-    - name: SNMP-MGMT
-      vrf: MGMT
-    - name: onur
-
-  ipv6_acls: # Copied from eos_cli_config_gen, since we pass this through 1:1
-    - name: SNMP-MGMT
-      vrf: MGMT
-    - name: onur_v6
 
   views: # Copied from eos_cli_config_gen, since we pass this through 1:1
     - name: VW-WRITE

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-1.yml
@@ -28,6 +28,7 @@ snmp_settings:
       enable: true
       ipv4_acl: acl-for-vrf-MGMT
       ipv6_acl: acl-for-vrf-MGMT
+    - name: vrf_without_enable
   users:
     - name: usertest-auth-priv
       group: usergroup

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-2.yml
@@ -11,37 +11,44 @@ l2leaf:
       inband_mgmt_interface: Vlan123
       # inband_mgmt_vrf: default ("default" by default)
 
+default_mgmt_method: inband
+
 snmp_settings:
-  enable_inband_mgmt_vrf: true # This one *should* be in the output, since this host *has* inband mgmt
-  enable_mgmt_interface_vrf: true # This one should not be in the output, since this host has no oob mgmt
   vrfs:
     - name: SNMPVRF
       enable: true
+    # Testing automatically picking up the inband VRF with the 'use_inband_mgmt_vrf' keyword.
+    # This errors if inband management is not configured.
+    - name: use_inband_mgmt_vrf
+      enable: true
+      ipv4_acl: acl-for-vrf-default
+      ipv6_acl: acl-for-vrf-default
   hosts:
     - host: 10.6.75.125
       vrf: SNMPVRF
-      use_inband_mgmt_vrf: true # This one *should* be in the output, since this host *has* inband mgmt
       version: 2c
       community: SNMP-COMMUNITY-2
     - host: 10.6.75.126
-      use_inband_mgmt_vrf: true # This one *should* be in the output, since this host *has* inband mgmt
       version: 3
       users:
         - username: USER-WRITE
           authentication_level: auth
     - host: 10.6.75.127
       vrf: SNMPVRF
-      use_inband_mgmt_vrf: true # This one *should* be in the output, since this host *has* inband mgmt
-      use_mgmt_interface_vrf: true # This one should not be in the output, since this host has no oob mgmt
       version: 2c
       community: SNMP-COMMUNITY-2
-    - host: 10.6.75.128
-      use_inband_mgmt_vrf: true # This one *should* be in the output, since this host *has* inband mgmt
-      use_mgmt_interface_vrf: true # This one should not be in the output, since this host has no oob mgmt
-      version: 3
-      users:
-        - username: USER-WRITE
-          authentication_level: auth
+    # Testing automatically picking up the inband VRF with the 'use_inband_mgmt_vrf' keyword.
+    # This errors if inband management is not configured.
+    - host: 10.6.75.129
+      vrf: use_inband_mgmt_vrf
+      version: 2c
+      community: SNMP-COMMUNITY-2
+    # Testing automatically picking up the inband VRF with the 'use_default_mgmt_method_vrf' keyword.
+    # This errors if inband management is not configured.
+    - host: 10.6.75.130
+      vrf: use_default_mgmt_method_vrf
+      version: 2c
+      community: SNMP-COMMUNITY-2
 
   traps:
     snmp_traps:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-avd-6-behavior.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/snmp-settings-avd-6-behavior.yml
@@ -1,0 +1,49 @@
+---
+# Minimum config to only test the specific feature.
+# This tests the general snmp_settings, excluding the tests for location, localize, engine id since that is tested in other files.
+# This tests the SNMP hosts ignoring inband management VRF.
+type: l2leaf
+
+l2leaf:
+  nodes:
+    - name: snmp-settings-avd-6-behavior
+      id: 43
+      mgmt_ip: 10.10.10.43/26
+
+mgmt_interface_vrf: MGMT
+mgmt_gateway: 10.10.10.1
+
+# AVD 6 behavior:
+# SNMP will only be enabled for VRFs specifically enabled under `snmp_settings.vrfs`.
+# Note this means SNMP will be disabled for VRF "default" unless it is defined there.
+# `snmp_settings.hosts[].vrf` defaults to `use_default_mgmt_method_vrf`.
+# If `default_mgmt_method` is 'none', the VRF must be specified. For VRF default set the string "default".
+avd_6_behaviors:
+  snmp_settings_vrfs: true
+
+snmp_settings:
+  hosts:
+    - host: 10.6.75.124
+      version: 3
+      vrf: default  # VRF must be set to "default" since the default changes.
+      users:
+        - username: USER-WRITE
+          authentication_level: auth
+    # Testing automatically picking up the oob VRF with the 'use_default_mgmt_method_vrf' keyword.
+    # This errors if mgmt_ip is missing.
+    - host: 10.6.75.130
+      # Notice no VRF here. With the AVD 6 behavior this means "use_default_mgmt_method_vrf"
+      version: 2c
+      community: SNMP-COMMUNITY-2
+
+  ipv4_acls:
+    - name: acl-for-vrf-MGMT
+      # Notice no VRF here. With the AVD 6 behavior this means "use_default_mgmt_method_vrf"
+    - name: acl-for-vrf-default
+      vrf: default  # VRF must be set to "default" since the default changes.
+
+  ipv6_acls:
+    - name: acl-for-vrf-MGMT
+      # Notice no VRF here. With the AVD 6 behavior this means "use_default_mgmt_method_vrf"
+    - name: acl-for-vrf-default
+      vrf: default  # VRF must be set to "default" since the default changes.

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/source-interfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/source-interfaces.yml
@@ -18,9 +18,6 @@ source_interfaces:
   radius:
     mgmt_interface: true
     inband_mgmt_interface: true
-  snmp:
-    mgmt_interface: true
-    inband_mgmt_interface: true
   ssh_client:
     mgmt_interface: true
     inband_mgmt_interface: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -348,6 +348,7 @@ all:
             SNMP_AUTOGEN_ENGINEID:
             snmp-settings-1:
             snmp-settings-2:
+            snmp-settings-avd-6-behavior:
         UNDERLAY_PEER_FILTER_TESTS:
           hosts:
             underlay_filter_peer_as_evpn_1:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-interface-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-interface-settings.md
@@ -7,7 +7,7 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>default_mgmt_method</samp>](## "default_mgmt_method") | String |  | `oob` | Valid Values:<br>- <code>oob</code><br>- <code>inband</code><br>- <code>none</code> | `default_mgmt_method` controls the default VRF and source interface used for the following management and monitoring protocols configured with `eos_designs`:<br>  - `ntp_settings`<br>  - `sflow_settings`<br><br>`oob` means the protocols will be configured with the VRF set by `mgmt_interface_vrf` and `mgmt_interface` as the source interface.<br>`inband` means the protocols will be configured with the VRF set by `inband_mgmt_vrf` and `inband_mgmt_interface` as the source interface.<br>`none` means the VRF and or interface must be manually set for each protocol.<br>This can be overridden under the settings for each protocol.<br> |
+    | [<samp>default_mgmt_method</samp>](## "default_mgmt_method") | String |  | `oob` | Valid Values:<br>- <code>oob</code><br>- <code>inband</code><br>- <code>none</code> | `default_mgmt_method` controls the default VRF and source interface used for the following management and monitoring protocols configured with `eos_designs`:<br>  - `logging_settings`<br>  - `ntp_settings`<br>  - `sflow_settings`<br>  - `snmp_settings`<br><br>`oob` means the protocols will be configured with the VRF set by `mgmt_interface_vrf` and `mgmt_interface` as the source interface.<br>`inband` means the protocols will be configured with the VRF set by `inband_mgmt_vrf` and `inband_mgmt_interface` as the source interface.<br>`none` means the VRF and or interface must be manually set for each protocol.<br>This can be overridden under the settings for each protocol.<br> |
     | [<samp>mgmt_destination_networks</samp>](## "mgmt_destination_networks") | List, items: String |  |  |  | List of IPv4 prefixes to configure as static routes towards the OOB Management interface gateway.<br>Replaces the default route. |
     | [<samp>&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "mgmt_destination_networks.[]") | String |  |  |  | IPv4_address/Mask. |
     | [<samp>mgmt_gateway</samp>](## "mgmt_gateway") | String |  |  |  | OOB Management interface gateway in IPv4 format.<br>Used as next-hop for default gateway or static routes defined under 'mgmt_destination_networks'.<br> |
@@ -20,8 +20,10 @@
 
     ```yaml
     # `default_mgmt_method` controls the default VRF and source interface used for the following management and monitoring protocols configured with `eos_designs`:
+    #   - `logging_settings`
     #   - `ntp_settings`
     #   - `sflow_settings`
+    #   - `snmp_settings`
     #
     # `oob` means the protocols will be configured with the VRF set by `mgmt_interface_vrf` and `mgmt_interface` as the source interface.
     # `inband` means the protocols will be configured with the VRF set by `inband_mgmt_vrf` and `inband_mgmt_interface` as the source interface.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
@@ -7,7 +7,7 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
-    | [<samp>snmp_settings</samp>](## "snmp_settings") | Dictionary |  |  |  | SNMP settings.<br>For SNMP local-interfaces see "source_interfaces.snmp".<br>Configuration of remote SNMP engine IDs are currently only possible using `structured_config`. |
+    | [<samp>snmp_settings</samp>](## "snmp_settings") | Dictionary |  |  |  | SNMP settings.<br>Configuration of remote SNMP engine IDs are currently only possible using `structured_config`. |
     | [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_settings.contact") | String |  |  |  | SNMP contact. |
     | [<samp>&nbsp;&nbsp;location</samp>](## "snmp_settings.location") | Boolean |  | `False` |  | Set SNMP location. Formatted as "<fabric_name> <dc_name> <pod_name> <switch_rack> <inventory_hostname>". |
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "snmp_settings.vrfs") | List, items: Dictionary |  |  |  |  |
@@ -75,7 +75,6 @@
 
     ```yaml
     # SNMP settings.
-    # For SNMP local-interfaces see "source_interfaces.snmp".
     # Configuration of remote SNMP engine IDs are currently only possible using `structured_config`.
     snmp_settings:
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-snmp-settings.md
@@ -10,11 +10,14 @@
     | [<samp>snmp_settings</samp>](## "snmp_settings") | Dictionary |  |  |  | SNMP settings.<br>For SNMP local-interfaces see "source_interfaces.snmp".<br>Configuration of remote SNMP engine IDs are currently only possible using `structured_config`. |
     | [<samp>&nbsp;&nbsp;contact</samp>](## "snmp_settings.contact") | String |  |  |  | SNMP contact. |
     | [<samp>&nbsp;&nbsp;location</samp>](## "snmp_settings.location") | Boolean |  | `False` |  | Set SNMP location. Formatted as "<fabric_name> <dc_name> <pod_name> <switch_rack> <inventory_hostname>". |
-    | [<samp>&nbsp;&nbsp;vrfs</samp>](## "snmp_settings.vrfs") | List, items: Dictionary |  |  |  | Enable/disable SNMP for one or more VRFs.<br>Can be used in combination with "enable_mgmt_interface_vrf" and "enable_inband_mgmt_vrf". |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "snmp_settings.vrfs.[].name") | String | Required, Unique |  |  | VRF name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_settings.vrfs.[].enable") | Boolean |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;enable_mgmt_interface_vrf</samp>](## "snmp_settings.enable_mgmt_interface_vrf") | Boolean |  |  |  | Enable/disable SNMP for the VRF set with "mgmt_interface_vrf".<br>Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device.<br>Can be used in combination with "vrfs" and "enable_inband_mgmt_vrf". |
-    | [<samp>&nbsp;&nbsp;enable_inband_mgmt_vrf</samp>](## "snmp_settings.enable_inband_mgmt_vrf") | Boolean |  |  |  | Enable/disable SNMP for the VRF set with "inband_mgmt_vrf".<br>Ignored if inband management is not configured for the device.<br>Can be used in combination with "vrfs" and "enable_mgmt_interface_vrf". |
+    | [<samp>&nbsp;&nbsp;vrfs</samp>](## "snmp_settings.vrfs") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "snmp_settings.vrfs.[].name") | String | Required, Unique |  |  | VRF name.<br>The value will be interpreted according to these rules:<br>- `use_mgmt_interface_vrf` will configure the SNMP ACL under the VRF set with `mgmt_interface_vrf`.<br>  An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.<br>- `use_inband_mgmt_vrf` will configure the SNMP ACL under the VRF set with `inband_mgmt_vrf`.<br>  An error will be raised if inband management is not configured for the device.<br>- `use_default_mgmt_method_vrf` will configure the VRF and source-interface for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the VRF name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enable</samp>](## "snmp_settings.vrfs.[].enable") | Boolean |  |  |  | Enable/disable SNMP for this VRF. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "snmp_settings.vrfs.[].source_interface") | String |  |  |  | Source interface to use for SNMP hosts in this VRF.<br>If set for the VRFs defined by `mgmt_interface_vrf` or `inband_mgmt_vrf`, this setting will take precedence. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl</samp>](## "snmp_settings.vrfs.[].ipv4_acl") | String |  |  |  | IPv4 access-list name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_acl</samp>](## "snmp_settings.vrfs.[].ipv6_acl") | String |  |  |  | IPv6 access-list name. |
+    | [<samp>&nbsp;&nbsp;enable_mgmt_interface_vrf</samp>](## "snmp_settings.enable_mgmt_interface_vrf") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable/disable SNMP for the VRF set with "mgmt_interface_vrf".<br>Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device.<br>Can be used in combination with "vrfs" and "enable_inband_mgmt_vrf".<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>vrfs[name="use_mgmt_interface_vrf"].enabled</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;enable_inband_mgmt_vrf</samp>](## "snmp_settings.enable_inband_mgmt_vrf") <span style="color:red">deprecated</span> | Boolean |  |  |  | Enable/disable SNMP for the VRF set with "inband_mgmt_vrf".<br>Ignored if inband management is not configured for the device.<br>Can be used in combination with "vrfs" and "enable_mgmt_interface_vrf".<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>vrfs[name="use_inband_mgmt_vrf"].enabled</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;compute_local_engineid</samp>](## "snmp_settings.compute_local_engineid") | Boolean |  | `False` |  | Generate a local engineId for SNMP using the 'compute_local_engineid_source' method.<br> |
     | [<samp>&nbsp;&nbsp;compute_local_engineid_source</samp>](## "snmp_settings.compute_local_engineid_source") | String |  | `hostname_and_ip` | Valid Values:<br>- <code>hostname_and_ip</code><br>- <code>system_mac</code> | `compute_local_engineid_source` supports:<br>- `hostname_and_ip` generate a local engineId for SNMP by hashing via SHA1<br>  the string generated via the concatenation of the hostname plus the management IP.<br>  {{ inventory_hostname }} + {{ switch.mgmt_ip }}.<br>- `system_mac` generate the switch default engine id for AVD usage.<br>  To use this, `system_mac_address` MUST be set for the device.<br>  The formula is f5717f + system_mac_address + 00.<br> |
     | [<samp>&nbsp;&nbsp;compute_v3_user_localized_key</samp>](## "snmp_settings.compute_v3_user_localized_key") | Boolean |  | `False` |  | Requires compute_local_engineid to be `true`.<br>If enabled, the SNMPv3 passphrases for auth and priv are transformed using RFC 2574, matching the value they would take in EOS CLI.<br>The algorithm requires a local engineId, which is unknown to AVD, hence the necessity to generate one beforehand.<br> |
@@ -28,9 +31,9 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;priv_passphrase</samp>](## "snmp_settings.users.[].priv_passphrase") | String |  |  |  | Cleartext passphrase so the recommendation is to use vault. Requires 'priv' to be set. |
     | [<samp>&nbsp;&nbsp;hosts</samp>](## "snmp_settings.hosts") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;host</samp>](## "snmp_settings.hosts.[].host") | String |  |  |  | Host IP address or name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_settings.hosts.[].vrf") | String |  |  |  | VRF Name.<br>Can be used in combination with "use_mgmt_interface_vrf" and "use_inband_mgmt_vrf" to configure the SNMP host under multiple VRFs. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_mgmt_interface_vrf</samp>](## "snmp_settings.hosts.[].use_mgmt_interface_vrf") | Boolean |  |  |  | Configure the SNMP host under the VRF set with "mgmt_interface_vrf". Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_inband_mgmt_vrf" to configure the SNMP host under multiple VRFs. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_inband_mgmt_vrf</samp>](## "snmp_settings.hosts.[].use_inband_mgmt_vrf") | Boolean |  |  |  | Configure the SNMP host under the VRF set with "inband_mgmt_vrf". Ignored if inband management is not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_mgmt_interface_vrf" to configure the SNMP host under multiple VRFs. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_settings.hosts.[].vrf") | String |  |  |  | VRF Name.<br>The value of `vrf` will be interpreted according to these rules:<br>- `use_mgmt_interface_vrf` will configure the SNMP host under the VRF set with `mgmt_interface_vrf` and set the `mgmt_interface` as SNMP source-interface.<br>  An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.<br>- `use_inband_mgmt_vrf` will configure the SNMP host under the VRF set with `inband_mgmt_vrf` and set the `inband_mgmt_interface` as SNMP source-interface.<br>  An error will be raised if inband management is not configured for the device.<br>- `use_default_mgmt_method_vrf` will configure the VRF and source-interface for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the VRF name. Remember to set the `snmp_settings.vrfs[].source_interface` if needed. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_mgmt_interface_vrf</samp>](## "snmp_settings.hosts.[].use_mgmt_interface_vrf") <span style="color:red">deprecated</span> | Boolean |  |  |  | Configure the SNMP host under the VRF set with "mgmt_interface_vrf". Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_inband_mgmt_vrf" to configure the SNMP host under multiple VRFs.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>vrf: "use_mgmt_interface_vrf"</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;use_inband_mgmt_vrf</samp>](## "snmp_settings.hosts.[].use_inband_mgmt_vrf") <span style="color:red">deprecated</span> | Boolean |  |  |  | Configure the SNMP host under the VRF set with "inband_mgmt_vrf". Ignored if inband management is not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_mgmt_interface_vrf" to configure the SNMP host under multiple VRFs.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>vrf: "use_inband_mgmt_vrf"</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_settings.hosts.[].version") | String |  |  | Valid Values:<br>- <code>1</code><br>- <code>2c</code><br>- <code>3</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;community</samp>](## "snmp_settings.hosts.[].community") | String |  |  |  | Community name. Required with version "1" or "2c". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;users</samp>](## "snmp_settings.hosts.[].users") | List, items: Dictionary |  |  |  |  |
@@ -44,10 +47,10 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;access_list_ipv6</samp>](## "snmp_settings.communities.[].access_list_ipv6") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "snmp_settings.communities.[].access_list_ipv6.name") | String |  |  |  | IPv6 access list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;view</samp>](## "snmp_settings.communities.[].view") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;ipv4_acls</samp>](## "snmp_settings.ipv4_acls") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;ipv4_acls</samp>](## "snmp_settings.ipv4_acls") <span style="color:red">deprecated</span> | List, items: Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>vrfs[].ipv4_acl</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "snmp_settings.ipv4_acls.[].name") | String |  |  |  | IPv4 access list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_settings.ipv4_acls.[].vrf") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;ipv6_acls</samp>](## "snmp_settings.ipv6_acls") | List, items: Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;ipv6_acls</samp>](## "snmp_settings.ipv6_acls") <span style="color:red">deprecated</span> | List, items: Dictionary |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>vrfs[].ipv6_acl</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "snmp_settings.ipv6_acls.[].name") | String |  |  |  | IPv6 access list name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vrf</samp>](## "snmp_settings.ipv6_acls.[].vrf") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;views</samp>](## "snmp_settings.views") | List, items: Dictionary |  |  |  |  |
@@ -81,23 +84,45 @@
 
       # Set SNMP location. Formatted as "<fabric_name> <dc_name> <pod_name> <switch_rack> <inventory_hostname>".
       location: <bool; default=False>
-
-      # Enable/disable SNMP for one or more VRFs.
-      # Can be used in combination with "enable_mgmt_interface_vrf" and "enable_inband_mgmt_vrf".
       vrfs:
 
           # VRF name.
+          # The value will be interpreted according to these rules:
+          # - `use_mgmt_interface_vrf` will configure the SNMP ACL under the VRF set with `mgmt_interface_vrf`.
+          #   An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.
+          # - `use_inband_mgmt_vrf` will configure the SNMP ACL under the VRF set with `inband_mgmt_vrf`.
+          #   An error will be raised if inband management is not configured for the device.
+          # - `use_default_mgmt_method_vrf` will configure the VRF and source-interface for one of the two options above depending on the value of `default_mgmt_method`.
+          # - Any other string will be used directly as the VRF name.
         - name: <str; required; unique>
+
+          # Enable/disable SNMP for this VRF.
           enable: <bool>
+
+          # Source interface to use for SNMP hosts in this VRF.
+          # If set for the VRFs defined by `mgmt_interface_vrf` or `inband_mgmt_vrf`, this setting will take precedence.
+          source_interface: <str>
+
+          # IPv4 access-list name.
+          ipv4_acl: <str>
+
+          # IPv6 access-list name.
+          ipv6_acl: <str>
 
       # Enable/disable SNMP for the VRF set with "mgmt_interface_vrf".
       # Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device.
       # Can be used in combination with "vrfs" and "enable_inband_mgmt_vrf".
+      # This key is deprecated.
+      # Support will be removed in AVD version 6.0.0.
+      # Use `vrfs[name="use_mgmt_interface_vrf"].enabled` instead.
       enable_mgmt_interface_vrf: <bool>
 
       # Enable/disable SNMP for the VRF set with "inband_mgmt_vrf".
       # Ignored if inband management is not configured for the device.
       # Can be used in combination with "vrfs" and "enable_mgmt_interface_vrf".
+      # This key is deprecated.
+      # Support will be removed in AVD version 6.0.0.
+      # Use `vrfs[name="use_inband_mgmt_vrf"].enabled` instead.
       enable_inband_mgmt_vrf: <bool>
 
       # Generate a local engineId for SNMP using the 'compute_local_engineid_source' method.
@@ -141,13 +166,25 @@
         - host: <str>
 
           # VRF Name.
-          # Can be used in combination with "use_mgmt_interface_vrf" and "use_inband_mgmt_vrf" to configure the SNMP host under multiple VRFs.
+          # The value of `vrf` will be interpreted according to these rules:
+          # - `use_mgmt_interface_vrf` will configure the SNMP host under the VRF set with `mgmt_interface_vrf` and set the `mgmt_interface` as SNMP source-interface.
+          #   An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.
+          # - `use_inband_mgmt_vrf` will configure the SNMP host under the VRF set with `inband_mgmt_vrf` and set the `inband_mgmt_interface` as SNMP source-interface.
+          #   An error will be raised if inband management is not configured for the device.
+          # - `use_default_mgmt_method_vrf` will configure the VRF and source-interface for one of the two options above depending on the value of `default_mgmt_method`.
+          # - Any other string will be used directly as the VRF name. Remember to set the `snmp_settings.vrfs[].source_interface` if needed.
           vrf: <str>
 
           # Configure the SNMP host under the VRF set with "mgmt_interface_vrf". Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_inband_mgmt_vrf" to configure the SNMP host under multiple VRFs.
+          # This key is deprecated.
+          # Support will be removed in AVD version 6.0.0.
+          # Use `vrf: "use_mgmt_interface_vrf"` instead.
           use_mgmt_interface_vrf: <bool>
 
           # Configure the SNMP host under the VRF set with "inband_mgmt_vrf". Ignored if inband management is not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all. Can be used in combination with "vrf" and "use_mgmt_interface_vrf" to configure the SNMP host under multiple VRFs.
+          # This key is deprecated.
+          # Support will be removed in AVD version 6.0.0.
+          # Use `vrf: "use_inband_mgmt_vrf"` instead.
           use_inband_mgmt_vrf: <bool>
           version: <str; "1" | "2c" | "3">
 
@@ -170,11 +207,17 @@
             # IPv6 access list name.
             name: <str>
           view: <str>
+      # This key is deprecated.
+      # Support will be removed in AVD version 6.0.0.
+      # Use `vrfs[].ipv4_acl` instead.
       ipv4_acls:
 
           # IPv4 access list name.
         - name: <str>
           vrf: <str>
+      # This key is deprecated.
+      # Support will be removed in AVD version 6.0.0.
+      # Use `vrfs[].ipv6_acl` instead.
       ipv6_acls:
 
           # IPv6 access list name.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-source-interfaces-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-source-interfaces-settings.md
@@ -17,7 +17,7 @@
     | [<samp>&nbsp;&nbsp;radius</samp>](## "source_interfaces.radius") | Dictionary |  |  |  | IP Radius source-interfaces. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mgmt_interface</samp>](## "source_interfaces.radius.mgmt_interface") | Boolean |  | `False` |  | Configure an IP Radius source-interface with the interface set by `mgmt_interface` for the VRF set by `mgmt_interface_vrf`.<br>`mgmt_interface` is typically the out-of-band Management interface, and can be set under the node settings, platform settings or as a group/host var. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;inband_mgmt_interface</samp>](## "source_interfaces.radius.inband_mgmt_interface") | Boolean |  | `False` |  | Configure an IP Radius source-interface with the interface set by `inband_mgmt_interface` for the VRF set by `inband_mgmt_vrf`.<br>`inband_mgmt_interface` is typically a loopback or SVI interface, and can be set under the node settings. |
-    | [<samp>&nbsp;&nbsp;snmp</samp>](## "source_interfaces.snmp") | Dictionary |  |  |  | SNMP local-interfaces. |
+    | [<samp>&nbsp;&nbsp;snmp</samp>](## "source_interfaces.snmp") <span style="color:red">deprecated</span> | Dictionary |  |  |  | SNMP local-interfaces.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>snmp_settings.vrfs[].source_interface or snmp_settings.hosts[].vrf: use_mgmt_interface_vrf or snmp_settings.hosts[].vrf: use_inband_mgmt_vrf or avd_6_behaviors.snmp_settings_vrfs</samp> instead.</span> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;mgmt_interface</samp>](## "source_interfaces.snmp.mgmt_interface") | Boolean |  | `False` |  | Configure a SNMP local-interface with the interface set by `mgmt_interface` for the VRF set by `mgmt_interface_vrf`.<br>`mgmt_interface` is typically the out-of-band Management interface, and can be set under the node settings, platform settings or as a group/host var. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;inband_mgmt_interface</samp>](## "source_interfaces.snmp.inband_mgmt_interface") | Boolean |  | `False` |  | Configure a SNMP local-interface with the interface set by `inband_mgmt_interface` for the VRF set by `inband_mgmt_vrf`.<br>`inband_mgmt_interface` is typically a loopback or SVI interface, and can be set under the node settings. |
     | [<samp>&nbsp;&nbsp;ssh_client</samp>](## "source_interfaces.ssh_client") | Dictionary |  |  |  | IP SSH Client source-interfaces. |
@@ -73,6 +73,9 @@
         inband_mgmt_interface: <bool; default=False>
 
       # SNMP local-interfaces.
+      # This key is deprecated.
+      # Support will be removed in AVD version 6.0.0.
+      # Use `snmp_settings.vrfs[].source_interface` or `snmp_settings.hosts[].vrf: use_mgmt_interface_vrf` or `snmp_settings.hosts[].vrf: use_inband_mgmt_vrf` or `avd_6_behaviors.snmp_settings_vrfs` instead.
       snmp:
 
         # Configure a SNMP local-interface with the interface set by `mgmt_interface` for the VRF set by `mgmt_interface_vrf`.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/role-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/role-settings.md
@@ -7,6 +7,8 @@
 
     | Variable | Type | Required | Default | Value Restrictions | Description |
     | -------- | ---- | -------- | ------- | ------------------ | ----------- |
+    | [<samp>avd_6_behaviors</samp>](## "avd_6_behaviors") <span style="color:red">deprecated</span> | Dictionary |  |  |  | Opt-in to AVD 6 behaviors. These behaviors will be the default behaviors in AVD 6.0.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0.</span> |
+    | [<samp>&nbsp;&nbsp;snmp_settings_vrfs</samp>](## "avd_6_behaviors.snmp_settings_vrfs") | Boolean |  | `False` |  | Opt-in to the new behavior for snmp_settings:<br>- SNMP will only be enabled for VRFs specifically enabled under `snmp_settings.vrfs`.<br>  Note this means SNMP will be disabled for VRF "default" unless it is defined there.<br>- `snmp_settings.hosts[].vrf` defaults to `use_default_mgmt_method_vrf`.<br>  If `default_mgmt_method` is 'none', the VRF must be specified. For VRF default set the string "default". |
     | [<samp>avd_eos_designs_debug</samp>](## "avd_eos_designs_debug") | Boolean |  | `False` |  | Dump all vars and facts per device after generating `avd_switch_facts`. |
     | [<samp>avd_eos_designs_enforce_duplication_checks_across_all_models</samp>](## "avd_eos_designs_enforce_duplication_checks_across_all_models") | Boolean |  | `False` |  | PREVIEW: This option is marked as "preview", while we refactor the code to conform to the described behavior.<br>When this is enabled, the generation of Structured Config in `eos_designs` will prevent duplicate objects generated<br>by different input models. This will also improve performance since `eos_designs` will not maintain separate copied of the Structured Configuration.<br>As an example, if you define an Ethernet interface under `l3_edge` and use the same interface for connectivity under `servers`:<br>- With this option disabled (default), AVD will merge these configurations together for the interface and not raise an error.<br>- With this option enabled, AVD will raise an error about duplicate interface definitions. |
     | [<samp>avd_eos_designs_structured_config</samp>](## "avd_eos_designs_structured_config") | Boolean |  | `True` |  | Generate structured configuration per device. |
@@ -21,6 +23,18 @@
 === "YAML"
 
     ```yaml
+    # Opt-in to AVD 6 behaviors. These behaviors will be the default behaviors in AVD 6.0.
+    # This key is deprecated.
+    # Support will be removed in AVD version 6.0.0.
+    avd_6_behaviors:
+
+      # Opt-in to the new behavior for snmp_settings:
+      # - SNMP will only be enabled for VRFs specifically enabled under `snmp_settings.vrfs`.
+      #   Note this means SNMP will be disabled for VRF "default" unless it is defined there.
+      # - `snmp_settings.hosts[].vrf` defaults to `use_default_mgmt_method_vrf`.
+      #   If `default_mgmt_method` is 'none', the VRF must be specified. For VRF default set the string "default".
+      snmp_settings_vrfs: <bool; default=False>
+
     # Dump all vars and facts per device after generating `avd_switch_facts`.
     avd_eos_designs_debug: <bool; default=False>
 

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -20,6 +20,48 @@ if TYPE_CHECKING:
 class EosDesigns(EosDesignsRootModel):
     """Subclass of EosDesignsRootModel."""
 
+    class Avd6Behaviors(AvdModel):
+        """Subclass of AvdModel."""
+
+        _fields: ClassVar[dict] = {"snmp_settings_vrfs": {"type": bool, "default": False}}
+        snmp_settings_vrfs: bool
+        """
+        Opt-in to the new behavior for snmp_settings:
+        - SNMP will only be enabled for VRFs specifically
+        enabled under `snmp_settings.vrfs`.
+          Note this means SNMP will be disabled for VRF "default" unless
+        it is defined there.
+        - `snmp_settings.hosts[].vrf` defaults to `use_default_mgmt_method_vrf`.
+          If
+        `default_mgmt_method` is 'none', the VRF must be specified. For VRF default set the string
+        "default".
+
+        Default value: `False`
+        """
+
+        if TYPE_CHECKING:
+
+            def __init__(self, *, snmp_settings_vrfs: bool | UndefinedType = Undefined) -> None:
+                """
+                Avd6Behaviors.
+
+
+                Subclass of AvdModel.
+
+                Args:
+                    snmp_settings_vrfs:
+                       Opt-in to the new behavior for snmp_settings:
+                       - SNMP will only be enabled for VRFs specifically
+                       enabled under `snmp_settings.vrfs`.
+                         Note this means SNMP will be disabled for VRF "default" unless
+                       it is defined there.
+                       - `snmp_settings.hosts[].vrf` defaults to `use_default_mgmt_method_vrf`.
+                         If
+                       `default_mgmt_method` is 'none', the VRF must be specified. For VRF default set the string
+                       "default".
+
+                """
+
     class BfdMultihop(AvdModel):
         """Subclass of AvdModel."""
 
@@ -12593,6 +12635,96 @@ class EosDesigns(EosDesignsRootModel):
     class SnmpSettings(AvdModel):
         """Subclass of AvdModel."""
 
+        class VrfsItem(AvdModel):
+            """Subclass of AvdModel."""
+
+            _fields: ClassVar[dict] = {
+                "name": {"type": str},
+                "enable": {"type": bool},
+                "source_interface": {"type": str},
+                "ipv4_acl": {"type": str},
+                "ipv6_acl": {"type": str},
+            }
+            name: str
+            """
+            VRF name.
+            The value will be interpreted according to these rules:
+            - `use_mgmt_interface_vrf` will
+            configure the SNMP ACL under the VRF set with `mgmt_interface_vrf`.
+              An error will be raised if
+            `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.
+            - `use_inband_mgmt_vrf` will
+            configure the SNMP ACL under the VRF set with `inband_mgmt_vrf`.
+              An error will be raised if inband
+            management is not configured for the device.
+            - `use_default_mgmt_method_vrf` will configure the VRF
+            and source-interface for one of the two options above depending on the value of
+            `default_mgmt_method`.
+            - Any other string will be used directly as the VRF name.
+            """
+            enable: bool | None
+            """Enable/disable SNMP for this VRF."""
+            source_interface: str | None
+            """
+            Source interface to use for SNMP hosts in this VRF.
+            If set for the VRFs defined by
+            `mgmt_interface_vrf` or `inband_mgmt_vrf`, this setting will take precedence.
+            """
+            ipv4_acl: str | None
+            """IPv4 access-list name."""
+            ipv6_acl: str | None
+            """IPv6 access-list name."""
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self,
+                    *,
+                    name: str | UndefinedType = Undefined,
+                    enable: bool | None | UndefinedType = Undefined,
+                    source_interface: str | None | UndefinedType = Undefined,
+                    ipv4_acl: str | None | UndefinedType = Undefined,
+                    ipv6_acl: str | None | UndefinedType = Undefined,
+                ) -> None:
+                    """
+                    VrfsItem.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        name:
+                           VRF name.
+                           The value will be interpreted according to these rules:
+                           - `use_mgmt_interface_vrf` will
+                           configure the SNMP ACL under the VRF set with `mgmt_interface_vrf`.
+                             An error will be raised if
+                           `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.
+                           - `use_inband_mgmt_vrf` will
+                           configure the SNMP ACL under the VRF set with `inband_mgmt_vrf`.
+                             An error will be raised if inband
+                           management is not configured for the device.
+                           - `use_default_mgmt_method_vrf` will configure the VRF
+                           and source-interface for one of the two options above depending on the value of
+                           `default_mgmt_method`.
+                           - Any other string will be used directly as the VRF name.
+                        enable: Enable/disable SNMP for this VRF.
+                        source_interface:
+                           Source interface to use for SNMP hosts in this VRF.
+                           If set for the VRFs defined by
+                           `mgmt_interface_vrf` or `inband_mgmt_vrf`, this setting will take precedence.
+                        ipv4_acl: IPv4 access-list name.
+                        ipv6_acl: IPv6 access-list name.
+
+                    """
+
+        class Vrfs(AvdIndexedList[str, VrfsItem]):
+            """Subclass of AvdIndexedList with `VrfsItem` items. Primary key is `name` (`str`)."""
+
+            _primary_key: ClassVar[str] = "name"
+
+        Vrfs._item_type = VrfsItem
+
         class UsersItem(AvdModel):
             """Subclass of AvdModel."""
 
@@ -12701,8 +12833,21 @@ class EosDesigns(EosDesignsRootModel):
             vrf: str | None
             """
             VRF Name.
-            Can be used in combination with "use_mgmt_interface_vrf" and "use_inband_mgmt_vrf" to
-            configure the SNMP host under multiple VRFs.
+            The value of `vrf` will be interpreted according to these rules:
+            -
+            `use_mgmt_interface_vrf` will configure the SNMP host under the VRF set with `mgmt_interface_vrf`
+            and set the `mgmt_interface` as SNMP source-interface.
+              An error will be raised if `mgmt_ip` or
+            `ipv6_mgmt_ip` are not configured for the device.
+            - `use_inband_mgmt_vrf` will configure the SNMP
+            host under the VRF set with `inband_mgmt_vrf` and set the `inband_mgmt_interface` as SNMP source-
+            interface.
+              An error will be raised if inband management is not configured for the device.
+            -
+            `use_default_mgmt_method_vrf` will configure the VRF and source-interface for one of the two options
+            above depending on the value of `default_mgmt_method`.
+            - Any other string will be used directly as
+            the VRF name. Remember to set the `snmp_settings.vrfs[].source_interface` if needed.
             """
             use_mgmt_interface_vrf: bool | None
             """
@@ -12747,8 +12892,21 @@ class EosDesigns(EosDesignsRootModel):
                         host: Host IP address or name.
                         vrf:
                            VRF Name.
-                           Can be used in combination with "use_mgmt_interface_vrf" and "use_inband_mgmt_vrf" to
-                           configure the SNMP host under multiple VRFs.
+                           The value of `vrf` will be interpreted according to these rules:
+                           -
+                           `use_mgmt_interface_vrf` will configure the SNMP host under the VRF set with `mgmt_interface_vrf`
+                           and set the `mgmt_interface` as SNMP source-interface.
+                             An error will be raised if `mgmt_ip` or
+                           `ipv6_mgmt_ip` are not configured for the device.
+                           - `use_inband_mgmt_vrf` will configure the SNMP
+                           host under the VRF set with `inband_mgmt_vrf` and set the `inband_mgmt_interface` as SNMP source-
+                           interface.
+                             An error will be raised if inband management is not configured for the device.
+                           -
+                           `use_default_mgmt_method_vrf` will configure the VRF and source-interface for one of the two options
+                           above depending on the value of `default_mgmt_method`.
+                           - Any other string will be used directly as
+                           the VRF name. Remember to set the `snmp_settings.vrfs[].source_interface` if needed.
                         use_mgmt_interface_vrf:
                            Configure the SNMP host under the VRF set with "mgmt_interface_vrf". Ignored if 'mgmt_ip' or
                            'ipv6_mgmt_ip' are not configured for the device, so if the host is only configured with this VRF,
@@ -12920,7 +13078,7 @@ class EosDesigns(EosDesignsRootModel):
         _fields: ClassVar[dict] = {
             "contact": {"type": str},
             "location": {"type": bool, "default": False},
-            "vrfs": {"type": EosCliConfigGen.SnmpServer.Vrfs},
+            "vrfs": {"type": Vrfs},
             "enable_mgmt_interface_vrf": {"type": bool},
             "enable_inband_mgmt_vrf": {"type": bool},
             "compute_local_engineid": {"type": bool, "default": False},
@@ -12944,12 +13102,8 @@ class EosDesigns(EosDesignsRootModel):
 
         Default value: `False`
         """
-        vrfs: EosCliConfigGen.SnmpServer.Vrfs
-        """
-        Enable/disable SNMP for one or more VRFs.
-        Can be used in combination with
-        "enable_mgmt_interface_vrf" and "enable_inband_mgmt_vrf".
-        """
+        vrfs: Vrfs
+        """Subclass of AvdIndexedList with `VrfsItem` items. Primary key is `name` (`str`)."""
         enable_mgmt_interface_vrf: bool | None
         """
         Enable/disable SNMP for the VRF set with "mgmt_interface_vrf".
@@ -13025,7 +13179,7 @@ class EosDesigns(EosDesignsRootModel):
                 *,
                 contact: str | None | UndefinedType = Undefined,
                 location: bool | UndefinedType = Undefined,
-                vrfs: EosCliConfigGen.SnmpServer.Vrfs | UndefinedType = Undefined,
+                vrfs: Vrfs | UndefinedType = Undefined,
                 enable_mgmt_interface_vrf: bool | None | UndefinedType = Undefined,
                 enable_inband_mgmt_vrf: bool | None | UndefinedType = Undefined,
                 compute_local_engineid: bool | UndefinedType = Undefined,
@@ -13051,10 +13205,7 @@ class EosDesigns(EosDesignsRootModel):
                     location:
                        Set SNMP location. Formatted as "<fabric_name> <dc_name> <pod_name> <switch_rack>
                        <inventory_hostname>".
-                    vrfs:
-                       Enable/disable SNMP for one or more VRFs.
-                       Can be used in combination with
-                       "enable_mgmt_interface_vrf" and "enable_inband_mgmt_vrf".
+                    vrfs: Subclass of AvdIndexedList with `VrfsItem` items. Primary key is `name` (`str`).
                     enable_mgmt_interface_vrf:
                        Enable/disable SNMP for the VRF set with "mgmt_interface_vrf".
                        Ignored if 'mgmt_ip' or
@@ -60218,6 +60369,7 @@ class EosDesigns(EosDesignsRootModel):
 
     _fields: ClassVar[dict] = {
         "application_classification": {"type": EosCliConfigGen.ApplicationTrafficRecognition},
+        "avd_6_behaviors": {"type": Avd6Behaviors},
         "avd_data_validation_mode": {"type": str, "default": "error"},
         "avd_eos_designs_debug": {"type": bool, "default": False},
         "avd_eos_designs_enforce_duplication_checks_across_all_models": {"type": bool, "default": False},
@@ -60611,6 +60763,13 @@ class EosDesigns(EosDesignsRootModel):
     _allow_other_keys: ClassVar[bool] = True
     application_classification: EosCliConfigGen.ApplicationTrafficRecognition
     """Application traffic recognition configuration."""
+    avd_6_behaviors: Avd6Behaviors
+    """
+    Opt-in to AVD 6 behaviors. These behaviors will be the default behaviors in AVD 6.0.
+
+    Subclass of
+    AvdModel.
+    """
     avd_data_validation_mode: Literal["error", "warning"]
     """
     Validation Mode for AVD input data validation.
@@ -62473,6 +62632,7 @@ class EosDesigns(EosDesignsRootModel):
             self,
             *,
             application_classification: EosCliConfigGen.ApplicationTrafficRecognition | UndefinedType = Undefined,
+            avd_6_behaviors: Avd6Behaviors | UndefinedType = Undefined,
             avd_data_validation_mode: Literal["error", "warning"] | UndefinedType = Undefined,
             avd_eos_designs_debug: bool | UndefinedType = Undefined,
             avd_eos_designs_enforce_duplication_checks_across_all_models: bool | UndefinedType = Undefined,
@@ -62682,6 +62842,11 @@ class EosDesigns(EosDesignsRootModel):
 
             Args:
                 application_classification: Application traffic recognition configuration.
+                avd_6_behaviors:
+                   Opt-in to AVD 6 behaviors. These behaviors will be the default behaviors in AVD 6.0.
+
+                   Subclass of
+                   AvdModel.
                 avd_data_validation_mode:
                    Validation Mode for AVD input data validation.
                    Input data validation will validate the input

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -61182,18 +61182,19 @@ class EosDesigns(EosDesignsRootModel):
     """
     `default_mgmt_method` controls the default VRF and source interface used for the following
     management and monitoring protocols configured with `eos_designs`:
-      - `ntp_settings`
+      - `logging_settings`
       -
-    `sflow_settings`
+    `ntp_settings`
+      - `sflow_settings`
+      - `snmp_settings`
 
-    `oob` means the protocols will be configured with the VRF set by
-    `mgmt_interface_vrf` and `mgmt_interface` as the source interface.
-    `inband` means the protocols will
-    be configured with the VRF set by `inband_mgmt_vrf` and `inband_mgmt_interface` as the source
-    interface.
-    `none` means the VRF and or interface must be manually set for each protocol.
-    This can be
-    overridden under the settings for each protocol.
+    `oob` means the protocols will be
+    configured with the VRF set by `mgmt_interface_vrf` and `mgmt_interface` as the source interface.
+    `inband` means the protocols will be configured with the VRF set by `inband_mgmt_vrf` and
+    `inband_mgmt_interface` as the source interface.
+    `none` means the VRF and or interface must be
+    manually set for each protocol.
+    This can be overridden under the settings for each protocol.
 
     Default value: `"oob"`
     """
@@ -63151,18 +63152,19 @@ class EosDesigns(EosDesignsRootModel):
                 default_mgmt_method:
                    `default_mgmt_method` controls the default VRF and source interface used for the following
                    management and monitoring protocols configured with `eos_designs`:
-                     - `ntp_settings`
+                     - `logging_settings`
                      -
-                   `sflow_settings`
+                   `ntp_settings`
+                     - `sflow_settings`
+                     - `snmp_settings`
 
-                   `oob` means the protocols will be configured with the VRF set by
-                   `mgmt_interface_vrf` and `mgmt_interface` as the source interface.
-                   `inband` means the protocols will
-                   be configured with the VRF set by `inband_mgmt_vrf` and `inband_mgmt_interface` as the source
-                   interface.
-                   `none` means the VRF and or interface must be manually set for each protocol.
-                   This can be
-                   overridden under the settings for each protocol.
+                   `oob` means the protocols will be
+                   configured with the VRF set by `mgmt_interface_vrf` and `mgmt_interface` as the source interface.
+                   `inband` means the protocols will be configured with the VRF set by `inband_mgmt_vrf` and
+                   `inband_mgmt_interface` as the source interface.
+                   `none` means the VRF and or interface must be
+                   manually set for each protocol.
+                   This can be overridden under the settings for each protocol.
                 default_network_ports_description:
                    Default description or description template to be used on all ports defined under `network_ports`.
                    This can be a template using the AVD string formatter syntax:

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -62223,9 +62223,8 @@ class EosDesigns(EosDesignsRootModel):
     snmp_settings: SnmpSettings
     """
     SNMP settings.
-    For SNMP local-interfaces see "source_interfaces.snmp".
-    Configuration of remote SNMP
-    engine IDs are currently only possible using `structured_config`.
+    Configuration of remote SNMP engine IDs are currently only possible using
+    `structured_config`.
 
     Subclass of AvdModel.
     """
@@ -63895,9 +63894,8 @@ class EosDesigns(EosDesignsRootModel):
                    are not present in the network.
                 snmp_settings:
                    SNMP settings.
-                   For SNMP local-interfaces see "source_interfaces.snmp".
-                   Configuration of remote SNMP
-                   engine IDs are currently only possible using `structured_config`.
+                   Configuration of remote SNMP engine IDs are currently only possible using
+                   `structured_config`.
 
                    Subclass of AvdModel.
                 source_interfaces:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -4094,8 +4094,6 @@ keys:
     type: dict
     description: 'SNMP settings.
 
-      For SNMP local-interfaces see "source_interfaces.snmp".
-
       Configuration of remote SNMP engine IDs are currently only possible using `structured_config`.'
     keys:
       contact:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -12,6 +12,25 @@ keys:
   application_classification:
     type: dict
     $ref: eos_cli_config_gen#/keys/application_traffic_recognition
+  avd_6_behaviors:
+    type: dict
+    description: Opt-in to AVD 6 behaviors. These behaviors will be the default behaviors
+      in AVD 6.0.
+    documentation_options:
+      table: role-settings
+    deprecation:
+      warning: false
+      remove_in_version: 6.0.0
+    keys:
+      snmp_settings_vrfs:
+        type: bool
+        default: false
+        description: "Opt-in to the new behavior for snmp_settings:\n- SNMP will only
+          be enabled for VRFs specifically enabled under `snmp_settings.vrfs`.\n  Note
+          this means SNMP will be disabled for VRF \"default\" unless it is defined
+          there.\n- `snmp_settings.hosts[].vrf` defaults to `use_default_mgmt_method_vrf`.\n
+          \ If `default_mgmt_method` is 'none', the VRF must be specified. For VRF
+          default set the string \"default\"."
   avd_data_conversion_mode:
     documentation_options:
       table: role-input-validation
@@ -4088,11 +4107,44 @@ keys:
         description: Set SNMP location. Formatted as "<fabric_name> <dc_name> <pod_name>
           <switch_rack> <inventory_hostname>".
       vrfs:
-        $ref: eos_cli_config_gen#/keys/snmp_server/keys/vrfs
         type: list
-        description: 'Enable/disable SNMP for one or more VRFs.
+        primary_key: name
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: "VRF name.\nThe value will be interpreted according to
+                these rules:\n- `use_mgmt_interface_vrf` will configure the SNMP ACL
+                under the VRF set with `mgmt_interface_vrf`.\n  An error will be raised
+                if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.\n-
+                `use_inband_mgmt_vrf` will configure the SNMP ACL under the VRF set
+                with `inband_mgmt_vrf`.\n  An error will be raised if inband management
+                is not configured for the device.\n- `use_default_mgmt_method_vrf`
+                will configure the VRF and source-interface for one of the two options
+                above depending on the value of `default_mgmt_method`.\n- Any other
+                string will be used directly as the VRF name."
+              convert_types:
+              - int
+            enable:
+              type: bool
+              description: Enable/disable SNMP for this VRF.
+            source_interface:
+              type: str
+              description: 'Source interface to use for SNMP hosts in this VRF.
 
-          Can be used in combination with "enable_mgmt_interface_vrf" and "enable_inband_mgmt_vrf".'
+                If set for the VRFs defined by `mgmt_interface_vrf` or `inband_mgmt_vrf`,
+                this setting will take precedence.'
+            ipv4_acl:
+              type: str
+              description: IPv4 access-list name.
+              convert_types:
+              - int
+            ipv6_acl:
+              type: str
+              description: IPv6 access-list name.
+              convert_types:
+              - int
       enable_mgmt_interface_vrf:
         type: bool
         description: 'Enable/disable SNMP for the VRF set with "mgmt_interface_vrf".
@@ -4100,6 +4152,10 @@ keys:
           Ignored if ''mgmt_ip'' or ''ipv6_mgmt_ip'' are not configured for the device.
 
           Can be used in combination with "vrfs" and "enable_inband_mgmt_vrf".'
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: vrfs[name="use_mgmt_interface_vrf"].enabled
       enable_inband_mgmt_vrf:
         type: bool
         description: 'Enable/disable SNMP for the VRF set with "inband_mgmt_vrf".
@@ -4107,6 +4163,10 @@ keys:
           Ignored if inband management is not configured for the device.
 
           Can be used in combination with "vrfs" and "enable_mgmt_interface_vrf".'
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: vrfs[name="use_inband_mgmt_vrf"].enabled
       compute_local_engineid:
         type: bool
         default: false
@@ -4189,13 +4249,21 @@ keys:
           keys:
             host:
               type: str
-              $ref: eos_cli_config_gen#/keys/snmp_server/keys/hosts/items/keys/host
             vrf:
               type: str
-              description: 'VRF Name.
-
-                Can be used in combination with "use_mgmt_interface_vrf" and "use_inband_mgmt_vrf"
-                to configure the SNMP host under multiple VRFs.'
+              description: "VRF Name.\nThe value of `vrf` will be interpreted according
+                to these rules:\n- `use_mgmt_interface_vrf` will configure the SNMP
+                host under the VRF set with `mgmt_interface_vrf` and set the `mgmt_interface`
+                as SNMP source-interface.\n  An error will be raised if `mgmt_ip`
+                or `ipv6_mgmt_ip` are not configured for the device.\n- `use_inband_mgmt_vrf`
+                will configure the SNMP host under the VRF set with `inband_mgmt_vrf`
+                and set the `inband_mgmt_interface` as SNMP source-interface.\n  An
+                error will be raised if inband management is not configured for the
+                device.\n- `use_default_mgmt_method_vrf` will configure the VRF and
+                source-interface for one of the two options above depending on the
+                value of `default_mgmt_method`.\n- Any other string will be used directly
+                as the VRF name. Remember to set the `snmp_settings.vrfs[].source_interface`
+                if needed."
               convert_types:
               - int
             use_mgmt_interface_vrf:
@@ -4206,6 +4274,10 @@ keys:
                 will not be configured at all. Can be used in combination with "vrf"
                 and "use_inband_mgmt_vrf" to configure the SNMP host under multiple
                 VRFs.
+              deprecation:
+                warning: true
+                remove_in_version: 6.0.0
+                new_key: 'vrf: "use_mgmt_interface_vrf"'
             use_inband_mgmt_vrf:
               type: bool
               description: Configure the SNMP host under the VRF set with "inband_mgmt_vrf".
@@ -4213,15 +4285,27 @@ keys:
                 if the host is only configured with this VRF, the host will not be
                 configured at all. Can be used in combination with "vrf" and "use_mgmt_interface_vrf"
                 to configure the SNMP host under multiple VRFs.
+              deprecation:
+                warning: true
+                remove_in_version: 6.0.0
+                new_key: 'vrf: "use_inband_mgmt_vrf"'
       communities:
         type: list
         $ref: eos_cli_config_gen#/keys/snmp_server/keys/communities
       ipv4_acls:
         type: list
         $ref: eos_cli_config_gen#/keys/snmp_server/keys/ipv4_acls
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: vrfs[].ipv4_acl
       ipv6_acls:
         type: list
         $ref: eos_cli_config_gen#/keys/snmp_server/keys/ipv6_acls
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: vrfs[].ipv6_acl
       views:
         type: list
         $ref: eos_cli_config_gen#/keys/snmp_server/keys/views
@@ -4316,6 +4400,12 @@ keys:
       snmp:
         type: dict
         description: SNMP local-interfaces.
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: 'snmp_settings.vrfs[].source_interface or snmp_settings.hosts[].vrf:
+            use_mgmt_interface_vrf or snmp_settings.hosts[].vrf: use_inband_mgmt_vrf
+            or avd_6_behaviors.snmp_settings_vrfs'
         keys:
           mgmt_interface:
             type: bool

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -1084,12 +1084,12 @@ keys:
     type: str
     description: "`default_mgmt_method` controls the default VRF and source interface
       used for the following management and monitoring protocols configured with `eos_designs`:\n
-      \ - `ntp_settings`\n  - `sflow_settings`\n\n`oob` means the protocols will be
-      configured with the VRF set by `mgmt_interface_vrf` and `mgmt_interface` as
-      the source interface.\n`inband` means the protocols will be configured with
-      the VRF set by `inband_mgmt_vrf` and `inband_mgmt_interface` as the source interface.\n`none`
-      means the VRF and or interface must be manually set for each protocol.\nThis
-      can be overridden under the settings for each protocol.\n"
+      \ - `logging_settings`\n  - `ntp_settings`\n  - `sflow_settings`\n  - `snmp_settings`\n\n`oob`
+      means the protocols will be configured with the VRF set by `mgmt_interface_vrf`
+      and `mgmt_interface` as the source interface.\n`inband` means the protocols
+      will be configured with the VRF set by `inband_mgmt_vrf` and `inband_mgmt_interface`
+      as the source interface.\n`none` means the VRF and or interface must be manually
+      set for each protocol.\nThis can be overridden under the settings for each protocol.\n"
     valid_values:
     - oob
     - inband

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_6_behaviors.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_6_behaviors.schema.yml
@@ -1,0 +1,27 @@
+# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
+# yaml-language-server: $schema=../../../_schema/avd_meta_schema.json
+# Line above is used by RedHat's YAML Schema vscode extension
+# Use Ctrl + Space to get suggestions for every field. Autocomplete will pop up after typing 2 letters.
+type: dict
+keys:
+  avd_6_behaviors:
+    type: dict
+    description: |-
+      Opt-in to AVD 6 behaviors. These behaviors will be the default behaviors in AVD 6.0.
+    documentation_options:
+      table: role-settings
+    deprecation:
+      warning: false
+      remove_in_version: 6.0.0
+    keys:
+      snmp_settings_vrfs:
+        type: bool
+        default: false
+        description: |-
+          Opt-in to the new behavior for snmp_settings:
+          - SNMP will only be enabled for VRFs specifically enabled under `snmp_settings.vrfs`.
+            Note this means SNMP will be disabled for VRF "default" unless it is defined there.
+          - `snmp_settings.hosts[].vrf` defaults to `use_default_mgmt_method_vrf`.
+            If `default_mgmt_method` is 'none', the VRF must be specified. For VRF default set the string "default".

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_mgmt_method.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_mgmt_method.schema.yml
@@ -12,8 +12,10 @@ keys:
     type: str
     description: |
       `default_mgmt_method` controls the default VRF and source interface used for the following management and monitoring protocols configured with `eos_designs`:
+        - `logging_settings`
         - `ntp_settings`
         - `sflow_settings`
+        - `snmp_settings`
 
       `oob` means the protocols will be configured with the VRF set by `mgmt_interface_vrf` and `mgmt_interface` as the source interface.
       `inband` means the protocols will be configured with the VRF set by `inband_mgmt_vrf` and `inband_mgmt_interface` as the source interface.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/snmp_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/snmp_settings.schema.yml
@@ -23,23 +23,63 @@ keys:
         default: false
         description: Set SNMP location. Formatted as "<fabric_name> <dc_name> <pod_name> <switch_rack> <inventory_hostname>".
       vrfs:
-        $ref: "eos_cli_config_gen#/keys/snmp_server/keys/vrfs"
         type: list
-        description: |-
-          Enable/disable SNMP for one or more VRFs.
-          Can be used in combination with "enable_mgmt_interface_vrf" and "enable_inband_mgmt_vrf".
+        primary_key: name
+        items:
+          type: dict
+          keys:
+            name:
+              type: str
+              description: |-
+                VRF name.
+                The value will be interpreted according to these rules:
+                - `use_mgmt_interface_vrf` will configure the SNMP ACL under the VRF set with `mgmt_interface_vrf`.
+                  An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.
+                - `use_inband_mgmt_vrf` will configure the SNMP ACL under the VRF set with `inband_mgmt_vrf`.
+                  An error will be raised if inband management is not configured for the device.
+                - `use_default_mgmt_method_vrf` will configure the VRF and source-interface for one of the two options above depending on the value of `default_mgmt_method`.
+                - Any other string will be used directly as the VRF name.
+              convert_types:
+                - int
+            enable:
+              type: bool
+              description: |-
+                Enable/disable SNMP for this VRF.
+            source_interface:
+              type: str
+              description: |-
+                Source interface to use for SNMP hosts in this VRF.
+                If set for the VRFs defined by `mgmt_interface_vrf` or `inband_mgmt_vrf`, this setting will take precedence.
+            ipv4_acl:
+              type: str
+              description: IPv4 access-list name.
+              convert_types:
+                - int
+            ipv6_acl:
+              type: str
+              description: IPv6 access-list name.
+              convert_types:
+                - int
       enable_mgmt_interface_vrf:
         type: bool
         description: |-
           Enable/disable SNMP for the VRF set with "mgmt_interface_vrf".
           Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device.
           Can be used in combination with "vrfs" and "enable_inband_mgmt_vrf".
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: vrfs[name="use_mgmt_interface_vrf"].enabled
       enable_inband_mgmt_vrf:
         type: bool
         description: |-
           Enable/disable SNMP for the VRF set with "inband_mgmt_vrf".
           Ignored if inband management is not configured for the device.
           Can be used in combination with "vrfs" and "enable_mgmt_interface_vrf".
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: vrfs[name="use_inband_mgmt_vrf"].enabled
       compute_local_engineid:
         type: bool
         default: false
@@ -101,15 +141,19 @@ keys:
         items:
           type: dict
           keys:
-            # Redefine host here to ensure it comes first in the docs.
             host:
               type: str
-              $ref: "eos_cli_config_gen#/keys/snmp_server/keys/hosts/items/keys/host"
             vrf:
               type: str
               description: |-
                 VRF Name.
-                Can be used in combination with "use_mgmt_interface_vrf" and "use_inband_mgmt_vrf" to configure the SNMP host under multiple VRFs.
+                The value of `vrf` will be interpreted according to these rules:
+                - `use_mgmt_interface_vrf` will configure the SNMP host under the VRF set with `mgmt_interface_vrf` and set the `mgmt_interface` as SNMP source-interface.
+                  An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.
+                - `use_inband_mgmt_vrf` will configure the SNMP host under the VRF set with `inband_mgmt_vrf` and set the `inband_mgmt_interface` as SNMP source-interface.
+                  An error will be raised if inband management is not configured for the device.
+                - `use_default_mgmt_method_vrf` will configure the VRF and source-interface for one of the two options above depending on the value of `default_mgmt_method`.
+                - Any other string will be used directly as the VRF name. Remember to set the `snmp_settings.vrfs[].source_interface` if needed.
               convert_types:
                 - int
             use_mgmt_interface_vrf:
@@ -118,21 +162,41 @@ keys:
                 Configure the SNMP host under the VRF set with "mgmt_interface_vrf".
                 Ignored if 'mgmt_ip' or 'ipv6_mgmt_ip' are not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all.
                 Can be used in combination with "vrf" and "use_inband_mgmt_vrf" to configure the SNMP host under multiple VRFs.
+              deprecation:
+                warning: true
+                remove_in_version: 6.0.0
+                new_key: |-
+                  vrf: "use_mgmt_interface_vrf"
             use_inband_mgmt_vrf:
               type: bool
               description:
                 Configure the SNMP host under the VRF set with "inband_mgmt_vrf".
                 Ignored if inband management is not configured for the device, so if the host is only configured with this VRF, the host will not be configured at all.
                 Can be used in combination with "vrf" and "use_mgmt_interface_vrf" to configure the SNMP host under multiple VRFs.
+              deprecation:
+                warning: true
+                remove_in_version: 6.0.0
+                new_key: |-
+                  vrf: "use_inband_mgmt_vrf"
       communities:
         type: list
         $ref: "eos_cli_config_gen#/keys/snmp_server/keys/communities"
       ipv4_acls:
         type: list
         $ref: "eos_cli_config_gen#/keys/snmp_server/keys/ipv4_acls"
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: |-
+            vrfs[].ipv4_acl
       ipv6_acls:
         type: list
         $ref: "eos_cli_config_gen#/keys/snmp_server/keys/ipv6_acls"
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: |-
+            vrfs[].ipv6_acl
       views:
         type: list
         $ref: "eos_cli_config_gen#/keys/snmp_server/keys/views"

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/snmp_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/snmp_settings.schema.yml
@@ -12,7 +12,6 @@ keys:
     type: dict
     description: |-
       SNMP settings.
-      For SNMP local-interfaces see "source_interfaces.snmp".
       Configuration of remote SNMP engine IDs are currently only possible using `structured_config`.
     keys:
       contact:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/source_interfaces.schema.yml
@@ -71,6 +71,14 @@ keys:
       snmp:
         type: dict
         description: SNMP local-interfaces.
+        deprecation:
+          warning: true
+          remove_in_version: 6.0.0
+          new_key: >-
+            snmp_settings.vrfs[].source_interface
+            or snmp_settings.hosts[].vrf: use_mgmt_interface_vrf
+            or snmp_settings.hosts[].vrf: use_inband_mgmt_vrf
+            or avd_6_behaviors.snmp_settings_vrfs
         keys:
           mgmt_interface:
             type: bool

--- a/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
@@ -45,15 +45,16 @@ class SnmpServerMixin(Protocol):
         self._snmp_engine_ids(snmp_settings)
         self._snmp_location(snmp_settings)
         self._snmp_users(snmp_settings)
+        # Local interfaces first, since it may be updated by snmp_hosts.
+        self._snmp_local_interfaces(source_interfaces_inputs)
         self._snmp_hosts(snmp_settings)
         self._snmp_vrfs(snmp_settings)
-        self._snmp_local_interfaces(source_interfaces_inputs)
+        self._snmp_ipv4_acls(snmp_settings)
+        self._snmp_ipv6_acls(snmp_settings)
 
         self.structured_config.snmp_server._update(
             contact=snmp_settings.contact,
             communities=snmp_settings.communities,
-            ipv4_acls=snmp_settings.ipv4_acls._cast_as(EosCliConfigGen.SnmpServer.Ipv4Acls),
-            ipv6_acls=snmp_settings.ipv6_acls._cast_as(EosCliConfigGen.SnmpServer.Ipv6Acls),
             views=snmp_settings.views._cast_as(EosCliConfigGen.SnmpServer.Views),
             groups=snmp_settings.groups._cast_as(EosCliConfigGen.SnmpServer.Groups),
             traps=snmp_settings.traps,
@@ -154,8 +155,18 @@ class SnmpServerMixin(Protocol):
         for host in natural_sort(hosts, "host"):
             host: EosDesigns.SnmpSettings.HostsItem
             vrfs = set()
-            if vrf := host.vrf:
-                vrfs.add(vrf)
+            # TODO: 6.0 remove the if condition since we have a default value for VRF.
+            if (vrf := host.vrf) or self.inputs.avd_6_behaviors.snmp_settings_vrfs:
+                host_vrf, source_interface = self._get_vrf_and_source_interface(
+                    vrf_input=vrf,
+                    vrfs=snmp_settings.vrfs,
+                    set_source_interfaces=True,
+                    context=f"snmp_settings.hosts[host={host.host}].vrf",
+                )
+                vrfs.add(host_vrf)
+
+                if source_interface:
+                    self.structured_config.snmp_server.local_interfaces.append_new(name=source_interface, vrf=host_vrf if host_vrf != "default" else None)
 
             if (use_mgmt_interface_vrf := host.use_mgmt_interface_vrf) and has_mgmt_ip:
                 vrfs.add(self.inputs.mgmt_interface_vrf)
@@ -187,17 +198,24 @@ class SnmpServerMixin(Protocol):
         self.structured_config.snmp_server.hosts = snmp_hosts
 
     def _snmp_local_interfaces(self: AvdStructuredConfigBaseProtocol, source_interfaces_inputs: EosDesigns.SourceInterfaces.Snmp) -> None:
-        """Set local_interfaces if "source_interfaces.snmp" is set."""
-        if not source_interfaces_inputs:
-            # Empty dict or None
-            return
-        local_interfaces = self._build_source_interfaces(
-            source_interfaces_inputs.mgmt_interface,
-            source_interfaces_inputs.inband_mgmt_interface,
-            error_context="SNMP",
-            output_type=EosCliConfigGen.SnmpServer.LocalInterfaces,
-        )
-        self.structured_config.snmp_server.local_interfaces = local_interfaces
+        """
+        Set local_interfaces from "source_interfaces.snmp" or "snmp_settings.vrfs[].source_interface.
+
+        TODO: AVD6.0 remove the legacy inputs.
+        """
+        if source_interfaces_inputs and not self.inputs.avd_6_behaviors.snmp_settings_vrfs:
+            self.structured_config.snmp_server.local_interfaces = self._build_source_interfaces(
+                source_interfaces_inputs.mgmt_interface,
+                source_interfaces_inputs.inband_mgmt_interface,
+                error_context="SNMP",
+                output_type=EosCliConfigGen.SnmpServer.LocalInterfaces,
+            )
+
+        # Settings defined under vrf.source_interface will take precedence over the legacy source_interfaces.snmp inputs consumed above.
+        # In reality they should never be set at the same time, since the schema will prevent it.
+        for vrf in self.inputs.snmp_settings.vrfs:
+            if vrf.source_interface is not None:
+                self.structured_config.snmp_server.local_interfaces.obtain(vrf.source_interface).vrf = vrf.name if vrf.name != "default" else None
 
     def _snmp_vrfs(self: AvdStructuredConfigBaseProtocol, snmp_settings: EosDesigns.SnmpSettings) -> None:
         """
@@ -205,17 +223,71 @@ class SnmpServerMixin(Protocol):
 
         Requires one of the following options to be set under snmp_settings:
         - vrfs
-        - enable_mgmt_interface_vrf
-        - enable_inband_mgmt_vrf
+        - enable_mgmt_interface_vrf     TODO: 6.0 remove
+        - enable_inband_mgmt_vrf        TODO: 6.0 remove
         """
         has_mgmt_ip = (self.shared_utils.node_config.mgmt_ip is not None) or (self.shared_utils.node_config.ipv6_mgmt_ip is not None)
 
-        vrfs = snmp_settings.vrfs._deepcopy()
-        if has_mgmt_ip and (enable_mgmt_interface_vrf := snmp_settings.enable_mgmt_interface_vrf) is not None:
-            vrfs.append(EosCliConfigGen.SnmpServer.VrfsItem(name=self.inputs.mgmt_interface_vrf, enable=enable_mgmt_interface_vrf))
+        vrfs = EosCliConfigGen.SnmpServer.Vrfs()
 
-        if (enable_inband_mgmt_vrf := snmp_settings.enable_inband_mgmt_vrf) is not None and self.shared_utils.inband_mgmt_interface is not None:
+        # TODO: 6.0 remove the if condition.
+        if self.inputs.avd_6_behaviors.snmp_settings_vrfs:
+            vrfs.append_new(name="default", enable=False)
+
+        for vrf in snmp_settings.vrfs:
+            if vrf.enable is None:
+                continue
+
+            vrf_name = self.get_vrf(vrf.name, context=f"snmp_settings.vrfs[name={vrf.name}]")
+            vrfs.append_new(name=vrf_name, enable=vrf.enable)
+
+        if (
+            has_mgmt_ip
+            and (enable_mgmt_interface_vrf := snmp_settings.enable_mgmt_interface_vrf) is not None
+            and not self.inputs.avd_6_behaviors.snmp_settings_vrfs
+        ):
+            vrfs.append_new(name=self.inputs.mgmt_interface_vrf, enable=enable_mgmt_interface_vrf)
+
+        if (
+            (enable_inband_mgmt_vrf := snmp_settings.enable_inband_mgmt_vrf) is not None
+            and self.shared_utils.inband_mgmt_interface is not None
+            and not self.inputs.avd_6_behaviors.snmp_settings_vrfs
+        ):
             # self.shared_utils.inband_mgmt_vrf returns None for the default VRF, but here we need "default" to avoid duplicates.
-            vrfs.append(EosCliConfigGen.SnmpServer.VrfsItem(name=self.shared_utils.inband_mgmt_vrf or "default", enable=enable_inband_mgmt_vrf))
+            vrfs.append_new(name=self.shared_utils.inband_mgmt_vrf or "default", enable=enable_inband_mgmt_vrf)
 
         self.structured_config.snmp_server.vrfs = vrfs._natural_sorted()
+
+    def _snmp_ipv4_acls(self: AvdStructuredConfigBaseProtocol, snmp_settings: EosDesigns.SnmpSettings) -> None:
+        """
+        SNMP IPv4 ACLs. Resolves VRF from management VRFs.
+
+        TODO: 6.0 once we have removed the old model, we can move the acl logic to the _snmp_vrfs() method to avoid looping over the VRFs again.
+        """
+        self.structured_config.snmp_server.ipv4_acls.extend(snmp_settings.ipv4_acls._cast_as(EosCliConfigGen.SnmpServer.Ipv4Acls))
+        for vrf in snmp_settings.vrfs:
+            if vrf.ipv4_acl is None:
+                continue
+
+            vrf_name = self.get_vrf(
+                vrf_input=vrf.name,
+                context=f"snmp_settings.vrfs[name={vrf.name}]",
+            )
+            self.structured_config.snmp_server.ipv4_acls.append_new(name=vrf.ipv4_acl, vrf=vrf_name if vrf_name != "default" else None)
+
+    def _snmp_ipv6_acls(self: AvdStructuredConfigBaseProtocol, snmp_settings: EosDesigns.SnmpSettings) -> None:
+        """
+        SNMP IPv6 ACLs. Resolves VRF from management VRFs.
+
+        TODO: 6.0 once we have removed the old model, we can move the acl logic to the _snmp_vrfs() method to avoid looping over the VRFs again.
+        """
+        self.structured_config.snmp_server.ipv6_acls.extend(snmp_settings.ipv6_acls._cast_as(EosCliConfigGen.SnmpServer.Ipv6Acls))
+        for vrf in snmp_settings.vrfs:
+            if vrf.ipv6_acl is None:
+                continue
+
+            vrf_name = self.get_vrf(
+                vrf_input=vrf.name,
+                context=f"snmp_settings.vrfs[name={vrf.name}]",
+            )
+            self.structured_config.snmp_server.ipv6_acls.append_new(name=vrf.ipv6_acl, vrf=vrf_name if vrf_name != "default" else None)

--- a/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
@@ -199,7 +199,7 @@ class SnmpServerMixin(Protocol):
 
     def _snmp_local_interfaces(self: AvdStructuredConfigBaseProtocol, source_interfaces_inputs: EosDesigns.SourceInterfaces.Snmp) -> None:
         """
-        Set local_interfaces from "source_interfaces.snmp" or "snmp_settings.vrfs[].source_interface.
+        Set local_interfaces from "source_interfaces.snmp".
 
         TODO: AVD6.0 remove this method.
         """

--- a/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
@@ -201,21 +201,17 @@ class SnmpServerMixin(Protocol):
         """
         Set local_interfaces from "source_interfaces.snmp" or "snmp_settings.vrfs[].source_interface.
 
-        TODO: AVD6.0 remove the legacy inputs.
+        TODO: AVD6.0 remove this method.
         """
-        if source_interfaces_inputs:
-            self.structured_config.snmp_server.local_interfaces = self._build_source_interfaces(
-                source_interfaces_inputs.mgmt_interface,
-                source_interfaces_inputs.inband_mgmt_interface,
-                error_context="SNMP",
-                output_type=EosCliConfigGen.SnmpServer.LocalInterfaces,
-            )
+        if not source_interfaces_inputs:
+            return
 
-        # Settings defined under vrf.source_interface will take precedence over the legacy source_interfaces.snmp inputs consumed above.
-        # In reality they should never be set at the same time, since the schema will prevent it.
-        for vrf in self.inputs.snmp_settings.vrfs:
-            if vrf.source_interface is not None:
-                self.structured_config.snmp_server.local_interfaces.obtain(vrf.source_interface).vrf = vrf.name if vrf.name != "default" else None
+        self.structured_config.snmp_server.local_interfaces = self._build_source_interfaces(
+            source_interfaces_inputs.mgmt_interface,
+            source_interfaces_inputs.inband_mgmt_interface,
+            error_context="SNMP",
+            output_type=EosCliConfigGen.SnmpServer.LocalInterfaces,
+        )
 
     def _snmp_vrfs(self: AvdStructuredConfigBaseProtocol, snmp_settings: EosDesigns.SnmpSettings) -> None:
         """

--- a/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
@@ -237,18 +237,10 @@ class SnmpServerMixin(Protocol):
             vrf_name = self.get_vrf(vrf.name, context=f"snmp_settings.vrfs[name={vrf.name}]")
             vrfs.append_new(name=vrf_name, enable=vrf.enable)
 
-        if (
-            has_mgmt_ip
-            and (enable_mgmt_interface_vrf := snmp_settings.enable_mgmt_interface_vrf) is not None
-            and not self.inputs.avd_6_behaviors.snmp_settings_vrfs
-        ):
+        if has_mgmt_ip and (enable_mgmt_interface_vrf := snmp_settings.enable_mgmt_interface_vrf) is not None:
             vrfs.append_new(name=self.inputs.mgmt_interface_vrf, enable=enable_mgmt_interface_vrf)
 
-        if (
-            (enable_inband_mgmt_vrf := snmp_settings.enable_inband_mgmt_vrf) is not None
-            and self.shared_utils.inband_mgmt_interface is not None
-            and not self.inputs.avd_6_behaviors.snmp_settings_vrfs
-        ):
+        if (enable_inband_mgmt_vrf := snmp_settings.enable_inband_mgmt_vrf) is not None and self.shared_utils.inband_mgmt_interface is not None:
             # self.shared_utils.inband_mgmt_vrf returns None for the default VRF, but here we need "default" to avoid duplicates.
             vrfs.append_new(name=self.shared_utils.inband_mgmt_vrf or "default", enable=enable_inband_mgmt_vrf)
 

--- a/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/snmp_server.py
@@ -203,7 +203,7 @@ class SnmpServerMixin(Protocol):
 
         TODO: AVD6.0 remove the legacy inputs.
         """
-        if source_interfaces_inputs and not self.inputs.avd_6_behaviors.snmp_settings_vrfs:
+        if source_interfaces_inputs:
             self.structured_config.snmp_server.local_interfaces = self._build_source_interfaces(
                 source_interfaces_inputs.mgmt_interface,
                 source_interfaces_inputs.inband_mgmt_interface,

--- a/python-avd/pyavd/_eos_designs/structured_config/base/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/utils.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
         "T_ProtocolVrfs",
         EosDesigns.DnsSettings.Vrfs,
         EosDesigns.SflowSettings.Vrfs,
+        EosDesigns.SnmpSettings.Vrfs,
     )
 
 
@@ -85,17 +86,22 @@ class UtilsMixin(Protocol):
         return source_interfaces
 
     def _get_vrf_and_source_interface(
-        self: AvdStructuredConfigBaseProtocol, vrf_input: str | None, vrfs: T_ProtocolVrfs, set_source_interfaces: bool, context: str
+        self: AvdStructuredConfigBaseProtocol,
+        vrf_input: str | None,
+        vrfs: T_ProtocolVrfs,
+        set_source_interfaces: bool,
+        context: str,
     ) -> tuple[str, str | None]:
         """
         Helper function to interpret the VRF field for a management protocol.
 
-        If not set, the VRF is automatically picked up from the global setting `default_mgmt_method`.
         The value of `vrf` will be interpreted according to these rules:
         - `use_mgmt_interface_vrf` will return `(<mgmt_interface_vrf>, <vrfs[].source_interface or mgmt_interface>)`.
           An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.
         - `use_inband_mgmt_vrf` will return `(<inband_mgmt_vrf>, <vrfs[].source_interface or inband_mgmt_interface>)`.
           An error will be raised if inband management is not configured for the device.
+        - `use_default_mgmt_method_vrf` will return one of the options above depending on the value of `default_mgmt_method`.
+          If `default_mgmt_method: none` an error will be raised.
         - Any other string will return `(<vrf_input>, <vrfs[].source_interface or None)`
 
         Args:
@@ -105,11 +111,52 @@ class UtilsMixin(Protocol):
             context: The variable path for the vrf input used for error messages.
 
         Returns:
-            VRF name, "default" if not set.
+            VRF name
             Source Interface if available.
         """
         source_interface: str | None = None
-        if not vrf_input:
+        vrf = self.get_vrf(vrf_input, context=context)
+        if set_source_interfaces:
+            match vrf_input:
+                case None | "" | "use_default_mgmt_method_vrf":
+                    source_interface = self.shared_utils.default_mgmt_protocol_interface
+                case "use_mgmt_interface_vrf":
+                    # source_interface may be overridden below if given in the 'vrfs'
+                    source_interface = self.shared_utils.mgmt_interface
+                case "use_inband_mgmt_vrf":
+                    # source_interface may be overridden below if given in the 'vrfs'
+                    source_interface = self.shared_utils.inband_mgmt_interface
+
+        if vrf in vrfs and vrfs[vrf].source_interface:
+            source_interface = vrfs[vrf].source_interface
+
+        return (vrf, source_interface)
+
+    def get_vrf(
+        self: AvdStructuredConfigBaseProtocol,
+        vrf_input: str | None,
+        context: str,
+    ) -> str:
+        """
+        Helper function to interpret the VRF field for a management protocol.
+
+        The value of `vrf` will be interpreted according to these rules:
+        - `use_mgmt_interface_vrf` will return `(<mgmt_interface_vrf>, <vrfs[].source_interface or mgmt_interface>)`.
+          An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.
+        - `use_inband_mgmt_vrf` will return `(<inband_mgmt_vrf>, <vrfs[].source_interface or inband_mgmt_interface>)`.
+          An error will be raised if inband management is not configured for the device.
+        - `use_default_mgmt_method_vrf` will return one of the options above depending on the value of `default_mgmt_method`.
+          If `default_mgmt_method: none` an error will be raised.
+        - Any other string will be returned directly.
+
+        Args:
+            vrf_input: The VRF input value for one server.
+            context: The variable path for the vrf input used for error messages.
+
+        Returns:
+            VRF name
+        """
+        if not vrf_input or vrf_input == "use_default_mgmt_method_vrf":
             match self.inputs.default_mgmt_method:
                 case "oob":
                     vrf_input = "use_mgmt_interface_vrf"
@@ -126,23 +173,12 @@ class UtilsMixin(Protocol):
                     msg = f"'{context}' is set to 'use_mgmt_interface_vrf' but this node is missing 'mgmt_ip' or 'ipv6_mgmt_ip'."
                     raise AristaAvdInvalidInputsError(msg)
 
-                vrf = self.inputs.mgmt_interface_vrf
-                if set_source_interfaces:
-                    # source_interface may be overridden below if given in the 'vrfs'
-                    source_interface = self.shared_utils.mgmt_interface
+                return self.inputs.mgmt_interface_vrf
             case "use_inband_mgmt_vrf":
                 if self.shared_utils.inband_mgmt_interface is None:
                     msg = f"'{context}' is set to 'use_inband_mgmt_vrf' but this node is missing configuration for inband management."
                     raise AristaAvdInvalidInputsError(msg)
 
-                vrf = self.shared_utils.inband_mgmt_vrf or "default"
-                if set_source_interfaces:
-                    # source_interface may be overridden below if given in the 'vrfs'
-                    source_interface = self.shared_utils.inband_mgmt_interface
+                return self.shared_utils.inband_mgmt_vrf or "default"
             case _:
-                vrf = vrf_input
-
-        if vrf in vrfs and vrfs[vrf].source_interface:
-            source_interface = vrfs[vrf].source_interface
-
-        return (vrf, source_interface)
+                return vrf_input

--- a/python-avd/pyavd/_eos_designs/structured_config/base/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/utils.py
@@ -113,6 +113,9 @@ class UtilsMixin(Protocol):
         Returns:
             VRF name
             Source Interface if available.
+
+        Raises:
+            AristaAvdInvalidInputsError raised by get_vrf() if conditions mentioned above are not met.
         """
         source_interface: str | None = None
         vrf = self.get_vrf(vrf_input, context=context)

--- a/python-avd/pyavd/_eos_designs/structured_config/base/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/utils.py
@@ -117,14 +117,13 @@ class UtilsMixin(Protocol):
         source_interface: str | None = None
         vrf = self.get_vrf(vrf_input, context=context)
         if set_source_interfaces:
+            # source_interface may be overridden below if given in the 'vrfs'
             match vrf_input:
                 case None | "" | "use_default_mgmt_method_vrf":
                     source_interface = self.shared_utils.default_mgmt_protocol_interface
                 case "use_mgmt_interface_vrf":
-                    # source_interface may be overridden below if given in the 'vrfs'
                     source_interface = self.shared_utils.mgmt_interface
                 case "use_inband_mgmt_vrf":
-                    # source_interface may be overridden below if given in the 'vrfs'
                     source_interface = self.shared_utils.inband_mgmt_interface
 
         if vrf in vrfs and vrfs[vrf].source_interface:
@@ -155,6 +154,11 @@ class UtilsMixin(Protocol):
 
         Returns:
             VRF name
+
+        Raises:
+            AristaAvdInvalidInputsError: If `vrf` is unset or set to `use_default_mgmt_method_vrf` and `default_mgmt_method` is set to 'none'.
+            AristaAvdInvalidInputsError: If `vrf` is set to `use_mgmt_interface_vrf` and no `mgmt_ip` is set for this device.
+            AristaAvdInvalidInputsError: If `vrf` is set to `use_inband_mgmt_vrf` and inband management is not configured for this device.
         """
         if not vrf_input or vrf_input == "use_default_mgmt_method_vrf":
             match self.inputs.default_mgmt_method:


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
VRF assignment improvements for snmp_settings

## Related Issue(s)

Fixes #5472

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Deprecate/replace `source_interfaces.snmp` with `snmp_settings.vrfs[].source_interface` and setting them automatically when using new keywords in `vrf` field on hosts.
- Deprecate/replace `snmp_settings.ipv4_acls` and `snmp_settings.ipv6_acls` with `snmp_settings.vrfs[].ipv4_acl` and `snmp_settings.vrfs[].ipv6_acl`.
- Deprecate/replace `snmp_settings.enable_inband_mgmt_vrf` with `snmp_settings.vrfs[name="use_inband_mgmt_vrf"].enable`
- Deprecate/replace `snmp_settings.enable_mgmt_interface_vrf` with `snmp_settings.vrfs[name="use_mgmt_interface_vrf"].enable`
- Deprecate/replace `snmp_settings.hosts[].use_inband_mgmt_vrf` with `snmp_settings.hosts[].vrf: use_inband_mgmt_vrf`
- Deprecate/replace `snmp_settings.hosts[].use_mgmt_interface_vrf` with `snmp_settings.hosts[].vrf: use_mgmt_interface_vrf`
- Add support for `use_default_mgmt_method_vrf` where we support the two others.
- Add new default behavior behind `avd_6_behaviors.snmp_settings_vrfs`

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Updated molecule tests for new things and moved old to deprecated vars scenario.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
