### PR TITLE
Doc: Update schema generated default values to avoid sorting keys.

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/connected-endpoints-keys.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/connected-endpoints-keys.md
@@ -51,40 +51,40 @@
 
         ```yaml
         connected_endpoints_keys:
-        - description: Server
-          key: servers
+        - key: servers
           type: server
-        - description: Firewall
-          key: firewalls
+          description: Server
+        - key: firewalls
           type: firewall
-        - description: Router
-          key: routers
+          description: Firewall
+        - key: routers
           type: router
-        - description: Load Balancer
-          key: load_balancers
+          description: Router
+        - key: load_balancers
           type: load_balancer
-        - description: Storage Array
-          key: storage_arrays
+          description: Load Balancer
+        - key: storage_arrays
           type: storage_array
-        - description: CPE
-          key: cpes
+          description: Storage Array
+        - key: cpes
           type: cpe
-        - description: Workstation
-          key: workstations
+          description: CPE
+        - key: workstations
           type: workstation
-        - description: Access Point
-          key: access_points
+          description: Workstation
+        - key: access_points
           type: access_point
-        - description: Phone
-          key: phones
+          description: Access Point
+        - key: phones
           type: phone
-        - description: Printer
-          key: printers
+          description: Phone
+        - key: printers
           type: printer
-        - description: Camera
-          key: cameras
+          description: Printer
+        - key: cameras
           type: camera
-        - description: Generic Device
-          key: generic_devices
+          description: Camera
+        - key: generic_devices
           type: generic_device
+          description: Generic Device
         ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-flow-tracking-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-flow-tracking-settings.md
@@ -234,14 +234,14 @@
 
         ```yaml
         trackers:
-        - exporters:
-          - collectors:
-            - host: 127.0.0.1
-            local_interface: Loopback0
-            name: CV-TELEMETRY
-            template_interval: 3600000
-          name: FLOW-TRACKER
+        - name: FLOW-TRACKER
           record_export:
             on_inactive_timeout: 70000
             on_interval: 300000
+          exporters:
+          - name: CV-TELEMETRY
+            collectors:
+            - host: 127.0.0.1
+            local_interface: Loopback0
+            template_interval: 3600000
         ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -908,6 +908,6 @@
 
         ```yaml
         vrfs:
-        - enabled: true
-          name: use_mgmt_interface_vrf
+        - name: use_mgmt_interface_vrf
+          enabled: true
         ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/platform-settings.md
@@ -540,236 +540,236 @@
 
         ```yaml
         platform_settings:
-        - digital_twin:
-            platform: vEOS-lab
+        - platforms:
+          - default
           feature_support:
             queue_monitor_length_notify: false
-          platforms:
-          - default
           reload_delay:
             mlag: 300
             non_mlag: 330
-        - digital_twin:
+          digital_twin:
             platform: vEOS-lab
+        - platforms:
+          - 7050X3
           feature_support:
             queue_monitor_length_notify: false
-          platforms:
-          - 7050X3
           reload_delay:
             mlag: 300
             non_mlag: 330
           trident_forwarding_table_partition: flexible exact-match 16384 l2-shared 98304 l3-shared
             131072
-        - digital_twin:
+          digital_twin:
             platform: vEOS-lab
+        - platforms:
+          - 720XP
           feature_support:
             poe: true
             queue_monitor_length_notify: false
-          platforms:
-          - 720XP
           reload_delay:
             mlag: 300
             non_mlag: 330
           trident_forwarding_table_partition: flexible exact-match 16000 l2-shared 18000 l3-shared
             22000
-        - digital_twin:
+          digital_twin:
             platform: vEOS-lab
-          feature_support:
-            poe: true
-            queue_monitor_length_notify: false
-          management_interface: Management0
-          platforms:
+        - platforms:
           - '750'
           - '755'
           - '758'
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - digital_twin:
-            platform: vEOS-lab
+          management_interface: Management0
           feature_support:
             poe: true
             queue_monitor_length_notify: false
-          platforms:
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+          digital_twin:
+            platform: vEOS-lab
+        - platforms:
           - 720DP
           - 722XP
           - 710P
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - digital_twin:
-            platform: vEOS-lab
           feature_support:
-            per_interface_mtu: false
+            poe: true
             queue_monitor_length_notify: false
-          platforms:
-          - 7010TX
           reload_delay:
             mlag: 300
             non_mlag: 330
