### PR TITLE
Fix(eos_designs)!: L2 VLANs ignoring fast_leave configuration

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-DISABLED.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-DISABLED.cfg
@@ -6,6 +6,7 @@ vlan internal order ascending range 1006 1199
 !
 ip igmp snooping vlan 230 querier
 ip igmp snooping vlan 230 querier address 192.168.255.8
+ip igmp snooping vlan 230 fast-leave
 !
 transceiver qsfp default-mode 4x10G
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1A.cfg
@@ -35,6 +35,7 @@ ip igmp snooping vlan 210 querier address 192.168.255.3
 ip igmp snooping vlan 210 fast-leave
 ip igmp snooping vlan 230 querier
 ip igmp snooping vlan 230 querier address 192.168.255.3
+ip igmp snooping vlan 230 fast-leave
 ip igmp snooping vlan 252 querier
 ip igmp snooping vlan 252 querier address 192.168.255.3
 ip igmp snooping vlan 252 fast-leave

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF1B.cfg
@@ -35,6 +35,7 @@ ip igmp snooping vlan 210 querier address 192.168.255.4
 ip igmp snooping vlan 210 fast-leave
 ip igmp snooping vlan 230 querier
 ip igmp snooping vlan 230 querier address 192.168.255.4
+ip igmp snooping vlan 230 fast-leave
 ip igmp snooping vlan 252 querier
 ip igmp snooping vlan 252 querier address 192.168.255.4
 ip igmp snooping vlan 252 fast-leave

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF2A.cfg
@@ -35,6 +35,7 @@ ip igmp snooping vlan 210 querier address 192.168.255.5
 ip igmp snooping vlan 210 fast-leave
 ip igmp snooping vlan 230 querier
 ip igmp snooping vlan 230 querier address 192.168.255.5
+ip igmp snooping vlan 230 fast-leave
 ip igmp snooping vlan 252 querier
 ip igmp snooping vlan 252 querier address 192.168.255.5
 ip igmp snooping vlan 252 fast-leave

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3A.cfg
@@ -35,6 +35,7 @@ ip igmp snooping vlan 210 querier address 192.168.255.6
 ip igmp snooping vlan 210 fast-leave
 ip igmp snooping vlan 230 querier
 ip igmp snooping vlan 230 querier address 192.168.255.6
+ip igmp snooping vlan 230 fast-leave
 ip igmp snooping vlan 252 querier
 ip igmp snooping vlan 252 querier address 192.168.255.6
 ip igmp snooping vlan 252 fast-leave

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/EVPN-MULTICAST-L3LEAF3B.cfg
@@ -35,6 +35,7 @@ ip igmp snooping vlan 210 querier address 192.168.255.7
 ip igmp snooping vlan 210 fast-leave
 ip igmp snooping vlan 230 querier
 ip igmp snooping vlan 230 querier address 192.168.255.7
+ip igmp snooping vlan 230 fast-leave
 ip igmp snooping vlan 252 querier
 ip igmp snooping vlan 252 querier address 192.168.255.7
 ip igmp snooping vlan 252 fast-leave

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
@@ -61,6 +61,9 @@ vlan 122
 vlan 123
    name VLAN_123
 !
+vlan 124
+   name VLAN_124
+!
 vrf instance MGMT
 !
 management api http-commands
@@ -73,7 +76,7 @@ management api http-commands
 interface Port-Channel1
    description L2_IGMP-QUERIER-L3LEAF1A_Port-Channel1
    no shutdown
-   switchport trunk allowed vlan 1-3,11-12,21-23,101-103,111-113,121-123
+   switchport trunk allowed vlan 1-3,11-12,21-23,101-103,111-113,121-124
    switchport mode trunk
    switchport
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L2LEAF1A.cfg
@@ -64,6 +64,9 @@ vlan 123
 vlan 124
    name VLAN_124
 !
+vlan 125
+   name VLAN_125
+!
 vrf instance MGMT
 !
 management api http-commands
@@ -76,7 +79,7 @@ management api http-commands
 interface Port-Channel1
    description L2_IGMP-QUERIER-L3LEAF1A_Port-Channel1
    no shutdown
-   switchport trunk allowed vlan 1-3,11-12,21-23,101-103,111-113,121-124
+   switchport trunk allowed vlan 1-3,11-12,21-23,101-103,111-113,121-125
    switchport mode trunk
    switchport
 !

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
@@ -46,6 +46,11 @@ no ip igmp snooping vlan 123 querier
 ip igmp snooping vlan 124 querier
 ip igmp snooping vlan 124 querier address 192.168.255.1
 ip igmp snooping vlan 124 querier version 3
