### PR TITLE
Cut(eos_designs): Remove deprecated keys `destination_address_prefix` and `gateway` from eos_designs

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/configs/host1.cfg
@@ -93,11 +93,6 @@ interface Ethernet43
    ip address 10.42.42.204/31
    pim ipv4 sparse-mode
 !
-interface Ethernet47
-   no shutdown
-   no switchport
-   ip address 10.10.1.1/30
-!
 interface Loopback0
    description ROUTER_ID
    no shutdown
@@ -123,10 +118,6 @@ ip routing
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 192.168.255.0/24 eq 32
    seq 20 permit 192.168.254.0/24 eq 32
-!
-ip route 0.0.0.0 10.10.1.1
-!
-ipv6 route ::/0 2001:db8:311::4 name IPv6-test-2
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
@@ -155,7 +146,6 @@ router bgp 101
    neighbor 192.168.42.200 remote-as 102
    neighbor 192.168.42.200 description host2_Ethernet42
    redistribute connected route-map RM-CONN-2-BGP
-   redistribute static
    !
    address-family evpn
       neighbor EVPN-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/intended/structured_configs/host1.yml
@@ -59,12 +59,6 @@ ethernet_interfaces:
   peer_type: l3leaf
   switchport:
     enabled: false
-- name: Ethernet47
-  shutdown: false
-  ip_address: 10.10.1.1/30
-  peer_type: l3_interface
-  switchport:
-    enabled: false
 - name: Ethernet1
   description: SERVER_OLD_SW-1/2_Endpoint_port1
   shutdown: false
@@ -97,11 +91,6 @@ hostname: host1
 ip_igmp_snooping:
   globally_enabled: true
 ip_routing: true
-ipv6_static_routes:
-- vrf: default
-  prefix: ::/0
-  next_hop: 2001:db8:311::4
-  name: IPv6-test-2
 local_users:
 - name: admin
   disabled: true
@@ -231,8 +220,6 @@ router_bgp:
     connected:
       enabled: true
       route_map: RM-CONN-2-BGP
-    static:
-      enabled: true
   address_family_evpn:
     peer_groups:
     - name: EVPN-OVERLAY-PEERS
@@ -244,10 +231,6 @@ router_bgp:
     - name: EVPN-OVERLAY-PEERS
       activate: false
 service_routing_protocols_model: multi-agent
-static_routes:
-- vrf: default
-  prefix: 0.0.0.0
-  next_hop: 10.10.1.1
 transceiver_qsfp_default_mode_4x10: true
 vlan_internal_order:
   allocation: ascending

--- a/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/group_vars/TENANTS.yml
+++ b/ansible_collections/arista/avd/molecule/eos_designs_deprecated_vars/inventory/group_vars/TENANTS.yml
@@ -5,22 +5,6 @@ tenants:
       - name: default
         vrf_id: 100
         address_families: []
-        static_routes:
-          - destination_address_prefix: 0.0.0.0
-            gateway: 10.10.1.1
-            nodes: [host1]
-        l3_interfaces:
-          - interfaces:
-              - Ethernet47
-            ip_addresses:
-              - 10.10.1.1/30
-            nodes:
-              - host1
-        ipv6_static_routes:
-          - destination_address_prefix: ::/0
-            gateway: 2001:db8:311::4
-            name: IPv6-test-2
-            nodes: [ host1 ]
         l3_port_channels:
           - name: Port-Channel11
             node: host1

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
@@ -19,7 +19,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_addresses</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ip_addresses") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ip_addresses.[]") | String |  |  |  | IPv4_address/Mask. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on every device where this interface is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -28,7 +28,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].static_routes.[].interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device where this interface is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_interfaces.[].ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -129,7 +129,7 @@
 
                 # Static routes to be configured on every device where this interface is configured.
                 static_routes:
-                  - prefix: <str>
+                  - prefix: <str; required>
                     next_hop: <str>
 
                     # Track next-hop using BFD.
@@ -144,7 +144,7 @@
 
                 # IPv6 static routes to be configured on every device where this interface is configured.
                 ipv6_static_routes:
-                  - prefix: <str>
+                  - prefix: <str; required>
                     next_hop: <str>
 
                     # Track next-hop using BFD.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
@@ -33,7 +33,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on the device where this Port-channel interface is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -42,7 +42,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].static_routes.[].interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on the device where this Port-channel interface is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].l3_port_channels.[].ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -163,7 +163,7 @@
 
                 # Static routes to be configured on the device where this Port-channel interface is configured.
                 static_routes:
-                  - prefix: <str>
+                  - prefix: <str; required>
                     next_hop: <str>
 
                     # Track next-hop using BFD.
@@ -178,7 +178,7 @@
 
                 # IPv6 static routes to be configured on the device where this Port-channel interface is configured.
                 ipv6_static_routes:
-                  - prefix: <str>
+                  - prefix: <str; required>
                     next_hop: <str>
 
                     # Track next-hop using BFD.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
@@ -41,11 +41,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hardware_forwarding</samp>](## "<network_services_keys.name>.[].vrfs.[].vtep_diagnostic.hardware_forwarding") | Boolean |  |  |  | Enable hardware forwarding for diagnostic loopbacks. This is required for correct forwarding in VRFs without physical interfaces.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "<network_services_keys.name>.[].vrfs.[].evpn_l2_multi_domain") | Boolean |  |  |  | Explicitly extend all VLANs/VLAN-Aware Bundles inside the VRF to remote EVPN domains.<br>Overrides `<network_services_key>[].evpn_l2_multi_domain`.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes") | List, items: Dictionary |  |  |  | List of static routes for v4 and/or v6.<br>This will create static routes inside the tenant VRF.<br>If nodes are not specified, all l3leafs that carry the VRF will also be applied the static routes.<br>If a node has a static route in the VRF, redistribute static will be automatically enabled in that VRF.<br>This automatic behavior can be overridden non-selectively with the redistribute_static knob for the VRF.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;destination_address_prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].destination_address_prefix") <span style="color:red">deprecated</span> | String |  |  |  | IPv4_address.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>prefix</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].gateway") <span style="color:red">deprecated</span> | String |  |  |  | IPv4_address.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>next_hop</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].nodes") | List, items: String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;nodes</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].nodes") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].nodes.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].destination_address_prefix") <span style="color:red">removed</span> | String |  |  |  | IPv4_address.<span style="color:red">This key was removed. Support was removed in AVD version 6.0.0. Use <samp>prefix</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].gateway") <span style="color:red">removed</span> | String |  |  |  | IPv4_address.<span style="color:red">This key was removed. Support was removed in AVD version 6.0.0. Use <samp>next_hop</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -54,11 +54,11 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].static_routes.[].interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes") | List, items: Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;destination_address_prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].destination_address_prefix") <span style="color:red">deprecated</span> | String |  |  |  | IPv6_address.<span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>prefix</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].gateway") <span style="color:red">deprecated</span> | String |  |  |  | <span style="color:red">This key is deprecated. Support will be removed in AVD version 6.0.0. Use <samp>next_hop</samp> instead.</span> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;nodes</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].nodes") | List, items: String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;nodes</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].nodes") | List, items: String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].nodes.[]") | String |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;destination_address_prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].destination_address_prefix") <span style="color:red">removed</span> | String |  |  |  | IPv6_address.<span style="color:red">This key was removed. Support was removed in AVD version 6.0.0. Use <samp>prefix</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;gateway</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].gateway") <span style="color:red">removed</span> | String |  |  |  | <span style="color:red">This key was removed. Support was removed in AVD version 6.0.0. Use <samp>next_hop</samp> instead.</span> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -251,21 +251,9 @@
             # If a node has a static route in the VRF, redistribute static will be automatically enabled in that VRF.
             # This automatic behavior can be overridden non-selectively with the redistribute_static knob for the VRF.
             static_routes:
-
-                # IPv4_address.
-                # This key is deprecated.
-                # Support will be removed in AVD version 6.0.0.
-                # Use `prefix` instead.
-              - destination_address_prefix: <str>
-
-                # IPv4_address.
-                # This key is deprecated.
-                # Support will be removed in AVD version 6.0.0.
-                # Use `next_hop` instead.
-                gateway: <str>
-                nodes:
+              - nodes:
                   - <str>
-                prefix: <str>
+                prefix: <str; required>
                 next_hop: <str>
 
                 # Track next-hop using BFD.
@@ -278,19 +266,9 @@
                 metric: <int; 0-4294967295>
                 interface: <str>
             ipv6_static_routes:
-
-                # IPv6_address.
-                # This key is deprecated.
-                # Support will be removed in AVD version 6.0.0.
-                # Use `prefix` instead.
-              - destination_address_prefix: <str>
-                # This key is deprecated.
-                # Support will be removed in AVD version 6.0.0.
-                # Use `next_hop` instead.
-                gateway: <str>
-                nodes:
+              - nodes:
                   - <str>
-                prefix: <str>
+                prefix: <str; required>
                 next_hop: <str>
 
                 # Track next-hop using BFD.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
@@ -48,7 +48,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_vrf</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].source_vrf") | String |  |  |  | VRF to originate DHCP relay packets to DHCP server. If not set, EOS uses the VRF on the SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on every device where the SVI is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -57,7 +57,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].static_routes.[].interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device where the SVI is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -101,7 +101,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_vrf</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers.[].source_vrf") | String |  |  |  | VRF to originate DHCP relay packets to DHCP server. If not set, EOS uses the VRF on the SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on every device where the SVI is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -110,7 +110,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].static_routes.[].interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device where the SVI is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -285,7 +285,7 @@
 
                     # Static routes to be configured on every device where the SVI is configured.
                     static_routes:
-                      - prefix: <str>
+                      - prefix: <str; required>
                         next_hop: <str>
 
                         # Track next-hop using BFD.
@@ -300,7 +300,7 @@
 
                     # IPv6 static routes to be configured on every device where the SVI is configured.
                     ipv6_static_routes:
-                      - prefix: <str>
+                      - prefix: <str; required>
                         next_hop: <str>
 
                         # Track next-hop using BFD.
@@ -446,7 +446,7 @@
 
                 # Static routes to be configured on every device where the SVI is configured.
                 static_routes:
-                  - prefix: <str>
+                  - prefix: <str; required>
                     next_hop: <str>
 
                     # Track next-hop using BFD.
@@ -461,7 +461,7 @@
 
                 # IPv6 static routes to be configured on every device where the SVI is configured.
                 ipv6_static_routes:
-                  - prefix: <str>
+                  - prefix: <str; required>
                     next_hop: <str>
 
                     # Track next-hop using BFD.

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
@@ -35,7 +35,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "svi_profiles.[].nodes.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_vrf</samp>](## "svi_profiles.[].nodes.[].ip_helpers.[].source_vrf") | String |  |  |  | VRF to originate DHCP relay packets to DHCP server. If not set, EOS uses the VRF on the SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "svi_profiles.[].nodes.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on every device where the SVI is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "svi_profiles.[].nodes.[].static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "svi_profiles.[].nodes.[].static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "svi_profiles.[].nodes.[].static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "svi_profiles.[].nodes.[].static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "svi_profiles.[].nodes.[].static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -44,7 +44,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "svi_profiles.[].nodes.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "svi_profiles.[].nodes.[].static_routes.[].interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "svi_profiles.[].nodes.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device where the SVI is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "svi_profiles.[].nodes.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "svi_profiles.[].nodes.[].ipv6_static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "svi_profiles.[].nodes.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "svi_profiles.[].nodes.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "svi_profiles.[].nodes.[].ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -89,7 +89,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "svi_profiles.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_vrf</samp>](## "svi_profiles.[].ip_helpers.[].source_vrf") | String |  |  |  | VRF to originate DHCP relay packets to DHCP server. If not set, EOS uses the VRF on the SVI. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;static_routes</samp>](## "svi_profiles.[].static_routes") | List, items: Dictionary |  |  |  | Static routes to be configured on every device where the SVI is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "svi_profiles.[].static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "svi_profiles.[].static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "svi_profiles.[].static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "svi_profiles.[].static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "svi_profiles.[].static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -98,7 +98,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;metric</samp>](## "svi_profiles.[].static_routes.[].metric") | Integer |  |  | Min: 0<br>Max: 4294967295 |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;interface</samp>](## "svi_profiles.[].static_routes.[].interface") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_static_routes</samp>](## "svi_profiles.[].ipv6_static_routes") | List, items: Dictionary |  |  |  | IPv6 static routes to be configured on every device where the SVI is configured. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "svi_profiles.[].ipv6_static_routes.[].prefix") | String |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;prefix</samp>](## "svi_profiles.[].ipv6_static_routes.[].prefix") | String | Required |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;next_hop</samp>](## "svi_profiles.[].ipv6_static_routes.[].next_hop") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;track_bfd</samp>](## "svi_profiles.[].ipv6_static_routes.[].track_bfd") | Boolean |  |  |  | Track next-hop using BFD. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "svi_profiles.[].ipv6_static_routes.[].distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
@@ -229,7 +229,7 @@
 
             # Static routes to be configured on every device where the SVI is configured.
             static_routes:
-              - prefix: <str>
+              - prefix: <str; required>
                 next_hop: <str>
 
                 # Track next-hop using BFD.
@@ -244,7 +244,7 @@
 
             # IPv6 static routes to be configured on every device where the SVI is configured.
             ipv6_static_routes:
-              - prefix: <str>
+              - prefix: <str; required>
                 next_hop: <str>
 
                 # Track next-hop using BFD.
@@ -393,7 +393,7 @@
 
         # Static routes to be configured on every device where the SVI is configured.
         static_routes:
-          - prefix: <str>
+          - prefix: <str; required>
             next_hop: <str>
 
             # Track next-hop using BFD.
@@ -408,7 +408,7 @@
 
         # IPv6 static routes to be configured on every device where the SVI is configured.
         ipv6_static_routes:
-          - prefix: <str>
+          - prefix: <str; required>
             next_hop: <str>
 
             # Track next-hop using BFD.

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -63,6 +63,10 @@ The following data model keys have been removed from `eos_designs` in AVD 6.0.0.
 | `l3_edge.p2p_links[].underlay_multicast` | `l3_edge.p2p_links.multicast_pim_sm` |
 | `l3_edge.p2p_links_profiles[].underlay_multicast` | `l3_edge.p2p_links_profiles.multicast_pim_sm` |
 | `name_servers` | `dns_settings.servers` |
+| `<network_services_key>[].vrfs[].static_routes.destination_address_prefix` | `<network_services_key>[].vrfs[].static_routes.prefix` |
+| `<network_services_key>[].vrfs[].l3_interfaces[].static_routes.destination_address_prefix` | `<network_services_key>[].vrfs[].l3_interfaces[].static_routes.prefix` |
+| `<network_services_key>[].vrfs[].l3_port_channels[].static_routes.destination_address_prefix` | `<network_services_key>[].vrfs[].l3_port_channels[].static_routes.prefix` |
+| `<network_services_key>[].vrfs[].svis[].static_routes.destination_address_prefix` | `<network_services_key>[].vrfs[].svis[].static_routes.prefix` |
 | `node_type_keys[].interface_descriptions.overlay_loopback_interface` | `node_type_keys[].interface_descriptions.router_id_loopback_interface`|
 | `snmp_settings.enable_inband_mgmt_vrf` | `snmp_settings.vrfs[name="use_inband_mgmt_vrf"].enabled` |
 | `snmp_settings.enable_mgmt_interface_vrf` | `snmp_settings.vrfs[name="use_mgmt_interface_vrf"].enabled` |

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -63,10 +63,13 @@ The following data model keys have been removed from `eos_designs` in AVD 6.0.0.
 | `l3_edge.p2p_links[].underlay_multicast` | `l3_edge.p2p_links.multicast_pim_sm` |
 | `l3_edge.p2p_links_profiles[].underlay_multicast` | `l3_edge.p2p_links_profiles.multicast_pim_sm` |
 | `name_servers` | `dns_settings.servers` |
-| `<network_services_key>[].vrfs[].static_routes.destination_address_prefix` | `<network_services_key>[].vrfs[].static_routes.prefix` |
-| `<network_services_key>[].vrfs[].l3_interfaces[].static_routes.destination_address_prefix` | `<network_services_key>[].vrfs[].l3_interfaces[].static_routes.prefix` |
-| `<network_services_key>[].vrfs[].l3_port_channels[].static_routes.destination_address_prefix` | `<network_services_key>[].vrfs[].l3_port_channels[].static_routes.prefix` |
-| `<network_services_key>[].vrfs[].svis[].static_routes.destination_address_prefix` | `<network_services_key>[].vrfs[].svis[].static_routes.prefix` |
+| `<network_services_key>[].vrfs[].static_routes[].destination_address_prefix` | `<network_services_key>[].vrfs[].static_routes[].prefix` |
+| `<network_services_key>[].vrfs[].static_routes[].gateway` | `<network_services_key>[].vrfs[].static_routes[].next_hop` |
+| `<network_services_key>[].vrfs[].l3_interfaces[].static_routes[].destination_address_prefix` | `<network_services_key>[].vrfs[].l3_interfaces[].static_routes[].prefix` |
+| `<network_services_key>[].vrfs[].l3_interfaces[].static_routes[].gateway` | `<network_services_key>[].vrfs[].l3_interfaces[].static_routes[].next_hop` |
+| `<network_services_key>[].vrfs[].l3_port_channels[].static_routes[].destination_address_prefix` | `<network_services_key>[].vrfs[].l3_port_channels[].static_routes[].prefix` |
+| `<network_services_key>[].vrfs[].svis[].static_routes[].destination_address_prefix` | `<network_services_key>[].vrfs[].svis[].static_routes[].prefix` |
+| `<network_services_key>[].vrfs[].svis[].static_routes.gateway` | `<network_services_key>[].vrfs[].svis[].static_routes.next_hop` |
 | `node_type_keys[].interface_descriptions.overlay_loopback_interface` | `node_type_keys[].interface_descriptions.router_id_loopback_interface`|
 | `snmp_settings.enable_inband_mgmt_vrf` | `snmp_settings.vrfs[name="use_inband_mgmt_vrf"].enabled` |
 | `snmp_settings.enable_mgmt_interface_vrf` | `snmp_settings.vrfs[name="use_mgmt_interface_vrf"].enabled` |

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -17234,7 +17234,7 @@ class EosDesigns(EosDesignsRootModel):
                     "metric": {"type": int},
                     "interface": {"type": str},
                 }
