### PR TITLE
Refactor(eos_designs): Use new eos_cli_config_gen model for SSH ACLs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-1.cfg
@@ -29,8 +29,8 @@ no ip routing vrf MGMT
 ip route vrf MGMT 0.0.0.0/0 10.10.10.1
 !
 management ssh
-   ip access-group ACL-SSH vrf MGMT in
    ip access-group ACL-SSH-MGMT-INTERFACE vrf MGMT in
+   ip access-group ACL-SSH vrf VRF20 in
    ipv6 access-group ACL-SSH6 vrf VRF10 in
    ipv6 access-group ACL-SSH-VRF-DEFAULT in
    idle-timeout 15
@@ -46,5 +46,8 @@ management ssh
    !
    vrf VRF12
       shutdown
+   !
+   vrf VRF20
+      no shutdown
 !
 end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-1.yml
@@ -20,25 +20,22 @@ management_interfaces:
   type: oob
   gateway: 10.10.10.1
 management_ssh:
-  access_groups:
-  - name: ACL-SSH
-    vrf: MGMT
-  - name: ACL-SSH-MGMT-INTERFACE
-    vrf: MGMT
-  ipv6_access_groups:
-  - name: ACL-SSH-VRF-DEFAULT
-  - name: ACL-SSH6
-    vrf: VRF10
+  ipv6_access_group_in: ACL-SSH-VRF-DEFAULT
   idle_timeout: 15
   vrfs:
   - name: default
     enable: true
   - name: MGMT
     enable: true
+    ip_access_group_in: ACL-SSH-MGMT-INTERFACE
   - name: VRF10
     enable: true
+    ipv6_access_group_in: ACL-SSH6
   - name: VRF12
     enable: false
+  - name: VRF20
+    enable: true
+    ip_access_group_in: ACL-SSH
 metadata:
   fabric_name: EOS_DESIGNS_UNIT_TESTS
 service_routing_protocols_model: multi-agent

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
@@ -12,8 +12,7 @@ management_api_http:
   enable_vrfs:
   - name: MGMT
 management_ssh:
-  access_groups:
-  - name: ACL-SSH-INBAND-MGMT
+  ip_access_group_in: ACL-SSH-INBAND-MGMT
   vrfs:
   - name: default
     enable: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-1.yml
@@ -11,7 +11,7 @@ mgmt_gateway: 10.10.10.1
 
 ssh_settings:
   vrfs:
-    - name: MGMT
+    - name: VRF20
       enabled: true
       ipv4_acl: ACL-SSH
     - name: VRF10

--- a/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
@@ -43,5 +43,5 @@ class ManagementSshMixin(Protocol):
                     self.structured_config.management_ssh.ipv6_access_group_in = vrf.ipv6_acl if vrf.ipv6_acl else None
                 else:
                     management_ssh_vrf = self.structured_config.management_ssh.vrfs.obtain(vrf_name)
-                    management_ssh_vrf.ip_access_group_in=vrf.ipv4_acl if vrf.ipv4_acl else None
-                    management_ssh_vrf.ipv6_access_group_in=vrf.ipv6_acl if vrf.ipv6_acl else None
+                    management_ssh_vrf.ip_access_group_in = vrf.ipv4_acl if vrf.ipv4_acl else None
+                    management_ssh_vrf.ipv6_access_group_in = vrf.ipv6_acl if vrf.ipv6_acl else None

--- a/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
@@ -38,8 +38,10 @@ class ManagementSshMixin(Protocol):
             self.structured_config.management_ssh.vrfs.append_new(name=vrf_name, enable=vrf.enabled)
 
             if vrf.enabled:
-                if vrf.ipv4_acl:
-                    self.structured_config.management_ssh.access_groups.append_new(name=vrf.ipv4_acl, vrf=vrf_name if vrf_name != "default" else None)
-
-                if vrf.ipv6_acl:
-                    self.structured_config.management_ssh.ipv6_access_groups.append_new(name=vrf.ipv6_acl, vrf=vrf_name if vrf_name != "default" else None)
+                if vrf_name == "default":
+                    self.structured_config.management_ssh.ip_access_group_in = vrf.ipv4_acl if vrf.ipv4_acl else None
+                    self.structured_config.management_ssh.ipv6_access_group_in = vrf.ipv6_acl if vrf.ipv6_acl else None
+                else:
+                    management_ssh_vrf = self.structured_config.management_ssh.vrfs.obtain(vrf_name)
+                    management_ssh_vrf.ip_access_group_in=vrf.ipv4_acl if vrf.ipv4_acl else None
+                    management_ssh_vrf.ipv6_access_group_in=vrf.ipv6_acl if vrf.ipv6_acl else None


### PR DESCRIPTION
## Change Summary

Refactored code to use new eos_cli_config_gen model for SSH ACLs

## Related Issue(s)

Fixes #5556 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Updated `management_ssh` method to to use new eos_cli_config_gen model for SSH ACLs


## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code has been rebased from devel before I start
- [ ] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [ ] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
