### PR TITLE
Doc: Fixing broken links

### DIFF
--- a/.github/workflows/offline-links-check.yml
+++ b/.github/workflows/offline-links-check.yml
@@ -1,5 +1,5 @@
 ---
-name: "Check links offline for dead targets"
+name: Check links offline for dead targets
 
 "on":
   # schedule every day at 3 AM on devel
@@ -14,41 +14,41 @@ concurrency:
 
 jobs:
   offline_link_check:
-    name: "Validate mkdoc content"
+    name: Validate mkdoc content
     if: github.repository == 'aristanetworks/avd'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
-      - name: "Start docker compose stack"
+      - name: Start docker compose stack
         run: |
           docker compose -f development/docker-compose.yml up -d webdoc_avd
           docker compose -f development/docker-compose.yml ps
       - name: "Test connectivity to mkdoc server"
         run: |
-          bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1:8000)" != "200" ]]; do sleep 5; done'
+          bash -c 'while [[ '$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1:8000)' != '200' ]]; do sleep 5; done'
       - name: Check links for 404
         # TODO: AVD 6.0 - remove avd.arista.com/6.x
         run: |
           docker run --network container:webdoc_avd raviqqe/muffet:2.10.9 http://127.0.0.1:8000/ -f \
             --buffer-size 8192 \
-            --exclude ".*fonts.googleapis.com.*" \
-            --exclude ".*fonts.gstatic.com.*" \
-            --exclude ".*tools.ietf.org.*" \
-            --exclude ".*edit.*" \
-            --exclude ".*docs.github.com.*" \
-            --exclude "twitter.com" \
-            --exclude "www.docker.com" \
-            --exclude "hub.docker.com" \
-            --exclude "tech-library.arista.com" \
-            --exclude "www.arista.com.*" \
-            --exclude "www.gnu.org" \
-            --exclude "https://developers.redhat.com" \
-            --exclude "https://avd.arista.com/6.x" \
+            --exclude '.*fonts.googleapis.com.*' \
+            --exclude '.*fonts.gstatic.com.*' \
+            --exclude '.*tools.ietf.org.*' \
+            --exclude '.*edit.*' \
+            --exclude '.*docs.github.com.*' \
+            --exclude 'twitter.com' \
+            --exclude 'www.docker.com' \
+            --exclude 'hub.docker.com' \
+            --exclude 'tech-library.arista.com' \
+            --exclude 'www.arista.com.*' \
+            --exclude 'www.gnu.org' \
+            --exclude 'https://developers.redhat.com' \
+            --exclude 'https://avd.arista.com/6.x' \
             --max-connections-per-host 30 \
             --max-redirections 3 \
             --rate-limit 1 \
             --timeout 30
-      - name: "Stop docker-compose stack"
+      - name: Stop docker-compose stack
         run: |
           docker compose -f development/docker-compose.yml down

--- a/.github/workflows/offline-links-check.yml
+++ b/.github/workflows/offline-links-check.yml
@@ -41,6 +41,9 @@ jobs:
             --exclude "hub.docker.com" \
             --exclude "tech-library.arista.com" \
             --exclude "www.arista.com.*" \
+            --exclude "www.gnu.org" \
+            --exclude "https://developers.redhat.com"
+            --exclude "https://avd.arista.com/6.x"
             --max-connections-per-host 30 \
             --max-redirections 3 \
             --rate-limit 1 \

--- a/.github/workflows/offline-links-check.yml
+++ b/.github/workflows/offline-links-check.yml
@@ -14,20 +14,21 @@ concurrency:
 
 jobs:
   offline_link_check:
-    name: 'Validate mkdoc content'
+    name: "Validate mkdoc content"
     if: github.repository == 'aristanetworks/avd'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v5
-      - name: 'Start docker compose stack'
+      - name: "Start docker compose stack"
         run: |
           docker compose -f development/docker-compose.yml up -d webdoc_avd
           docker compose -f development/docker-compose.yml ps
-      - name: 'Test connectivity to mkdoc server'
+      - name: "Test connectivity to mkdoc server"
         run: |
           bash -c 'while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' 127.0.0.1:8000)" != "200" ]]; do sleep 5; done'
       - name: Check links for 404
+        # TODO: AVD 6.0 - remove avd.arista.com/6.x
         run: |
           docker run --network container:webdoc_avd raviqqe/muffet:2.10.9 http://127.0.0.1:8000/ -f \
             --buffer-size 8192 \
@@ -42,12 +43,12 @@ jobs:
             --exclude "tech-library.arista.com" \
             --exclude "www.arista.com.*" \
             --exclude "www.gnu.org" \
-            --exclude "https://developers.redhat.com"
-            --exclude "https://avd.arista.com/6.x"
+            --exclude "https://developers.redhat.com" \
+            --exclude "https://avd.arista.com/6.x" \
             --max-connections-per-host 30 \
             --max-redirections 3 \
             --rate-limit 1 \
             --timeout 30
