### PR TITLE
Fix(eos_designs): Avoid restricting valid user tags in generate_cv_tags.device_tags

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/generate-cv-tags-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/intended/structured_configs/generate-cv-tags-1.yml
@@ -47,6 +47,8 @@ metadata:
       value: '65000'
     - name: UPPERCASE_DEVICE_TAG
       value: something with spaces
+    - name: Role
+      value: DC23
     interface_tags:
     - interface: Ethernet1
       tags:

--- a/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/generate-cv-tags-1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_unit_tests/inventory/host_vars/generate-cv-tags-1.yml
@@ -28,6 +28,8 @@ generate_cv_tags:
       data_path: some.key.that.we.do.not.have
     - name: UPPERCASE_DEVICE_TAG
       value: something with spaces
+    - name: Role
+      data_path: metadata.dc_name
   interface_tags:
     - name: static-interface-tag
       value: myinterfacevalue

--- a/python-avd/pyavd/_eos_designs/structured_config/metadata/cv_tags.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/metadata/cv_tags.py
@@ -38,7 +38,7 @@ INVALID_CUSTOM_DEVICE_TAGS = [
     "hostname",
     "terminattr",
 ]
-"""These tag names overlap with CV system tags or topology_hints"""
+"""These tag names overlap with CV system tags."""
 CAMPUS_LINK_TYPE_MAP = {
     "downlink": "Downlink",
     "egress": "Egress",

--- a/python-avd/pyavd/_eos_designs/structured_config/metadata/cv_tags.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/metadata/cv_tags.py
@@ -20,15 +20,10 @@ if TYPE_CHECKING:
 
 CAMPUS_TOPOLOGY_NETWORK_TYPE = "campusV2"
 INVALID_CUSTOM_DEVICE_TAGS = [
-    "topology_hint_network_type",
-    "topology_hint_type",
     "topology_type",
-    "topology_hint_datacenter",
     "topology_datacenter",
-    "topology_hint_rack",
     "topology_rack",
     "topology_pod",
-    "topology_hint_pod",
     "eos",
     "eostrain",
     "ztp",
@@ -42,10 +37,6 @@ INVALID_CUSTOM_DEVICE_TAGS = [
     "tapagg",
     "hostname",
     "terminattr",
-    "Campus",
-    "Campus-Pod",
-    "Access-Pod",
-    "Role",
 ]
 """These tag names overlap with CV system tags or topology_hints"""
 CAMPUS_LINK_TYPE_MAP = {


### PR DESCRIPTION
## Change Summary

Fix the invalid customer generate_cv_tags.device_tags

## Related Issue(s)

Fixes #5879 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
I am trying to set tags to devices in cvp with eos_designs and cv_deploy and have defined the following tags.

```
# eos_designs automatically sets topology tag in cvp
generate_cv_tags:
  topology_hints: true
  device_tags:
    - name: DC
      data_path: metadata.dc_name
    - name: DC-Pod
      data_path: metadata.pod_name
    - name: Role
      data_path: type
```

I get the follwing error message, when executing the playbook:

```
fatal: [de-dcp-e-dcn-cs-208-11 -> localhost]: FAILED! => {"changed": false, "msg": "The CloudVision tag name 'generate_cv_tags.device_tags[name=Role] is invalid. System Tags cannot be overridden. Try using a different name for this tag."}
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: pyavd._errors.AristaAvdError: The CloudVision tag name 'generate_cv_tags.device_tags[name=Role] is invalid. System Tags cannot be overridden. Try using a different name for this tag.
```

It claims that the tag `Role`is a fixed system tag in CVP.

But I cannot find a tag named "Role" in CVP under system tags.

So updated the INVALID_CUSTOM_DEVICE_TAGS in code.

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
