### PR TITLE
Feat(eos_cli_config_gen): Add support for vxlan interface shutdown option

### DIFF
--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -7341,6 +7341,7 @@ interface Vlan4094
 | Setting | Value |
 | ------- | ----- |
 | Source Interface | Loopback0 |
+| Shutdown | False |
 | Controller Client | True |
 | MLAG Source Interface | Loopback1 |
 | UDP port | 4789 |
@@ -7385,6 +7386,7 @@ interface Vlan4094
 !
 interface Vxlan1
    description DC1-LEAF2A_VTEP
+   no shutdown
    vxlan source-interface Loopback0
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -7341,7 +7341,6 @@ interface Vlan4094
 | Setting | Value |
 | ------- | ----- |
 | Source Interface | Loopback0 |
-| Shutdown | True |
 | Controller Client | True |
 | MLAG Source Interface | Loopback1 |
 | UDP port | 4789 |
@@ -7386,7 +7385,6 @@ interface Vlan4094
 !
 interface Vxlan1
    description DC1-LEAF2A_VTEP
-   shutdown
    vxlan source-interface Loopback0
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -7341,6 +7341,7 @@ interface Vlan4094
 | Setting | Value |
 | ------- | ----- |
 | Source Interface | Loopback0 |
+| Shutdown | True |
 | Controller Client | True |
 | MLAG Source Interface | Loopback1 |
 | UDP port | 4789 |
@@ -7385,6 +7386,7 @@ interface Vlan4094
 !
 interface Vxlan1
    description DC1-LEAF2A_VTEP
+   shutdown
    vxlan source-interface Loopback0
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/documentation/devices/host2.md
@@ -915,6 +915,7 @@ interface Dps1
 
 | Setting | Value |
 | ------- | ----- |
+| Shutdown | True |
 | UDP port | 4789 |
 | Qos dscp propagation encapsulation | Disabled |
 | Qos ECN propagation | Disabled |
