### PR TITLE
Feat(cv_deploy): Add support for username and password authentication

### DIFF
--- a/ansible_collections/arista/avd/plugins/action/cv_workflow.py
+++ b/ansible_collections/arista/avd/plugins/action/cv_workflow.py
@@ -52,7 +52,9 @@ ARGUMENT_SPEC = {
     "strict_system_mac_address": {"type": "bool", "required": False, "default": False},
     "configlet_name_template": {"type": "str", "default": "AVD-${hostname}"},
     "cv_servers": {"type": "list", "elements": "str", "required": True},
-    "cv_token": {"type": "str", "secret": True, "required": True},
+    "cv_token": {"type": "str", "secret": True, "required": False},
+    "cv_username": {"type": "str", "required": False},
+    "cv_password": {"type": "str", "secret": True, "required": False},
     "cv_verify_certs": {"type": "bool", "default": True},
     "workspace": {
         "type": "dict",
@@ -112,12 +114,19 @@ class ActionModule(ActionBase):
 
     async def deploy(self, validated_args: dict, result: dict) -> dict:
         """Prepare data, perform deployment and convert result data."""
-        LOGGER.info("deploy: %s", {**validated_args, "cv_token": "<removed>"})
+        logged_args = validated_args.copy()
+        if "cv_token" in logged_args:
+            logged_args["cv_token"] = "<removed>"  # noqa: S105
+        if "cv_password" in logged_args:
+            logged_args["cv_password"] = "<removed>"  # noqa: S105
+        LOGGER.info("deploy: %s", logged_args)
         try:
             # Create CloudVision object
             cloudvision = CloudVision(
                 servers=validated_args["cv_servers"],
-                token=validated_args["cv_token"],
+                token=validated_args.get("cv_token"),
+                username=validated_args.get("cv_username"),
+                password=validated_args.get("cv_password"),
                 verify_certs=validated_args["cv_verify_certs"],
             )
             # Build lists of CVEosConfig, CVDeviceTag, CVInterfaceTag and CVPathfinderMetadata objects.

--- a/ansible_collections/arista/avd/plugins/action/cv_workflow.py
+++ b/ansible_collections/arista/avd/plugins/action/cv_workflow.py
@@ -115,10 +115,12 @@ class ActionModule(ActionBase):
     async def deploy(self, validated_args: dict, result: dict) -> dict:
         """Prepare data, perform deployment and convert result data."""
         logged_args = validated_args.copy()
+        # Excempting the lines below from Ruff and Sonar since they think we are hardcoding a password,
+        # when we are actually just being conscious about not printing passwords.
         if "cv_token" in logged_args:
             logged_args["cv_token"] = "<removed>"  # noqa: S105
         if "cv_password" in logged_args:
-            logged_args["cv_password"] = "<removed>"  # noqa: S105
+            logged_args["cv_password"] = "<removed>"  # NOSONAR # noqa: S105
         LOGGER.info("deploy: %s", logged_args)
         try:
             # Create CloudVision object

--- a/ansible_collections/arista/avd/plugins/modules/cv_workflow.py
+++ b/ansible_collections/arista/avd/plugins/modules/cv_workflow.py
@@ -27,7 +27,13 @@ options:
   cv_token:
     description: Service account token. It is strongly recommended to use Vault for this.
     type: str
-    required: true
+    required: false
+  cv_username:
+    description: Username to use if `cv_token` is missing. Not supported for CVaaS.
+    type: str
+    required: false
+  cv_password:
+    description: Password to use if `cv_token` is missing. Not supported for CVaaS. It is strongly recommended to use Vault for this.
   cv_verify_certs:
     description: Verifies CloudVison server certificates.
     type: bool

--- a/ansible_collections/arista/avd/plugins/modules/cv_workflow.py
+++ b/ansible_collections/arista/avd/plugins/modules/cv_workflow.py
@@ -34,6 +34,8 @@ options:
     required: false
   cv_password:
     description: Password to use if `cv_token` is missing. Not supported for CVaaS. It is strongly recommended to use Vault for this.
+    type: str
+    required: false
   cv_verify_certs:
     description: Verifies CloudVison server certificates.
     type: bool

--- a/ansible_collections/arista/avd/roles/cv_deploy/README.md
+++ b/ansible_collections/arista/avd/roles/cv_deploy/README.md
@@ -141,7 +141,7 @@ cv_verify_certs: false
 ```
 
 For an on-premise CloudVision cluster it is possible to authenticate with username/password instead of a service account token.
-The username and password must be set via variables and `ansible_password` and `cv_token` **must not** be set.
+The username and password below must be set via variables on the task, play or in the fabric-level group vars. `ansible_password` and `cv_token` **must not** be set.
 
 ```yaml
 # Use username/password instead of a service account token for authentication to CloudVision.

--- a/ansible_collections/arista/avd/roles/cv_deploy/README.md
+++ b/ansible_collections/arista/avd/roles/cv_deploy/README.md
@@ -140,6 +140,15 @@ For test and lab usage the certificate verification can be disabled.
 cv_verify_certs: false
 ```
 
+For an on-premise CloudVision cluster it is possible to authenticate with username/password instead of a service account token.
+The username and password must be set via variables and `ansible_password` and `cv_token` **must not** be set.
+
+```yaml
+# Use username/password instead of a service account token for authentication to CloudVision.
+cv_username: <username>
+cv_password: <password. This value should be using Ansible Vault>
+```
+
 #### EOS Devices configuration
 
 By default this role will deploy configurations for all hosts targeted by the Ansible "play".

--- a/ansible_collections/arista/avd/roles/cv_deploy/tasks/main.yml
+++ b/ansible_collections/arista/avd/roles/cv_deploy/tasks/main.yml
@@ -19,6 +19,8 @@
   arista.avd.cv_workflow:
     cv_servers: [ "{{ cv_server }}" ]
     cv_token: "{{ cv_token }}"
+    cv_username: "{{ cv_username | arista.avd.default }}"
+    cv_password: "{{ cv_password | arista.avd.default }}"
     cv_verify_certs: "{{ cv_verify_certs }}"
     configuration_dir: "{{ eos_config_dir }}"
     structured_config_dir: "{{ structured_dir }}"

--- a/docs/plugins/Modules_and_action_plugins/cv_workflow.md
+++ b/docs/plugins/Modules_and_action_plugins/cv_workflow.md
@@ -34,7 +34,7 @@ The `arista.avd.cv_workflow` module is an Ansible Action Plugin providing the fo
 | <samp>cv_servers</samp> | list | True | None |  | List of hostnames or IP addresses for CloudVision instance to deploy to. |
 | <samp>cv_token</samp> | str | False | None |  | Service account token. It is strongly recommended to use Vault for this. |
 | <samp>cv_username</samp> | str | False | None |  | Username to use if `cv_token` is missing. Not supported for CVaaS. |
-| <samp>cv_password</samp> | any | optional | None |  | Password to use if `cv_token` is missing. Not supported for CVaaS. It is strongly recommended to use Vault for this. |
+| <samp>cv_password</samp> | str | False | None |  | Password to use if `cv_token` is missing. Not supported for CVaaS. It is strongly recommended to use Vault for this. |
 | <samp>cv_verify_certs</samp> | bool | optional | True |  | Verifies CloudVison server certificates. |
 | <samp>configuration_dir</samp> | str | True | None |  | Path to directory containing .cfg files with EOS configurations. |
 | <samp>structured_config_dir</samp> | str | False | None |  | Path to directory containing files with AVD structured configurations.<br>If found, the `serial_number` or `system_mac_address` will be used to identify the Device on CloudVision.<br>Any tags found in the structured configuration metadata will be applied to the Device and/or Interfaces. |

--- a/docs/plugins/Modules_and_action_plugins/cv_workflow.md
+++ b/docs/plugins/Modules_and_action_plugins/cv_workflow.md
@@ -32,7 +32,9 @@ The `arista.avd.cv_workflow` module is an Ansible Action Plugin providing the fo
 | Argument | Type | Required | Default | Value Restrictions | Description |
 | -------- | ---- | -------- | ------- | ------------------ | ----------- |
 | <samp>cv_servers</samp> | list | True | None |  | List of hostnames or IP addresses for CloudVision instance to deploy to. |
-| <samp>cv_token</samp> | str | True | None |  | Service account token. It is strongly recommended to use Vault for this. |
+| <samp>cv_token</samp> | str | False | None |  | Service account token. It is strongly recommended to use Vault for this. |
+| <samp>cv_username</samp> | str | False | None |  | Username to use if `cv_token` is missing. Not supported for CVaaS. |
+| <samp>cv_password</samp> | any | optional | None |  | Password to use if `cv_token` is missing. Not supported for CVaaS. It is strongly recommended to use Vault for this. |
 | <samp>cv_verify_certs</samp> | bool | optional | True |  | Verifies CloudVison server certificates. |
 | <samp>configuration_dir</samp> | str | True | None |  | Path to directory containing .cfg files with EOS configurations. |
 | <samp>structured_config_dir</samp> | str | False | None |  | Path to directory containing files with AVD structured configurations.<br>If found, the `serial_number` or `system_mac_address` will be used to identify the Device on CloudVision.<br>Any tags found in the structured configuration metadata will be applied to the Device and/or Interfaces. |

--- a/python-avd/pyavd/_cv/workflows/deploy_to_cv.py
+++ b/python-avd/pyavd/_cv/workflows/deploy_to_cv.py
@@ -137,7 +137,13 @@ async def deploy_to_cv(
     if cv_pathfinder_metadata is None:
         cv_pathfinder_metadata = []
     try:
-        async with CVClient(servers=cloudvision.servers, token=cloudvision.token, verify_certs=cloudvision.verify_certs) as cv_client:
+        async with CVClient(
+            servers=cloudvision.servers,
+            token=cloudvision.token,
+            username=cloudvision.username,
+            password=cloudvision.password,
+            verify_certs=cloudvision.verify_certs,
+        ) as cv_client:
             # Create workspace
             await create_workspace_on_cv(workspace=result.workspace, cv_client=cv_client)
 

--- a/python-avd/pyavd/_cv/workflows/models.py
+++ b/python-avd/pyavd/_cv/workflows/models.py
@@ -21,7 +21,9 @@ if TYPE_CHECKING:
 @dataclass
 class CloudVision:
     servers: str | list[str]
-    token: str
+    token: str | None
+    username: str | None
+    password: str | None
     verify_certs: bool = True
 
 


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Add support for username and password authentication

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.cv_deploy`
`arista.avd.cv_workflow`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Add support for `cv_username` and `cv_password` only support for on-premise CloudVision.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- [ ] Pending manual testing

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
