### PR TITLE
Fix(eos_designs)!: Removed autoconversion of bgp_as from float under node config

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-leaf11.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-leaf11.cfg
@@ -71,10 +71,10 @@ router bgp 65199
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor 172.17.0.1 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.17.0.1 remote-as 4259840001
+   neighbor 172.17.0.1 remote-as 4259840100
    neighbor 172.17.0.1 description asdot-for-wan-ha-transit1A1_Ethernet52
    neighbor 172.17.0.3 peer group IPv4-UNDERLAY-PEERS
-   neighbor 172.17.0.3 remote-as 4259840001
+   neighbor 172.17.0.3 remote-as 4259840100
    neighbor 172.17.0.3 description asdot-for-wan-ha-transit1B1_Ethernet52
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1A1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1A1.cfg
@@ -178,7 +178,7 @@ application traffic recognition
 ip routing
 no ip routing vrf MGMT
 !
-ip as-path access-list ASPATH-WAN permit 65000\.1 any
+ip as-path access-list ASPATH-WAN permit 65000\.100 any
 !
 ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.1:422
 !
@@ -245,7 +245,7 @@ route-map RM-WAN-HA-PEER-OUT permit 20
 router bfd
    multihop interval 300 min-rx 300 multiplier 3
 !
-router bgp 65000.1
+router bgp 65000.100
    bgp asn notation asdot
    router-id 192.168.42.1
    update wait-install
@@ -258,7 +258,7 @@ router bgp 65000.1
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor WAN-OVERLAY-PEERS peer group
-   neighbor WAN-OVERLAY-PEERS remote-as 65000.1
+   neighbor WAN-OVERLAY-PEERS remote-as 65000.100
    neighbor WAN-OVERLAY-PEERS update-source Dps1
    neighbor WAN-OVERLAY-PEERS bfd
    neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
@@ -269,7 +269,7 @@ router bgp 65000.1
    neighbor 172.17.0.0 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.0.0 remote-as 65199
    neighbor 172.17.0.0 description asdot-for-wan-ha-leaf11_Ethernet1
-   neighbor 192.168.142.2 remote-as 65000.1
+   neighbor 192.168.142.2 remote-as 65000.100
    neighbor 192.168.142.2 update-source Dps1
    neighbor 192.168.142.2 description asdot-for-wan-ha-transit1B1
    neighbor 192.168.142.2 route-reflector-client

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1B1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/asdot-for-wan-ha-transit1B1.cfg
@@ -178,7 +178,7 @@ application traffic recognition
 ip routing
 no ip routing vrf MGMT
 !
-ip as-path access-list ASPATH-WAN permit 65000\.1 any
+ip as-path access-list ASPATH-WAN permit 65000\.100 any
 !
 ip extcommunity-list ECL-EVPN-SOO permit soo 192.168.42.1:422
 !
@@ -245,7 +245,7 @@ route-map RM-WAN-HA-PEER-OUT permit 20
 router bfd
    multihop interval 300 min-rx 300 multiplier 3
 !
-router bgp 65000.1
+router bgp 65000.100
    bgp asn notation asdot
    router-id 192.168.42.2
    update wait-install
@@ -258,7 +258,7 @@ router bgp 65000.1
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000
    neighbor WAN-OVERLAY-PEERS peer group
-   neighbor WAN-OVERLAY-PEERS remote-as 65000.1
+   neighbor WAN-OVERLAY-PEERS remote-as 65000.100
    neighbor WAN-OVERLAY-PEERS update-source Dps1
    neighbor WAN-OVERLAY-PEERS bfd
    neighbor WAN-OVERLAY-PEERS bfd interval 1000 min-rx 1000 multiplier 10
@@ -269,7 +269,7 @@ router bgp 65000.1
    neighbor 172.17.0.2 peer group IPv4-UNDERLAY-PEERS
    neighbor 172.17.0.2 remote-as 65199
    neighbor 172.17.0.2 description asdot-for-wan-ha-leaf11_Ethernet2
-   neighbor 192.168.142.1 remote-as 65000.1
+   neighbor 192.168.142.1 remote-as 65000.100
    neighbor 192.168.142.1 update-source Dps1
    neighbor 192.168.142.1 description asdot-for-wan-ha-transit1A1
    neighbor 192.168.142.1 route-reflector-client

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-leaf11.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-leaf11.yml
@@ -85,12 +85,12 @@ router_bgp:
   neighbors:
   - ip_address: 172.17.0.1
     peer_group: IPv4-UNDERLAY-PEERS
