### PR TITLE
Feat(eos_designs): Added support for ipv6_static_routes under l3_interfaces and l3_portchannel_interfaces in network_services

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-services-static-routes.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/network-services-static-routes.cfg
@@ -157,6 +157,9 @@ ip route vrf TESTING 10.10.10.0/24 10.10.10.10
 ip route vrf VRF_STATIC_ROUTE_ON_L3_INTERFACE 10.10.10.0/24 10.10.10.10
 ip route vrf VRF_STATIC_ROUTE_ON_L3_PORT_CHANNEL 10.10.10.0/24 10.10.10.10
 !
+ipv6 route vrf TESTING 2001:db8::0/64 2001:db8::10
+ipv6 route vrf TESTING 2002:db8::0/64 2002:db8::10
+!
 route-map RM-BGP-UNDERLAY-PEERS-OUT deny 10
    match ip address prefix-list PL-SVI-VRF-DEFAULT
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-static-routes.yml
@@ -85,6 +85,13 @@ ip_igmp_snooping:
   globally_enabled: true
 ip_routing: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
+ipv6_static_routes:
+- vrf: TESTING
+  prefix: 2001:db8::0/64
+  next_hop: 2001:db8::10
+- vrf: TESTING
+  prefix: 2002:db8::0/64
+  next_hop: 2002:db8::10
 is_deployed: true
 loopback_interfaces:
 - name: Loopback0

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/network-services-static-routes.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/network-services-static-routes.yml
@@ -75,6 +75,9 @@ tenants:
             static_routes:
               - prefix: 10.10.10.0/24
                 next_hop: 10.10.10.10
+            ipv6_static_routes:
+              - prefix: 2001:db8::0/64
+                next_hop: 2001:db8::10
         l3_port_channels:
           - name: Port-Channel2
             mode: active
@@ -89,6 +92,9 @@ tenants:
             static_routes:
               - prefix: 10.10.10.0/24
                 next_hop: 10.10.10.10
+            ipv6_static_routes:
+              - prefix: 2002:db8::0/64
+                next_hop: 2002:db8::10
       - name: VRF_STATIC_ROUTE_ON_L3_INTERFACE
         vrf_id: 3
         l3_interfaces:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
@@ -18,7 +18,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;int&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].encapsulation_dot1q_vlan.[]") | Integer |  |  | Min: 1<br>Max: 4094 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_addresses</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ip_addresses") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ip_addresses.[]") | String |  |  |  | IPv4_address/Mask. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on every device when this interface is configured. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on every device where this interface is configured. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].prefix") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
@@ -27,7 +27,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].name") | String |  |  |  | description. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].interface") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device when this interface is configured. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device where this interface is configured. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
@@ -105,7 +105,7 @@
                     # IPv4_address/Mask.
                   - <str>
 
-                # Static routes to be configured on every device when this interface is configured.
+                # Static routes to be configured on every device where this interface is configured.
                 static_routes:
                   - prefix: <str>
                     next_hop: <str>
@@ -120,7 +120,7 @@
                     metric: <int; 0-4294967295>
                     interface: <str>
 
-                # IPv6 static routes to be configured on every device when this interface is configured.
+                # IPv6 static routes to be configured on every device where this interface is configured.
                 ipv6_static_routes:
                   - prefix: <str>
                     next_hop: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
@@ -27,6 +27,15 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].name") | String |  |  |  | description. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].interface") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device when this interface is configured. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tag</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].tag") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].name") | String |  |  |  | description. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].nodes") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].nodes.[]") | String |  |  |  | Node. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].description") | String |  |  |  |  |
@@ -98,6 +107,21 @@
 
                 # Static routes to be configured on every device when this interface is configured.
                 static_routes:
+                  - prefix: <str>
+                    next_hop: <str>
+
+                    # Track next-hop using BFD.
+                    track_bfd: <bool>
+                    distance: <int; 1-255>
+                    tag: <int; 0-4294967295>
+
+                    # description.
+                    name: <str>
+                    metric: <int; 0-4294967295>
+                    interface: <str>
+
+                # IPv6 static routes to be configured on every device when this interface is configured.
+                ipv6_static_routes:
                   - prefix: <str>
                     next_hop: <str>
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
@@ -31,7 +31,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;mtu</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].mtu") | Integer |  |  |  | MTU can only be set on the parent Port-Channel. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on the device when this Port-channel is configured. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on the device where this Port-channel interface is configured. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].prefix") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
@@ -40,7 +40,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].name") | String |  |  |  | description. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].interface") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device when this interface is configured. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on the device where this Port-channel interface is configured. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
@@ -157,7 +157,7 @@
                 # Name of the IPv4 Access-list to be assigned in the egress direction.
                 ipv4_acl_out: <str>
 