+no ip igmp snooping vlan 124 fast-leave
+ip igmp snooping vlan 125 querier
+ip igmp snooping vlan 125 querier address 192.168.255.1
+ip igmp snooping vlan 125 querier version 3
+ip igmp snooping vlan 125 fast-leave
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -107,6 +112,9 @@ vlan 123
 vlan 124
    name VLAN_124
 !
+vlan 125
+   name VLAN_125
+!
 vrf instance IGMP_QUERIER_TEST_1
    description IGMP_QUERIER_TEST_1
 !
@@ -128,7 +136,7 @@ management api http-commands
 interface Port-Channel1
    description L2_IGMP-QUERIER-L2LEAF1A_Port-Channel1
    no shutdown
-   switchport trunk allowed vlan 1-3,11-12,21-23,101-103,111-113,121-124
+   switchport trunk allowed vlan 1-3,11-12,21-23,101-103,111-113,121-125
    switchport mode trunk
    switchport
 !
@@ -223,6 +231,7 @@ interface Vxlan1
    vxlan vlan 122 vni 40122
    vxlan vlan 123 vni 40123
    vxlan vlan 124 vni 40124
+   vxlan vlan 125 vni 40125
    vxlan vrf IGMP_QUERIER_TEST_1 vni 11
    vxlan vrf IGMP_QUERIER_TEST_2 vni 21
    vxlan vrf IGMP_QUERIER_TEST_3 vni 41
@@ -351,6 +360,11 @@ router bgp 65101
    vlan 124
       rd 192.168.255.1:40124
       route-target both 40124:40124
+      redistribute learned
+   !
+   vlan 125
+      rd 192.168.255.1:40125
+      route-target both 40125:40125
       redistribute learned
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/configs/IGMP-QUERIER-L3LEAF1A.cfg
@@ -43,6 +43,9 @@ ip igmp snooping vlan 121 querier version 1
 ip igmp snooping vlan 122 querier
 ip igmp snooping vlan 122 querier address 192.168.255.1
 no ip igmp snooping vlan 123 querier
+ip igmp snooping vlan 124 querier
+ip igmp snooping vlan 124 querier address 192.168.255.1
+ip igmp snooping vlan 124 querier version 3
 !
 transceiver qsfp default-mode 4x10G
 !
@@ -101,6 +104,9 @@ vlan 122
 vlan 123
    name VLAN_123
 !
+vlan 124
+   name VLAN_124
+!
 vrf instance IGMP_QUERIER_TEST_1
    description IGMP_QUERIER_TEST_1
 !
@@ -122,7 +128,7 @@ management api http-commands
 interface Port-Channel1
    description L2_IGMP-QUERIER-L2LEAF1A_Port-Channel1
    no shutdown
-   switchport trunk allowed vlan 1-3,11-12,21-23,101-103,111-113,121-123
+   switchport trunk allowed vlan 1-3,11-12,21-23,101-103,111-113,121-124
    switchport mode trunk
    switchport
 !
@@ -216,6 +222,7 @@ interface Vxlan1
    vxlan vlan 121 vni 40121
    vxlan vlan 122 vni 40122
    vxlan vlan 123 vni 40123
+   vxlan vlan 124 vni 40124
    vxlan vrf IGMP_QUERIER_TEST_1 vni 11
    vxlan vrf IGMP_QUERIER_TEST_2 vni 21
    vxlan vrf IGMP_QUERIER_TEST_3 vni 41
@@ -339,6 +346,11 @@ router bgp 65101
    vlan 123
       rd 192.168.255.1:40123
       route-target both 40123:40123
+      redistribute learned
+   !
+   vlan 124
+      rd 192.168.255.1:40124
+      route-target both 40124:40124
       redistribute learned
    !
    address-family evpn

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-DISABLED.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-DISABLED.yml
@@ -25,6 +25,7 @@ ip_igmp_snooping:
     querier:
       enabled: true
       address: 192.168.255.8
+    fast_leave: true
 ip_routing: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 loopback_interfaces:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1A.yml
@@ -159,6 +159,7 @@ ip_igmp_snooping:
     querier:
       enabled: true
       address: 192.168.255.3
+    fast_leave: true
   - id: 252
     querier:
       enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF1B.yml