-    remote_as: '4259840001'
+    remote_as: '4259840100'
     peer: asdot-for-wan-ha-transit1A1
     description: asdot-for-wan-ha-transit1A1_Ethernet52
   - ip_address: 172.17.0.3
     peer_group: IPv4-UNDERLAY-PEERS
-    remote_as: '4259840001'
+    remote_as: '4259840100'
     peer: asdot-for-wan-ha-transit1B1
     description: asdot-for-wan-ha-transit1B1_Ethernet52
   redistribute:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1A1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1A1.yml
@@ -17,7 +17,7 @@ as_path:
   - name: ASPATH-WAN
     entries:
     - type: permit
-      match: 65000\.1
+      match: 65000\.100
 config_end: true
 dps_interfaces:
 - name: Dps1
@@ -325,7 +325,7 @@ router_bfd:
     min_rx: 300
     multiplier: 3
 router_bgp:
-  as: '65000.1'
+  as: '65000.100'
   as_notation: asdot
   router_id: 192.168.42.1
   maximum_paths:
@@ -347,7 +347,7 @@ router_bgp:
     route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
-    remote_as: '65000.1'
+    remote_as: '65000.100'
     update_source: Dps1
     bfd: true
     bfd_timers:
@@ -365,7 +365,7 @@ router_bgp:
     peer: asdot-for-wan-ha-leaf11
     description: asdot-for-wan-ha-leaf11_Ethernet1
   - ip_address: 192.168.142.2
-    remote_as: '65000.1'
+    remote_as: '65000.100'
     peer: asdot-for-wan-ha-transit1B1
     description: asdot-for-wan-ha-transit1B1
     route_reflector_client: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1B1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1B1.yml
@@ -17,7 +17,7 @@ as_path:
   - name: ASPATH-WAN
     entries:
     - type: permit
-      match: 65000\.1
+      match: 65000\.100
 config_end: true
 dps_interfaces:
 - name: Dps1
@@ -322,7 +322,7 @@ router_bfd:
     min_rx: 300
     multiplier: 3
 router_bgp:
-  as: '65000.1'
+  as: '65000.100'
   as_notation: asdot
   router_id: 192.168.42.2
   maximum_paths:
@@ -344,7 +344,7 @@ router_bgp:
     route_map_out: RM-BGP-UNDERLAY-PEERS-OUT
   - name: WAN-OVERLAY-PEERS
     type: wan
-    remote_as: '65000.1'
+    remote_as: '65000.100'
     update_source: Dps1
     bfd: true
     bfd_timers:
@@ -362,7 +362,7 @@ router_bgp:
     peer: asdot-for-wan-ha-leaf11
     description: asdot-for-wan-ha-leaf11_Ethernet2
   - ip_address: 192.168.142.1
-    remote_as: '65000.1'
+    remote_as: '65000.100'
     peer: asdot-for-wan-ha-transit1A1
     description: asdot-for-wan-ha-transit1A1
     route_reflector_client: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/ASDOT_FOR_WAN_HA.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/ASDOT_FOR_WAN_HA.yml
@@ -65,7 +65,7 @@ wan_router:
     loopback_ipv4_pool: 192.168.42.0/24
     vtep_loopback_ipv4_pool: 192.168.142.0/24
     uplink_ipv4_pool: 172.17.0.0/16
-    bgp_as: 65000.100
+    bgp_as: "65000.100"
   node_groups:
     - group: ASDOT-FOR-WAN-HA-TRANSIT
       uplink_switches: [asdot-for-wan-ha-leaf11]

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/AUTO_BGP_ASN.yml
@@ -56,7 +56,7 @@ l3leaf:
           bgp_as: 65333
           mgmt_ip: 192.168.202.113/24
     - group: AUTO_BGP_ASN_LEAF5_4BYTE_DOTZERO
-      bgp_as: 65222.0
+      bgp_as: "65222.0"
       nodes:
         - name: AUTO_BGP_ASN_LEAF7A
           id: 11

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/MLAG_BGP_DIFFERENT_AS_NOTATION.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/MLAG_BGP_DIFFERENT_AS_NOTATION.yml
@@ -14,7 +14,7 @@ l3leaf:
     virtual_router_mac_address: 00:1c:73:00:00:99
   node_groups:
     - group: MLAG_BGP_DIFFERENT_AS_NOTATION
-      bgp_as: 923.923
+      bgp_as: "923.923"
       nodes:
         - name: MLAG_BGP_DIFFERENT_AS_NOTATION_1
           id: 0

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -539,6 +539,13 @@ In AVD 5.0.0, p2p_links list keys `nodes`, `ip`, `interfaces` and `descriptions`
 
 Starting AVD 6.0.0, the length to all these lists have been restricted to exactly 2 items (`min_length: 2` and `max_length: 2`).
 
