### PR TITLE
Fix(eos_designs): Relax schema for parent port-channel interfaces with subinterfaces

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/l3-port-channel-no-ip-address-no-subif.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/l3-port-channel-no-ip-address-no-subif.yml
@@ -1,0 +1,17 @@
+---
+type: l3leaf
+l3leaf:
+  nodes:
+    - name: l3-port-channel-no-ip-address-no-subif
+      bgp_as: 65000
+      id: 1
+      loopback_ipv4_pool: 192.168.0.0/24
+      vtep_loopback_ipv4_pool: 192.168.1.0/24
+      l3_port_channels:
+        - name: Port-Channel5
+          member_interfaces:
+            - name: Ethernet1/19
+              peer_interface: Ethernet1/19
+
+expected_error_message: >-
+  'l3leaf.nodes[name=l3-port-channel-no-ip-address-no-subif].l3_port_channels[name=Port-Channel5].ip_address' is required but was not found.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/l3-port-channel-no-ip-address-subif.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/host_vars/l3-port-channel-no-ip-address-subif.yml
@@ -1,0 +1,19 @@
+---
+type: l3leaf
+l3leaf:
+  nodes:
+    - name: l3-port-channel-no-ip-address-subif
+      bgp_as: 65000
+      id: 1
+      loopback_ipv4_pool: 192.168.0.0/24
+      vtep_loopback_ipv4_pool: 192.168.1.0/24
+      l3_port_channels:
+        - name: Port-Channel5
+          member_interfaces:
+            - name: Ethernet1/19
+              peer_interface: Ethernet1/19
+        - name: Port-Channel5.108
+          encapsulation_dot1q_vlan: 108
+
+expected_error_message: >-
+  'l3leaf.nodes[name=l3-port-channel-no-ip-address-subif].l3_port_channels[name=Port-Channel5.108].ip_address' is required but was not found.

--- a/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_negative_unit_tests/inventory/hosts.yml
@@ -262,6 +262,8 @@ all:
             ipv4-acls-internet-exit-access-lists:
             ipv4-acls-zscaler-internet-exit-access-lists:
             isis-system-id-format-missing-node-id:
+            l3-port-channel-no-ip-address-no-subif:
+            l3-port-channel-no-ip-address-subif:
             l3-port-channel-sub-interface-with-member-interfaces:
             l3-port-channel-sub-interface-with-mode:
             missing-avt-id-cv-pathfinder:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-port-channels-subinterfaces.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/node-type-l3-port-channels-subinterfaces.cfg
@@ -1,0 +1,54 @@
+!
+no enable password
+no aaa root
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname node-type-l3-port-channels-subinterfaces
+!
+vrf instance MGMT
+!
+management api http-commands
+   protocol https
+   no shutdown
+   !
+   vrf MGMT
+      no shutdown
+!
+interface Port-Channel1
+   no shutdown
+   no switchport
+!
+interface Port-Channel1.100
+   no shutdown
+   encapsulation dot1q vlan 100
+   ip address 10.10.100.1/30
+!
+interface Port-Channel1.200
+   no shutdown
+   encapsulation dot1q vlan 200
+   ip address 10.10.200.1/30
+!
+interface Ethernet5
+   description Ethernet5
+   no shutdown
+   channel-group 1 mode active
+!
+interface Ethernet6
+   description Ethernet6
+   no shutdown
+   channel-group 1 mode active
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 192.168.255.1/32
+!
+ip routing
+no ip routing vrf MGMT
+!
+end

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-port-channels-subinterfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-port-channels-subinterfaces.yml
@@ -1,0 +1,66 @@
+aaa_root:
+  disabled: true
+config_end: true
+enable_password:
+  disabled: true
+ethernet_interfaces:
+- name: Ethernet5
+  description: Ethernet5
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+  peer_interface: Ethernet5
+  peer_type: l3_port_channel_member
+- name: Ethernet6
+  description: Ethernet6
+  shutdown: false
+  channel_group:
+    id: 1
+    mode: active
+  peer_interface: Ethernet6
+  peer_type: l3_port_channel_member
+hostname: node-type-l3-port-channels-subinterfaces
+ip_igmp_snooping:
+  globally_enabled: true
+ip_routing: true
+loopback_interfaces:
+- name: Loopback0
+  description: ROUTER_ID
+  shutdown: false
+  ip_address: 192.168.255.1/32
+management_api_http:
+  enable_https: true
+  enable_vrfs:
+  - name: MGMT
+metadata:
+  is_deployed: true
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+port_channel_interfaces:
+- name: Port-Channel1
+  shutdown: false
+  peer_type: l3_port_channel
+  switchport:
+    enabled: false
+- name: Port-Channel1.100
+  shutdown: false
+  encapsulation_dot1q:
+    vlan: 100
+  ip_address: 10.10.100.1/30
+  peer_type: l3_port_channel
+- name: Port-Channel1.200
+  shutdown: false
+  encapsulation_dot1q:
+    vlan: 200
+  ip_address: 10.10.200.1/30
+  peer_type: l3_port_channel
+service_routing_protocols_model: multi-agent
+transceiver_qsfp_default_mode_4x10: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-port-channels-subinterfaces.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/node-type-l3-port-channels-subinterfaces.yml
@@ -1,0 +1,22 @@
+---
+# The goal of this test is to verify that the `ip_address` is optional on parent L3 port-channel interfaces but required on subinterfaces.
+
+type: l3spine
+
+l3spine:
+  nodes:
+    - name: node-type-l3-port-channels-subinterfaces
+      loopback_ipv4_pool: 192.168.255.0/24
+      id: 1
+      l3_port_channels:
+        - name: Port-Channel1
+          member_interfaces:
+            - name: Ethernet5
+              peer_interface: Ethernet5
+            - name: Ethernet6
+              peer_interface: Ethernet6
+          # IP addresses are declared on subinterfaces
+        - name: Port-Channel1.100
+          ip_address: 10.10.100.1/30
+        - name: Port-Channel1.200
+          ip_address: 10.10.200.1/30

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -53,6 +53,7 @@ all:
             spanning-tree-mode-rapid-pvst:
             node-type-l3-interfaces:
             node-type-l3-interfaces-bgp:
+            node-type-l3-port-channels-subinterfaces:
             node-type-l3-port-channels:
             sfe-interface-profile-options:
             cv-pathfinder-edge-no-ipsec-for-wan-path-group:

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
@@ -3,6 +3,7 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING, Protocol
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
@@ -24,6 +25,11 @@ class PortChannelInterfacesMixin(Protocol):
 
     Class should only be used as Mixin to a AvdStructuredConfig class.
     """
+
+    @cached_property
+    def _l3_port_channels_with_subinterfaces(self: AvdStructuredConfigUnderlayProtocol) -> set:
+        """Return a set of L3 Port-Channel names that have sub-interfaces."""
+        return {pc.name.split(".", maxsplit=1)[0] for pc in self.shared_utils.node_config.l3_port_channels if "." in pc.name}
 
     @structured_config_contributor
     def port_channel_interfaces(self: AvdStructuredConfigUnderlayProtocol) -> None:
@@ -113,35 +119,7 @@ class PortChannelInterfacesMixin(Protocol):
             self.structured_config.port_channel_interfaces.append(port_channel_interface)
 
         # Support l3_port_channels including sub-interfaces
-        subif_parent_port_channel_names = set()
-        regular_l3_port_channel_names = set()
-        for l3_port_channel in self.shared_utils.node_config.l3_port_channels:
-            interface_name = l3_port_channel.name
-            is_subinterface = "." in interface_name
-            if not is_subinterface:
-                # This is a regular Port-Channel (not sub-interface)
-                regular_l3_port_channel_names.add(interface_name)
-                continue
-            # This is a subinterface for a port-channel interface.
-            # We need to ensure that parent port-channel interface is also included explicitly
-            # within list of Port-Channel interfaces.
-            parent_port_channel_name = interface_name.split(".", maxsplit=1)[0]
-            subif_parent_port_channel_names.add(parent_port_channel_name)
-            if l3_port_channel.member_interfaces:
-                msg = f"L3 Port-Channel sub-interface '{interface_name}' has 'member_interfaces' set. This is not a valid setting."
-                raise AristaAvdInvalidInputsError(msg)
-            if l3_port_channel._get("mode"):
-                # implies 'mode' is set when not applicable for a sub-interface
-                msg = f"L3 Port-Channel sub-interface '{interface_name}' has 'mode' set. This is not a valid setting."
-                raise AristaAvdInvalidInputsError(msg)
-
-        # Sanity check if there are any sub-interfaces for which parent Port-channel is not explicitly specified
-        if missing_parent_port_channels := subif_parent_port_channel_names.difference(regular_l3_port_channel_names):
-            msg = (
-                f"One or more L3 Port-Channels '{', '.join(natural_sort(missing_parent_port_channels))}' "
-                "need to be specified as they have sub-interfaces referencing them."
-            )
-            raise AristaAvdInvalidInputsError(msg)
+        self._validate_l3_port_channels()
 
         # Now that validation is complete, we can make another pass at all l3_port_channels
         # (subinterfaces or otherwise) and generate their structured config.
@@ -150,6 +128,35 @@ class PortChannelInterfacesMixin(Protocol):
 
         # WAN HA interface for direct connection
         self._set_direct_ha_port_channel_interface()
+
+    def _validate_l3_port_channels(self: AvdStructuredConfigUnderlayProtocol) -> None:
+        """
+        Perform validation on l3_port_channels.
+
+        Raises AristaAvdInvalidInputsError if the data model is invalid.
+        """
+        parent_names = self._l3_port_channels_with_subinterfaces
+        regular_names = set()
+
+        for l3_port_channel in self.shared_utils.node_config.l3_port_channels:
+            if "." in l3_port_channel.name:
+                # Sub-interface specific validations.
+                if l3_port_channel.member_interfaces:
+                    msg = f"L3 Port-Channel sub-interface '{l3_port_channel.name}' has 'member_interfaces' set. This is not a valid setting."
+                    raise AristaAvdInvalidInputsError(msg)
+                if l3_port_channel._get("mode"):
+                    # Implies 'mode' is set when not applicable for a sub-interface.
+                    msg = f"L3 Port-Channel sub-interface '{l3_port_channel.name}' has 'mode' set. This is not a valid setting."
+                    raise AristaAvdInvalidInputsError(msg)
+            else:
+                regular_names.add(l3_port_channel.name)
+
+        # We need to ensure that parent port-channel interfaces are also included explicitly within list of port-channel interfaces.
+        if missing_parents := parent_names.difference(regular_names):
+            msg = (
+                f"One or more L3 Port-Channels '{', '.join(natural_sort(missing_parents))}' need to be specified as they have sub-interfaces referencing them."
+            )
+            raise AristaAvdInvalidInputsError(msg)
 
     def _set_l3_port_channel(
         self: AvdStructuredConfigUnderlayProtocol, l3_port_channel: EosDesigns._DynamicKeys.DynamicNodeTypesItem.NodeTypes.NodesItem.L3PortChannelsItem

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
@@ -27,7 +27,7 @@ class PortChannelInterfacesMixin(Protocol):
     """
 
     @cached_property