-                # Static routes to be configured on the device when this Port-channel is configured.
+                # Static routes to be configured on the device where this Port-channel interface is configured.
                 static_routes:
                   - prefix: <str>
                     next_hop: <str>
@@ -172,7 +172,7 @@
                     metric: <int; 0-4294967295>
                     interface: <str>
 
-                # IPv6 static routes to be configured on every device when this interface is configured.
+                # IPv6 static routes to be configured on the device where this Port-channel interface is configured.
                 ipv6_static_routes:
                   - prefix: <str>
                     next_hop: <str>

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
@@ -40,6 +40,15 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].name") | String |  |  |  | description. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].interface") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device when this interface is configured. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;tag</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].tag") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].name") | String |  |  |  | description. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ospf</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ospf") | Dictionary |  |  |  | OSPF interface configuration. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ospf.enabled") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;point_to_point</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ospf.point_to_point") | Boolean |  | `False` |  |  |
@@ -150,6 +159,21 @@
 
                 # Static routes to be configured on the device when this Port-channel is configured.
                 static_routes:
+                  - prefix: <str>
+                    next_hop: <str>
+
+                    # Track next-hop using BFD.
+                    track_bfd: <bool>
+                    distance: <int; 1-255>
+                    tag: <int; 0-4294967295>
+
+                    # description.
+                    name: <str>
+                    metric: <int; 0-4294967295>
+                    interface: <str>
+
+                # IPv6 static routes to be configured on every device when this interface is configured.
+                ipv6_static_routes:
                   - prefix: <str>
                     next_hop: <str>
 

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -44986,14 +44986,14 @@ class EosDesigns(EosDesignsRootModel):
                         """Subclass of AvdList with `str` items."""
                         static_routes: StaticRoutes
                         """
-                        Static routes to be configured on every device when this interface is configured.
+                        Static routes to be configured on every device where this interface is configured.
 
                         Subclass of
                         AvdList with `StaticRoutesItem` items.
                         """
                         ipv6_static_routes: Ipv6StaticRoutes
                         """
-                        IPv6 static routes to be configured on every device when this interface is configured.
+                        IPv6 static routes to be configured on every device where this interface is configured.
 
                         Subclass of
                         AvdList with `Ipv6StaticRoutesItem` items.
@@ -45094,12 +45094,12 @@ class EosDesigns(EosDesignsRootModel):
                                        Subclass of AvdList with `int` items.
                                     ip_addresses: Subclass of AvdList with `str` items.
                                     static_routes:
-                                       Static routes to be configured on every device when this interface is configured.
+                                       Static routes to be configured on every device where this interface is configured.
 
                                        Subclass of
                                        AvdList with `StaticRoutesItem` items.
                                     ipv6_static_routes:
-                                       IPv6 static routes to be configured on every device when this interface is configured.
+                                       IPv6 static routes to be configured on every device where this interface is configured.
 
                                        Subclass of
                                        AvdList with `Ipv6StaticRoutesItem` items.
@@ -45609,17 +45609,13 @@ class EosDesigns(EosDesignsRootModel):
                         """Name of the IPv4 Access-list to be assigned in the egress direction."""
                         static_routes: StaticRoutes
                         """
-                        Static routes to be configured on the device when this Port-channel is configured.
-
-                        Subclass of
-                        AvdList with `StaticRoutesItem` items.
+                        Static routes to be configured on the device where this Port-channel interface is configured.
+                        Subclass of AvdList with `StaticRoutesItem` items.
                         """
                         ipv6_static_routes: Ipv6StaticRoutes
                         """
-                        IPv6 static routes to be configured on every device when this interface is configured.
-
-                        Subclass of
-                        AvdList with `Ipv6StaticRoutesItem` items.
+                        IPv6 static routes to be configured on the device where this Port-channel interface is configured.
+                        Subclass of AvdList with `Ipv6StaticRoutesItem` items.
                         """
                         ospf: Ospf
                         """
