### PR TITLE
CI: Added ignore rule for sanity test failures on ansible-core 2.21

### DIFF
--- a/ansible_collections/arista/avd/tests/sanity/ignore-2.21.txt
+++ b/ansible_collections/arista/avd/tests/sanity/ignore-2.21.txt
@@ -1,0 +1,9 @@
+plugins/modules/eos_designs_documentation.py validate-modules:missing-gplv3-license
+plugins/modules/eos_designs_facts.py validate-modules:missing-gplv3-license
+plugins/modules/eos_designs_structured_config.py validate-modules:missing-gplv3-license
+plugins/modules/set_vars.py validate-modules:missing-gplv3-license
+plugins/modules/verify_requirements.py validate-modules:missing-gplv3-license
+plugins/vars/global_vars.py validate-modules:missing-gplv3-license
+plugins/modules/cv_workflow.py validate-modules:missing-gplv3-license
+plugins/modules/eos_cli_config_gen.py validate-modules:missing-gplv3-license
+plugins/modules/anta_workflow.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
## Change Summary

Added the ignore for ansbile-core-2.21 for sanity test. The sanity test pull the latest ansible version and now we have ansible-core-2.21. Similar to other version we need the ignore validation modules:missing-gplv3-license.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
Added the ignore for ansbile-core-2.21 for sanity test. The sanity test pull the latest ansible version and now we have ansible-core-2.21. Similar to other version we need the ignore validation modules:missing-gplv3-license.

## How to test
Check the sanity test github action on this PR.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/molecule) testing accordingly. (check the box if not applicable)
