### PR TITLE
Fix(eos_designs): per-interface L3 MTU feature support for iBGP SVIs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -182,7 +182,6 @@ interface Port-Channel571
 interface Ethernet49/1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet28
    no shutdown
-   mtu 1500
    speed forced 100gfull
    no switchport
    ip address 172.31.255.129/31
@@ -190,7 +189,6 @@ interface Ethernet49/1
 interface Ethernet50/1
    description P2P_LINK_TO_DC1-SPINE2_Ethernet28
    no shutdown
-   mtu 1500
    speed forced 100gfull
    no switchport
    ip address 172.31.255.131/31
@@ -198,7 +196,6 @@ interface Ethernet50/1
 interface Ethernet51/1
    description P2P_LINK_TO_DC1-SPINE3_Ethernet28
    no shutdown
-   mtu 1500
    speed forced 100gfull
    no switchport
    ip address 172.31.255.133/31
@@ -206,7 +203,6 @@ interface Ethernet51/1
 interface Ethernet52/1
    description P2P_LINK_TO_DC1-SPINE4_Ethernet28
    no shutdown
-   mtu 1500
    speed forced 100gfull
    no switchport
    ip address 172.31.255.135/31
@@ -248,7 +244,6 @@ interface Management42
 interface Vlan2
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.24/31
 !
@@ -270,7 +265,6 @@ interface Vlan111
 interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
-   mtu 1560
    vrf Tenant_A_OP_Zone
    ip helper-address 2.2.2.2 vrf MGMT source-interface lo101
 !
@@ -286,7 +280,6 @@ interface Vlan120
 interface Vlan121
    description Tenant_A_WEBZone_2
    shutdown
-   mtu 1560
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.10.254/24
 !
@@ -363,69 +356,59 @@ interface Vlan350
 interface Vlan3008
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.24/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_WEB_Zone
    ip address 172.31.11.24/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.24/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.24/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.24/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.24/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.24/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.24/31
 !
 interface Vlan4090
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 1500
    ip address 10.255.251.24/31
 !
 interface Vlan4092
    description MLAG_PEER
    no shutdown
-   mtu 1500
    no autostate
    ip address 10.255.252.24/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -182,7 +182,6 @@ interface Port-Channel571
 interface Ethernet49/1
    description P2P_LINK_TO_DC1-SPINE1_Ethernet29
    no shutdown
-   mtu 1500
    speed forced 100gfull
    no switchport
    ip address 172.31.255.161/31
@@ -190,7 +189,6 @@ interface Ethernet49/1
 interface Ethernet50/1
    description P2P_LINK_TO_DC1-SPINE2_Ethernet29
    no shutdown
-   mtu 1500
    speed forced 100gfull
    no switchport
    ip address 172.31.255.163/31
@@ -198,7 +196,6 @@ interface Ethernet50/1
 interface Ethernet51/1
    description P2P_LINK_TO_DC1-SPINE3_Ethernet29
    no shutdown
-   mtu 1500
    speed forced 100gfull
    no switchport
    ip address 172.31.255.165/31
@@ -206,7 +203,6 @@ interface Ethernet51/1
 interface Ethernet52/1
    description P2P_LINK_TO_DC1-SPINE4_Ethernet29
    no shutdown
-   mtu 1500
    speed forced 100gfull
    no switchport
    ip address 172.31.255.167/31
@@ -248,7 +244,6 @@ interface Management42
 interface Vlan2
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_OP_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_C_OP_Zone
    ip address 10.255.251.25/31
 !
@@ -270,7 +265,6 @@ interface Vlan111
 interface Vlan112
    description Tenant_A_OP_Zone_3
    no shutdown
-   mtu 1560
    vrf Tenant_A_OP_Zone
    ip helper-address 2.2.2.2 vrf MGMT source-interface lo101
 !
@@ -286,7 +280,6 @@ interface Vlan120
 interface Vlan121
    description Tenant_A_WEBZone_2
    shutdown
-   mtu 1560
    vrf Tenant_A_WEB_Zone
    ip address virtual 10.1.10.254/24
 !