@@ -45703,15 +45699,11 @@ class EosDesigns(EosDesignsRootModel):
                                     ipv4_acl_in: Name of the IPv4 access-list to be assigned in the ingress direction.
                                     ipv4_acl_out: Name of the IPv4 Access-list to be assigned in the egress direction.
                                     static_routes:
-                                       Static routes to be configured on the device when this Port-channel is configured.
-
-                                       Subclass of
-                                       AvdList with `StaticRoutesItem` items.
+                                       Static routes to be configured on the device where this Port-channel interface is configured.
+                                       Subclass of AvdList with `StaticRoutesItem` items.
                                     ipv6_static_routes:
-                                       IPv6 static routes to be configured on every device when this interface is configured.
-
-                                       Subclass of
-                                       AvdList with `Ipv6StaticRoutesItem` items.
+                                       IPv6 static routes to be configured on the device where this Port-channel interface is configured.
+                                       Subclass of AvdList with `Ipv6StaticRoutesItem` items.
                                     ospf:
                                        OSPF interface configuration.
 

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -44578,6 +44578,67 @@ class EosDesigns(EosDesignsRootModel):
 
                         StaticRoutes._item_type = StaticRoutesItem
 
+                        class Ipv6StaticRoutesItem(AvdModel):
+                            """Subclass of AvdModel."""
+
+                            _fields: ClassVar[dict] = {
+                                "prefix": {"type": str},
+                                "next_hop": {"type": str},
+                                "track_bfd": {"type": bool},
+                                "distance": {"type": int},
+                                "tag": {"type": int},
+                                "name": {"type": str},
+                                "metric": {"type": int},
+                                "interface": {"type": str},
+                            }
+                            prefix: str | None
+                            next_hop: str | None
+                            track_bfd: bool | None
+                            """Track next-hop using BFD."""
+                            distance: int | None
+                            tag: int | None
+                            name: str | None
+                            """description."""
+                            metric: int | None
+                            interface: str | None
+
+                            if TYPE_CHECKING:
+
+                                def __init__(
+                                    self,
+                                    *,
+                                    prefix: str | None | UndefinedType = Undefined,
+                                    next_hop: str | None | UndefinedType = Undefined,
+                                    track_bfd: bool | None | UndefinedType = Undefined,
+                                    distance: int | None | UndefinedType = Undefined,
+                                    tag: int | None | UndefinedType = Undefined,
+                                    name: str | None | UndefinedType = Undefined,
+                                    metric: int | None | UndefinedType = Undefined,
+                                    interface: str | None | UndefinedType = Undefined,
+                                ) -> None:
+                                    """
+                                    Ipv6StaticRoutesItem.
+
+
+                                    Subclass of AvdModel.
+
+                                    Args:
+                                        prefix: prefix
+                                        next_hop: next_hop
+                                        track_bfd: Track next-hop using BFD.
+                                        distance: distance
+                                        tag: tag
+                                        name: description.
+                                        metric: metric
+                                        interface: interface
+
+                                    """
+
+                        class Ipv6StaticRoutes(AvdList[Ipv6StaticRoutesItem]):
+                            """Subclass of AvdList with `Ipv6StaticRoutesItem` items."""
+
+                        Ipv6StaticRoutes._item_type = Ipv6StaticRoutesItem
+
                         class Nodes(AvdList[str]):
                             """Subclass of AvdList with `str` items."""
 
@@ -44791,6 +44852,7 @@ class EosDesigns(EosDesignsRootModel):
                             "encapsulation_dot1q_vlan": {"type": EncapsulationDot1qVlan},
                             "ip_addresses": {"type": IpAddresses},
                             "static_routes": {"type": StaticRoutes},
+                            "ipv6_static_routes": {"type": Ipv6StaticRoutes},
                             "nodes": {"type": Nodes},
                             "description": {"type": str},
                             "descriptions": {"type": Descriptions},
@@ -44822,6 +44884,13 @@ class EosDesigns(EosDesignsRootModel):
 
                         Subclass of
                         AvdList with `StaticRoutesItem` items.