@@ -159,6 +159,7 @@ ip_igmp_snooping:
     querier:
       enabled: true
       address: 192.168.255.4
+    fast_leave: true
   - id: 252
     querier:
       enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF2A.yml
@@ -84,6 +84,7 @@ ip_igmp_snooping:
     querier:
       enabled: true
       address: 192.168.255.5
+    fast_leave: true
   - id: 252
     querier:
       enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3A.yml
@@ -122,6 +122,7 @@ ip_igmp_snooping:
     querier:
       enabled: true
       address: 192.168.255.6
+    fast_leave: true
   - id: 252
     querier:
       enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/EVPN-MULTICAST-L3LEAF3B.yml
@@ -122,6 +122,7 @@ ip_igmp_snooping:
     querier:
       enabled: true
       address: 192.168.255.7
+    fast_leave: true
   - id: 252
     querier:
       enabled: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
@@ -39,7 +39,7 @@ port_channel_interfaces:
     enabled: true
     mode: trunk
     trunk:
-      allowed_vlan: 1-3,11-12,21-23,101-103,111-113,121-124
+      allowed_vlan: 1-3,11-12,21-23,101-103,111-113,121-125
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
@@ -105,6 +105,9 @@ vlans:
   tenant: Tenant_D
 - id: 124
   name: VLAN_124
+  tenant: Tenant_D
+- id: 125
+  name: VLAN_125
   tenant: Tenant_D
 vrfs:
 - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L2LEAF1A.yml
@@ -39,7 +39,7 @@ port_channel_interfaces:
     enabled: true
     mode: trunk
     trunk:
-      allowed_vlan: 1-3,11-12,21-23,101-103,111-113,121-123
+      allowed_vlan: 1-3,11-12,21-23,101-103,111-113,121-124
 service_routing_protocols_model: multi-agent
 static_routes:
 - vrf: MGMT
@@ -102,6 +102,9 @@ vlans:
   tenant: Tenant_D
 - id: 123
   name: VLAN_123
+  tenant: Tenant_D
+- id: 124
+  name: VLAN_124
   tenant: Tenant_D
 vrfs:
 - name: MGMT

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -90,6 +90,11 @@ ip_igmp_snooping:
   - id: 123
     querier:
       enabled: false
+  - id: 124
+    querier:
+      enabled: true
+      address: 192.168.255.1
+      version: 3
 ip_routing: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 loopback_interfaces:
@@ -125,7 +130,7 @@ port_channel_interfaces:
     enabled: true
     mode: trunk
     trunk:
-      allowed_vlan: 1-3,11-12,21-23,101-103,111-113,121-123
+      allowed_vlan: 1-3,11-12,21-23,101-103,111-113,121-124
 prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
@@ -307,6 +312,14 @@ router_bgp:
     route_targets:
       both:
       - 40123:40123
+    redistribute_routes:
+    - learned
+  - id: 124
+    tenant: Tenant_D
+    rd: 192.168.255.1:40124
+    route_targets:
+      both:
+      - 40124:40124
     redistribute_routes:
     - learned
   address_family_evpn:
@@ -493,6 +506,9 @@ vlans:
 - id: 123
   name: VLAN_123
   tenant: Tenant_D
+- id: 124
+  name: VLAN_124
+  tenant: Tenant_D
 vrfs:
 - name: MGMT
   ip_routing: false
@@ -549,6 +565,8 @@ vxlan_interface:
         vni: 40122
       - id: 123
         vni: 40123
+      - id: 124
+        vni: 40124
       vrfs:
       - name: IGMP_QUERIER_TEST_1
         vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/IGMP-QUERIER-L3LEAF1A.yml
@@ -95,6 +95,13 @@ ip_igmp_snooping:
       enabled: true
       address: 192.168.255.1
       version: 3
+    fast_leave: false
+  - id: 125
+    querier:
+      enabled: true
+      address: 192.168.255.1
+      version: 3
+    fast_leave: true
 ip_routing: true
 ip_virtual_router_mac_address: 00:dc:00:00:00:0a
 loopback_interfaces:
@@ -130,7 +137,7 @@ port_channel_interfaces:
     enabled: true
     mode: trunk
     trunk:
-      allowed_vlan: 1-3,11-12,21-23,101-103,111-113,121-124
+      allowed_vlan: 1-3,11-12,21-23,101-103,111-113,121-125
 prefix_lists:
 - name: PL-LOOPBACKS-EVPN-OVERLAY
   sequence_numbers:
@@ -322,6 +329,14 @@ router_bgp:
       - 40124:40124
     redistribute_routes:
     - learned
+  - id: 125
+    tenant: Tenant_D
+    rd: 192.168.255.1:40125
+    route_targets:
+      both:
+      - 40125:40125
+    redistribute_routes:
+    - learned
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -509,6 +524,9 @@ vlans:
 - id: 124
   name: VLAN_124
   tenant: Tenant_D
+- id: 125
+  name: VLAN_125
+  tenant: Tenant_D
 vrfs:
 - name: MGMT
   ip_routing: false
@@ -567,6 +585,8 @@ vxlan_interface:
         vni: 40123
       - id: 124
         vni: 40124
+      - id: 125
+        vni: 40125
       vrfs:
       - name: IGMP_QUERIER_TEST_1
         vni: 11

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/EVPN_MULTICAST_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/EVPN_MULTICAST_TESTS.yml
@@ -362,6 +362,8 @@ tenants:
             ip_address_virtual: 10.2.23.1/24
             # test for fast-leave when igmp_snooping_querier.fast_leave: true but evpn_l2_multicast.enabled is not set
             # fast-leave is not expected for VLAN 230 since evpn_l2_multicast.enabled is not set
+            # TODO: Revisit this test. I don't believe this should be the behavior.
+            # evpn_l2_multicast.enabled should not be required for fast-leave configuration since it's not OISM specific.
             igmp_snooping_querier:
               enabled: true
               fast_leave: true

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_TESTS.yml
@@ -184,3 +184,12 @@ tenants:
         tags: ['test_l2']
         igmp_snooping_querier:
           enabled: false
+      # Expected results:
+      # igmp querier enabled, querier address set to loopback 0 address 192.168.255.1, version 3 with fast-leave
+      - id: 124
+        name: "VLAN_124"
+        tags: ['test_l2']
+        igmp_snooping_querier:
+          enabled: true
+          version: 3
+          fast_leave: false

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_TESTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/group_vars/IGMP_QUERIER_TESTS.yml
@@ -185,7 +185,7 @@ tenants:
         igmp_snooping_querier:
           enabled: false
       # Expected results:
-      # igmp querier enabled, querier address set to loopback 0 address 192.168.255.1, version 3 with fast-leave
+      # igmp querier enabled, querier address set to loopback 0 address 192.168.255.1, version 3 with fast-leave disable
       - id: 124
         name: "VLAN_124"
         tags: ['test_l2']
@@ -193,3 +193,11 @@ tenants:
           enabled: true
           version: 3
           fast_leave: false
+      # igmp querier enabled, querier address set to loopback 0 address 192.168.255.1, version 3 with fast-leave enabled
+      - id: 125
+        name: "VLAN_125"
+        tags: ['test_l2']
+        igmp_snooping_querier:
+          enabled: true
+          version: 3
+          fast_leave: true

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_igmp_snooping.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ip_igmp_snooping.py
@@ -78,9 +78,7 @@ class IpIgmpSnoopingMixin(Protocol):
                     vlan.igmp_snooping_querier.source_address, tenant.igmp_snooping_querier.source_address, self.shared_utils.router_id
                 )
                 vlan_item.querier.version = default(vlan.igmp_snooping_querier.version, tenant.igmp_snooping_querier.version)
-
-        if evpn_l2_multicast_enabled:
-            vlan_item.fast_leave = default(vlan.igmp_snooping_querier.fast_leave, tenant.evpn_l2_multicast.fast_leave)
+                vlan_item.fast_leave = default(vlan.igmp_snooping_querier.fast_leave, tenant.evpn_l2_multicast.fast_leave)
 
         if vlan_item:
             vlan_item.id = vlan.id


### PR DESCRIPTION
## Change Summary

In network service, when configuring L2 VLANs, it is ignoring fast_leave configuration

fast-leave is not configured when evpn_l2_multicast.enabled is not enabled.
I don't beleive this should be the behaviour since IGMP fast-leave is not an OISM specific feature.
This is a potentially breaking change, as seen in the molecule tests.

## Related Issue(s)

Fixes #5884 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

Configure fast-leave when IGMP is enabled on the vlan

## How to test

See the new molecule tests

## Checklist

### User Checklist

- [ ] Revisit changed molecule tests
- [ ] Document breaking change in release notes