-                prefix: str | None
+                prefix: str
                 next_hop: str | None
                 track_bfd: bool | None
                 """Track next-hop using BFD."""
@@ -17250,7 +17250,7 @@ class EosDesigns(EosDesignsRootModel):
                     def __init__(
                         self,
                         *,
-                        prefix: str | None | UndefinedType = Undefined,
+                        prefix: str | UndefinedType = Undefined,
                         next_hop: str | None | UndefinedType = Undefined,
                         track_bfd: bool | None | UndefinedType = Undefined,
                         distance: int | None | UndefinedType = Undefined,
@@ -17295,7 +17295,7 @@ class EosDesigns(EosDesignsRootModel):
                     "metric": {"type": int},
                     "interface": {"type": str},
                 }
-                prefix: str | None
+                prefix: str
                 next_hop: str | None
                 track_bfd: bool | None
                 """Track next-hop using BFD."""
@@ -17311,7 +17311,7 @@ class EosDesigns(EosDesignsRootModel):
                     def __init__(
                         self,
                         *,
-                        prefix: str | None | UndefinedType = Undefined,
+                        prefix: str | UndefinedType = Undefined,
                         next_hop: str | None | UndefinedType = Undefined,
                         track_bfd: bool | None | UndefinedType = Undefined,
                         distance: int | None | UndefinedType = Undefined,
@@ -18159,7 +18159,7 @@ class EosDesigns(EosDesignsRootModel):
                 "metric": {"type": int},
                 "interface": {"type": str},
             }
