### PR TITLE
Refactor(eos_validate_state): Deprecate eos_validate_state

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -10,6 +10,12 @@ title: Ansible Collection Role eos_validate_state
 
 # eos_validate_state
 
+!!! warning
+    Deprecation Warning!
+    Please note this role has been replaced with the `arista.avd.anta_runner` role.
+    Please update your playbook accordingly.
+    This role will be removed in AVD version 6.0.0.
+
 ## Overview
 
 **eos_validate_state** is a role leveraged to validate Arista EOS devices' operational states.

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -12,8 +12,9 @@ title: Ansible Collection Role eos_validate_state
 
 !!! warning
     Deprecation Warning!
-    Please note this role has been replaced with the `arista.avd.anta_runner` role.
-    Please update your playbook accordingly.
+    The role 'arista.avd.eos_validate_state' has been deprecated."
+    Update your playbook to leverage the new the new 'arista.avd.anta_runner' role instead."
+    See [arista.avd.anta_runner](../anta_runner/README.md) documentation for more details."
     This role will be removed in AVD version 6.0.0.
 
 ## Overview

--- a/ansible_collections/arista/avd/roles/eos_validate_state/README.md
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/README.md
@@ -13,7 +13,7 @@ title: Ansible Collection Role eos_validate_state
 !!! warning
     Deprecation Warning!
     The role 'arista.avd.eos_validate_state' has been deprecated."
-    Update your playbook to leverage the new the new 'arista.avd.anta_runner' role instead."
+    Update your playbook to leverage the new 'arista.avd.anta_runner' role instead."
     See [arista.avd.anta_runner](../anta_runner/README.md) documentation for more details."
     This role will be removed in AVD version 6.0.0.
 

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -2,6 +2,15 @@
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 ---
+- name: Deprecation warning!
+  delegate_to: localhost
+  ansible.builtin.debug:
+    msg:
+      - "!!! Deprecation Warning - Please note this role has been replaced with the arista.avd.anta_runner role."
+      - "!!! Deprecation Warning - Please update your playbook accordingly."
+      - "!!! Deprecation Warning - This role will be removed in AVD version 6.0.0."
+  run_once: true
+
 - name: Verify Requirements
   delegate_to: localhost
   when: avd_requirements is not defined and avd_verify_requirements | default(true)

--- a/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/eos_validate_state/tasks/main.yml
@@ -6,8 +6,9 @@
   delegate_to: localhost
   ansible.builtin.debug:
     msg:
-      - "!!! Deprecation Warning - Please note this role has been replaced with the arista.avd.anta_runner role."
-      - "!!! Deprecation Warning - Please update your playbook accordingly."
+      - "!!! Deprecation Warning - The role 'arista.avd.eos_validate_state' has been deprecated."
+      - "!!! Deprecation Warning - Update your playbook to leverage the new 'arista.avd.anta_runner' role instead."
+      - "!!! Deprecation Warning - See 'https://avd.arista.com' for details on 'arista.avd.anta_runner'."
       - "!!! Deprecation Warning - This role will be removed in AVD version 6.0.0."
   run_once: true
 

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -14,6 +14,19 @@ title: Release Notes for AVD 5.x.x
 
 <!-- Release notes generated using configuration in .github/release.yml at devel -->
 
+## Release 5.6.0
+
+### Deprecations
+
+#### arista.avd.eos_validate_state role
+
+- In AVD 6.0.0 the `eos_validate_state` role will be removed. Update your playbook to leverage the new the new 'arista.avd.anta_runner' role instead.
+- The new `arista.avd.anta_runner` role provides the following benefits and slight changes in behaviors, specifically a reduction in the number of tests reported:
+  - **Tighter ANTA integration:** Direct access to ANTA's full capabilities and automatic adoption of new ANTA features and improvements, including new tests.
+  - **Smarter test generation:** Generated tests by AVD are now more intelligent and condensed, improving execution efficiency by grouping required inputs per test and reducing the number of commands sent to devices.
+  - **Improved performance:** Uses multiprocessing to run tests in parallel batches, improving execution time for large environments.
+  - **Enhanced filtering:** Provides more granular control over test execution through multiple filtering mechanisms.
+
 ## Release 5.5.1
 
 ### Fixed issues in eos_cli_config_gen

--- a/docs/release-notes/5.x.x.md
+++ b/docs/release-notes/5.x.x.md
@@ -20,7 +20,7 @@ title: Release Notes for AVD 5.x.x
 
 #### arista.avd.eos_validate_state role
 
-- In AVD 6.0.0 the `eos_validate_state` role will be removed. Update your playbook to leverage the new the new 'arista.avd.anta_runner' role instead.
+- In AVD 6.0.0 the `eos_validate_state` role will be removed. Update your playbook to leverage the new 'arista.avd.anta_runner' role instead.
 - The new `arista.avd.anta_runner` role provides the following benefits and slight changes in behaviors, specifically a reduction in the number of tests reported:
   - **Tighter ANTA integration:** Direct access to ANTA's full capabilities and automatic adoption of new ANTA features and improvements, including new tests.
   - **Smarter test generation:** Generated tests by AVD are now more intelligent and condensed, improving execution efficiency by grouping required inputs per test and reducing the number of commands sent to devices.


### PR DESCRIPTION
## Change Summary

Deprecated eos_validate_state role in favour of anta_runner

## Related Issue(s)

Fixes aristanetworks/avd-internal#241

## Component(s) name

`arista.avd.eos_validate_state`

## Proposed changes

- Added debug message stating role deprecation
- Updated role readme text

## How to test

- Run eos_validate_state playbook and review debug message
- review documentation

