### PR TITLE
Feat(eos_designs): Add possibility to pass cleartext IPsec keys for wan_ipsec_profiles

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles-control-plane-key.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles-control-plane-key.yml
@@ -1,0 +1,60 @@
+---
+# Testing missing wan_ipsec_profiles.control_plane.shared_key and cleartext_shared_key
+wan_mode: cv-pathfinder
+# Disabling underlay for tests
+underlay_routing_protocol: none
+
+type: wan_router
+
+bgp_as: 65000
+
+cv_pathfinder_regions:
+  - name: AVD_Land_West
+    id: 42
+    description: AVD Region
+    sites:
+      - name: Site422
+        id: 422
+        location: Somewhere
+
+bgp_peer_groups:
+  wan_overlay_peers:
+    password: "htm4AZe9mIQOO1uiMuGgYQ=="
+    listen_range_prefixes:
+      - 192.168.255.0/24
+
+wan_router:
+  defaults:
+    loopback_ipv4_pool: 192.168.42.0/24
+    vtep_loopback_ipv4_pool: 192.168.255.0/24
+    filter:
+      always_include_vrfs_in_tenants: [TenantA]
+  nodes:
+    - name: missing-wan-ipsec-profiles-control-plane-key
+      cv_pathfinder_region: AVD_Land_West
+      cv_pathfinder_site: Site422
+      id: 1
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: ATT
+          wan_circuit_id: 666
+          peer_ip: 1.1.1.1
+          ip_address: dhcp
+          dhcp_ip: 10.0.0.145
+
+wan_ipsec_profiles:
+  control_plane:
+    ike_policy_name: SOMETHING
+    # No shared_key nor cleartext_shared_key
+
+wan_path_groups:
+  - name: INET
+    id: 101
+
+wan_carriers:
+  - name: ATT
+    path_group: INET
+    trusted: true
+
+expected_error_message: |-
+  '`wan_ipsec_profile.control_plane.shared_key` or `wan_ipsec_profile.control_plane.cleartext_shared_key`' is required but was not found.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles-data-plane-key.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/missing-wan-ipsec-profiles-data-plane-key.yml
@@ -1,0 +1,62 @@
+---
+# Testing missing wan_ipsec_profiles.data_plane.shared_key and cleartext_shared_key
+wan_mode: cv-pathfinder
+# Disabling underlay for tests
+underlay_routing_protocol: none
+
+type: wan_router
+
+bgp_as: 65000
+
+cv_pathfinder_regions:
+  - name: AVD_Land_West
+    id: 42
+    description: AVD Region
+    sites:
+      - name: Site422
+        id: 422
+        location: Somewhere
+
+bgp_peer_groups:
+  wan_overlay_peers:
+    password: "htm4AZe9mIQOO1uiMuGgYQ=="
+    listen_range_prefixes:
+      - 192.168.255.0/24
+
+wan_router:
+  defaults:
+    loopback_ipv4_pool: 192.168.42.0/24
+    vtep_loopback_ipv4_pool: 192.168.255.0/24
+    filter:
+      always_include_vrfs_in_tenants: [TenantA]
+  nodes:
+    - name: missing-wan-ipsec-profiles-data-plane-key
+      cv_pathfinder_region: AVD_Land_West
+      cv_pathfinder_site: Site422
+      id: 1
+      l3_interfaces:
+        - name: Ethernet1
+          wan_carrier: ATT
+          wan_circuit_id: 666
+          peer_ip: 1.1.1.1
+          ip_address: dhcp
+          dhcp_ip: 10.0.0.145
+
+wan_ipsec_profiles:
+  control_plane:
+    shared_key: 11080B0C04060A
+  data_plane:
+    ike_policy_name: SOMETHING
+    # No shared_key nor cleartext_shared_key
+
+wan_path_groups:
+  - name: INET
+    id: 101
+
+wan_carriers:
+  - name: ATT
+    path_group: INET
+    trusted: true
+
+expected_error_message: |-
+  '`wan_ipsec_profile.data_plane.shared_key` or `wan_ipsec_profile.data_plane.cleartext_shared_key`' is required but was not found.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -267,6 +267,8 @@ all:
             missing-peer-router-id-for-router-pim-sparse-mode:
             missing-vrf-vtep-diagnostic-loopback:
             missing-virtual-router-mac-address:
+            missing-wan-ipsec-profiles-control-plane-key:
+            missing-wan-ipsec-profiles-data-plane-key:
             wan-router-l3-interfaces-unsupported-rxtx-for-subinterface:
             wan-router-policy-unmatched:
             ntp-settings-server-vrf-missing-mgmt-ip:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -308,14 +308,14 @@ ip security
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
-      shared-key 7 045A190F1C354D
+      shared-key 7 0112140D481F07
       dpd 10 50 clear
       mode transport
    !
    profile DP-PROFILE
       sa-policy DP-SA-POLICY
       connection start
-      shared-key 7 11080B0C04060A
+      shared-key 7 0207165218120E
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/cv-pathfinder-edge1.cfg
@@ -308,14 +308,14 @@ ip security
       ike-policy CP-IKE-POLICY
       sa-policy CP-SA-POLICY
       connection start
-      shared-key 7 ABCDEF1234567890
+      shared-key 7 045A190F1C354D
       dpd 10 50 clear
       mode transport
    !
    profile DP-PROFILE
       sa-policy DP-SA-POLICY
       connection start
-      shared-key 7 ABCDEF1234567890666
+      shared-key 7 11080B0C04060A
       dpd 10 50 clear
       mode transport
    !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -362,7 +362,7 @@ ip_security:
   - name: DP-PROFILE
     sa_policy: DP-SA-POLICY
     connection: start
-    shared_key: 11080B0C04060A
+    shared_key: 0207165218120E
     dpd:
       interval: 10
       time: 50
@@ -372,7 +372,7 @@ ip_security:
     ike_policy: CP-IKE-POLICY
     sa_policy: CP-SA-POLICY
     connection: start
-    shared_key: 045A190F1C354D
+    shared_key: 0112140D481F07
     dpd:
       interval: 10
       time: 50

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -362,7 +362,7 @@ ip_security:
   - name: DP-PROFILE
     sa_policy: DP-SA-POLICY
     connection: start
-    shared_key: ABCDEF1234567890666
+    shared_key: 11080B0C04060A
     dpd:
       interval: 10
       time: 50
@@ -372,7 +372,7 @@ ip_security:
     ike_policy: CP-IKE-POLICY
     sa_policy: CP-SA-POLICY
     connection: start
-    shared_key: ABCDEF1234567890
+    shared_key: 045A190F1C354D
     dpd:
       interval: 10
       time: 50

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/CV_PATHFINDER_TESTS.yml
@@ -78,8 +78,12 @@ wan_route_servers:
 wan_ipsec_profiles:
   control_plane:
     shared_key: ABCDEF1234567890
+    # Making sure shared_key has precedence
+    cleartext_shared_key: arista
   data_plane:
     shared_key: ABCDEF1234567890666
+    # Making sure shared_key has precedence
+    cleartext_shared_key: arista
 
 default_node_types:
   - node_type: wan_rr

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/cv-pathfinder-edge1.yml
@@ -8,6 +8,13 @@ wan_route_servers:
   - hostname: cv-pathfinder-pathfinder1
   - hostname: cv-pathfinder-pathfinder2
 
