### PR TITLE
CI: Add ignore for ansible 2.20 when testing devel

### DIFF
--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.20.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.20.txt
@@ -1,0 +1,13 @@
+plugins/modules/configlet_build_config.py validate-modules:missing-gplv3-license
+plugins/modules/eos_designs_documentation.py validate-modules:missing-gplv3-license
+plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
+plugins/modules/eos_designs_structured_config.py validate-modules:missing-gplv3-license
+plugins/modules/inventory_to_container.py validate-modules:missing-gplv3-license
+plugins/modules/set_vars.py validate-modules:missing-gplv3-license
+plugins/modules/verify_requirements.py validate-modules:missing-gplv3-license
+plugins/vars/global_vars.py validate-modules:missing-gplv3-license
+plugins/modules/eos_validate_state_runner.py validate-modules:missing-gplv3-license
+plugins/modules/eos_validate_state_reports.py validate-modules:missing-gplv3-license
+plugins/modules/cv_workflow.py validate-modules:missing-gplv3-license
+plugins/modules/eos_cli_config_gen.py validate-modules:missing-gplv3-license
+plugins/modules/anta_workflow.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
## Change Summary

Ansible devel just bumped its version to 2.20.0..dev0 which is not covered by our sanity ignores
this PR fixes it

## Related Issue(s)

CI is sad 🔴 

## Component(s) name

`ci`

## Proposed changes

Add ignore file

## How to test

CI is happy 🍏 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