+                        """
+                        ipv6_static_routes: Ipv6StaticRoutes
+                        """
+                        IPv6 static routes to be configured on every device when this interface is configured.
+
+                        Subclass of
+                        AvdList with `Ipv6StaticRoutesItem` items.
                         """
                         nodes: Nodes
                         """Subclass of AvdList with `str` items."""
@@ -44889,6 +44958,7 @@ class EosDesigns(EosDesignsRootModel):
                                 encapsulation_dot1q_vlan: EncapsulationDot1qVlan | UndefinedType = Undefined,
                                 ip_addresses: IpAddresses | UndefinedType = Undefined,
                                 static_routes: StaticRoutes | UndefinedType = Undefined,
+                                ipv6_static_routes: Ipv6StaticRoutes | UndefinedType = Undefined,
                                 nodes: Nodes | UndefinedType = Undefined,
                                 description: str | None | UndefinedType = Undefined,
                                 descriptions: Descriptions | UndefinedType = Undefined,
@@ -44922,6 +44992,11 @@ class EosDesigns(EosDesignsRootModel):
 
                                        Subclass of
                                        AvdList with `StaticRoutesItem` items.
+                                    ipv6_static_routes:
+                                       IPv6 static routes to be configured on every device when this interface is configured.
+
+                                       Subclass of
+                                       AvdList with `Ipv6StaticRoutesItem` items.
                                     nodes: Subclass of AvdList with `str` items.
                                     description: description
                                     descriptions:
@@ -45119,6 +45194,67 @@ class EosDesigns(EosDesignsRootModel):
 
                         StaticRoutes._item_type = StaticRoutesItem
 
+                        class Ipv6StaticRoutesItem(AvdModel):
+                            """Subclass of AvdModel."""
+
+                            _fields: ClassVar[dict] = {
+                                "prefix": {"type": str},
+                                "next_hop": {"type": str},
+                                "track_bfd": {"type": bool},
+                                "distance": {"type": int},
+                                "tag": {"type": int},
+                                "name": {"type": str},
+                                "metric": {"type": int},
+                                "interface": {"type": str},
+                            }
+                            prefix: str | None
+                            next_hop: str | None
+                            track_bfd: bool | None
+                            """Track next-hop using BFD."""
+                            distance: int | None
+                            tag: int | None
+                            name: str | None
+                            """description."""
+                            metric: int | None
+                            interface: str | None
+
+                            if TYPE_CHECKING:
+
+                                def __init__(
+                                    self,
+                                    *,
+                                    prefix: str | None | UndefinedType = Undefined,
+                                    next_hop: str | None | UndefinedType = Undefined,
+                                    track_bfd: bool | None | UndefinedType = Undefined,
+                                    distance: int | None | UndefinedType = Undefined,
+                                    tag: int | None | UndefinedType = Undefined,
+                                    name: str | None | UndefinedType = Undefined,
+                                    metric: int | None | UndefinedType = Undefined,
+                                    interface: str | None | UndefinedType = Undefined,
+                                ) -> None:
+                                    """
+                                    Ipv6StaticRoutesItem.
+
+
+                                    Subclass of AvdModel.
+
+                                    Args:
+                                        prefix: prefix
+                                        next_hop: next_hop
+                                        track_bfd: Track next-hop using BFD.
+                                        distance: distance
+                                        tag: tag
+                                        name: description.
+                                        metric: metric
+                                        interface: interface
+
+                                    """
+
+                        class Ipv6StaticRoutes(AvdList[Ipv6StaticRoutesItem]):
+                            """Subclass of AvdList with `Ipv6StaticRoutesItem` items."""
+
+                        Ipv6StaticRoutes._item_type = Ipv6StaticRoutesItem
+
                         class Ospf(AvdModel):
                             """Subclass of AvdModel."""
 
@@ -45307,6 +45443,7 @@ class EosDesigns(EosDesignsRootModel):
                             "ipv4_acl_in": {"type": str},
                             "ipv4_acl_out": {"type": str},
                             "static_routes": {"type": StaticRoutes},
+                            "ipv6_static_routes": {"type": Ipv6StaticRoutes},
                             "ospf": {"type": Ospf},
                             "flow_tracking": {"type": FlowTracking},
                             "structured_config": {"type": EosCliConfigGen.PortChannelInterfacesItem},
@@ -45371,6 +45508,13 @@ class EosDesigns(EosDesignsRootModel):
                         Subclass of
                         AvdList with `StaticRoutesItem` items.
                         """