+# Testing cleartext_shared_key
+wan_ipsec_profiles:
+  control_plane:
+    cleartext_shared_key: arista
+  data_plane:
+    cleartext_shared_key: arista
+
 # Testing overriding internet exit acls using custom rules with substitution
 ipv4_acls:
   - name: TEST-IPV4-ACL-WITH-IP-FIELDS-IN

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
@@ -17,12 +17,14 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ike_policy_name</samp>](## "wan_ipsec_profiles.control_plane.ike_policy_name") | String |  | `CP-IKE-POLICY` |  | Name of the IKE policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sa_policy_name</samp>](## "wan_ipsec_profiles.control_plane.sa_policy_name") | String |  | `CP-SA-POLICY` |  | Name of the SA policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile_name</samp>](## "wan_ipsec_profiles.control_plane.profile_name") | String |  | `CP-PROFILE` |  | Name of the IPSec profile. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shared_key</samp>](## "wan_ipsec_profiles.control_plane.shared_key") | String | Required |  |  | The IPSec shared key.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shared_key</samp>](## "wan_ipsec_profiles.control_plane.shared_key") | String |  |  |  | Type 7 IPSec shared key.<br>Takes precedence over `cleartext_shared_key`.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cleartext_shared_key</samp>](## "wan_ipsec_profiles.control_plane.cleartext_shared_key") | String |  |  |  | Cleartext IPSec shared key.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
     | [<samp>&nbsp;&nbsp;data_plane</samp>](## "wan_ipsec_profiles.data_plane") | Dictionary |  |  |  | If `data_plane` is not defined, `control_plane` information is used for both. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ike_policy_name</samp>](## "wan_ipsec_profiles.data_plane.ike_policy_name") | String |  | `DP-IKE-POLICY` |  | Name of the IKE policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sa_policy_name</samp>](## "wan_ipsec_profiles.data_plane.sa_policy_name") | String |  | `DP-SA-POLICY` |  | Name of the SA policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile_name</samp>](## "wan_ipsec_profiles.data_plane.profile_name") | String |  | `DP-PROFILE` |  | Name of the IPSec profile. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shared_key</samp>](## "wan_ipsec_profiles.data_plane.shared_key") | String | Required |  |  | The type 7 encrypted IPSec shared key.<br>This variable is sensitive and should be configured using some vault mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shared_key</samp>](## "wan_ipsec_profiles.data_plane.shared_key") | String |  |  |  | Type 7 IPSec shared key.<br>Takes precedence over `cleartext_shared_key`.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cleartext_shared_key</samp>](## "wan_ipsec_profiles.data_plane.cleartext_shared_key") | String |  |  |  | Cleartext IPSec shared key.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
     | [<samp>wan_mode</samp>](## "wan_mode") | String |  | `cv-pathfinder` | Valid Values:<br>- <code>autovpn</code><br>- <code>cv-pathfinder</code> | Select if the WAN should be run using CV Pathfinder or AutoVPN only. |
     | [<samp>wan_stun_dtls_disable</samp>](## "wan_stun_dtls_disable") | Boolean |  | `False` |  | WAN STUN connections are authenticated and secured with DTLS by default.<br>For CV Pathfinder deployments CloudVision will automatically deploy certificates on the devices.<br>In case of AutoVPN the certificates must be deployed manually to all devices.<br><br>For LAB environments this can be disabled, if there are no certificates available.<br>This should NOT be disabled for a WAN network connected to the internet, since it will leave the STUN service exposed with no authentication. |
     | [<samp>wan_stun_dtls_profile_name</samp>](## "wan_stun_dtls_profile_name") | String |  | `STUN-DTLS` |  | Name of the SSL profile used for DTLS on WAN STUN connections.<br>When using automatic ceritficate deployment via CloudVision this name must be the same on all WAN routers. |
@@ -62,9 +64,14 @@
         # Name of the IPSec profile.
         profile_name: <str; default="CP-PROFILE">
 
-        # The IPSec shared key.
+        # Type 7 IPSec shared key.
+        # Takes precedence over `cleartext_shared_key`.
         # This variable is sensitive and SHOULD be configured using some vault mechanism.
-        shared_key: <str; required>
+        shared_key: <str>
+
+        # Cleartext IPSec shared key.
+        # This variable is sensitive and SHOULD be configured using some vault mechanism.
+        cleartext_shared_key: <str>
 
       # If `data_plane` is not defined, `control_plane` information is used for both.
       data_plane:
@@ -78,9 +85,14 @@
         # Name of the IPSec profile.
         profile_name: <str; default="DP-PROFILE">
 
-        # The type 7 encrypted IPSec shared key.
-        # This variable is sensitive and should be configured using some vault mechanism.
-        shared_key: <str; required>
+        # Type 7 IPSec shared key.
+        # Takes precedence over `cleartext_shared_key`.
+        # This variable is sensitive and SHOULD be configured using some vault mechanism.
+        shared_key: <str>
+
+        # Cleartext IPSec shared key.
+        # This variable is sensitive and SHOULD be configured using some vault mechanism.
+        cleartext_shared_key: <str>
 
     # Select if the WAN should be run using CV Pathfinder or AutoVPN only.
     wan_mode: <str; "autovpn" | "cv-pathfinder"; default="cv-pathfinder">

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/wan-settings.md
@@ -17,13 +17,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ike_policy_name</samp>](## "wan_ipsec_profiles.control_plane.ike_policy_name") | String |  | `CP-IKE-POLICY` |  | Name of the IKE policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sa_policy_name</samp>](## "wan_ipsec_profiles.control_plane.sa_policy_name") | String |  | `CP-SA-POLICY` |  | Name of the SA policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile_name</samp>](## "wan_ipsec_profiles.control_plane.profile_name") | String |  | `CP-PROFILE` |  | Name of the IPSec profile. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shared_key</samp>](## "wan_ipsec_profiles.control_plane.shared_key") | String |  |  |  | Type 7 IPSec shared key.<br>Takes precedence over `cleartext_shared_key`.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shared_key</samp>](## "wan_ipsec_profiles.control_plane.shared_key") | String |  |  |  | Type 7 obfuscated IPSec shared key.<br>Takes precedence over `cleartext_shared_key`.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cleartext_shared_key</samp>](## "wan_ipsec_profiles.control_plane.cleartext_shared_key") | String |  |  |  | Cleartext IPSec shared key.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
     | [<samp>&nbsp;&nbsp;data_plane</samp>](## "wan_ipsec_profiles.data_plane") | Dictionary |  |  |  | If `data_plane` is not defined, `control_plane` information is used for both. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ike_policy_name</samp>](## "wan_ipsec_profiles.data_plane.ike_policy_name") | String |  | `DP-IKE-POLICY` |  | Name of the IKE policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;sa_policy_name</samp>](## "wan_ipsec_profiles.data_plane.sa_policy_name") | String |  | `DP-SA-POLICY` |  | Name of the SA policy. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;profile_name</samp>](## "wan_ipsec_profiles.data_plane.profile_name") | String |  | `DP-PROFILE` |  | Name of the IPSec profile. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shared_key</samp>](## "wan_ipsec_profiles.data_plane.shared_key") | String |  |  |  | Type 7 IPSec shared key.<br>Takes precedence over `cleartext_shared_key`.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;shared_key</samp>](## "wan_ipsec_profiles.data_plane.shared_key") | String |  |  |  | Type 7 obfuscated IPSec shared key.<br>Takes precedence over `cleartext_shared_key`.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;cleartext_shared_key</samp>](## "wan_ipsec_profiles.data_plane.cleartext_shared_key") | String |  |  |  | Cleartext IPSec shared key.<br>This variable is sensitive and SHOULD be configured using some vault mechanism. |
     | [<samp>wan_mode</samp>](## "wan_mode") | String |  | `cv-pathfinder` | Valid Values:<br>- <code>autovpn</code><br>- <code>cv-pathfinder</code> | Select if the WAN should be run using CV Pathfinder or AutoVPN only. |
     | [<samp>wan_stun_dtls_disable</samp>](## "wan_stun_dtls_disable") | Boolean |  | `False` |  | WAN STUN connections are authenticated and secured with DTLS by default.<br>For CV Pathfinder deployments CloudVision will automatically deploy certificates on the devices.<br>In case of AutoVPN the certificates must be deployed manually to all devices.<br><br>For LAB environments this can be disabled, if there are no certificates available.<br>This should NOT be disabled for a WAN network connected to the internet, since it will leave the STUN service exposed with no authentication. |
@@ -64,7 +64,7 @@
         # Name of the IPSec profile.
         profile_name: <str; default="CP-PROFILE">
 
-        # Type 7 IPSec shared key.
+        # Type 7 obfuscated IPSec shared key.
         # Takes precedence over `cleartext_shared_key`.
         # This variable is sensitive and SHOULD be configured using some vault mechanism.
         shared_key: <str>
@@ -85,7 +85,7 @@
         # Name of the IPSec profile.
         profile_name: <str; default="DP-PROFILE">
 
-        # Type 7 IPSec shared key.
+        # Type 7 obfuscated IPSec shared key.
         # Takes precedence over `cleartext_shared_key`.
         # This variable is sensitive and SHOULD be configured using some vault mechanism.
         shared_key: <str>

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -15984,6 +15984,7 @@ class EosDesigns(EosDesignsRootModel):
                 "sa_policy_name": {"type": str, "default": "CP-SA-POLICY"},
                 "profile_name": {"type": str, "default": "CP-PROFILE"},
                 "shared_key": {"type": str},
+                "cleartext_shared_key": {"type": str},
             }
             ike_policy_name: str
             """
@@ -16003,9 +16004,16 @@ class EosDesigns(EosDesignsRootModel):
 
             Default value: `"CP-PROFILE"`
             """
-            shared_key: str
+            shared_key: str | None
             """
-            The IPSec shared key.
+            Type 7 IPSec shared key.
+            Takes precedence over `cleartext_shared_key`.
+            This variable is sensitive
+            and SHOULD be configured using some vault mechanism.
+            """
+            cleartext_shared_key: str | None
+            """
+            Cleartext IPSec shared key.
             This variable is sensitive and SHOULD be configured using some vault
             mechanism.
             """
@@ -16018,7 +16026,8 @@ class EosDesigns(EosDesignsRootModel):
                     ike_policy_name: str | UndefinedType = Undefined,
                     sa_policy_name: str | UndefinedType = Undefined,
                     profile_name: str | UndefinedType = Undefined,
-                    shared_key: str | UndefinedType = Undefined,
+                    shared_key: str | None | UndefinedType = Undefined,
+                    cleartext_shared_key: str | None | UndefinedType = Undefined,
                 ) -> None:
                     """
                     ControlPlane.
@@ -16031,7 +16040,12 @@ class EosDesigns(EosDesignsRootModel):
                         sa_policy_name: Name of the SA policy.
                         profile_name: Name of the IPSec profile.
                         shared_key:
-                           The IPSec shared key.
+                           Type 7 IPSec shared key.
+                           Takes precedence over `cleartext_shared_key`.
+                           This variable is sensitive
+                           and SHOULD be configured using some vault mechanism.
+                        cleartext_shared_key:
+                           Cleartext IPSec shared key.
                            This variable is sensitive and SHOULD be configured using some vault
                            mechanism.
 
@@ -16045,6 +16059,7 @@ class EosDesigns(EosDesignsRootModel):
                 "sa_policy_name": {"type": str, "default": "DP-SA-POLICY"},
                 "profile_name": {"type": str, "default": "DP-PROFILE"},
                 "shared_key": {"type": str},
+                "cleartext_shared_key": {"type": str},
             }
             ike_policy_name: str
             """
@@ -16064,11 +16079,18 @@ class EosDesigns(EosDesignsRootModel):
 
             Default value: `"DP-PROFILE"`
             """
-            shared_key: str
+            shared_key: str | None
             """
-            The type 7 encrypted IPSec shared key.
-            This variable is sensitive and should be configured using
-            some vault mechanism.
+            Type 7 IPSec shared key.
+            Takes precedence over `cleartext_shared_key`.
+            This variable is sensitive
+            and SHOULD be configured using some vault mechanism.
+            """
+            cleartext_shared_key: str | None
+            """
+            Cleartext IPSec shared key.
+            This variable is sensitive and SHOULD be configured using some vault
+            mechanism.
             """
 
             if TYPE_CHECKING:
@@ -16079,7 +16101,8 @@ class EosDesigns(EosDesignsRootModel):
                     ike_policy_name: str | UndefinedType = Undefined,
                     sa_policy_name: str | UndefinedType = Undefined,
                     profile_name: str | UndefinedType = Undefined,
-                    shared_key: str | UndefinedType = Undefined,
+                    shared_key: str | None | UndefinedType = Undefined,
+                    cleartext_shared_key: str | None | UndefinedType = Undefined,
                 ) -> None:
                     """
                     DataPlane.
@@ -16092,9 +16115,14 @@ class EosDesigns(EosDesignsRootModel):
                         sa_policy_name: Name of the SA policy.
                         profile_name: Name of the IPSec profile.
                         shared_key:
-                           The type 7 encrypted IPSec shared key.
-                           This variable is sensitive and should be configured using
-                           some vault mechanism.
+                           Type 7 IPSec shared key.
+                           Takes precedence over `cleartext_shared_key`.
+                           This variable is sensitive
+                           and SHOULD be configured using some vault mechanism.
+                        cleartext_shared_key:
+                           Cleartext IPSec shared key.
+                           This variable is sensitive and SHOULD be configured using some vault
+                           mechanism.
 
                     """
 

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -16042,10 +16042,10 @@ class EosDesigns(EosDesignsRootModel):
             """
             shared_key: str | None
             """
-            Type 7 IPSec shared key.
+            Type 7 obfuscated IPSec shared key.
             Takes precedence over `cleartext_shared_key`.
-            This variable is sensitive
-            and SHOULD be configured using some vault mechanism.
+            This variable is
+            sensitive and SHOULD be configured using some vault mechanism.
             """
             cleartext_shared_key: str | None
             """
@@ -16076,10 +16076,10 @@ class EosDesigns(EosDesignsRootModel):
                         sa_policy_name: Name of the SA policy.
                         profile_name: Name of the IPSec profile.
                         shared_key:
-                           Type 7 IPSec shared key.
+                           Type 7 obfuscated IPSec shared key.
                            Takes precedence over `cleartext_shared_key`.
-                           This variable is sensitive
-                           and SHOULD be configured using some vault mechanism.
+                           This variable is
+                           sensitive and SHOULD be configured using some vault mechanism.
                         cleartext_shared_key:
                            Cleartext IPSec shared key.
                            This variable is sensitive and SHOULD be configured using some vault
@@ -16117,10 +16117,10 @@ class EosDesigns(EosDesignsRootModel):
             """
             shared_key: str | None
             """
-            Type 7 IPSec shared key.
+            Type 7 obfuscated IPSec shared key.
             Takes precedence over `cleartext_shared_key`.
-            This variable is sensitive
-            and SHOULD be configured using some vault mechanism.
+            This variable is
+            sensitive and SHOULD be configured using some vault mechanism.
             """
             cleartext_shared_key: str | None
             """
@@ -16151,10 +16151,10 @@ class EosDesigns(EosDesignsRootModel):
                         sa_policy_name: Name of the SA policy.
                         profile_name: Name of the IPSec profile.
                         shared_key:
-                           Type 7 IPSec shared key.
+                           Type 7 obfuscated IPSec shared key.
                            Takes precedence over `cleartext_shared_key`.
-                           This variable is sensitive
-                           and SHOULD be configured using some vault mechanism.
+                           This variable is
+                           sensitive and SHOULD be configured using some vault mechanism.
                         cleartext_shared_key:
                            Cleartext IPSec shared key.
                            This variable is sensitive and SHOULD be configured using some vault

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -5147,13 +5147,6 @@ keys:
           profile_name:
             type: str
             default: CP-PROFILE
-          shared_key:
-            type: str
-            required: true
-            description: 'The IPSec shared key.
-
-              This variable is sensitive and SHOULD be configured using some vault
-              mechanism.'
       data_plane:
         type: dict
         $ref: eos_designs#/$defs/ipsec_profile
@@ -6345,10 +6338,16 @@ $defs:
         description: Name of the IPSec profile.
       shared_key:
         type: str
-        required: true
-        description: 'The type 7 encrypted IPSec shared key.
+        description: 'Type 7 IPSec shared key.
 
-          This variable is sensitive and should be configured using some vault mechanism.'
+          Takes precedence over `cleartext_shared_key`.
+
+          This variable is sensitive and SHOULD be configured using some vault mechanism.'
+      cleartext_shared_key:
+        type: str
+        description: 'Cleartext IPSec shared key.
+
+          This variable is sensitive and SHOULD be configured using some vault mechanism.'
   l3_edge:
     type: dict
     keys:

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -6355,7 +6355,7 @@ $defs:
         description: Name of the IPSec profile.
       shared_key:
         type: str
-        description: 'Type 7 IPSec shared key.
+        description: 'Type 7 obfuscated IPSec shared key.
 
           Takes precedence over `cleartext_shared_key`.
 

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_ipsec_profile.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_ipsec_profile.schema.yml
@@ -21,7 +21,7 @@ $defs:
       shared_key:
         type: str
         description: |-
-          Type 7 IPSec shared key.
+          Type 7 obfuscated IPSec shared key.
           Takes precedence over `cleartext_shared_key`.
           This variable is sensitive and SHOULD be configured using some vault mechanism.
       cleartext_shared_key:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_ipsec_profile.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_ipsec_profile.schema.yml
@@ -20,7 +20,12 @@ $defs:
         description: Name of the IPSec profile.
       shared_key:
         type: str
-        required: true
         description: |-
-          The type 7 encrypted IPSec shared key.
-          This variable is sensitive and should be configured using some vault mechanism.
+          Type 7 IPSec shared key.
+          Takes precedence over `cleartext_shared_key`.
+          This variable is sensitive and SHOULD be configured using some vault mechanism.
+      cleartext_shared_key:
+        type: str
+        description: |-
+          Cleartext IPSec shared key.
+          This variable is sensitive and SHOULD be configured using some vault mechanism.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_ipsec_profiles.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_ipsec_profiles.schema.yml
@@ -26,12 +26,6 @@ keys:
           profile_name:
             type: str
             default: CP-PROFILE
-          shared_key:
-            type: str
-            required: true
-            description: |-
-              The IPSec shared key.
-              This variable is sensitive and SHOULD be configured using some vault mechanism.
       data_plane:
         type: dict
         $ref: "eos_designs#/$defs/ipsec_profile"

--- a/python-avd/pyavd/_eos_designs/shared_utils/misc.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/misc.py
@@ -418,17 +418,18 @@ class MiscMixin(Protocol):
 
         return all_connected_endpoints
 
-    def get_ipsec_key(self: SharedUtilsProtocol, cleartext_key: str) -> str:
+    def get_ipsec_key(self: SharedUtilsProtocol, cleartext_key: str, profile_name: str) -> str:
         """
         Return a type 7 encrypted shared key for IPsec.
 
         Args:
-            cleartext_key: str
+            cleartext_key: The cleartext key to encrypt
+            profile_name: The profile name to derive a salt deterministically
 
         Returns:
             str: type 7 encrypted key.
         """
         # Need to compute it deterministically
-        salt = 0
+        salt = sum(bytearray(profile_name, "ascii")) % 16
 
-        return simple_7_encrypt(key, salt)
+        return simple_7_encrypt(cleartext_key, salt)

--- a/python-avd/pyavd/_eos_designs/shared_utils/misc.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/misc.py
@@ -11,6 +11,7 @@ from pyavd._eos_designs.eos_designs_facts.schema import EosDesignsFacts
 from pyavd._eos_designs.schema import EosDesigns
 from pyavd._errors import AristaAvdError, AristaAvdInvalidInputsError, AristaAvdMissingVariableError
 from pyavd._utils import default, get
+from pyavd._utils.password_utils.password import simple_7_encrypt
 from pyavd.api.interface_descriptions import InterfaceDescriptionData
 from pyavd.api.pool_manager import PoolManager
 from pyavd.j2filters import range_expand
@@ -416,3 +417,12 @@ class MiscMixin(Protocol):
                 all_connected_endpoints.append(connected_endpoint)
 
         return all_connected_endpoints
+
+    def get_ipsec_key(self: SharedUtilsProtocol, stuff: str) -> str:
+        """
+        Return a type 7 encrypted shared key for IPsec.
+
+        Args:
+            stuff: dasdas
+        """
+        return simple_7_encrypt(stuff)

--- a/python-avd/pyavd/_eos_designs/shared_utils/misc.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/misc.py
@@ -418,11 +418,17 @@ class MiscMixin(Protocol):
 
         return all_connected_endpoints
 
-    def get_ipsec_key(self: SharedUtilsProtocol, stuff: str) -> str:
+    def get_ipsec_key(self: SharedUtilsProtocol, cleartext_key: str) -> str:
         """
         Return a type 7 encrypted shared key for IPsec.
 
         Args:
-            stuff: dasdas
+            cleartext_key: str
+
+        Returns:
+            str: type 7 encrypted key.
         """
-        return simple_7_encrypt(stuff)
+        # Need to compute it deterministically
+        salt = 0
+
+        return simple_7_encrypt(key, salt)

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/ip_security.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/ip_security.py
@@ -53,7 +53,7 @@ class IpSecurityMixin(Protocol):
         if data_plane_config.shared_key:
             key = data_plane_config.shared_key
         elif data_plane_config.cleartext_shared_key:
-            key = self.shared_utils.get_ipsec_key(data_plane_config.cleartext_shared_key)
+            key = self.shared_utils.get_ipsec_key(data_plane_config.cleartext_shared_key, profile_name)
         else:
             msg = "`wan_ipsec_profile.data_plane.shared_key` or `wan_ipsec_profile.data_plane.cleartext_shared_key`"
             raise AristaAvdMissingVariableError(msg)
@@ -80,7 +80,7 @@ class IpSecurityMixin(Protocol):
         if control_plane_config.shared_key:
             key = control_plane_config.shared_key
         elif control_plane_config.cleartext_shared_key:
-            key = self.shared_utils.get_ipsec_key(control_plane_config.cleartext_shared_key)
+            key = self.shared_utils.get_ipsec_key(control_plane_config.cleartext_shared_key, profile_name)
         else:
             msg = "`wan_ipsec_profile.control_plane.shared_key` or `wan_ipsec_profile.control_plane.cleartext_shared_key`"
             raise AristaAvdMissingVariableError(msg)

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/ip_security.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/ip_security.py
@@ -50,7 +50,13 @@ class IpSecurityMixin(Protocol):
         ike_policy_name = data_plane_config.ike_policy_name if self.shared_utils.wan_ha_ipsec else None
         sa_policy_name = data_plane_config.sa_policy_name
         profile_name = data_plane_config.profile_name
-        key = data_plane_config.shared_key
+        if data_plane_config.shared_key:
+            key = data_plane_config.shared_key
+        elif data_plane_config.cleartext_shared_key:
+            key = self.shared_utils.get_ipsec_key(data_plane_config.cleartext_shared_key)
+        else:
+            msg = "`wan_ipsec_profile.data_plane.shared_key` or `wan_ipsec_profile.data_plane.cleartext_shared_key`"
+            raise AristaAvdMissingVariableError(msg)
 
         # IKE policy for data-plane is not required for dynamic tunnels except for HA cases
         if self.shared_utils.wan_ha_ipsec:
@@ -71,7 +77,13 @@ class IpSecurityMixin(Protocol):
         ike_policy_name = control_plane_config.ike_policy_name
         sa_policy_name = control_plane_config.sa_policy_name
         profile_name = control_plane_config.profile_name
-        key = control_plane_config.shared_key
+        if control_plane_config.shared_key:
+            key = control_plane_config.shared_key
+        elif control_plane_config.cleartext_shared_key:
+            key = self.shared_utils.get_ipsec_key(control_plane_config.cleartext_shared_key)
+        else:
+            msg = "`wan_ipsec_profile.control_plane.shared_key` or `wan_ipsec_profile.control_plane.cleartext_shared_key`"
+            raise AristaAvdMissingVariableError(msg)
 
         self.structured_config.ip_security.ike_policies.append_new(name=ike_policy_name, local_id=self.shared_utils.vtep_ip)
         self._set_sa_policy(sa_policy_name)


### PR DESCRIPTION
## Change Summary

Add `cleartext_shared_key` in the vein of #5481 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

* Add cleartext_shared_key in parallel of shared_key
* shared_key is taking precedence

## How to test

molecule

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
