### PR TITLE
Feat(eos_designs): Add the ability in ssh_settings to explicitly enable or disable management ssh

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-1.cfg
@@ -28,6 +28,7 @@ management ssh
    ipv6 access-group ACL-SSH6 vrf VRF10 in
    ipv6 access-group ACL-SSH-VRF-DEFAULT in
    idle-timeout 15
+   shutdown
    !
    vrf default
       no shutdown

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-2.cfg
@@ -24,6 +24,7 @@ no ip routing vrf MGMT
 !
 management ssh
    ip access-group ACL-SSH-INBAND-MGMT in
+   no shutdown
    !
    vrf default
       no shutdown

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-2.cfg
@@ -24,6 +24,7 @@ no ip routing vrf MGMT
 !
 management ssh
    ip access-group ACL-SSH-INBAND-MGMT in
+   idle-timeout 0
    no shutdown
    !
    vrf default

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/ssh-settings-3.cfg
@@ -1,0 +1,23 @@
+!
+no enable password
+no aaa root
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname ssh-settings-3
+!
+vrf instance MGMT
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 10.10.10.1
+!
+management ssh
+   !
+   vrf default
+      shutdown
+!
+end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-1.yml
@@ -18,6 +18,7 @@ management_ssh:
   ip_access_group_in: IPv4-ACL-SSH-VRF-DEFAULT
   ipv6_access_group_in: ACL-SSH-VRF-DEFAULT
   idle_timeout: 15
+  enable: false
   vrfs:
   - name: default
     enable: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
@@ -8,6 +8,7 @@ ip_igmp_snooping:
   globally_enabled: true
 management_ssh:
   ip_access_group_in: ACL-SSH-INBAND-MGMT
+  idle_timeout: 0
   enable: true
   vrfs:
   - name: default

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
@@ -8,6 +8,7 @@ ip_igmp_snooping:
   globally_enabled: true
 management_ssh:
   ip_access_group_in: ACL-SSH-INBAND-MGMT
+  enable: true
   vrfs:
   - name: default
     enable: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-3.yml
@@ -1,0 +1,29 @@
+aaa_root:
+  disabled: true
+config_end: true
+enable_password:
+  disabled: true
+hostname: ssh-settings-3
+ip_igmp_snooping:
+  globally_enabled: true
+management_ssh:
+  vrfs:
+  - name: default
+    enable: false
+metadata:
+  is_deployed: true
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+service_routing_protocols_model: multi-agent
+static_routes:
+- vrf: MGMT
+  prefix: 0.0.0.0/0
+  next_hop: 10.10.10.1
+transceiver_qsfp_default_mode_4x10: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-1.yml
@@ -10,6 +10,7 @@ mgmt_interface_vrf: MGMT
 mgmt_gateway: 10.10.10.1
 
 ssh_settings:
+  enabled: false
   vrfs:
     - name: VRF20
       enabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-2.yml
@@ -10,6 +10,7 @@ l2leaf:
 default_mgmt_method: inband
 
 ssh_settings:
+  enabled: true
   vrfs:
     - name: use_inband_mgmt_vrf
       enabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-2.yml
@@ -11,6 +11,7 @@ default_mgmt_method: inband
 
 ssh_settings:
   enabled: true
+  idle_timeout: 0
   vrfs:
     - name: use_inband_mgmt_vrf
       enabled: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/ssh-settings-3.yml
@@ -1,0 +1,16 @@
+type: l2leaf
+
+l2leaf:
+  nodes:
+    - name: ssh-settings-1
+      id: 43
+      mgmt_ip: 10.10.10.43/26
+
+mgmt_interface_vrf: MGMT
+mgmt_gateway: 10.10.10.1
+
+ssh_settings:
+  vrfs:
+    - name: default
+      enabled: false
+      ipv4_acl: ACL-SSH

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -62,6 +62,7 @@ all:
             platform_settings:
             ssh-settings-1:
             ssh-settings-2:
+            ssh-settings-3:
             varpv6:
             custom-structured-configuration:
             MLAG-ISIS-SPINE:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/management-ssh.md