+                        ipv6_static_routes: Ipv6StaticRoutes
+                        """
+                        IPv6 static routes to be configured on every device when this interface is configured.
+
+                        Subclass of
+                        AvdList with `Ipv6StaticRoutesItem` items.
+                        """
                         ospf: Ospf
                         """
                         OSPF interface configuration.
@@ -45411,6 +45555,7 @@ class EosDesigns(EosDesignsRootModel):
                                 ipv4_acl_in: str | None | UndefinedType = Undefined,
                                 ipv4_acl_out: str | None | UndefinedType = Undefined,
                                 static_routes: StaticRoutes | UndefinedType = Undefined,
+                                ipv6_static_routes: Ipv6StaticRoutes | UndefinedType = Undefined,
                                 ospf: Ospf | UndefinedType = Undefined,
                                 flow_tracking: FlowTracking | UndefinedType = Undefined,
                                 structured_config: EosCliConfigGen.PortChannelInterfacesItem | UndefinedType = Undefined,
@@ -45456,6 +45601,11 @@ class EosDesigns(EosDesignsRootModel):
 
                                        Subclass of
                                        AvdList with `StaticRoutesItem` items.
+                                    ipv6_static_routes:
+                                       IPv6 static routes to be configured on every device when this interface is configured.
+
+                                       Subclass of
+                                       AvdList with `Ipv6StaticRoutesItem` items.
                                     ospf:
                                        OSPF interface configuration.
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -8482,12 +8482,12 @@ $defs:
                       type: list
                       $ref: eos_designs#/$defs/static_routes
                       description: Static routes to be configured on every device
-                        when this interface is configured.
+                        where this interface is configured.
                     ipv6_static_routes:
                       type: list
                       $ref: eos_designs#/$defs/static_routes
                       description: IPv6 static routes to be configured on every device
-                        when this interface is configured.
+                        where this interface is configured.
                     nodes:
                       type: list
                       items:
@@ -8766,14 +8766,14 @@ $defs:
                       - int
                     static_routes:
                       type: list
-                      description: Static routes to be configured on the device when
-                        this Port-channel is configured.
+                      description: Static routes to be configured on the device where
+                        this Port-channel interface is configured.
                       $ref: eos_designs#/$defs/static_routes
                     ipv6_static_routes:
                       type: list
                       $ref: eos_designs#/$defs/static_routes
-                      description: IPv6 static routes to be configured on every device
-                        when this interface is configured.
+                      description: IPv6 static routes to be configured on the device
+                        where this Port-channel interface is configured.
                     ospf:
                       type: dict
                       description: OSPF interface configuration.

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -8472,6 +8472,11 @@ $defs:
                       $ref: eos_designs#/$defs/static_routes
                       description: Static routes to be configured on every device
                         when this interface is configured.
+                    ipv6_static_routes:
+                      type: list
+                      $ref: eos_designs#/$defs/static_routes
+                      description: IPv6 static routes to be configured on every device
+                        when this interface is configured.
                     nodes:
                       type: list
                       items:
@@ -8753,6 +8758,11 @@ $defs:
                       description: Static routes to be configured on the device when
                         this Port-channel is configured.
                       $ref: eos_designs#/$defs/static_routes
+                    ipv6_static_routes:
+                      type: list
+                      $ref: eos_designs#/$defs/static_routes
+                      description: IPv6 static routes to be configured on every device
+                        when this interface is configured.
                     ospf:
                       type: dict
                       description: OSPF interface configuration.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -827,12 +827,12 @@ $defs:
                     static_routes:
                       type: list
                       $ref: "eos_designs#/$defs/static_routes"
-                      description: Static routes to be configured on every device when this interface is configured.
+                      description: Static routes to be configured on every device where this interface is configured.
                     ipv6_static_routes:
                       type: list
                       # Reusing the schema from `static_routes` since IPv4 and IPv6 static routes share the same keys.
                       $ref: "eos_designs#/$defs/static_routes"
-                      description: IPv6 static routes to be configured on every device when this interface is configured.
+                      description: IPv6 static routes to be configured on every device where this interface is configured.
                     nodes:
                       type: list
                       items:
@@ -1080,13 +1080,13 @@ $defs:
                         - int
                     static_routes:
                       type: list
-                      description: Static routes to be configured on the device when this Port-channel is configured.
+                      description: Static routes to be configured on the device where this Port-channel interface is configured.
                       $ref: "eos_designs#/$defs/static_routes"
                     ipv6_static_routes:
                       type: list
                       # Reusing the schema from `static_routes` since IPv4 and IPv6 static routes share the same keys.
                       $ref: "eos_designs#/$defs/static_routes"
-                      description: IPv6 static routes to be configured on every device when this interface is configured.
+                      description: IPv6 static routes to be configured on the device where this Port-channel interface is configured.
                     ospf:
                       type: dict
                       description: OSPF interface configuration.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -831,7 +831,6 @@ $defs:
                     ipv6_static_routes:
                       type: list
                       # Reusing the schema from `static_routes` since IPv4 and IPv6 static routes share the same keys.
-                      # TODO: Once the deprecated keys for eos_cli_config_gen are removed in AVD 6.0, the schema can be referenced directly from there.
                       $ref: "eos_designs#/$defs/static_routes"
                       description: IPv6 static routes to be configured on every device when this interface is configured.
                     nodes:
@@ -1086,7 +1085,6 @@ $defs:
                     ipv6_static_routes:
                       type: list
                       # Reusing the schema from `static_routes` since IPv4 and IPv6 static routes share the same keys.
-                      # TODO: Once the deprecated keys for eos_cli_config_gen are removed in AVD 6.0, the schema can be referenced directly from there.
                       $ref: "eos_designs#/$defs/static_routes"
                       description: IPv6 static routes to be configured on every device when this interface is configured.
                     ospf:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -828,6 +828,10 @@ $defs:
                       type: list
                       $ref: "eos_designs#/$defs/static_routes"
                       description: Static routes to be configured on every device when this interface is configured.
+                    ipv6_static_routes:
+                      type: list
+                      $ref: "eos_designs#/$defs/static_routes"
+                      description: IPv6 static routes to be configured on every device when this interface is configured.
                     nodes:
                       type: list
                       items:
@@ -1077,6 +1081,10 @@ $defs:
                       type: list
                       description: Static routes to be configured on the device when this Port-channel is configured.
                       $ref: "eos_designs#/$defs/static_routes"
+                    ipv6_static_routes:
+                      type: list
+                      $ref: "eos_designs#/$defs/static_routes"
+                      description: IPv6 static routes to be configured on every device when this interface is configured.
                     ospf:
                       type: dict
                       description: OSPF interface configuration.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -830,6 +830,8 @@ $defs:
                       description: Static routes to be configured on every device when this interface is configured.
                     ipv6_static_routes:
                       type: list
+                      # Reusing the schema from `static_routes` since IPv4 and IPv6 static routes share the same keys.
+                      # TODO: Once deprecated AVD 6.0 keys are removed from eos_cli_config_gen, this can reference the schema directly from there.
                       $ref: "eos_designs#/$defs/static_routes"
                       description: IPv6 static routes to be configured on every device when this interface is configured.
                     nodes:
@@ -1083,6 +1085,8 @@ $defs:
                       $ref: "eos_designs#/$defs/static_routes"
                     ipv6_static_routes:
                       type: list
+                      # Reusing the schema from `static_routes` since IPv4 and IPv6 static routes share the same keys.
+                      # TODO: Once deprecated AVD 6.0 keys are removed from eos_cli_config_gen, this can reference the schema directly from there.
                       $ref: "eos_designs#/$defs/static_routes"
                       description: IPv6 static routes to be configured on every device when this interface is configured.
                     ospf:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -831,7 +831,7 @@ $defs:
                     ipv6_static_routes:
                       type: list
                       # Reusing the schema from `static_routes` since IPv4 and IPv6 static routes share the same keys.
-                      # TODO: Once deprecated AVD 6.0 keys are removed from eos_cli_config_gen, this can reference the schema directly from there.
+                      # TODO: Once the deprecated keys for eos_cli_config_gen are removed in AVD 6.0, the schema can be referenced directly from there.
                       $ref: "eos_designs#/$defs/static_routes"
                       description: IPv6 static routes to be configured on every device when this interface is configured.
                     nodes:
@@ -1086,7 +1086,7 @@ $defs:
                     ipv6_static_routes:
                       type: list
                       # Reusing the schema from `static_routes` since IPv4 and IPv6 static routes share the same keys.
-                      # TODO: Once deprecated AVD 6.0 keys are removed from eos_cli_config_gen, this can reference the schema directly from there.
+                      # TODO: Once the deprecated keys for eos_cli_config_gen are removed in AVD 6.0, the schema can be referenced directly from there.
                       $ref: "eos_designs#/$defs/static_routes"
                       description: IPv6 static routes to be configured on every device when this interface is configured.
                     ospf:

--- a/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
@@ -342,6 +342,10 @@ class FilteredTenantsMixin(Protocol):
                 vrf.static_routes.extend(
                     l3_interface.static_routes._cast_as(EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.StaticRoutes)
                 )
+            if l3_interface.ipv6_static_routes:
+                vrf.ipv6_static_routes.extend(
+                    l3_interface.ipv6_static_routes._cast_as(EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.Ipv6StaticRoutes)
+                )
             filtered_l3_interfaces.append(l3_interface)
 
         return filtered_l3_interfaces
@@ -361,6 +365,10 @@ class FilteredTenantsMixin(Protocol):
             if l3_port_channel.static_routes:
                 vrf.static_routes.extend(
                     l3_port_channel.static_routes._cast_as(EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.StaticRoutes)
+                )
+            if l3_port_channel.ipv6_static_routes:
+                vrf.ipv6_static_routes.extend(
+                    l3_port_channel.ipv6_static_routes._cast_as(EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.Ipv6StaticRoutes)
                 )
             filtered_l3_port_channels.append(l3_port_channel)
 

--- a/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
@@ -368,7 +368,9 @@ class FilteredTenantsMixin(Protocol):
                 )
             if l3_port_channel.ipv6_static_routes:
                 vrf.ipv6_static_routes.extend(
-                    l3_port_channel.ipv6_static_routes._cast_as(EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.Ipv6StaticRoutes)
+                    l3_port_channel.ipv6_static_routes._cast_as(
+                        EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.Ipv6StaticRoutes
+                    )
                 )
             filtered_l3_port_channels.append(l3_port_channel)
 

--- a/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
@@ -332,7 +332,7 @@ class FilteredTenantsMixin(Protocol):
         """
         Returns filtered l3_interfaces for the VRFs.
 