@@ -933,6 +934,7 @@ interface Dps1
 ```eos
 !
 interface Vxlan1
+   shutdown
    vxlan vlan 110 vni 10110
    vxlan vlan 111,113,115-118 vni 10111,10113,10115-10118
    vxlan vlan 111 flood vtep 10.1.1.10 10.1.1.11

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4239,6 +4239,7 @@ interface Vlan4094
 !
 interface Vxlan1
    description DC1-LEAF2A_VTEP
+   no shutdown
    vxlan source-interface Loopback0
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4239,7 +4239,6 @@ interface Vlan4094
 !
 interface Vxlan1
    description DC1-LEAF2A_VTEP
-   shutdown
    vxlan source-interface Loopback0
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -4239,6 +4239,7 @@ interface Vlan4094
 !
 interface Vxlan1
    description DC1-LEAF2A_VTEP
+   shutdown
    vxlan source-interface Loopback0
    vxlan controller-client
    vxlan virtual-router encapsulation mac-address mlag-system-id

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/intended/configs/host2.cfg
@@ -218,6 +218,7 @@ interface Management1
    ip address 10.73.255.122/24
 !
 interface Vxlan1
+   shutdown
    vxlan vlan 110 vni 10110
    vxlan vlan 111,113,115-118 vni 10111,10113,10115-10118
    vxlan vlan 111 flood vtep 10.1.1.10 10.1.1.11

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vxlan-interface.yml
@@ -6,6 +6,7 @@ vxlan_interface:
     description: DC1-LEAF2A_VTEP
     vxlan:
       source_interface: Loopback0
+      shutdown: false
       multicast:
         headend_replication: true
       controller_client:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vxlan-interface.yml
@@ -6,7 +6,6 @@ vxlan_interface:
     description: DC1-LEAF2A_VTEP
     vxlan:
       source_interface: Loopback0
-      shutdown: true
       multicast:
         headend_replication: true
       controller_client:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host1/vxlan-interface.yml
@@ -6,6 +6,7 @@ vxlan_interface:
     description: DC1-LEAF2A_VTEP
     vxlan:
       source_interface: Loopback0
+      shutdown: true
       multicast:
         headend_replication: true
       controller_client:

--- a/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/vxlan-interface.yml
+++ b/ansible_collections/arista/avd/molecule/eos_cli_config_gen/inventory/host_vars/host2/vxlan-interface.yml
@@ -5,6 +5,7 @@
 vxlan_interface:
   vxlan1:
     vxlan:
+      shutdown: true
       qos:
         dscp_propagation_encapsulation: false
         map_dscp_to_traffic_class_decapsulation: false

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vxlan-interface.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/vxlan-interface.md
@@ -12,6 +12,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "vxlan_interface.vxlan1.description") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;vxlan</samp>](## "vxlan_interface.vxlan1.vxlan") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "vxlan_interface.vxlan1.vxlan.source_interface") | String |  |  |  | Source Interface Name. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;shutdown</samp>](## "vxlan_interface.vxlan1.vxlan.shutdown") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;multicast</samp>](## "vxlan_interface.vxlan1.vxlan.multicast") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;headend_replication</samp>](## "vxlan_interface.vxlan1.vxlan.multicast.headend_replication") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;controller_client</samp>](## "vxlan_interface.vxlan1.vxlan.controller_client") | Dictionary |  |  |  | Client to CVX Controllers. |
@@ -68,6 +69,7 @@
 
           # Source Interface Name.
           source_interface: <str>
+          shutdown: <bool>
           multicast:
             headend_replication: <bool>
 

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vxlan-interface.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/vxlan-interface.j2
@@ -17,6 +17,9 @@
 {%     if vxlan_config.vxlan.source_interface is arista.avd.defined %}
 | Source Interface | {{ vxlan_config.vxlan.source_interface }} |
 {%     endif %}
+{%     if vxlan_config.vxlan.shutdown is arista.avd.defined %}
+| Shutdown | {{ vxlan_config.vxlan.shutdown }} |
+{%     endif %}
 {%     if vxlan_config.vxlan.controller_client.enabled is arista.avd.defined %}
 | Controller Client | {{ vxlan_config.vxlan.controller_client.enabled }} |
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vxlan-interface.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/vxlan-interface.j2
@@ -12,6 +12,11 @@ interface Vxlan1
 {%     if vxlan_config.description is arista.avd.defined %}
    description {{ vxlan_config.description }}
 {%     endif %}
+{%     if vxlan_config.vxlan.shutdown is arista.avd.defined(true) %}
+   shutdown
+{%     elif vxlan_config.vxlan.shutdown is arista.avd.defined(false) %}
+   no shutdown
+{%     endif %}
 {%     if vxlan_config.vxlan.source_interface is arista.avd.defined %}
    vxlan source-interface {{ vxlan_config.vxlan.source_interface }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -67139,6 +67139,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                 _fields: ClassVar[dict] = {
                     "source_interface": {"type": str},
+                    "shutdown": {"type": bool},
                     "multicast": {"type": Multicast},
                     "controller_client": {"type": ControllerClient},
                     "mlag_source_interface": {"type": str},
@@ -67156,6 +67157,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 }
                 source_interface: str | None
                 """Source Interface Name."""
+                shutdown: bool | None
                 multicast: Multicast
                 """Subclass of AvdModel."""
                 controller_client: ControllerClient
@@ -67212,6 +67214,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         self,
                         *,
                         source_interface: str | None | UndefinedType = Undefined,
+                        shutdown: bool | None | UndefinedType = Undefined,
                         multicast: Multicast | UndefinedType = Undefined,
                         controller_client: ControllerClient | UndefinedType = Undefined,
                         mlag_source_interface: str | None | UndefinedType = Undefined,
@@ -67235,6 +67238,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         Args:
                             source_interface: Source Interface Name.
+                            shutdown: shutdown
                             multicast: Subclass of AvdModel.
                             controller_client:
                                Client to CVX Controllers.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -24548,6 +24548,8 @@ keys:
               source_interface:
                 type: str
                 description: Source Interface Name.
+              shutdown:
+                type: bool
               multicast:
                 type: dict
                 keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vxlan_interface.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/vxlan_interface.schema.yml
@@ -20,6 +20,8 @@ keys:
               source_interface:
                 type: str
                 description: Source Interface Name.
+              shutdown:
+                type: bool
               multicast:
                 type: dict
                 keys:


### PR DESCRIPTION
## Change Summary

Add support for vxlan interface shutdown option

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd. eos_cli_config_gen `

## Proposed changes


## How to test

Run Molecule

## Checklist

### User Checklist
- N/A

### Repository Checklist
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