-        - digital_twin:
+          digital_twin:
             platform: vEOS-lab
+        - platforms:
+          - 7010TX
           feature_support:
-            private_vlan: false
-          lag_hardware_only: true
-          platforms:
+            queue_monitor_length_notify: false
+            per_interface_mtu: false
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+          digital_twin:
+            platform: vEOS-lab
+        - platforms:
           - 7280R
           - 7280R2
           - 7020R
+          lag_hardware_only: true
           reload_delay:
             mlag: 900
             non_mlag: 1020
           tcam_profile: vxlan-routing
-        - digital_twin:
-            platform: vEOS-lab
           feature_support:
-            evpn_gateway_all_active_multihoming: true
             private_vlan: false
-          platforms:
+          digital_twin:
+            platform: vEOS-lab
+        - platforms:
           - 7280R3
           reload_delay:
             mlag: 900
             non_mlag: 1020
           tcam_profile: vxlan-routing
-        - digital_twin:
-            platform: vEOS-lab
-          feature_support:
-            private_vlan: false
-          lag_hardware_only: true
-          management_interface: Management0
-          platforms:
-          - 7500R
-          - 7500R2
-          reload_delay:
-            mlag: 900
-            non_mlag: 1020
-          tcam_profile: vxlan-routing
-        - digital_twin:
-            platform: vEOS-lab
           feature_support:
             evpn_gateway_all_active_multihoming: true
             private_vlan: false
+          digital_twin:
+            platform: vEOS-lab
+        - platforms:
+          - 7500R
+          - 7500R2
+          lag_hardware_only: true
           management_interface: Management0
-          platforms:
-          - 7500R3
-          - 7800R3
           reload_delay:
             mlag: 900
             non_mlag: 1020
           tcam_profile: vxlan-routing
-        - digital_twin:
-            platform: vEOS-lab
           feature_support:
+            private_vlan: false
+          digital_twin:
+            platform: vEOS-lab
+        - platforms:
+          - 7500R3
+          - 7800R3
+          management_interface: Management0
+          reload_delay:
+            mlag: 900
+            non_mlag: 1020
+          tcam_profile: vxlan-routing
+          feature_support:
+            evpn_gateway_all_active_multihoming: true
+            private_vlan: false
+          digital_twin:
+            platform: vEOS-lab
+        - platforms:
+          - 7358X4
+          management_interface: Management1/1
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+          feature_support:
+            queue_monitor_length_notify: false
+            interface_storm_control: true
             bgp_update_wait_for_convergence: true
             bgp_update_wait_install: false
-            interface_storm_control: true
-            queue_monitor_length_notify: false
-          management_interface: Management1/1
-          platforms:
-          - 7358X4
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - digital_twin:
+          digital_twin:
             platform: vEOS-lab
-          management_interface: Management0
-          platforms:
+        - platforms:
           - 7368X4
+          management_interface: Management0
           reload_delay:
             mlag: 300
             non_mlag: 330
-        - digital_twin:
+          digital_twin:
             platform: vEOS-lab
-          management_interface: Management0
-          platforms:
+        - platforms:
           - 7300X3
+          management_interface: Management0
           reload_delay:
             mlag: 1200
             non_mlag: 1320
           trident_forwarding_table_partition: flexible exact-match 16384 l2-shared 98304 l3-shared
             131072
-        - digital_twin:
-            act_node_type: veos
-          feature_support:
-            bgp_update_wait_for_convergence: false
-            bgp_update_wait_install: false
-            evpn_gateway_all_active_multihoming: true
-            interface_storm_control: false
-            queue_monitor_length_notify: false
-          platforms:
+          digital_twin:
+            platform: vEOS-lab
+        - platforms:
           - VEOS
           - VEOS-LAB
           - vEOS
           - vEOS-lab
-          reload_delay:
-            mlag: 300
-            non_mlag: 330
-        - digital_twin:
-            act_node_type: veos
           feature_support:
             bgp_update_wait_for_convergence: false
             bgp_update_wait_install: false
-            evpn_gateway_all_active_multihoming: true
             interface_storm_control: false
             queue_monitor_length_notify: false
-          management_interface: Management0
-          platforms:
+            evpn_gateway_all_active_multihoming: true
+          reload_delay:
+            mlag: 300
+            non_mlag: 330
+          digital_twin:
+            act_node_type: veos
+        - platforms:
           - CEOS
           - cEOS
           - ceos
           - cEOSLab
