### PR TITLE
CI: Add bump-my-version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,4 +1,7 @@
 [workspace]
+package.version = "6.0.0-dev1"
+package.license = "Apache-2.0"
+
 members = [
     "rust/avdschema",
     "rust/included_store",

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,30 @@ integration-tests: ## Run integration test cases using ansible-test. Specify `AN
 	cd ansible_collections/arista/avd/ ; \
 	ansible-test integration --requirements --$(ANSIBLE_TEST_MODE)
 
+################
+# Bump version #
+################
+
+.PHONY: bump-dev
+bump-dev: ## Bump dev release. 6.0.0-dev0 -> 6.0.0-dev1
+	bump-my-version bump pre_n
+
+.PHONY: bump-release
+bump-release: ## Bump from dev to final release. 6.2.0-dev2 -> 6.2.0
+	bump-my-version bump pre_l
+
+.PHONY: bump-minor
+bump-minor: ## Bump minor release. 6.1.4 -> 6.2.0-dev0
+	bump-my-version bump minor
+
+.PHONY: bump-major
+bump-major: ## Bump major release. 6.2.4 -> 7.0.0-dev0
+	bump-my-version bump major
+
+.PHONY: bump-patch
+bump-patch: ## Bump patch release. 6.2.4 -> 6.2.5-dev0
+	bump-my-version bump patch
+
 ####################
 # Random shortcuts #
 ####################

--- a/ansible_collections/arista/avd/requirements-dev.txt
+++ b/ansible_collections/arista/avd/requirements-dev.txt
@@ -10,6 +10,7 @@ ansible-core>=2.16.0,<2.19.0
 ansible-doc-extractor>=0.1.10
 ansible-lint>=25.1.3
 aristaproto[compiler]>=0.1.1
+bump-my-version>=1.2.4
 codespell>=2.2.6
 deepmerge>=1.1.0
 docker>=7.1.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,3 +139,82 @@ exclude = [
   "python-avd/pyavd/_eos_designs/schema/__init__.py",
 ]
 pythonVersion = "3.10"
+
+[tool.bumpversion]
+
+current_version = "6.0.0-dev1"
+
+allow_dirty = true
+commit = false
+tag = false
+parse = """(?x)
+    (?P<major>0|[1-9]\\d*)\\.
+    (?P<minor>0|[1-9]\\d*)\\.
+    (?P<patch>0|[1-9]\\d*)
+    (?:
+        -                             # dash separator for pre-release section
+        (?P<pre_l>[a-zA-Z-]+)         # pre-release label
+        (?P<pre_n>0|[1-9]\\d*)        # pre-release version number
+    )?                                # pre-release section is optional
+"""
+serialize = [
+    "{major}.{minor}.{patch}-{pre_l}{pre_n}",
+    "{major}.{minor}.{patch}",
+]
+
+[tool.bumpversion.parts.pre_l]
+values = [
+  "dev",
+  "final",
+]
+optional_value = "final"
+
+[[tool.bumpversion.files]]
+filename = "ansible_collections/arista/avd/galaxy.yml"
+search = "version: {current_version}"
+replace = "version: {new_version}"
+
+[[tool.bumpversion.files]]
+filename = "Cargo.toml"
+search = 'package.version = "{current_version}"'
+replace = 'package.version = "{new_version}"'
+
+### Bumping version using PEP440 style like x.y.z.dev1
+
+[[tool.bumpversion.files]]
+filename = "ansible_collections/arista/avd/requirements.txt"
+search = "pyavd[ansible-collection]=={current_version}"
+replace = "pyavd[ansible-collection]=={new_version}"
+parse = """(?x)
+    (?P<major>0|[1-9]\\d*)\\.
+    (?P<minor>0|[1-9]\\d*)\\.
+    (?P<patch>0|[1-9]\\d*)
+    (?:
+        \\.                           # dot separator for pre-release section
+        (?P<pre_l>[a-zA-Z-]+)         # pre-release label
+        (?P<pre_n>0|[1-9]\\d*)        # pre-release version number
+    )?                                # pre-release section is optional
+"""
+serialize = [
+    "{major}.{minor}.{patch}.{pre_l}{pre_n}",
+    "{major}.{minor}.{patch}",
+]
+
+[[tool.bumpversion.files]]
+filename = "python-avd/pyavd/__init__.py"
+search = '__version__ = "{current_version}"'
+replace = '__version__ = "{new_version}"'
+parse = """(?x)
+    (?P<major>0|[1-9]\\d*)\\.
+    (?P<minor>0|[1-9]\\d*)\\.
+    (?P<patch>0|[1-9]\\d*)
+    (?:
+        \\.                           # dot separator for pre-release section
+        (?P<pre_l>[a-zA-Z-]+)         # pre-release label
+        (?P<pre_n>0|[1-9]\\d*)        # pre-release version number
+    )?                                # pre-release section is optional
+"""
+serialize = [
+    "{major}.{minor}.{patch}.{pre_l}{pre_n}",
+    "{major}.{minor}.{patch}",
+]

--- a/rust/avdschema/Cargo.toml
+++ b/rust/avdschema/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "avdschema"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 derive_more = { version = "2.0.1", features = [

--- a/rust/avdschema_macros/Cargo.toml
+++ b/rust/avdschema_macros/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "avdschema_macros"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 avdschema = { path = "../avdschema", features = ["dump_load_files"] }

--- a/rust/included_store/Cargo.toml
+++ b/rust/included_store/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "included_store"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
-license = "Apache-2.0"
+license.workspace = true
 
 [dependencies]
 avdschema = { path = "../avdschema" }

--- a/rust/passwords/Cargo.toml
+++ b/rust/passwords/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "passwords"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
-license = "Apache-2.0"
+license.workspace = true
 
 [build-dependencies]
 pyo3-build-config = { version = "0.24.2"}

--- a/rust/validation/Cargo.toml
+++ b/rust/validation/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "validation"
-version = "0.0.0"
+version.workspace = true
 edition = "2024"
-license = "Apache-2.0"
+license.workspace = true
 
 [build-dependencies]
 pyo3-build-config = { version = "0.24.2"}


### PR DESCRIPTION
To assist us maintain the AVD version number across many different packages in our mono repo, the bump-my-version tool will be useful.

New make targets:
```diff
$ make help
+bump-dev                       Bump dev release. 6.0.0-dev0 -> 6.0.0-dev1
+bump-major                     Bump major release. 6.2.4 -> 7.0.0-dev0
+bump-minor                     Bump minor release. 6.1.4 -> 6.2.0-dev0
+bump-patch                     Bump patch release. 6.2.4 -> 6.2.5-dev0
+bump-release                   Bump from dev to final release. 6.2.0-dev2 -> 6.2.0
collection-build               Build arista.avd collection locally.
config-diff                    Run git diff comparing molecule configs with 'devel' using our special config diff ignoring reordering of config lines.
galaxy-importer                Run galaxy importer tests.
help                           Display help message
integration-tests              Run integration test cases using ansible-test. Specify `ANSIBLE_TEST_MODE=<venv|docker>` (default: `venv`).
pyavd-build                    Build PyAVD Python package locally.
pyavd-editable-install         Build and install PyAVD as editable
pyavd-install                  Build and install PyAVD Python package.
pyavd-publish                  Build and publish PyAVD Python package.
pyavd-test                     Test PyAVD Python code with tox.
sanity-import                  Run ansible-test sanity for code import. Specify `ANSIBLE_TEST_MODE=<venv|docker>` (default: `venv`).
sanity-info                    Show information about ansible-test.
sanity-lint                    Run ansible-test sanity for code sanity. Specify `ANSIBLE_TEST_MODE=<venv|docker>` (default: `venv`).
sanity                         Run ansible-test sanity validation.
unit-tests                     Run unit test cases using ansible-test. Specify `ANSIBLE_TEST_MODE=<venv|docker>` (default: `venv`).
uv-pyavd-build                 Build PyAVD Python package locally.
uv-pyavd-editable-install      Build and install PyAVD as editable
uv-pyavd-install               Build and install PyAVD Python package.
uv-pyavd-publish               Build and publish PyAVD Python package.
```