-            prefix: str | None
+            prefix: str
             next_hop: str | None
             track_bfd: bool | None
             """Track next-hop using BFD."""
@@ -18175,7 +18175,7 @@ class EosDesigns(EosDesignsRootModel):
                 def __init__(
                     self,
                     *,
-                    prefix: str | None | UndefinedType = Undefined,
+                    prefix: str | UndefinedType = Undefined,
                     next_hop: str | None | UndefinedType = Undefined,
                     track_bfd: bool | None | UndefinedType = Undefined,
                     distance: int | None | UndefinedType = Undefined,
@@ -18220,7 +18220,7 @@ class EosDesigns(EosDesignsRootModel):
                 "metric": {"type": int},
                 "interface": {"type": str},
             }
-            prefix: str | None
+            prefix: str
             next_hop: str | None
             track_bfd: bool | None
             """Track next-hop using BFD."""
@@ -18236,7 +18236,7 @@ class EosDesigns(EosDesignsRootModel):
                 def __init__(
                     self,
                     *,
-                    prefix: str | None | UndefinedType = Undefined,
+                    prefix: str | UndefinedType = Undefined,
                     next_hop: str | None | UndefinedType = Undefined,
                     track_bfd: bool | None | UndefinedType = Undefined,
                     distance: int | None | UndefinedType = Undefined,
@@ -44527,7 +44527,7 @@ class EosDesigns(EosDesignsRootModel):
                                     "metric": {"type": int},
                                     "interface": {"type": str},
                                 }
-                                prefix: str | None
+                                prefix: str
                                 next_hop: str | None
                                 track_bfd: bool | None
                                 """Track next-hop using BFD."""
@@ -44543,7 +44543,7 @@ class EosDesigns(EosDesignsRootModel):
                                     def __init__(
                                         self,
                                         *,
-                                        prefix: str | None | UndefinedType = Undefined,
+                                        prefix: str | UndefinedType = Undefined,
                                         next_hop: str | None | UndefinedType = Undefined,
                                         track_bfd: bool | None | UndefinedType = Undefined,
                                         distance: int | None | UndefinedType = Undefined,
@@ -44588,7 +44588,7 @@ class EosDesigns(EosDesignsRootModel):
                                     "metric": {"type": int},
                                     "interface": {"type": str},
                                 }
-                                prefix: str | None
+                                prefix: str
                                 next_hop: str | None
                                 track_bfd: bool | None
                                 """Track next-hop using BFD."""
@@ -44604,7 +44604,7 @@ class EosDesigns(EosDesignsRootModel):
                                     def __init__(
                                         self,
                                         *,
-                                        prefix: str | None | UndefinedType = Undefined,
+                                        prefix: str | UndefinedType = Undefined,
                                         next_hop: str | None | UndefinedType = Undefined,
                                         track_bfd: bool | None | UndefinedType = Undefined,
                                         distance: int | None | UndefinedType = Undefined,
@@ -45481,7 +45481,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "metric": {"type": int},
                                 "interface": {"type": str},
                             }
-                            prefix: str | None
+                            prefix: str
                             next_hop: str | None
                             track_bfd: bool | None
                             """Track next-hop using BFD."""
@@ -45497,7 +45497,7 @@ class EosDesigns(EosDesignsRootModel):
                                 def __init__(
                                     self,
                                     *,
-                                    prefix: str | None | UndefinedType = Undefined,
+                                    prefix: str | UndefinedType = Undefined,
                                     next_hop: str | None | UndefinedType = Undefined,
                                     track_bfd: bool | None | UndefinedType = Undefined,
                                     distance: int | None | UndefinedType = Undefined,
@@ -45542,7 +45542,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "metric": {"type": int},
                                 "interface": {"type": str},
                             }