@@ -27,7 +27,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "management_ssh.hostkey.server.[]") | String |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;server_cert</samp>](## "management_ssh.hostkey.server_cert") | String |  |  |  | Configure switch's hostkey cert file. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;client_strict_checking</samp>](## "management_ssh.hostkey.client_strict_checking") | Boolean |  |  |  | Enforce strict host key checking. |
-    | [<samp>&nbsp;&nbsp;enable</samp>](## "management_ssh.enable") | Boolean |  |  |  | Enable SSH for VRF default. |
+    | [<samp>&nbsp;&nbsp;enable</samp>](## "management_ssh.enable") | Boolean |  |  |  | Explicitly enable or disable SSH for all VRFs. |
     | [<samp>&nbsp;&nbsp;connection</samp>](## "management_ssh.connection") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;limit</samp>](## "management_ssh.connection.limit") | Integer |  |  | Min: 1<br>Max: 100 | Maximum total number of SSH sessions to device. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;per_host</samp>](## "management_ssh.connection.per_host") | Integer |  |  | Min: 1<br>Max: 20 | Maximum number of SSH sessions to device from a single host. |
@@ -91,7 +91,7 @@
         # Enforce strict host key checking.
         client_strict_checking: <bool>
 
-      # Enable SSH for VRF default.
+      # Explicitly enable or disable SSH for all VRFs.
       enable: <bool>
       connection:
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-settings.md
@@ -244,6 +244,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;hash_algorithm</samp>](## "ntp_settings.authentication_keys.[].hash_algorithm") | String | Required |  | Valid Values:<br>- <code>md5</code><br>- <code>sha1</code> |  |
     | [<samp>&nbsp;&nbsp;trusted_keys</samp>](## "ntp_settings.trusted_keys") | String |  |  |  | List of trusted-keys as string ex. 10-12,15. |
     | [<samp>ssh_settings</samp>](## "ssh_settings") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;enabled</samp>](## "ssh_settings.enabled") | Boolean |  |  |  | Explicitly enable or disable management ssh for all VRFs. By default EOS enables management ssh for all VRFs. |
     | [<samp>&nbsp;&nbsp;vrfs</samp>](## "ssh_settings.vrfs") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "ssh_settings.vrfs.[].name") | String | Required, Unique |  |  | VRF name.<br>The value will be interpreted according to these rules:<br>- `use_mgmt_interface_vrf` will configure SSH for the VRF set with `mgmt_interface_vrf`.<br>  An error will be raised if `mgmt_ip` or `ipv6_mgmt_ip` are not configured for the device.<br>- `use_inband_mgmt_vrf` will configure SSH for the VRF set with `inband_mgmt_vrf`.<br>  An error will be raised if inband management is not configured for the device.<br>- `use_default_mgmt_method_vrf` will configure the VRF for one of the two options above depending on the value of `default_mgmt_method`.<br>- Any other string will be used directly as the VRF name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "ssh_settings.vrfs.[].enabled") | Boolean | Required |  |  | Enable SSH in VRF. |
@@ -833,6 +834,9 @@
       # List of trusted-keys as string ex. 10-12,15.
       trusted_keys: <str>
     ssh_settings:
+
+      # Explicitly enable or disable management ssh for all VRFs. By default EOS enables management ssh for all VRFs.
+      enabled: <bool>
       vrfs:
 
           # VRF name.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -22800,7 +22800,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         hostkey: Hostkey
         """Subclass of AvdModel."""
         enable: bool | None
-        """Enable SSH for VRF default."""
+        """Explicitly enable or disable SSH for all VRFs."""
         connection: Connection
         """Subclass of AvdModel."""
         vrfs: Vrfs
@@ -22855,7 +22855,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                        Subclass of AvdList with `str` items.
                     fips_restrictions: Use FIPS compliant algorithms.
                     hostkey: Subclass of AvdModel.
-                    enable: Enable SSH for VRF default.
+                    enable: Explicitly enable or disable SSH for all VRFs.
                     connection: Subclass of AvdModel.
                     vrfs: Subclass of AvdIndexedList with `VrfsItem` items. Primary key is `name` (`str`).
                     log_level: SSH daemon log level.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -8987,7 +8987,7 @@ keys:
             type: bool
             description: Enforce strict host key checking.
       enable:
-        description: Enable SSH for VRF default.
+        description: Explicitly enable or disable SSH for all VRFs.
         type: bool
       connection:
         type: dict

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/management_ssh.schema.yml
@@ -73,7 +73,7 @@ keys:
             type: bool
             description: Enforce strict host key checking.
       enable:
-        description: Enable SSH for VRF default.
+        description: Explicitly enable or disable SSH for all VRFs.
         type: bool
       connection:
         type: dict

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -19604,7 +19604,12 @@ class EosDesigns(EosDesignsRootModel):
 
         Vrfs._item_type = VrfsItem
 
-        _fields: ClassVar[dict] = {"vrfs": {"type": Vrfs}, "idle_timeout": {"type": int}}
+        _fields: ClassVar[dict] = {"enabled": {"type": bool}, "vrfs": {"type": Vrfs}, "idle_timeout": {"type": int}}
+        enabled: bool | None
+        """
+        Explicitly enable or disable management ssh for all VRFs. By default EOS enables management ssh for
+        all VRFs.
+        """
         vrfs: Vrfs
         """Subclass of AvdIndexedList with `VrfsItem` items. Primary key is `name` (`str`)."""
         idle_timeout: int | None
@@ -19612,7 +19617,13 @@ class EosDesigns(EosDesignsRootModel):
 
         if TYPE_CHECKING:
 
-            def __init__(self, *, vrfs: Vrfs | UndefinedType = Undefined, idle_timeout: int | None | UndefinedType = Undefined) -> None:
+            def __init__(
+                self,
+                *,
+                enabled: bool | None | UndefinedType = Undefined,
+                vrfs: Vrfs | UndefinedType = Undefined,
+                idle_timeout: int | None | UndefinedType = Undefined,
+            ) -> None:
                 """
                 SshSettings.
 
@@ -19620,6 +19631,9 @@ class EosDesigns(EosDesignsRootModel):
                 Subclass of AvdModel.
 
                 Args:
+                    enabled:
+                       Explicitly enable or disable management ssh for all VRFs. By default EOS enables management ssh for
+                       all VRFs.
                     vrfs: Subclass of AvdIndexedList with `VrfsItem` items. Primary key is `name` (`str`).
                     idle_timeout: Idle timeout in minutes.
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -5599,6 +5599,10 @@ keys:
     documentation_options:
       table: management-settings
     keys:
+      enabled:
+        type: bool
+        description: Explicitly enable or disable management ssh for all VRFs. By
+          default EOS enables management ssh for all VRFs.
       vrfs:
         type: list
         primary_key: name

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/ssh_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/ssh_settings.schema.yml
@@ -11,6 +11,9 @@ keys:
     documentation_options:
       table: management-settings
     keys:
+      enabled:
+        type: bool
+        description: Explicitly enable or disable management ssh for all VRFs. By default EOS enables management ssh for all VRFs.
       vrfs:
         type: list
         primary_key: name

--- a/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
@@ -29,9 +29,10 @@ class ManagementSshMixin(Protocol):
         if ssh_settings.idle_timeout is not None:
             self.structured_config.management_ssh.idle_timeout = ssh_settings.idle_timeout
 
-        self._set_vrfs_and_acls(ssh_settings)
+        if ssh_settings.enabled is not None:
+            self.structured_config.management_ssh.enable = ssh_settings.enabled
 
-        self.structured_config.management_ssh.enable = ssh_settings.enabled
+        self._set_vrfs_and_acls(ssh_settings)
 
     def _set_vrfs_and_acls(self: AvdStructuredConfigBaseProtocol, ssh_settings: EosDesigns.SshSettings) -> None:
         """SSH IPv4/IPv6 ACLs with VRFs. Resolves VRF from management VRFs."""

--- a/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
@@ -31,6 +31,8 @@ class ManagementSshMixin(Protocol):
 
         self._set_vrfs_and_acls(ssh_settings)
 
+        self.structured_config.management_ssh.enable = ssh_settings.enabled
+
     def _set_vrfs_and_acls(self: AvdStructuredConfigBaseProtocol, ssh_settings: EosDesigns.SshSettings) -> None:
         """SSH IPv4/IPv6 ACLs with VRFs. Resolves VRF from management VRFs."""
         for vrf in ssh_settings.vrfs._natural_sorted():

--- a/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/base/management_ssh.py
@@ -26,7 +26,7 @@ class ManagementSshMixin(Protocol):
         if not (ssh_settings := self.inputs.ssh_settings):
             return
 
-        if ssh_settings.idle_timeout:
+        if ssh_settings.idle_timeout is not None:
             self.structured_config.management_ssh.idle_timeout = ssh_settings.idle_timeout
 
         self._set_vrfs_and_acls(ssh_settings)


### PR DESCRIPTION
## Change Summary

Add the ability in ssh_settings to explicitly enable or disable management ssh

## Related Issue(s)

Fixes #6038

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

- Add the ability in ssh_settings to explicitly enable or disable management ssh
- Fix description in eos_cli_config_gen

## How to test

See molecule tests


