### PR TITLE
CI: Exclude Ansible plugins from Sonar coverage stats

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success")'
+      - run: echo '${{ toJSON(needs) }}' | jq -e 'to_entries | all(.value.result == "success" or .value.result == "skipped")'
 
   file-changes:
     runs-on: ubuntu-latest

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -45,6 +45,9 @@ sonar.python.coverage.reportPaths=\
     python/avdutils/coverage.xml,\
     ansible_collections/arista/avd/*coverage.xml
 
+sonar.coverage.exclusions=\
+    ansible_collections/arista/avd/plugins/**
+
 sonar.rust.lcov.reportPaths=\
     lcov.info
 


### PR DESCRIPTION
Exclude Ansible plugins from Sonar coverage stats.

We know we are not running coverage for most of those files, since testing is done in molecule.