### PR TITLE
Fix(eos_cli_config_gen): Fix documentation generation when using vrf default for SSH

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -778,6 +778,9 @@ management ssh
    no shutdown
    log-level debug
    !
+   vrf default
+      no shutdown
+   !
    vrf mgt
       no shutdown
 ```

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -6811,6 +6811,9 @@ management ssh
    no shutdown
    log-level debug
    !
+   vrf default
+      no shutdown
+   !
    vrf mgt
       no shutdown
 !

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ssh.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ssh.yml
@@ -18,7 +18,7 @@ management_ssh:
       enable: true
       ip_access_group_in: ACL-SSH-VRF
       ipv6_access_group_in: ACL-SSH-VRF6
-    - name: default # the great evil
+    - name: default
       enable: true
   log_level: debug
   client_alive:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ssh.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/management-ssh.yml
@@ -18,6 +18,8 @@ management_ssh:
       enable: true
       ip_access_group_in: ACL-SSH-VRF
       ipv6_access_group_in: ACL-SSH-VRF6
+    - name: default # the great evil
+      enable: true
   log_level: debug
   client_alive:
     count_max: 42

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-ssh.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/management-ssh.j2
@@ -16,7 +16,7 @@
 {%     if management_ssh.vrfs is arista.avd.defined %}
 {%         for vrf in management_ssh.vrfs | arista.avd.natural_sort %}
 {%             if vrf.name == "default" %}
-{%                 set _vrf_default_.enable = vrf.enable | arista.avd.default(_vrf_default.enable) %}
+{%                 set _vrf_default.enable = vrf.enable | arista.avd.default(_vrf_default.enable) %}
 {%             else %}
 {%                 if vrf.enable is arista.avd.defined and _vrf_default.enable is not arista.avd.defined %}
 {%                     set _vrf_default.enable = false %}


### PR DESCRIPTION
## Change Summary

title

## Related Issue(s)

reported by the field

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

Fix typo + add test

## How to test

molecule is 🍏 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
