### PR TITLE
Fix(eos_cli_config_gen): Counters for default matches in traffic policies must also be explicitly created

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -12593,6 +12593,8 @@ traffic-policies
       match ipv6-all-default ipv6
    !
    traffic-policy BLUE-C3-POLICY
+      counter test
+      !
       match ipv4-all-default ipv4
          actions
             count test
@@ -12602,6 +12604,8 @@ traffic-policies
       match ipv6-all-default ipv6
    !
    traffic-policy BLUE-C4-POLICY
+      counter test
+      !
       match ipv4-all-default ipv4
       !
       match ipv6-all-default ipv6

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -6742,6 +6742,8 @@ traffic-policies
       match ipv6-all-default ipv6
    !
    traffic-policy BLUE-C3-POLICY
+      counter test
+      !
       match ipv4-all-default ipv4
          actions
             count test
@@ -6751,6 +6753,8 @@ traffic-policies
       match ipv6-all-default ipv6
    !
    traffic-policy BLUE-C4-POLICY
+      counter test
+      !
       match ipv4-all-default ipv4
       !
       match ipv6-all-default ipv6

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/traffic-policies.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/traffic-policies.j2
@@ -46,20 +46,28 @@ traffic-policies
 {# TRAFFIC POLICIES #}
 {%     for policy in traffic_policies.policies | arista.avd.natural_sort('name') %}
    traffic-policy {{ policy.name }}
+{%         set transient_values = namespace() %}
+{%         set transient_values.counters = [] %}
+{%         if policy.default_actions.ipv4.count is arista.avd.defined %}
+{%             do transient_values.counters.append(policy.default_actions.ipv4.count | string) %}
+{%         endif %}
+{%         if policy.default_actions.ipv6.count is arista.avd.defined %}
+{%             do transient_values.counters.append(policy.default_actions.ipv6.count | string) %}
+{%         endif %}
 {%         if policy.matches is arista.avd.defined %}
 {# COUNTER CREATION SECTION #}
-{%             set transient_values = namespace() %}
-{%             set transient_values.counters = [] %}
 {%             for match in policy.matches %}
 {%                 if match.actions.count is arista.avd.defined %}
 {%                     do transient_values.counters.append(match.actions.count | string) %}
 {%                 endif %}
 {%             endfor %}
-{%             if transient_values.counters | length > 0 %}
+{%         endif %}
+{%         if transient_values.counters | length > 0 %}
       counter {{ transient_values.counters | arista.avd.natural_sort | join(' ') }}
       !
-{%             endif %}
+{%         endif %}
 {# MATCH SECTION #}
+{%         if policy.matches is arista.avd.defined %}
 {%             for match in policy.matches %}
       match {{ match.name }} {{ match.type | lower }}
 {#                 -- SOURCE PREFIX MANAGEMENT -- #}


### PR DESCRIPTION
## Change Summary

Named counters for `ipv4-all-default` and `ipv6-all-default` can be created, but must also be explicitly defined for them to work.  

## Related Issue(s)

Fixes #5628

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
I reworked some of the logic so that we also check if any counters for the defaults have been created, and add them to the list. Some of the if checks needed to be reworked, as they assumed that you would only have named counters created within match statements, rather than if you just have default_actions

## How to test
The existing tests covered this usecase, just that the outputs were wrong.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