-    def _l3_port_channels_with_subinterfaces(self: AvdStructuredConfigUnderlayProtocol) -> set:
+    def _l3_port_channels_with_subinterfaces(self: AvdStructuredConfigUnderlayProtocol) -> set[str]:
         """Return a set of L3 Port-Channel names that have sub-interfaces."""
         return {pc.name.split(".", maxsplit=1)[0] for pc in self.shared_utils.node_config.l3_port_channels if "." in pc.name}
 

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/port_channel_interfaces.py
@@ -29,7 +29,7 @@ class PortChannelInterfacesMixin(Protocol):
     @cached_property
     def _l3_port_channels_with_subinterfaces(self: AvdStructuredConfigUnderlayProtocol) -> set[str]:
         """Return a set of L3 Port-Channel names that have sub-interfaces."""
-        return {pc.name.split(".", maxsplit=1)[0] for pc in self.shared_utils.node_config.l3_port_channels if "." in pc.name}
+        return {port_channel.name.split(".", maxsplit=1)[0] for port_channel in self.shared_utils.node_config.l3_port_channels if "." in port_channel.name}
 
     @structured_config_contributor
     def port_channel_interfaces(self: AvdStructuredConfigUnderlayProtocol) -> None:

--- a/python-avd/pyavd/_eos_designs/structured_config/underlay/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/underlay/utils.py
@@ -143,8 +143,11 @@ class UtilsMixin(Protocol):
 
         # logic below is common to l3_interface and l3_port_channel interface types
 
+        # Check if the interface is a parent L3 Port-Channel with subinterfaces.
+        is_parent_l3_port_channel = schema_key == "l3_port_channels" and l3_generic_interface.name in self._l3_port_channels_with_subinterfaces
+
         # TODO: catch if ip_address is not valid or not dhcp
-        if not l3_generic_interface.ip_address:
+        if not l3_generic_interface.ip_address and not is_parent_l3_port_channel:
             msg = f"{self.shared_utils.node_type_key_data.key}.nodes[name={self.shared_utils.hostname}].{schema_key}"
             msg += f"[name={l3_generic_interface.name}].ip_address"
             raise AristaAvdMissingVariableError(msg)


### PR DESCRIPTION
## Change Summary

AVD will no longer raise an error when `ip_address` is missing on L3 port-channels that have subinterfaces configured.

## Related Issue(s)

Fixes #5760

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
- Store the L3 port-channel interfaces that have subinterfaces in a property to avoid erroring on missing `ip_address` for those.

## How to test
```
nodes:
    - name: DC1-LEAF1A
      l3_port_channels:
        - name: Port-Channel1
          member_interfaces:
            - name: Ethernet1
        - name: Port-Channel1.100
          ip_address: 10.10.10.1/24
 ```

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code has been rebased from devel before I start
- [X] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [X] My change requires a change to the documentation and documentation have been updated accordingly.
- [X] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