+### Removed autoconversion of `bgp_as` from float under node config
+
+In AVD 5.x.x, the `bgp_as` value under node configuration was automatically converted from a float to a string. This could lead to unintended truncation, for example, `65000.100` being interpreted as `65000.1`.
+
+Starting with AVD 6.0.0, this automatic float-to-string conversion has been removed.
+To use ASDOT notation in YAML inputs, you must enclose the value in quotes (e.g., "65000.100") to ensure it is treated as a string and not a float.
+
 ### Changing behavior of cv_topology and use_cv_topology
 
 The behavior of `cv_topology` and `use_cv_topology` has been changed in the following areas:

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -546,6 +546,27 @@ In AVD 5.x.x, the `bgp_as` value under node configuration was automatically conv
 Starting with AVD 6.0.0, this automatic float-to-string conversion has been removed.
 To use ASDOT notation in YAML inputs, you must enclose the value in quotes (e.g., "65000.100") to ensure it is treated as a string and not a float.
 
+This change applies to below instances of bgp_as:
+
+ - node_type.defaults
+ - node_type.defaults.evpn_gateway.remote_peers
+ - node_type.defaults.ipvpn_gateway.remote_peers
+
+```diff
+node_type:
+  defaults:
+-   bgp_as: 65000.100
++   bgp_as: "65000.100"
+    evpn_gateway:
+      remote_peers:
+-       bgp_as: 65000.100
++       bgp_as: "65000.100"
+    ipvpn_gateway:
+      remote_peers:
+-       bgp_as: 65000.100
++       bgp_as: "65000.100"    
+```
+
 ### Changing behavior of cv_topology and use_cv_topology
 
 The behavior of `cv_topology` and `use_cv_topology` has been changed in the following areas:

--- a/docs/porting-guides/6.x.x.md
+++ b/docs/porting-guides/6.x.x.md
@@ -548,9 +548,9 @@ To use ASDOT notation in YAML inputs, you must enclose the value in quotes (e.g.
 
 This change applies to below instances of bgp_as:
 
- - node_type.defaults
- - node_type.defaults.evpn_gateway.remote_peers
- - node_type.defaults.ipvpn_gateway.remote_peers
+- node_type.defaults
+- node_type.defaults.evpn_gateway.remote_peers
+- node_type.defaults.ipvpn_gateway.remote_peers
 
 ```diff
 node_type:
@@ -564,7 +564,7 @@ node_type:
     ipvpn_gateway:
       remote_peers:
 -       bgp_as: 65000.100
-+       bgp_as: "65000.100"    
++       bgp_as: "65000.100"
 ```
 
 ### Changing behavior of cv_topology and use_cv_topology

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -10476,7 +10476,6 @@ $defs:
             type: str
             convert_types:
             - int
-            - float
           bgp_defaults:
             documentation_options:
               table: node-type-bgp-configuration
@@ -10646,7 +10645,6 @@ $defs:
                       type: str
                       convert_types:
                       - int
-                      - float
               evpn_l2:
                 description: Enable EVPN Gateway functionality for route-types 2 (MAC-IP)
                   and 3 (IMET).
@@ -10780,7 +10778,6 @@ $defs:
                       required: true
                       convert_types:
                       - int
-                      - float
           mlag:
             documentation_options:
               table: node-type-l2-mlag-configuration

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_node_type.schema.yml
@@ -575,7 +575,6 @@ $defs:
             type: str
             convert_types:
               - int
-              - float
           bgp_defaults:
             documentation_options:
               table: node-type-bgp-configuration
@@ -709,7 +708,6 @@ $defs:
                       type: str
                       convert_types:
                         - int
-                        - float
               evpn_l2:
                 description: Enable EVPN Gateway functionality for route-types 2 (MAC-IP) and 3 (IMET).
                 type: dict
@@ -826,7 +824,6 @@ $defs:
                       required: true
                       convert_types:
                         - int
-                        - float
           mlag:
             documentation_options:
               table: node-type-l2-mlag-configuration


### PR DESCRIPTION
## Change Summary

Removed autoconversion of bgp_as from float under node config

## Related Issue(s)

Fixes #6014 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Removed autoconversion of bgp_as from float under node config. Starting with AVD 6.0.0, this automatic float-to-string conversion has been removed.
To use ASDOT notation in YAML inputs, you must enclose the value in quotes (e.g., "65000.100") to ensure it is treated as a string and not a float.

## How to test
Run molecule

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
