### PR TITLE
CI(containers): bump qemu to 9.2.2

### DIFF
--- a/.github/workflows/container_build_template.yml
+++ b/.github/workflows/container_build_template.yml
@@ -171,7 +171,7 @@ jobs:
         uses: docker/setup-qemu-action@v3
         with:
           platforms: ${{ inputs.platform }}
-          image: tonistiigi/binfmt:qemu-v7.0.0-28
+          image: tonistiigi/binfmt:qemu-v9.2.2-52
           # workaround for Failed to CreateCacheEntry warning
           cache-image: false
 


### PR DESCRIPTION
## Change Summary

Bump tonistiigi/binfmt:qemu image to 9.2.2.
QEMU 9.2.2 fixes segfault error for ARM builds
Reference:
- https://gitlab.com/qemu-project/qemu/-/issues/1913
- https://github.com/tonistiigi/binfmt/pull/243

## Component(s) name

Containers