@@ -363,69 +356,59 @@ interface Vlan350
 interface Vlan3008
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_OP_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_OP_Zone
    ip address 10.255.251.25/31
 !
 interface Vlan3010
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WEB_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_WEB_Zone
    ip address 172.31.11.25/31
 !
 interface Vlan3011
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_APP_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_APP_Zone
    ip address 10.255.251.25/31
 !
 interface Vlan3012
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_DB_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_DB_Zone
    ip address 10.255.251.25/31
 !
 interface Vlan3013
    description MLAG_PEER_L3_iBGP: vrf Tenant_A_WAN_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_A_WAN_Zone
    ip address 10.255.251.25/31
 !
 interface Vlan3019
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_OP_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_B_OP_Zone
    ip address 10.255.251.25/31
 !
 interface Vlan3020
    description MLAG_PEER_L3_iBGP: vrf Tenant_B_WAN_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_B_WAN_Zone
    ip address 10.255.251.25/31
 !
 interface Vlan3030
    description MLAG_PEER_L3_iBGP: vrf Tenant_C_WAN_Zone
    no shutdown
-   mtu 1500
    vrf Tenant_C_WAN_Zone
    ip address 10.255.251.25/31
 !
 interface Vlan4090
    description MLAG_PEER_L3_PEERING
    no shutdown
-   mtu 1500
    ip address 10.255.251.25/31
 !
 interface Vlan4092
    description MLAG_PEER
    no shutdown
-   mtu 1500
    no autostate
    ip address 10.255.252.25/31
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/add-subnets-to-redistribution-in-default-vrf-with-sequence30.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/add-subnets-to-redistribution-in-default-vrf-with-sequence30.cfg
@@ -114,7 +114,6 @@ interface Ethernet1
 interface Ethernet2
    description L2_tenant-default-vrf-static-routes_Ethernet1
    no shutdown
-   mtu 9214
    no switchport
 !
 interface Ethernet2.111

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -40,7 +40,6 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DC1-SPINE1_Ethernet28
   shutdown: false
   speed: forced 100gfull
-  mtu: 1500
   ip_address: 172.31.255.129/31
   peer: DC1-SPINE1
   peer_interface: Ethernet28
@@ -51,7 +50,6 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DC1-SPINE2_Ethernet28
   shutdown: false
   speed: forced 100gfull
-  mtu: 1500
   ip_address: 172.31.255.131/31
   peer: DC1-SPINE2
   peer_interface: Ethernet28
@@ -62,7 +60,6 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DC1-SPINE3_Ethernet28
   shutdown: false
   speed: forced 100gfull
-  mtu: 1500
   ip_address: 172.31.255.133/31
   peer: DC1-SPINE3
   peer_interface: Ethernet28
@@ -73,7 +70,6 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DC1-SPINE4_Ethernet28
   shutdown: false
   speed: forced 100gfull
-  mtu: 1500
   ip_address: 172.31.255.135/31
   peer: DC1-SPINE4
   peer_interface: Ethernet28
@@ -673,12 +669,10 @@ vlan_interfaces:
   description: MLAG_PEER_L3_PEERING
   shutdown: false
   ip_address: 10.255.251.24/31
-  mtu: 1500
 - name: Vlan4092
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.24/31
-  mtu: 1500
   no_autostate: true
 - name: Vlan130
   description: Tenant_A_APP_Zone_1
@@ -702,7 +696,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_APP_Zone
   ip_address: 10.255.251.24/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan140
@@ -727,7 +720,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_DB_Zone
   ip_address: 10.255.251.24/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan110
@@ -760,7 +752,6 @@ vlan_interfaces:
   - ip_helper: 2.2.2.2
     source_interface: lo101
     vrf: MGMT
-  mtu: 1560
   tenant: Tenant_A
   tags:
   - opzone
@@ -769,7 +760,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_OP_Zone
   ip_address: 10.255.251.24/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan150
@@ -790,7 +780,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_WAN_Zone
   ip_address: 10.255.251.24/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan120
@@ -814,7 +803,6 @@ vlan_interfaces:
   shutdown: true
   vrf: Tenant_A_WEB_Zone
   ip_address_virtual: 10.1.10.254/24
-  mtu: 1560
   tenant: Tenant_A
   tags:
   - web
@@ -823,7 +811,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_WEB_Zone
   ip_address: 172.31.11.24/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan210
@@ -847,7 +834,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_B_OP_Zone
   ip_address: 10.255.251.24/31
-  mtu: 1500
   tenant: Tenant_B
   type: underlay_peering
 - name: Vlan250
