### PR TITLE
Fix(dhcp_provisioner): Add ztp_bootstrap_file option when used with cv_settings

### DIFF
--- a/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_configuration/inventory/group_vars/AVD_LAB.yml
@@ -13,12 +13,16 @@ local_users:
     role: network-admin
     sha512_password: "$6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj."
 
-# Cloud Vision server
+# CloudVision server
 cv_settings:
   onprem_clusters:
     - name: test
       servers:
         - name: 192.168.200.11
+
+# Note! The arista.avd.dhcp_provisioner role does not support cv_settings.
+# Instead the ZTP URL can be set with 'ztp_bootstrap_file'
+ztp_bootstrap_file: http://192.168.200.11/ztp/bootstrap
 
 # OOB Management network default gateway.
 mgmt_gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/dhcp_provisioning/inventory/group_vars/AVD_LAB.yml
@@ -13,12 +13,16 @@ local_users:
     role: network-admin
     sha512_password: "$6$rZKcbIZ7iWGAWTUM$TCgDn1KcavS0s.OV8lacMTUkxTByfzcGlFlYUWroxYuU7M/9bIodhRO7nXGzMweUxvbk8mJmQl8Bh44cRktUj."
 
-# Cloud Vision server
+# CloudVision server
 cv_settings:
   onprem_clusters:
     - name: test
       servers:
         - name: 192.168.200.11
+
+# Note! The arista.avd.dhcp_provisioner role does not support cv_settings.
+# Instead the ZTP URL can be set with 'ztp_bootstrap_file'
+ztp_bootstrap_file: http://192.168.200.11/ztp/bootstrap
 
 # OOB Management network default gateway.
 mgmt_gateway: 192.168.200.5

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/README.md
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/README.md
@@ -20,6 +20,10 @@ title: Ansible Collection Role dhcp_provisioner
 - `Offline` mode let you generate a configuration you can apply on your DHCP server after carefully reviewing it.
 - `Online` mode lets you generate and push configuration to CloudVision, RHEL, or Ubuntu-based Linux systems.
 
+!!! Note
+    The role cannot automatically generate the ZTP bootstrap URL when using `cv_settings` in AVD.
+    Set `ztp_bootstrap_file` instead.
+
 ## Role requirements
 
 This role requires installing the `arista.cvp` collection to support CloudVision interactions.
@@ -55,6 +59,7 @@ all:
 - **`ztp_lease_time`**: Maximum lease time before devices lose IP. Renewal is max/2 (default is 300 sec).
 - **`ztp_mac_source`**: Define which mac-address field is used for identification: interface mac-address (`interface`) or system-mac-address (`system`). Default: `system`
 - **`ztp_mode`**: Define how role works either `offline` or `online` (Default `offline`).
+- **`ztp_bootstrap_file`**: URL to set as boot-file option (Default `http://<cvp_instance_ips[0]>/ztp/bootstrap`).
 - **`avd_dhcp_provisioner_provision`**: Run `arista.cvp.dhcp_configuration` in either online or offline mode (Default `true`).
 
 *Example*:

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/defaults/main.yml
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/defaults/main.yml
@@ -32,3 +32,6 @@ ztp_mac_source: system
 
 # Default value to build config or deploy config
 ztp_mode: offline
+
+# Default value is generated in the template
+# ztp_bootstrap_file: http://<cvp_instance_ips[0]>/ztp/bootstrap

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
@@ -5,13 +5,13 @@
 #}
 {# HEADER -- LOGIC implementation #}
 {% if ztp_bootstrap_file is not arista.avd.defined %}
-{%     set cvp_instance_ip = 'cvp_instance_ip is unset - please set' %}
+{%     set cvp_instance_ip = '<ztp_bootstrap_file is unset - please set>' %}
 {%     if hostvars[groups[fabric_group][0]]['cvp_instance_ips'] is arista.avd.defined %}
 {%         set cvp_instance_ip = hostvars[groups[fabric_group][0]]['cvp_instance_ips'][0] %}
 {%     elif hostvars[groups[fabric_group][0]]['cvp_instance_ip'] is arista.avd.defined %}
 {%         set cvp_instance_ip = hostvars[groups[fabric_group][0]]['cvp_instance_ip'] %}
 {%     endif %}
-{%     set ztp_bootstrap_file = "http://{{ cvp_instance_ip }}/ztp/bootstrap" %}
+{%     set ztp_bootstrap_file = "http://" ~ cvp_instance_ip ~ "/ztp/bootstrap" %}
 {% endif %}
 {% set node_types = dict() %}
 {% if hostvars[groups[fabric_group][0]]['node_type_keys'] is arista.avd.defined %}

--- a/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
+++ b/ansible_collections/arista/avd/roles/dhcp_provisioner/templates/ztp_configuration.j2
@@ -4,11 +4,14 @@
  that can be found in the LICENSE file.
 #}
 {# HEADER -- LOGIC implementation #}
-{% set cvp_instance_ip = 'cvp_instance_ip is unset - please set' %}
-{% if hostvars[groups[fabric_group][0]]['cvp_instance_ips'] is arista.avd.defined %}
-{%     set cvp_instance_ip = hostvars[groups[fabric_group][0]]['cvp_instance_ips'][0] %}
-{% elif hostvars[groups[fabric_group][0]]['cvp_instance_ip'] is arista.avd.defined %}
-{%     set cvp_instance_ip = hostvars[groups[fabric_group][0]]['cvp_instance_ip'] %}
+{% if ztp_bootstrap_file is not arista.avd.defined %}
+{%     set cvp_instance_ip = 'cvp_instance_ip is unset - please set' %}
+{%     if hostvars[groups[fabric_group][0]]['cvp_instance_ips'] is arista.avd.defined %}
+{%         set cvp_instance_ip = hostvars[groups[fabric_group][0]]['cvp_instance_ips'][0] %}
+{%     elif hostvars[groups[fabric_group][0]]['cvp_instance_ip'] is arista.avd.defined %}
+{%         set cvp_instance_ip = hostvars[groups[fabric_group][0]]['cvp_instance_ip'] %}
+{%     endif %}
+{%     set ztp_bootstrap_file = "http://{{ cvp_instance_ip }}/ztp/bootstrap" %}
 {% endif %}
 {% set node_types = dict() %}
 {% if hostvars[groups[fabric_group][0]]['node_type_keys'] is arista.avd.defined %}
@@ -42,7 +45,7 @@
 ---
 ztp:
   default:
-    registration: http://{{ cvp_instance_ip }}/ztp/bootstrap
+    registration: {{ ztp_bootstrap_file }}
 {% if hostvars[groups[fabric_group][0]]['mgmt_gateway'] is arista.avd.defined %}
     gateway: {{ hostvars[groups[fabric_group][0]]['mgmt_gateway'] }}
 {% endif %}


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add ztp_bootstrap_file option when used with cv_settings

arista.avd.dhcp_provisioner cannot generate the URL automatically from cv_settings.
Instead this PR adds a new `ztp_bootstrap_file` option to the role, which overrides the
default logic.

## Component(s) name

`arista.avd.dhcp_provisioner`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

```yaml
# CloudVision server
cv_settings:
  onprem_clusters:
    - name: test
      servers:
        - name: 192.168.200.11

# Note! The arista.avd.dhcp_provisioner role does not support cv_settings.
# Instead the ZTP URL can be set with 'ztp_bootstrap_file'
ztp_bootstrap_file: http://192.168.200.11/ztp/bootstrap
```

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Existing molecule covers this now, since `cv_instance_ips` has been deprecated. We no longer test the `cv_instance_ips` variant, but nothing has changed there for a long time.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