-      - name: 'Stop docker-compose stack'
+      - name: "Stop docker-compose stack"
         run: |
           docker compose -f development/docker-compose.yml down

--- a/docs/contribution/authoring_eos_cli_config_gen.md
+++ b/docs/contribution/authoring_eos_cli_config_gen.md
@@ -22,7 +22,7 @@ This document outlines the steps and checklist for contributing to the `eos_cli_
 
 ### Prepare development environment
 
-Follow the [Development Tooling Guide](https://avd.arista.com/stable/docs/contribution/development-tooling.html).
+Follow the [Development Tooling Guide](../contribution/development-tooling.md).
 
 ### Schema creation
 
@@ -78,7 +78,7 @@ Run `pre-commit run --all`, this will trigger recompiling the schemas and the te
 
 !!! Note
 
-    When using Ansible (either through molecule or from a test repo), AVD is able to detect when it is running from source, and recompiles schemas and templates automatically during the "Verify Requirements" step, as outlined in the [Development Tooling Guide](https://avd.arista.com/stable/docs/contribution/development-tooling.html).
+    When using Ansible (either through molecule or from a test repo), AVD is able to detect when it is running from source, and recompiles schemas and templates automatically during the "Verify Requirements" step, as outlined in the [Development Tooling Guide](../contribution/development-tooling.md).
 
     However, if you are using pyavd or need to manually recompile the schemas and templates for any other reason, you can run the following commands:
 

--- a/docs/getting-started/avd-aap.md
+++ b/docs/getting-started/avd-aap.md
@@ -16,7 +16,7 @@ This guide will walk you through the steps required to get up and running with A
 - An accessible lab topology running Arista EOS.
 - An AVD project or Git repository with playbooks and an inventory. To get started, you may also use any of our [example topologies](../../ansible_collections/arista/avd/examples/single-dc-l3ls/README.md).
 - A RHEL instance running AAP.
-  - If you need access to a RHEL instance, you can join the [developer program](https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux/developer-program) to get a copy.
+  - If you need access to a RHEL instance, you can join the [developer program](https://developers.redhat.com) to get a copy.
   - To get started, you may also sign up for a 60-day [trial license](https://www.redhat.com/en/technologies/management/ansible/trial) for AAP.
 
 !!! note
@@ -274,7 +274,7 @@ One thing that may need some clarification is the naming of "job templates." The
 
 === "Templates - Job"
 
-    The job template is where we leverage the custom execution environment. Since our setup requires specific Ansible collections and Python packages installed, we would like to use a pre-packaged environment with that software. We can modify a decent number of settings, and they may look familiar from previous history with Ansible configurations. If you need a refresher on these options, please see the [official documentation](https://docs.ansible.com/automation-controller/latest/html/userguide/job_templates.html). Once you are happy with the settings, click `Save`.
+    The job template is where we leverage the custom execution environment. Since our setup requires specific Ansible collections and Python packages installed, we would like to use a pre-packaged environment with that software. We can modify a decent number of settings, and they may look familiar from previous history with Ansible configurations. If you need a refresher on these options, please see the [official documentation](https://docs.redhat.com/en/documentation/red_hat_ansible_automation_platform/2.4/html/automation_controller_user_guide/controller-job-templates). Once you are happy with the settings, click `Save`.
 
     !!! warning
         The playbook is set to "Run," and the EOS instances in use will be changed. Please ensure you are leveraging nonproduction instances when testing.
@@ -365,7 +365,7 @@ Below is an example of the playbook we are leveraging to build and deploy our co
 We have everything we need to run our job template now.
 
 !!! note
-    This guide leverages the `cv_deploy` role for provisioning through CV. The `cv_deploy` role requires additional options and tokens to be generated. Please see the `cv_deploy` role [documentation](https://avd.arista.com/stable/roles/cv_deploy/index.html) for the most up-to-date settings. We also set `cv_change_control` to `true`, the default it `false`. This allows the change control to be executed automatically.
+    This guide leverages the `cv_deploy` role for provisioning through CV. The `cv_deploy` role requires additional options and tokens to be generated. Please see the `cv_deploy` role [documentation](../../ansible_collections/arista/avd/roles/cv_deploy/README.md) for the most up-to-date settings. We also set `cv_change_control` to `true`, the default it `false`. This allows the change control to be executed automatically.
 
 === "Templates Run"
 


### PR DESCRIPTION
## Change Summary

Latest offline link check reporting errors.

- Updated links to point directly to source files in the docs
- Added exclude for gnu as the site seems to have prolonged issues from time to time
- Added exclude for Red Hat Developers page. Keep getting 403 from server when running muffet
- Added exclude for AVD 6.x release within the release notes, this can be removed when 6.x is published

## Proposed changes

Please see the change summary.

## How to test

View locally and test or view the test output from link checks.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