@@ -863,7 +849,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_B_WAN_Zone
   ip_address: 10.255.251.24/31
-  mtu: 1500
   tenant: Tenant_B
   type: underlay_peering
 - name: Vlan310
@@ -887,7 +872,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_C_OP_Zone
   ip_address: 10.255.251.24/31
-  mtu: 1500
   tenant: Tenant_C
   type: underlay_peering
 - name: Vlan350
@@ -903,7 +887,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_C_WAN_Zone
   ip_address: 10.255.251.24/31
-  mtu: 1500
   tenant: Tenant_C
   type: underlay_peering
 vlan_internal_order:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -40,7 +40,6 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DC1-SPINE1_Ethernet29
   shutdown: false
   speed: forced 100gfull
-  mtu: 1500
   ip_address: 172.31.255.161/31
   peer: DC1-SPINE1
   peer_interface: Ethernet29
@@ -51,7 +50,6 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DC1-SPINE2_Ethernet29
   shutdown: false
   speed: forced 100gfull
-  mtu: 1500
   ip_address: 172.31.255.163/31
   peer: DC1-SPINE2
   peer_interface: Ethernet29
@@ -62,7 +60,6 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DC1-SPINE3_Ethernet29
   shutdown: false
   speed: forced 100gfull
-  mtu: 1500
   ip_address: 172.31.255.165/31
   peer: DC1-SPINE3
   peer_interface: Ethernet29
@@ -73,7 +70,6 @@ ethernet_interfaces:
   description: P2P_LINK_TO_DC1-SPINE4_Ethernet29
   shutdown: false
   speed: forced 100gfull
-  mtu: 1500
   ip_address: 172.31.255.167/31
   peer: DC1-SPINE4
   peer_interface: Ethernet29
@@ -673,12 +669,10 @@ vlan_interfaces:
   description: MLAG_PEER_L3_PEERING
   shutdown: false
   ip_address: 10.255.251.25/31
-  mtu: 1500
 - name: Vlan4092
   description: MLAG_PEER
   shutdown: false
   ip_address: 10.255.252.25/31
-  mtu: 1500
   no_autostate: true
 - name: Vlan130
   description: Tenant_A_APP_Zone_1
@@ -702,7 +696,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_APP_Zone
   ip_address: 10.255.251.25/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan140
@@ -727,7 +720,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_DB_Zone
   ip_address: 10.255.251.25/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan110
@@ -760,7 +752,6 @@ vlan_interfaces:
   - ip_helper: 2.2.2.2
     source_interface: lo101
     vrf: MGMT
-  mtu: 1560
   tenant: Tenant_A
   tags:
   - opzone
@@ -769,7 +760,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_OP_Zone
   ip_address: 10.255.251.25/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan150
@@ -790,7 +780,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_WAN_Zone
   ip_address: 10.255.251.25/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan120
@@ -814,7 +803,6 @@ vlan_interfaces:
   shutdown: true
   vrf: Tenant_A_WEB_Zone
   ip_address_virtual: 10.1.10.254/24
-  mtu: 1560
   tenant: Tenant_A
   tags:
   - web
@@ -823,7 +811,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_A_WEB_Zone
   ip_address: 172.31.11.25/31
-  mtu: 1500
   tenant: Tenant_A
   type: underlay_peering
 - name: Vlan210
@@ -847,7 +834,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_B_OP_Zone
   ip_address: 10.255.251.25/31
-  mtu: 1500
   tenant: Tenant_B
   type: underlay_peering
 - name: Vlan250
@@ -863,7 +849,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_B_WAN_Zone
   ip_address: 10.255.251.25/31
-  mtu: 1500
   tenant: Tenant_B
   type: underlay_peering
 - name: Vlan310
@@ -887,7 +872,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_C_OP_Zone
   ip_address: 10.255.251.25/31
-  mtu: 1500
   tenant: Tenant_C
   type: underlay_peering
 - name: Vlan350
@@ -903,7 +887,6 @@ vlan_interfaces:
   shutdown: false
   vrf: Tenant_C_WAN_Zone
   ip_address: 10.255.251.25/31
-  mtu: 1500
   tenant: Tenant_C
   type: underlay_peering
 vlan_internal_order:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/add-subnets-to-redistribution-in-default-vrf-with-sequence30.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/add-subnets-to-redistribution-in-default-vrf-with-sequence30.yml
