### PR TITLE
Refactor(eos_cli_config_gen)!: Added vrf as unique key for tacacs and radius source interfaces

### DIFF
--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -6246,6 +6246,8 @@ keys:
                   description: In seconds.
   ip_radius_source_interfaces:
     type: list
+    unique_keys:
+    - vrf
     items:
       type: dict
       keys:
@@ -6505,6 +6507,8 @@ keys:
   ip_tacacs_source_interfaces:
     type: list
     display_name: IP Tacacs Source Interfaces
+    unique_keys:
+    - vrf
     items:
       type: dict
       keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_radius_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_radius_source_interfaces.schema.yml
@@ -8,6 +8,8 @@ type: dict
 keys:
   ip_radius_source_interfaces:
     type: list
+    unique_keys:
+      - vrf
     items:
       type: dict
       keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_tacacs_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_tacacs_source_interfaces.schema.yml
@@ -9,6 +9,8 @@ keys:
   ip_tacacs_source_interfaces:
     type: list
     display_name: IP Tacacs Source Interfaces
+    unique_keys:
+      - vrf
     items:
       type: dict
       keys:


### PR DESCRIPTION

## Change Summary

Added vrf as unique key for tacacs and radius source interfaces. Since EOS supports only unique vrf name with source interface hence added vrf key as unique key. If we add different interface for duplicate vrf the EOS overwrite the command with latest source interface.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Made vrf as unique key for tacacs and radius source interface.

## How to test
Run eos_cli_config_gen molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
