### PR TITLE
Test(eos_designs): Removing Error message task from rescue from eos_designs negative unit test converge.yml

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/converge.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/converge.yml
@@ -262,10 +262,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           run_once: true
           ansible.builtin.assert:
@@ -283,10 +279,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           run_once: true
           ansible.builtin.assert:
@@ -304,10 +296,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           run_once: true
           ansible.builtin.assert:
@@ -325,10 +313,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           run_once: true
           ansible.builtin.assert:
@@ -346,10 +330,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           run_once: true
           ansible.builtin.assert:
@@ -367,10 +347,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           run_once: true
           ansible.builtin.assert:
@@ -388,10 +364,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           run_once: true
           ansible.builtin.assert:
@@ -409,10 +381,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           run_once: true
           ansible.builtin.assert:
@@ -463,10 +431,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           ansible.builtin.assert:
             that:
@@ -534,10 +498,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           ansible.builtin.assert:
             that:
@@ -622,10 +582,6 @@
           ansible.builtin.import_role:
             name: arista.avd.eos_designs
       rescue:
-        - name: Error message
-          run_once: true
-          ansible.builtin.debug:
-            var: ansible_failed_result.msg
         - name: Assert eos_designs failed with the expected error message
           ansible.builtin.assert:
             that:


### PR DESCRIPTION
## Change Summary

Removing Error message task from rescue from eos_designs negative unit test converge.yml

## Related Issue(s)

Fixes #5527 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
let's do it on all in a different PR

Remove all the ansible.builtin.debug entries

Originally posted by @gmuloc in https://github.com/aristanetworks/avd/pull/5362#discussion_r2150177180

## How to test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
