### PR TITLE
CI: Fix concurrency rules for merge_groups

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -4,12 +4,15 @@ name: "Collection code testing"
 "on":
   pull_request:
   merge_group:
+    types: [checks_requested]
+
   push:
     branches:
       - devel
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref }}
+  # For PRs the head_ref will be used. For Merge Queues (merge_group) we fallback to run_id.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Merge groups cancel too much because the head_ref is missing, so it ends up with overlapping groups.