### PR TITLE
CI(cv_deploy): Adjust cv_deploy molecule following 6006

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/duplicated_devices.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/duplicated_devices.yml
@@ -83,15 +83,15 @@
     - name: "{{ test_id | upper }} Process raw device_inventory_status_on_cv variables"
       tags: ["{{ test_id }}"]
       ansible.builtin.set_fact:
-        serial_number: "{{ device_inventory_status_on_cv.json.result.value.key.deviceId }}"
         metadata:
+          serial_number: "{{ device_inventory_status_on_cv.json.result.value.key.deviceId }}"
           system_mac_address: "{{ device_inventory_status_on_cv.json.result.value.systemMacAddress }}"
 
     - name: "{{ test_id | upper }} Expose new variables set on DUTs"
       tags: ["{{ test_id }}"]
       ansible.builtin.debug:
         msg:
-          - "DEVICE {{ inventory_hostname }} | SERIAL_NUMBER: {{ serial_number }} | SYSTEM_MAC_ADDRESS: {{ metadata.system_mac_address }}"
+          - "DEVICE {{ inventory_hostname }} | SERIAL_NUMBER: {{ metadata.serial_number }} | SYSTEM_MAC_ADDRESS: {{ metadata.system_mac_address }}"
 
     - name: "{{ test_id | upper }} Copy content of the original test's structured_config files into new structured_config files"
       tags: ["{{ test_id }}"]
@@ -101,27 +101,21 @@
         dest: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
         mode: "0644"
 
-    - name: "{{ test_id | upper }} Update content of the structured_config files with new serial_number variable"
-      tags: ["{{ test_id }}"]
-      ansible.builtin.lineinfile:
-        line: "serial_number: {{ hostvars['avd-ci-leaf1'].serial_number if inventory_hostname == 'avd-ci-leaf2' else serial_number }}"
-        path: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
-        create: true
-        mode: "0644"
-        insertbefore: BOF
-      no_log: true
-
     - name: "{{ test_id | upper }} Read current content of the structured files"
       tags: ["{{ test_id }}"]
       ansible.builtin.slurp:
         src: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
       register: structured_config_file_content
 
-    - name: "{{ test_id | upper }} Update content of the structured_config files with new metadata.system_mac_address variable if metadata is not present"
+    - name: "{{ test_id | upper }} Update content of the structured_config files if metadata is not present"
       tags: ["{{ test_id }}"]
       ansible.builtin.lineinfile:
         line: |-
           metadata:
+            serial_number: {{
+              hostvars['avd-ci-leaf1'].metadata.serial_number
+              if inventory_hostname == 'avd-ci-leaf2' else metadata.serial_number
+            }}
             system_mac_address: {{
               hostvars['avd-ci-spine1'].metadata.system_mac_address
               if inventory_hostname == 'avd-ci-spine2' else metadata.system_mac_address
@@ -133,11 +127,15 @@
       no_log: true
       when: "'metadata:' not in structured_config_file_content.content | b64decode"
 
-    - name: "{{ test_id | upper }} Update metadata in the structured_config files with new metadata.system_mac_address variable if metadata is already present"
+    - name: "{{ test_id | upper }} Update metadata in the structured_config files if metadata is already present"
       tags: ["{{ test_id }}"]
       ansible.builtin.lineinfile:
         line: |-
           metadata:
+            serial_number: {{
+              hostvars['avd-ci-leaf1'].metadata.serial_number
+              if inventory_hostname == 'avd-ci-leaf2' else metadata.serial_number
+            }}
             system_mac_address: {{
               hostvars['avd-ci-spine1'].metadata.system_mac_address
               if inventory_hostname == 'avd-ci-spine2' else metadata.system_mac_address
@@ -241,7 +239,7 @@
               # confirm that there is an error regarding overlapping serial_number between avd-ci-leaf1 and avd-ci-leaf2
               - >
                 cv_deploy_results.errors | select('search', '.*Duplicated devices found in inventory.*' +
-                hostvars['avd-ci-leaf1'].serial_number +
+                hostvars['avd-ci-leaf1'].metadata.serial_number +
                 '.*avd-ci-leaf1.*avd-ci-leaf2.*') | list | length > 0
               # confirm that there is no error regarding overlapping system_mac_address between avd-ci-spine1 and avd-ci-spine2
               - >

--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/duplicated_devices_strict_system_mac.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/duplicated_devices_strict_system_mac.yml
@@ -83,15 +83,15 @@
     - name: "{{ test_id | upper }} Process raw device_inventory_status_on_cv variables"
       tags: ["{{ test_id }}"]
       ansible.builtin.set_fact:
-        serial_number: "{{ device_inventory_status_on_cv.json.result.value.key.deviceId }}"
         metadata:
+          serial_number: "{{ device_inventory_status_on_cv.json.result.value.key.deviceId }}"
           system_mac_address: "{{ device_inventory_status_on_cv.json.result.value.systemMacAddress }}"
 
     - name: "{{ test_id | upper }} Expose new variables set on DUTs"
       tags: ["{{ test_id }}"]
       ansible.builtin.debug:
         msg:
-          - "DEVICE {{ inventory_hostname }} | SERIAL_NUMBER: {{ serial_number }} | SYSTEM_MAC_ADDRESS: {{ metadata.system_mac_address }}"
+          - "DEVICE {{ inventory_hostname }} | SERIAL_NUMBER: {{ metadata.serial_number }} | SYSTEM_MAC_ADDRESS: {{ metadata.system_mac_address }}"
 
     - name: "{{ test_id | upper }} Copy content of the original test's structured_config files into new structured_config files"
       tags: ["{{ test_id }}"]
@@ -101,27 +101,21 @@
         dest: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
         mode: "0644"
 
-    - name: "{{ test_id | upper }} Update content of the structured_config files with new serial_number variable"
-      tags: ["{{ test_id }}"]
-      ansible.builtin.lineinfile:
-        line: "serial_number: {{ hostvars['avd-ci-leaf1'].serial_number if inventory_hostname == 'avd-ci-leaf2' else serial_number }}"
-        path: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
-        create: true
-        mode: "0644"
-        insertbefore: BOF
-      no_log: true
-
     - name: "{{ test_id | upper }} Read current content of the structured files"
       tags: ["{{ test_id }}"]
       ansible.builtin.slurp:
         src: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
       register: structured_config_file_content
 
-    - name: "{{ test_id | upper }} Update content of the structured_config files with new metadata.system_mac_address variable if metadata is not present"
+    - name: "{{ test_id | upper }} Update content of the structured_config files if metadata is not present"
       tags: ["{{ test_id }}"]
       ansible.builtin.lineinfile:
         line: |-
           metadata:
+            serial_number: {{
+              hostvars['avd-ci-leaf1'].metadata.serial_number
+              if inventory_hostname == 'avd-ci-leaf2' else metadata.serial_number
+            }}
             system_mac_address: {{
               hostvars['avd-ci-spine1'].metadata.system_mac_address
               if inventory_hostname == 'avd-ci-spine2' else metadata.system_mac_address
@@ -133,11 +127,15 @@
       no_log: true
       when: "'metadata:' not in structured_config_file_content.content | b64decode"
 
-    - name: "{{ test_id | upper }} Update metadata in the structured_config files with new metadata.system_mac_address variable if metadata is already present"
+    - name: "{{ test_id | upper }} Update metadata in the structured_config files if metadata is already present"
       tags: ["{{ test_id }}"]
       ansible.builtin.lineinfile:
         line: |-
           metadata:
+            serial_number: {{
+              hostvars['avd-ci-leaf1'].metadata.serial_number
+              if inventory_hostname == 'avd-ci-leaf2' else metadata.serial_number
+            }}
             system_mac_address: {{
               hostvars['avd-ci-spine1'].metadata.system_mac_address
               if inventory_hostname == 'avd-ci-spine2' else metadata.system_mac_address
@@ -243,7 +241,7 @@
               # and overlapping system_mac_address between avd-ci-spine1 and avd-ci-spine2
               - >
                 cv_deploy_results.errors | select('search', '.*Duplicated devices found in inventory.*' +
-                hostvars['avd-ci-leaf1'].serial_number +
+                hostvars['avd-ci-leaf1'].metadata.serial_number +
                 '.*avd-ci-leaf1.*avd-ci-leaf2.*' +
                 hostvars['avd-ci-spine1'].metadata.system_mac_address +
                 '.*avd-ci-spine1.*avd-ci-spine2.*') | list | length > 0

--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/invalid_config.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/invalid_config.yml
@@ -55,7 +55,7 @@
           run_once: true
           delegate_to: localhost
           arista.avd.cv_workflow:
-            cv_servers: [ "{{ cv_server }}" ]
+            cv_servers: ["{{ cv_server }}"]
             cv_token: "{{ cv_token }}"
             cv_verify_certs: "{{ cv_verify_certs }}"
             configuration_dir: "{{ eos_config_dir }}"

--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/no_duplicated_devices.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/no_duplicated_devices.yml
@@ -80,15 +80,15 @@
     - name: "{{ test_id | upper }} Process raw device_inventory_status_on_cv variables"
       tags: ["{{ test_id }}"]
       ansible.builtin.set_fact:
-        serial_number: "{{ device_inventory_status_on_cv.json.result.value.key.deviceId }}"
         metadata:
+          serial_number: "{{ device_inventory_status_on_cv.json.result.value.key.deviceId }}"
           system_mac_address: "{{ device_inventory_status_on_cv.json.result.value.systemMacAddress }}"
 
     - name: "{{ test_id | upper }} Expose new variables set on DUTs"
       tags: ["{{ test_id }}"]
       ansible.builtin.debug:
         msg:
-          - "DEVICE {{ inventory_hostname }} | SERIAL_NUMBER: {{ serial_number }} | SYSTEM_MAC_ADDRESS: {{ metadata.system_mac_address }}"
+          - "DEVICE {{ inventory_hostname }} | SERIAL_NUMBER: {{ metadata.serial_number }} | SYSTEM_MAC_ADDRESS: {{ metadata.system_mac_address }}"
 
     - name: "{{ test_id | upper }} Copy content of the original test's structured_config files into new structured_config files"
       tags: ["{{ test_id }}"]
@@ -97,26 +97,16 @@
         dest: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
         mode: "0644"
 
-    - name: "{{ test_id | upper }} Update content of the structured_config files with new serial_number variable"
-      tags: ["{{ test_id }}"]
-      ansible.builtin.lineinfile:
-        line: "serial_number: {{ serial_number }}"
-        path: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
-        create: true
-        mode: "0644"
-        insertbefore: BOF
-      no_log: true
-
     - name: "{{ test_id | upper }} Read current content of the structured files"
       tags: ["{{ test_id }}"]
       ansible.builtin.slurp:
         src: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
       register: structured_config_file_content
 
-    - name: "{{ test_id | upper }} Update content of the structured_config files with new metadata.system_mac_address variable if metadata is not present"
+    - name: "{{ test_id | upper }} Update content of the structured_config files if metadata is not present"
       tags: ["{{ test_id }}"]
       ansible.builtin.lineinfile:
-        line: "metadata:\n  system_mac_address: {{ metadata.system_mac_address }}"
+        line: "metadata:\n  serial_number: {{ metadata.serial_number }}\n  system_mac_address: {{ metadata.system_mac_address }}"
         path: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
         create: true
         mode: "0644"
@@ -124,10 +114,10 @@
       no_log: true
       when: "'metadata:' not in structured_config_file_content.content | b64decode"
 
-    - name: "{{ test_id | upper }} Update metadata in the structured_config files with new metadata.system_mac_address variable if metadata is already present"
+    - name: "{{ test_id | upper }} Update metadata in the structured_config files if metadata is already present"
       tags: ["{{ test_id }}"]
       ansible.builtin.lineinfile:
-        line: "metadata:\n  system_mac_address: {{ metadata.system_mac_address }}"
+        line: "metadata:\n  serial_number: {{ metadata.serial_number }}\n  system_mac_address: {{ metadata.system_mac_address }}"
         path: "{{ structured_dir }}/{{ inventory_hostname }}.yml"
         regexp: '^metadata:'
       no_log: true

--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/workspace_force_false.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/workspace_force_false.yml
@@ -67,7 +67,7 @@
             cv_change_control_name: "{{ cv_common_pattern }}_{{ r }}_converge"
             cv_change_control_description: "{{ (cv_common_pattern + '_' + r + '_converge') | upper }}"
             cv_register_detailed_results: true
-            cv_devices: [ avd-ci-leaf1, avd-ci-core1 ]
+            cv_devices: [avd-ci-leaf1, avd-ci-core1]
 
         # If task above did not fail for whatever reason - execute following task to catch this
         # Task below is not expected to run under normal conditions

--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/workspace_force_true.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/workspace_force_true.yml
@@ -67,7 +67,7 @@
             cv_change_control_name: "{{ cv_common_pattern }}_{{ r }}_converge"
             cv_change_control_description: "{{ (cv_common_pattern + '_' + r + '_converge') | upper }}"
             cv_register_detailed_results: true
-            cv_devices: [ avd-ci-leaf1, avd-ci-core1 ]
+            cv_devices: [avd-ci-leaf1, avd-ci-core1]
             cv_submit_workspace_force: true
 
         - name: "(BLOCK) {{ test_id | upper }} Check CVP returns"


### PR DESCRIPTION
## Change Summary

Adjust logic of the `cv_deploy` workflows following `serial_number`-related changes introduced in PR#6006

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.cv_deply`

## Proposed changes
Fix failing workflows

## How to test
`cv_deploy` molecule scenario

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
