### PR TITLE
CI: Fix regex for insert-license in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,7 @@ repos:
       - id: check-added-large-files
         name: Prevents giant files from being committed.
         exclude: >-
+          (?x)
           (ansible_collections/arista/avd/molecule
           |pickle$
           |python-avd/pyavd/_(eos_cli_config_gen|eos_designs)/schema/__init__.py
@@ -44,7 +45,13 @@ repos:
 
       - id: insert-license
         name: Check and insert license on select YAML files.
-        files: ansible_collections/arista/avd/roles/.*/(handlers|schemas|tasks)/.*\.yml$
+        files: >-
+          (?x)
+          (ansible_collections/arista/avd/roles/.*/(handlers|tasks)/.*\.yml
+          |python-avd/pyavd/_(eos_cli_config_gen|eos_designs)/schema/.*\.yml
+          |python-avd/pyavd/_eos_designs/eos_designs_facts/schema/.*\.yml
+          )
+
         args:
           - --license-filepath
           - development/license-short.txt

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/_defaults.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/_defaults.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_accounting.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_accounting.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_authentication.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_authentication.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_authorization.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_authorization.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_root.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_root.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_server_groups.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aaa_server_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/access_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/access_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/address_locking.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/address_locking.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/agents.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/agents.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aliases.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/aliases.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/application_traffic_recognition.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/application_traffic_recognition.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/arp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/arp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/as_path.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/as_path.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/avd_data_validation_mode.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/avd_data_validation_mode.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/banners.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/banners.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/bgp_groups.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/bgp_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/boot.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/boot.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/class_maps.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/class_maps.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/clock.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/clock.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/community_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/community_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/config_comment.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/config_comment.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/config_end.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/config_end.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/custom_templates.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/custom_templates.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/cvx.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/cvx.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemon_terminattr.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemons.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/daemons.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_aaa_methods.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_aaa_methods.schema.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
 ---
 type: dict
 $defs:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_application_traffic_recognition.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_application_traffic_recognition.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_bgp_additional_paths.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_bgp_additional_paths.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 type: dict

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_flow_tracking.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_flow_tracking.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_interface_ip_nat.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_interface_ip_nat.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_interface_ip_nat_static.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/defs_interface_ip_nat_static.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_relay.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_relay.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dhcp_servers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dns_domain.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dns_domain.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/domain_list.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/domain_list.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dot1x.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dps-interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dps-interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dynamic_prefix_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/dynamic_prefix_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/enable_password.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/enable_password.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_cli.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_cli.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_cli_config_gen_configuration.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_cli_config_gen_configuration.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_cli_config_gen_documentation.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/eos_cli_config_gen_documentation.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/errdisable.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/errdisable.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ethernet_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/event_handlers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/event_handlers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/event_monitor.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/event_monitor.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/flow_tracking.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/flow_tracking.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/generate_default_config.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/generate_default_config.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/generate_device_documentation.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/generate_device_documentation.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/hardware.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/hardware.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/hardware_counters.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/hardware_counters.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/hostname.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/hostname.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/interface_defaults.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/interface_defaults.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/interface_groups.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/interface_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/interface_profiles.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/interface_profiles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_access_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_access_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_access_lists_max_entries.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_access_lists_max_entries.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_community_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_community_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_dhcp_relay.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_dhcp_relay.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_dhcp_snooping.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_dhcp_snooping.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_domain_lookup.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_domain_lookup.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_extcommunity_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_extcommunity_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_extcommunity_lists_regexp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_extcommunity_lists_regexp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_ftp_client_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_ftp_client_source_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_hardware.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_hardware.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_http_client_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_http_client_source_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_icmp_redirect.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_icmp_redirect.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_igmp_snooping.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_igmp_snooping.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_name_server_groups.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_name_server_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_name_servers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_name_servers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_nat.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_nat.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_radius_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_radius_source_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_routing.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_routing.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_routing_ipv6_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_routing_ipv6_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_security.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_ssh_client_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_ssh_client_source_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_tacacs_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_tacacs_source_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_telnet_client_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_telnet_client_source_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_tftp_client_source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_tftp_client_source_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_virtual_router_mac_address.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_virtual_router_mac_address.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_virtual_router_mac_address_advertisement_interval.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_virtual_router_mac_address_advertisement_interval.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_virtual_router_mac_address_mlag_peer.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ip_virtual_router_mac_address_mlag_peer.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_access_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_access_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_dhcp_relay.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_dhcp_relay.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_hardware.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_hardware.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_icmp_redirect.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_icmp_redirect.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_neighbors.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_neighbors.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_prefix_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_prefix_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_router_ospf.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_router_ospf.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_standard_access_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_standard_access_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_static_routes.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_static_routes.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_unicast_routing.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ipv6_unicast_routing.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/is_deployed.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/is_deployed.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/kernel.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/kernel.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
 type: dict
 keys:
   kernel:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/l2_protocol_forwarding.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/l2_protocol_forwarding.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/lacp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/lacp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/link_tracking_groups.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/link_tracking_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/lldp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/lldp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/load_interval.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/load_interval.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/local_users.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/local_users.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/logging.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/logging.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/loopback_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/loopback_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_access_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_access_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_address_table.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_address_table.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mac_security.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/maintenance.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/maintenance.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_accounts.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_accounts.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_gnmi.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_gnmi.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_http.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_http.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_models.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_api_models.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_console.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_console.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_cvx.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_cvx.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_defaults.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_defaults.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_security.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_tech_support.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_tech_support.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/match_list_input.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/match_list_input.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mcs_client.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mcs_client.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/metadata.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/metadata.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mlag_configuration.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mlag_configuration.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_connectivity.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_connectivity.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_layer1.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_layer1.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_server_radius.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_server_radius.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_session_default_encapsulation_gre.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_session_default_encapsulation_gre.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_sessions.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_sessions.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_telemetry_influx.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_telemetry_influx.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_telemetry_postcard_policy.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_telemetry_postcard_policy.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_twamp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/monitor_twamp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/mpls.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ntp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ntp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/patch_panel.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/patch_panel.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/peer_filters.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/peer_filters.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/platform.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/platform.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/poe.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/poe.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/policy_maps.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/policy_maps.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/prefix_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/prefix_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/priority_flow_control.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/priority_flow_control.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/prompt.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/prompt.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ptp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/ptp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/qos.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/qos.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/qos_profiles.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/qos_profiles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/queue_monitor_length.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/queue_monitor_length.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/queue_monitor_streaming.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/queue_monitor_streaming.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/radius_server.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/radius_server.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/redundancy.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/redundancy.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/roles.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/roles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/route_maps.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/route_maps.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_adaptive_virtual_topology.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_adaptive_virtual_topology.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bfd.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bfd.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_bgp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_general.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_general.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_igmp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_igmp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_internet_exit.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_internet_exit.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_isis.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_l2_vpn.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_l2_vpn.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_msdp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_msdp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_multicast.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_multicast.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_ospf.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_ospf.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_path_selection.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_path_selection.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_pim_sparse_mode.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_pim_sparse_mode.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_segment_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_segment_security.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_service_insertion.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_service_insertion.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_traffic_engineering.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/router_traffic_engineering.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/serial_number.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/serial_number.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/service_routing_configuration_bgp.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/service_routing_configuration_bgp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/service_routing_protocols_model.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/service_routing_protocols_model.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/service_unsupported_transceiver.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/service_unsupported_transceiver.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/sflow.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/sflow.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/spanning_tree.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/spanning_tree.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/standard_access_lists.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/standard_access_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/static_routes.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/static_routes.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/stun.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/stun.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/switchport_default.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/switchport_default.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/switchport_port_security.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/switchport_port_security.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/sync_e.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/sync_e.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/system.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/system.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tacacs_servers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tacacs_servers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tap_aggregation.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tap_aggregation.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tcam_profile.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tcam_profile.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/terminal.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/terminal.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/trackers.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/trackers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/transceiver.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/transceiver.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/transceiver_qsfp_default_mode_channelized.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/transceiver_qsfp_default_mode_channelized.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tunnel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/tunnel_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/virtual_source_nat_vrfs.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/virtual_source_nat_vrfs.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_internal_order.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlan_internal_order.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vlans.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vmtracer_sessions.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vmtracer_sessions.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vrfs.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vrfs.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vxlan_interface.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vxlan_interface.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/_defaults.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/_defaults.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/aaa_settings.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/aaa_settings.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
 type: dict
 keys:
   aaa_settings:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/address_locking_settings.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/address_locking_settings.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/application_traffic_recognition.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/application_traffic_recognition.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_6_behaviors.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_6_behaviors.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_data_validation_mode.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_data_validation_mode.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_eos_designs_debug.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_eos_designs_debug.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_eos_designs_enforce_duplication_checks_across_all_models.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_eos_designs_enforce_duplication_checks_across_all_models.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_eos_designs_structured_config.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_eos_designs_structured_config.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_eos_designs_unset_facts.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/avd_eos_designs_unset_facts.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bfd_multihop.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bfd_multihop.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_as.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_as.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_default_ipv4_unicast.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_default_ipv4_unicast.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_distance.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_distance.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_ecmp.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_ecmp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_graceful_restart.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_graceful_restart.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_maximum_paths.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_maximum_paths.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_mesh_pes.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_mesh_pes.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_peer_groups.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_peer_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_update_wait_install.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_update_wait_install.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_wait_for_convergence.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/bgp_wait_for_convergence.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/campus.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/campus.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/campus_access_pod.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/campus_access_pod.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/campus_pod.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/campus_pod.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/connected_endpoints.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/connected_endpoints.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/connected_endpoints_keys.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/connected_endpoints_keys.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/core_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/core_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/custom_connected_endpoints.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/custom_connected_endpoints.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/custom_node_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/custom_node_type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/custom_structured_configuration_list_merge.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/custom_structured_configuration_list_merge.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/custom_structured_configuration_prefix.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/custom_structured_configuration_prefix.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_global_sites.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_global_sites.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_internet_exit_policies.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_internet_exit_policies.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_regions.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_pathfinder_regions.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_server.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_server.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_tags_topology_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_tags_topology_type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_token.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_token.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_topology.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cv_topology.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cvp_ingestauth_key.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cvp_ingestauth_key.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cvp_instance_ips.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cvp_instance_ips.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/cvp_token_file.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/cvp_token_file.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/dc_name.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/dc_name.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_connected_endpoints_description.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_connected_endpoints_description.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_connected_endpoints_port_channel_description.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_connected_endpoints_port_channel_description.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_igmp_snooping_enabled.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_igmp_snooping_enabled.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_interface_mtu.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_interface_mtu.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_mgmt_method.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_mgmt_method.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_network_ports_description.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_network_ports_description.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_network_ports_port_channel_description.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_network_ports_port_channel_description.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_node_types.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_node_types.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_underlay_p2p_ethernet_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_underlay_p2p_ethernet_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_underlay_p2p_port_channel_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_underlay_p2p_port_channel_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_vrf_diag_loopback_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/default_vrf_diag_loopback_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_adapter_config.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_adapter_config.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_campus_link_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_campus_link_type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_connected_endpoints.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_connected_endpoints.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_flow_tracking_link.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_flow_tracking_link.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_ipsec_profile.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_ipsec_profile.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_l3_edge.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_l3_edge.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_monitor_sessions.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_monitor_sessions.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_network_services.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type_l3_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type_l3_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type_l3_port_channels.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type_l3_port_channels.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_p2p_links.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_p2p_links.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_static_routes.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_static_routes.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_virtual_topology.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_virtual_topology.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/design.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/design.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/digital_twin.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/digital_twin.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/enable_trunk_groups.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/enable_trunk_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/eos_designs_custom_templates.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/eos_designs_custom_templates.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/eos_designs_documentation.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/eos_designs_documentation.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/event_handlers.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/event_handlers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/event_monitor.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/event_monitor.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_ebgp_gateway_multihop.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_ebgp_gateway_multihop.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_ebgp_multihop.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_ebgp_multihop.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_hostflap_detection.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_hostflap_detection.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_import_pruning.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_import_pruning.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_multicast.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_multicast.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_overlay_bgp_rtc.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_overlay_bgp_rtc.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_prevent_readvertise_to_server.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_prevent_readvertise_to_server.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_short_esi_prefix.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_short_esi_prefix.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_vlan_aware_bundles.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_vlan_aware_bundles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_vlan_bundles.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/evpn_vlan_bundles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_evpn_encapsulation.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_evpn_encapsulation.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_flow_tracking.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_flow_tracking.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_ip_addressing.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_ip_addressing.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_name.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_name.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_numbering.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_numbering.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_numbering_node_id_pool_key.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_numbering_node_id_pool_key.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_sflow.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/fabric_sflow.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/flow_tracking_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/flow_tracking_settings.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/generate_cv_tags.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/generate_cv_tags.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/hardware_counters.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/hardware_counters.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/inband_ztp_bootstrap_file.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/inband_ztp_bootstrap_file.schema.yml
@@ -1,3 +1,6 @@
+# Copyright (c) 2025 Arista Networks, Inc.
+# Use of this source code is governed by the Apache License 2.0
+# that can be found in the LICENSE file.
 ---
 type: dict
 keys:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/internal_vlan_order.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/internal_vlan_order.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ipv4_acls.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ipv4_acls.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ipv4_prefix_lists.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ipv4_prefix_lists.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ipv6_mgmt_destination_networks.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ipv6_mgmt_destination_networks.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ipv6_mgmt_gateway.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ipv6_mgmt_gateway.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/is_deployed.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/is_deployed.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_advertise_passive_only.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_advertise_passive_only.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_area_id.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_area_id.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_default_circuit_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_default_circuit_type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_default_is_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_default_is_type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_default_metric.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_default_metric.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_maximum_paths.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_maximum_paths.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_system_id_format.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_system_id_format.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_ti_lfa.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/isis_ti_lfa.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/l3_edge.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/l3_edge.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/l3_interface_profiles.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/l3_interface_profiles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/load_interval_default.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/load_interval_default.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/local_users.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/local_users.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mac_address_table.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mac_address_table.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/management_eapi.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/management_eapi.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_destination_networks.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_destination_networks.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_gateway.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_gateway.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_interface.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_interface.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_interface_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_interface_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_interface_vrf.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_interface_vrf.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_vrf_routing.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mgmt_vrf_routing.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_bgp_peer_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_bgp_peer_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_bgp_peer_group_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_bgp_peer_group_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_ibgp_peering_vrfs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_ibgp_peering_vrfs.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_member_description.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_member_description.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_on_orphan_port_channel_downlink.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_on_orphan_port_channel_downlink.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2024 Arista Networks, Inc.
+# Copyright (c) 2024-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_l3_svi_description.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_l3_svi_description.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_l3_vlan_name.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_l3_vlan_name.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_l3_vrf_svi_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_l3_vrf_svi_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_l3_vrf_vlan_name.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_l3_vrf_vlan_name.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_svi_description.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_svi_description.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_vlan_name.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_peer_vlan_name.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_port_channel_description.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/mlag_port_channel_description.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_ports.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_ports.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services_keys.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/network_services_keys.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type_keys.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/node_type_keys.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ntp_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ntp_settings.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/only_local_vlan_trunk_groups.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/only_local_vlan_trunk_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_bgp_peer_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_bgp_peer_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_cvx_servers.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_cvx_servers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_her_flood_list_per_vni.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_her_flood_list_per_vni.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_her_flood_list_scope.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_her_flood_list_scope.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_loopback_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_loopback_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_mlag_rfc5549.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_mlag_rfc5549.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_rd_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_rd_type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_routing_protocol.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_routing_protocol.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_routing_protocol_address_family.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_routing_protocol_address_family.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_rt_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/overlay_rt_type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/p2p_uplinks_mtu.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/p2p_uplinks_mtu.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/p2p_uplinks_qos_profile.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/p2p_uplinks_qos_profile.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_settings.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_speed_groups.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/platform_speed_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/pod_name.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/pod_name.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/port_profiles.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/port_profiles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ptp_profiles.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ptp_profiles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ptp_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ptp_settings.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/queue_monitor_length.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/queue_monitor_length.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/queue_monitor_streaming.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/queue_monitor_streaming.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/redundancy.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/redundancy.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/router_id_loopback_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/router_id_loopback_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/serial_number.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/serial_number.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/sflow_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/sflow_settings.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/shutdown_bgp_towards_undeployed_peers.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/shutdown_bgp_towards_undeployed_peers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/shutdown_interfaces_towards_undeployed_peers.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/shutdown_interfaces_towards_undeployed_peers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/source_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/source_interfaces.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ssh_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ssh_settings.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/svi_profiles.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/svi_profiles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/system_mac_address.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/system_mac_address.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/terminattr_disable_aaa.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/terminattr_disable_aaa.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/terminattr_ingestexclude.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/terminattr_ingestexclude.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/terminattr_ingestgrpcurl_port.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/terminattr_ingestgrpcurl_port.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/terminattr_smashexcludes.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/terminattr_smashexcludes.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/timezone.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/timezone.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/trunk_groups.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/trunk_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/type.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_filter_peer_as.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_filter_peer_as.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_filter_redistribute_connected.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_filter_redistribute_connected.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ipv6.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ipv6.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ipv6_numbered.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ipv6_numbered.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_isis_authentication_key.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_isis_authentication_key.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_isis_authentication_mode.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_isis_authentication_mode.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../../plugins/plugin_utils/schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_isis_bfd.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_isis_bfd.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_isis_instance_name.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_isis_instance_name.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_l2_ethernet_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_l2_ethernet_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_l2_port_channel_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_l2_port_channel_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast_anycast_rp.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast_anycast_rp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast_pim_sm.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast_pim_sm.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast_rps.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast_rps.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast_static.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_multicast_static.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_area.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_area.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_authentication.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_authentication.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_bfd_enable.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_bfd_enable.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_graceful_restart.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_graceful_restart.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_max_lsa.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_max_lsa.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_process_id.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_ospf_process_id.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_rfc5549.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_rfc5549.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_routing_protocol.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/underlay_routing_protocol.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/unsupported_transceiver.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/unsupported_transceiver.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/uplink_ptp.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/uplink_ptp.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/use_cv_topology.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/use_cv_topology.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/use_router_general_for_router_id.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/use_router_general_for_router_id.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/vtep_loopback_description.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/vtep_loopback_description.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/vtep_vvtep_ip.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/vtep_vvtep_ip.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_carriers.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_carriers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_encapsulation.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_encapsulation.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_ha.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_ha.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_ipsec_profiles.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_ipsec_profiles.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_mode.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_mode.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_path_groups.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_path_groups.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_route_servers.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_route_servers.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_stun_dtls_disable.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_stun_dtls_disable.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_stun_dtls_profile_name.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_stun_dtls_profile_name.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_use_evpn_node_settings_for_lan.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_use_evpn_node_settings_for_lan.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_virtual_topologies.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/wan_virtual_topologies.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/zscaler_endpoints.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/zscaler_endpoints.schema.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json


### PR DESCRIPTION
The regex used for insert-license in pre-commit.yaml was not correct after we moved the schemas to pyavd. This PR updates the regex with a verbose regex (?x) and updates all existing schemas.