+          feature_support:
+            bgp_update_wait_for_convergence: false
+            bgp_update_wait_install: false
+            interface_storm_control: false
+            queue_monitor_length_notify: false
+            evpn_gateway_all_active_multihoming: true
+          management_interface: Management0
           reload_delay:
             mlag: 300
             non_mlag: 330
-        - digital_twin:
-            act_node_type: cloudeos
-          feature_support:
-            bgp_update_wait_install: false
-            interface_storm_control: false
-            queue_monitor_length_notify: false
-          p2p_uplinks_mtu: 9194
-          platforms:
+          digital_twin:
+            act_node_type: veos
+        - platforms:
           - CloudEOS
-        - digital_twin:
-            platform: CloudEOS
           feature_support:
-            bgp_update_wait_for_convergence: true
             bgp_update_wait_install: false
             interface_storm_control: false
-            platform_sfe_interface_profile:
-              max_rx_queues: 6
-              supported: true
             queue_monitor_length_notify: false
-          management_interface: Management1/1
           p2p_uplinks_mtu: 9194
-          platforms:
+          digital_twin:
+            act_node_type: cloudeos
+        - platforms:
           - AWE-5310
           - AWE-7230R
-        - digital_twin:
-            platform: CloudEOS
           feature_support:
             bgp_update_wait_for_convergence: true
             bgp_update_wait_install: false
             interface_storm_control: false
-            platform_sfe_interface_profile:
-              max_rx_queues: 16
-              supported: true
             queue_monitor_length_notify: false
+            platform_sfe_interface_profile:
+              supported: true
+              max_rx_queues: 6
           management_interface: Management1/1
           p2p_uplinks_mtu: 9194
-          platforms:
+          digital_twin:
+            platform: CloudEOS
+        - platforms:
           - AWE-5510
           - AWE-7250R
-        - digital_twin:
-            platform: CloudEOS
           feature_support:
             bgp_update_wait_for_convergence: true
             bgp_update_wait_install: false
             interface_storm_control: false
-            poe: true
             queue_monitor_length_notify: false
+            platform_sfe_interface_profile:
+              supported: true
+              max_rx_queues: 16
+          management_interface: Management1/1
+          p2p_uplinks_mtu: 9194
+          digital_twin:
+            platform: CloudEOS
+        - platforms:
+          - AWE-7220R
+          feature_support:
+            bgp_update_wait_for_convergence: true
+            bgp_update_wait_install: false
+            interface_storm_control: false
+            queue_monitor_length_notify: false
+            poe: true
           management_interface: Management1
           p2p_uplinks_mtu: 9194
-          platforms:
-          - AWE-7220R
+          digital_twin:
+            platform: CloudEOS
         ```

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/ptp_settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/ptp_settings.md
@@ -62,27 +62,27 @@
 
         ```yaml
         ptp_profiles:
-        - announce:
+        - profile: aes67-r16-2016
+          announce:
             interval: 0
             timeout: 3
           delay_req: -3
-          profile: aes67-r16-2016
           sync_message:
             interval: -3
           transport: ipv4
-        - announce:
+        - profile: smpte2059-2
+          announce:
             interval: -2
             timeout: 3
           delay_req: -4
-          profile: smpte2059-2
           sync_message:
             interval: -4
           transport: ipv4
-        - announce:
+        - profile: aes67
+          announce:
             interval: 2
             timeout: 3
           delay_req: 0
-          profile: aes67
           sync_message:
             interval: 0
           transport: ipv4

--- a/python-avd/schema_tools/generate_docs/yamllinegen.py
+++ b/python-avd/schema_tools/generate_docs/yamllinegen.py
@@ -204,7 +204,7 @@ class YamlLineGenBase:
 
     def get_annotation(self) -> str | None:
         if self.needs_annotation_for_default_value:
-            return yaml.dump({self.schema._key: self.schema.default}, indent=2)
+            return yaml.dump({self.schema._key: self.schema.default}, sort_keys=False, indent=2)
         return None
 
     def render_restrictions(self) -> str | None:


### PR DESCRIPTION
Update schema generated default values to avoid sorting keys.

When the tooling generates default values for dicts or lists it uses a yaml dump function, which by default sorts the keys. This skews the default values in the popups behind the (+) buttons.

This PR removes the sort, so we rely on the order of default values from the schema.