-                            prefix: str | None
+                            prefix: str
                             next_hop: str | None
                             track_bfd: bool | None
                             """Track next-hop using BFD."""
@@ -45558,7 +45558,7 @@ class EosDesigns(EosDesignsRootModel):
                                 def __init__(
                                     self,
                                     *,
-                                    prefix: str | None | UndefinedType = Undefined,
+                                    prefix: str | UndefinedType = Undefined,
                                     next_hop: str | None | UndefinedType = Undefined,
                                     track_bfd: bool | None | UndefinedType = Undefined,
                                     distance: int | None | UndefinedType = Undefined,
@@ -46445,7 +46445,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "metric": {"type": int},
                                 "interface": {"type": str},
                             }
-                            prefix: str | None
+                            prefix: str
                             next_hop: str | None
                             track_bfd: bool | None
                             """Track next-hop using BFD."""
@@ -46461,7 +46461,7 @@ class EosDesigns(EosDesignsRootModel):
                                 def __init__(
                                     self,
                                     *,
-                                    prefix: str | None | UndefinedType = Undefined,
+                                    prefix: str | UndefinedType = Undefined,
                                     next_hop: str | None | UndefinedType = Undefined,
                                     track_bfd: bool | None | UndefinedType = Undefined,
                                     distance: int | None | UndefinedType = Undefined,
@@ -46506,7 +46506,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "metric": {"type": int},
                                 "interface": {"type": str},
                             }
-                            prefix: str | None
+                            prefix: str
                             next_hop: str | None
                             track_bfd: bool | None
                             """Track next-hop using BFD."""
@@ -46522,7 +46522,7 @@ class EosDesigns(EosDesignsRootModel):
                                 def __init__(
                                     self,
                                     *,
-                                    prefix: str | None | UndefinedType = Undefined,
+                                    prefix: str | UndefinedType = Undefined,
                                     next_hop: str | None | UndefinedType = Undefined,
                                     track_bfd: bool | None | UndefinedType = Undefined,
                                     distance: int | None | UndefinedType = Undefined,
@@ -47335,7 +47335,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "metric": {"type": int},
                                 "interface": {"type": str},
                             }
-                            prefix: str | None
+                            prefix: str
                             next_hop: str | None
                             track_bfd: bool | None
                             """Track next-hop using BFD."""
@@ -47351,7 +47351,7 @@ class EosDesigns(EosDesignsRootModel):
                                 def __init__(
                                     self,
                                     *,
-                                    prefix: str | None | UndefinedType = Undefined,
+                                    prefix: str | UndefinedType = Undefined,
                                     next_hop: str | None | UndefinedType = Undefined,
                                     track_bfd: bool | None | UndefinedType = Undefined,
                                     distance: int | None | UndefinedType = Undefined,
@@ -47396,7 +47396,7 @@ class EosDesigns(EosDesignsRootModel):
                                 "metric": {"type": int},
                                 "interface": {"type": str},
                             }
-                            prefix: str | None
+                            prefix: str
                             next_hop: str | None
                             track_bfd: bool | None
                             """Track next-hop using BFD."""