-        Extracts static_routes set under l3_interfaces and appends to vrf.static_routes.
+        Extracts static_routes and ipv6_static_routes defined under l3_interfaces, and appends them to vrf.static_routes and vrf.ipv6_static_routes.
         """
         filtered_l3_interfaces = EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.L3Interfaces()
         for l3_interface in vrf.l3_interfaces:
@@ -356,7 +356,7 @@ class FilteredTenantsMixin(Protocol):
         """
         Returns filtered l3_port_channels for the VRFs.
 
-        Extracts static_routes set under l3_port_channels and appends to vrf.static_routes.
+        Extracts static_routes and ipv6_static_routes defined under l3_port_channels, and appends them to vrf.static_routes and vrf.ipv6_static_routes.
         """
         filtered_l3_port_channels = EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.L3PortChannels()
         for l3_port_channel in vrf.l3_port_channels:

--- a/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
@@ -332,7 +332,7 @@ class FilteredTenantsMixin(Protocol):
         """
         Returns filtered l3_interfaces for the VRFs.
 
-        Extracts static_routes and ipv6_static_routes defined under l3_interfaces, and appends them to vrf.static_routes and vrf.ipv6_static_routes.
+        Extracts static_routes and ipv6_static_routes defined under l3_interfaces and appends them to vrf.static_routes and vrf.ipv6_static_routes.
         """
         filtered_l3_interfaces = EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.L3Interfaces()
         for l3_interface in vrf.l3_interfaces:
@@ -356,7 +356,7 @@ class FilteredTenantsMixin(Protocol):
         """
         Returns filtered l3_port_channels for the VRFs.
 
-        Extracts static_routes and ipv6_static_routes defined under l3_port_channels, and appends them to vrf.static_routes and vrf.ipv6_static_routes.
+        Extracts static_routes and ipv6_static_routes defined under l3_port_channels and appends them to vrf.static_routes and vrf.ipv6_static_routes.
         """
         filtered_l3_port_channels = EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.L3PortChannels()
         for l3_port_channel in vrf.l3_port_channels:


### PR DESCRIPTION

## Change Summary

Added support for ipv6_static_routes under l3_interfaces and l3_portchannel_interfaces in network_services

## Related Issue(s)

Partial fix of #5610 

## Component(s) name

`arista.avd.eos_designs>`

## Proposed changes
Added support for ipv6_static_routes under l3_interfaces and l3_portchannel_interfaces in network_services

## How to test
Run eos_designs_unit_tests molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
