### PR TITLE
Doc(eos_designs): Remove incorrect model for evpn_vlan_bundle

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -1556,8 +1556,7 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
 
 ### EVPN VLAN aware bundles settings
 
-EVPN VLAN aware bundles referenced by name in `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].evpn_vlan_bundle`
-or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle` or `<network_services_key>[].l2vlans[].evpn_vlan_bundle`.
+EVPN VLAN aware bundles referenced by name in `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle` or `<network_services_key>[].l2vlans[].evpn_vlan_bundle`.
 
 An EVPN VLAN aware bundle will only be configured if at least one VLAN is associated with it.
 


### PR DESCRIPTION
## Change Summary

Remove `<network_services_key>[].vrfs[].evpn_vlan_bundle` from the doc, as this key is invalid under vrfs.

This key is not present in the schema or code.

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Fix incorrect documentation

## How to test

Review documentation