@@ -40,7 +40,6 @@ ethernet_interfaces:
 - name: Ethernet2
   description: L2_tenant-default-vrf-static-routes_Ethernet1
   shutdown: false
-  mtu: 9214
   peer: tenant-default-vrf-static-routes
   peer_interface: Ethernet1
   peer_type: l3leaf
@@ -117,6 +116,7 @@ management_security:
       file: STUN-DTLS.crt
       key: STUN-DTLS.key
 metadata:
+  platform: custom_platform
   fabric_name: EOS_DESIGNS_UNIT_TESTS
   cv_tags:
     device_tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/AVD_LAB.yml
@@ -159,6 +159,7 @@ custom_platform_settings:
       interface_storm_control: false
       bgp_update_wait_for_convergence: true
       bgp_update_wait_install: true
+      per_interface_mtu: false
 
   # Test overwriting an existing platform
   - platforms: [ 7280R ]

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/add-subnets-to-redistribution-in-default-vrf-with-sequence30.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/add-subnets-to-redistribution-in-default-vrf-with-sequence30.yml
@@ -9,11 +9,13 @@ wan_router: # dynamic_key: node_type
     uplink_type: lan
     uplink_switches: [tenant-default-vrf-static-routes]
     uplink_interfaces: [Ethernet2]
+    uplink_mtu: 9216
     filter:
       tags: [wan_router]
   nodes:
     - name: add-subnets-to-redistribution-in-default-vrf-with-sequence30
       id: 1
+      platform: custom_platform
       uplink_switch_interfaces: [Ethernet1]
       uplink_native_vlan: 10
       cv_pathfinder_region: region1
@@ -23,6 +25,11 @@ wan_router: # dynamic_key: node_type
           wan_carrier: Comcast
           wan_circuit_id: 999
           ip_address: 10.9.9.9/31
+
+custom_platform_settings:
+  - platforms: [ custom_platform ]
+    feature_support:
+      per_interface_mtu: false
 
 tenants: # dynamic_key: network_services
   - name: TEST

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
@@ -172,7 +172,7 @@ class VlanInterfacesMixin(Protocol):
                 InterfaceDescriptionData(shared_utils=self.shared_utils, interface=f"Vlan{vlan_id}", vrf=vrf.name, vlan=vlan_id)
             ),
             vrf=vrf.name,
-            mtu=self.shared_utils.p2p_uplinks_mtu,
+            mtu=self.shared_utils.get_interface_mtu(f"Vlan{vlan_id}", self.shared_utils.p2p_uplinks_mtu),
         )
         vlan_interface_config._update(**self._get_vlan_ip_config_for_mlag_peering(vrf))
         return vlan_interface_config

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/utils.py
@@ -196,10 +196,14 @@ class UtilsMixin(Protocol):
             del interfaces[link.interface]
         else:
             main_interface = EosCliConfigGen.EthernetInterfacesItem(
-                switchport=EosCliConfigGen.EthernetInterfacesItem.Switchport(enabled=False), mtu=self.shared_utils.p2p_uplinks_mtu
+                switchport=EosCliConfigGen.EthernetInterfacesItem.Switchport(enabled=False),
+                mtu=self.shared_utils.get_interface_mtu(link.interface, self.shared_utils.p2p_uplinks_mtu),
             )
 
-        if (mtu := default(main_interface.mtu, 1500)) != self.shared_utils.p2p_uplinks_mtu:
+        if (
+            self.shared_utils.platform_settings.feature_support.per_interface_mtu
+            and (mtu := default(main_interface.mtu, 1500)) != self.shared_utils.p2p_uplinks_mtu
+        ):
             msg = (
                 f"MTU '{self.shared_utils.p2p_uplinks_mtu}' set for 'p2p_uplinks_mtu' conflicts with MTU '{mtu}' "
                 f"set on SVI for uplink_native_vlan '{link.native_vlan}'."


### PR DESCRIPTION
## Change Summary

Respect `feature_support.per_interface_mtu` flag when rendering L3 MTU for iBGP SVIs

## Related Issue(s)

Fixes #5683

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Use `get_interface_mtu` (which respects L3 MTU feature support) when rendering L3 MTU for iBGP SVIs over MLAG peer-link

## How to test
molecule scenario `eos_designs_unit_tests` (device group `DC1_UNDEPLOYED_LEAF1`)

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