@@ -47412,7 +47412,7 @@ class EosDesigns(EosDesignsRootModel):
                                 def __init__(
                                     self,
                                     *,
-                                    prefix: str | None | UndefinedType = Undefined,
+                                    prefix: str | UndefinedType = Undefined,
                                     next_hop: str | None | UndefinedType = Undefined,
                                     track_bfd: bool | None | UndefinedType = Undefined,
                                     distance: int | None | UndefinedType = Undefined,
@@ -47925,8 +47925,6 @@ class EosDesigns(EosDesignsRootModel):
                         Nodes._item_type = str
 
                         _fields: ClassVar[dict] = {
-                            "destination_address_prefix": {"type": str},
-                            "gateway": {"type": str},
                             "nodes": {"type": Nodes},
                             "prefix": {"type": str},
                             "next_hop": {"type": str},
@@ -47937,13 +47935,9 @@ class EosDesigns(EosDesignsRootModel):
                             "metric": {"type": int},
                             "interface": {"type": str},
                         }
-                        destination_address_prefix: str | None
-                        """IPv4_address."""
-                        gateway: str | None
-                        """IPv4_address."""
                         nodes: Nodes
                         """Subclass of AvdList with `str` items."""
-                        prefix: str | None
+                        prefix: str
                         next_hop: str | None
                         track_bfd: bool | None
                         """Track next-hop using BFD."""
@@ -47959,10 +47953,8 @@ class EosDesigns(EosDesignsRootModel):
                             def __init__(
                                 self,
                                 *,
-                                destination_address_prefix: str | None | UndefinedType = Undefined,
-                                gateway: str | None | UndefinedType = Undefined,
                                 nodes: Nodes | UndefinedType = Undefined,
-                                prefix: str | None | UndefinedType = Undefined,
+                                prefix: str | UndefinedType = Undefined,
                                 next_hop: str | None | UndefinedType = Undefined,
                                 track_bfd: bool | None | UndefinedType = Undefined,
                                 distance: int | None | UndefinedType = Undefined,
@@ -47978,8 +47970,6 @@ class EosDesigns(EosDesignsRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    destination_address_prefix: IPv4_address.
-                                    gateway: IPv4_address.
                                     nodes: Subclass of AvdList with `str` items.
                                     prefix: prefix
                                     next_hop: next_hop
@@ -48006,8 +47996,6 @@ class EosDesigns(EosDesignsRootModel):
                         Nodes._item_type = str
 
                         _fields: ClassVar[dict] = {
-                            "destination_address_prefix": {"type": str},
-                            "gateway": {"type": str},
                             "nodes": {"type": Nodes},
                             "prefix": {"type": str},
                             "next_hop": {"type": str},
@@ -48018,12 +48006,9 @@ class EosDesigns(EosDesignsRootModel):
                             "metric": {"type": int},
                             "interface": {"type": str},
                         }
-                        destination_address_prefix: str | None
-                        """IPv6_address."""
-                        gateway: str | None
                         nodes: Nodes
                         """Subclass of AvdList with `str` items."""
-                        prefix: str | None
+                        prefix: str
                         next_hop: str | None
                         track_bfd: bool | None
                         """Track next-hop using BFD."""
@@ -48039,10 +48024,8 @@ class EosDesigns(EosDesignsRootModel):
                             def __init__(
                                 self,
                                 *,
-                                destination_address_prefix: str | None | UndefinedType = Undefined,
-                                gateway: str | None | UndefinedType = Undefined,
                                 nodes: Nodes | UndefinedType = Undefined,
-                                prefix: str | None | UndefinedType = Undefined,
+                                prefix: str | UndefinedType = Undefined,
                                 next_hop: str | None | UndefinedType = Undefined,
                                 track_bfd: bool | None | UndefinedType = Undefined,
                                 distance: int | None | UndefinedType = Undefined,
@@ -48058,8 +48041,6 @@ class EosDesigns(EosDesignsRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    destination_address_prefix: IPv6_address.
-                                    gateway: gateway
                                     nodes: Subclass of AvdList with `str` items.
                                     prefix: prefix
                                     next_hop: next_hop

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -9118,11 +9118,16 @@ $defs:
                 items:
                   type: dict
                   keys:
+                    nodes:
+                      type: list
+                      items:
+                        type: str
                     destination_address_prefix:
                       type: str
                       description: IPv4_address.
                       deprecation:
                         warning: true
+                        removed: true
                         remove_in_version: 6.0.0
                         new_key: prefix
                     gateway:
@@ -9130,35 +9135,34 @@ $defs:
                       description: IPv4_address.
                       deprecation:
                         warning: true
+                        removed: true
                         remove_in_version: 6.0.0
                         new_key: next_hop
-                    nodes:
-                      type: list
-                      items:
-                        type: str
               ipv6_static_routes:
                 type: list
                 $ref: eos_designs#/$defs/static_routes
                 items:
                   type: dict
                   keys:
+                    nodes:
+                      type: list
+                      items:
+                        type: str
                     destination_address_prefix:
                       type: str
                       description: IPv6_address.
                       deprecation:
                         warning: true
+                        removed: true
                         remove_in_version: 6.0.0
                         new_key: prefix
                     gateway:
                       type: str
                       deprecation:
                         warning: true
+                        removed: true
                         remove_in_version: 6.0.0
                         new_key: next_hop
-                    nodes:
-                      type: list
-                      items:
-                        type: str
               redistribute_static:
                 type: bool
                 description: Enable or disable the redistribution of all static routes
@@ -12595,6 +12599,7 @@ $defs:
       keys:
         prefix:
           type: str
+          required: true
         next_hop:
           type: str
         track_bfd:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -1248,11 +1248,16 @@ $defs:
                 items:
                   type: dict
                   keys:
+                    nodes:
+                      type: list
+                      items:
+                        type: str
                     destination_address_prefix:
                       type: str
                       description: IPv4_address.
                       deprecation:
                         warning: true
+                        removed: true
                         remove_in_version: 6.0.0
                         new_key: prefix
                     gateway:
@@ -1260,35 +1265,34 @@ $defs:
                       description: IPv4_address.
                       deprecation:
                         warning: true
+                        removed: true
                         remove_in_version: 6.0.0
                         new_key: next_hop
-                    nodes:
-                      type: list
-                      items:
-                        type: str
               ipv6_static_routes:
                 type: list
                 $ref: "eos_designs#/$defs/static_routes"
                 items:
                   type: dict
                   keys:
+                    nodes:
+                      type: list
+                      items:
+                        type: str
                     destination_address_prefix:
                       type: str
                       description: IPv6_address.
                       deprecation:
                         warning: true
+                        removed: true
                         remove_in_version: 6.0.0
                         new_key: prefix
                     gateway:
                       type: str
                       deprecation:
                         warning: true
+                        removed: true
                         remove_in_version: 6.0.0
                         new_key: next_hop
-                    nodes:
-                      type: list
-                      items:
-                        type: str
               redistribute_static:
                 type: bool
                 description: Enable or disable the redistribution of all static routes to BGP in the VRF.

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_static_routes.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_static_routes.schema.yml
@@ -13,6 +13,7 @@ $defs:
       keys:
         prefix:
           type: str
+          required: true
         next_hop:
           type: str
         track_bfd:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/ipv6_static_routes.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
+from pyavd._utils import Undefined
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigNetworkServicesProtocol
@@ -37,9 +38,9 @@ class Ipv6StaticRoutesMixin(Protocol):
                     static_route_item = EosCliConfigGen.Ipv6StaticRoutesItem()
                     static_route_item._update(
                         vrf=vrf.name,
-                        prefix=static_route.prefix or static_route.destination_address_prefix,
+                        prefix=static_route.prefix or Undefined,
                         interface=static_route.interface,
-                        next_hop=static_route.next_hop or static_route.gateway,
+                        next_hop=static_route.next_hop or Undefined,
                         track_bfd=static_route.track_bfd,
                         distance=static_route.distance,
                         tag=static_route.tag,

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/static_routes.py
@@ -41,7 +41,7 @@ class StaticRoutesMixin(Protocol):
                         vrf=vrf.name,
                         prefix=static_route.prefix or Undefined,
                         interface=static_route.interface,
-                        next_hop=static_route.next_hop or static_route.gateway,
+                        next_hop=static_route.next_hop or Undefined,
                         track_bfd=static_route.track_bfd,
                         distance=static_route.distance,
                         tag=static_route.tag,

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/static_routes.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/static_routes.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Protocol
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
+from pyavd._utils import Undefined
 
 if TYPE_CHECKING:
     from . import AvdStructuredConfigNetworkServicesProtocol
@@ -38,7 +39,7 @@ class StaticRoutesMixin(Protocol):
                 for static_route in vrf.static_routes:
                     static_route_item = EosCliConfigGen.StaticRoutesItem(
                         vrf=vrf.name,
-                        prefix=static_route.prefix or static_route.destination_address_prefix,
+                        prefix=static_route.prefix or Undefined,
                         interface=static_route.interface,
                         next_hop=static_route.next_hop or static_route.gateway,
                         track_bfd=static_route.track_bfd,

--- a/python-avd/tests/schema_tools/artifacts/DC1-BL1A.json
+++ b/python-avd/tests/schema_tools/artifacts/DC1-BL1A.json
@@ -3311,15 +3311,15 @@
                         },
                         {
                             "prefix": "2001:db9::/32",
-                            "gateway": "2001:db8:310::1",
+                            "next_hop": "2001:db8:310::1",
                             "name": "IPv6-test-1",
                             "nodes": [
                                 "DC1-LEAF1A"
                             ]
                         },
                         {
-                            "next_hop": "2001:dba::/32",
-                            "gateway": "2001:db8:310::1",
+                            "prefix": "2001:dba::/32",
+                            "next_hop": "2001:db8:310::1",
                             "name": "Track-bfd-network-services",
                             "track_bfd": true,
                             "nodes": [

--- a/python-avd/tests/schema_tools/artifacts/eos_designs.schema.yml
+++ b/python-avd/tests/schema_tools/artifacts/eos_designs.schema.yml
@@ -4345,10 +4345,10 @@ $defs:
                 items:
                   type: dict
                   keys:
-                    destination_address_prefix:
+                    prefix:
                       type: str
                       description: IPv4_address.
-                    gateway:
+                    next_hop:
                       type: str
                       description: IPv4_address.
                     track_bfd:
@@ -4386,10 +4386,10 @@ $defs:
                 items:
                   type: dict
                   keys:
-                    destination_address_prefix:
+                    prefix:
                       type: str
                       description: IPv6_address.
-                    gateway:
+                    next_hop:
                       type: str
                     track_bfd:
                       type: bool


### PR DESCRIPTION
## Change Summary

Remove deprecated keys `destination_address_prefix` and `gateway` from eos_designs

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Remove deprecated keys `destination_address_prefix` and `gateway` from eos_designs.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
