### PR TITLE
Refactor(eos_designs): Deprecate support for unknown variables in structured_config

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
@@ -230,3 +230,4 @@ vxlan_interface:
     vxlan:
       source_interface: Loopback1
       udp_port: 4789
+custom_key2: foo

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/node_type.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/host_vars/host1/node_type.yml
@@ -16,6 +16,9 @@ l3leaf:
     - name: host1
       id: 101
       bgp_as: 101
+      structured_config:
+        # Having custom keys in structured_config is deprecated and support will be removed in AVD 6.0.0.
+        custom_key2: foo
   node_groups:
     - group: sflow-tests-leaf-mlag
       bgp_as: 65105


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Deprecate support for unknown variables in structured_config

## Related Issue(s)

Preparing for 6.0

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Detect unknown variables in places where the whole schema has been $ref. Effectively this only applies to structured_config keys in eos_designs.
- Emit a deprecation warning suggesting to prefix the key with underscore.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Added test to molecule and verified deprecation warning:

```sh
[DEPRECATION WARNING]: [host1]: The input data model 
'l3leaf.nodes[0].structured_config.custom_key2' is deprecated. Use 
'_custom_key2' instead. This feature will be removed from 
arista.avd.eos_designs in version 6.0.0. Deprecation warnings can be disabled 
by setting deprecation_warnings=False in ansible.cfg.
```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
