### PR TITLE
CI(cv_deploy): Force cv_workflow through proxy

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/cv_deploy.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/cv_deploy.yml
@@ -75,7 +75,7 @@
               - cv_deploy_results.workspace.description == cv_workspace_description
               # errors and warnings
               - cv_deploy_results.errors == []
-              - cv_deploy_results.warnings == []
+              - cv_deploy_results.warnings | default([]) | length == 0
               # tags
               - cv_deploy_results.deployed_device_tags != []
               - cv_deploy_results.deployed_interface_tags != []

--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/duplicated_devices.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/duplicated_devices.yml
@@ -233,7 +233,7 @@
               # confirm that cv_deploy has failed
               - cv_deploy_results.failed is defined and cv_deploy_results.failed
               # confirm there are no warnings returned
-              - cv_deploy_results.warnings is defined and cv_deploy_results.warnings == []
+              - cv_deploy_results.warnings | default([]) | length == 0
               # confirm there are returned errors
               - cv_deploy_results.errors is defined and cv_deploy_results.errors != []
               # confirm that there is an error regarding overlapping serial_number between avd-ci-leaf1 and avd-ci-leaf2

--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/duplicated_devices_strict_system_mac.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/duplicated_devices_strict_system_mac.yml
@@ -234,7 +234,7 @@
               # confirm that cv_deploy has failed
               - cv_deploy_results.failed is defined and cv_deploy_results.failed
               # confirm there are no warnings returned
-              - cv_deploy_results.warnings is defined and cv_deploy_results.warnings == []
+              - cv_deploy_results.warnings | default([]) | length == 0
               # confirm there are returned errors
               - cv_deploy_results.errors is defined and cv_deploy_results.errors != []
               # confirm that there is an error regarding both overlapping serial_number between avd-ci-leaf1 and avd-ci-leaf2

--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/invalid_config.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/invalid_config.yml
@@ -17,7 +17,7 @@
     intended_tag_device: avd-ci-leaf1
     intended_tags: "{{ lookup('file', structured_dir ~ '/' ~ intended_tag_device ~ '.yml')| from_yaml }}"
     test_id: "workspace-invalid-configs"
-    cv_common_pattern: "avd-cv-deploy-{{ test_id }}"
+    cv_common_pattern: "avd_cv-deploy_{{ test_id }}"
 
   tasks:
     - name: "{{ test_id | upper }} Banner"
@@ -25,15 +25,15 @@
       run_once: true
       ansible.builtin.debug:
         msg:
-          - "######################################################################"
-          - "### STARTING MOLECULE TEST {{ '{:<38}'.format(test_id[:38]) | upper }} ####"
-          - "######################################################################"
+          - "{{ ('#' * (31 + test_id | length))[:100] }}"
+          - "### STARTING MOLECULE TEST {{ test_id[:69] | upper }} ###"
+          - "{{ ('#' * (31 + test_id | length))[:100] }}"
 
-    - name: "{{ test_id | upper }} Generate random string"
+    - name: "{{ test_id | upper }} {{ 'Read' if lookup('env', 'MOLECULE_EXECUTION_ID') else 'Generate' }} molecule execution ID"
       tags: ["{{ test_id }}"]
       run_once: true
       ansible.builtin.set_fact:
-        r: "{{ lookup('password', '/dev/null chars=ascii_lowercase,digits length=4') }}"
+        r: "{{ lookup('env', 'MOLECULE_EXECUTION_ID') or lookup('password', '/dev/null chars=ascii_lowercase,digits length=4') }}"
 
     - name: "{{ test_id | upper }} Code block to provision CVP with AVD configuration"
       tags: ["{{ test_id }}"]
@@ -57,13 +57,17 @@
           arista.avd.cv_workflow:
             cv_servers: ["{{ cv_server }}"]
             cv_token: "{{ cv_token }}"
+            proxy_host: "{{ proxy_host }}"
+            proxy_port: "{{ proxy_port | int }}"
+            proxy_username: "{{ proxy_username }}"
+            proxy_password: "{{ proxy_password }}"
             cv_verify_certs: "{{ cv_verify_certs }}"
             configuration_dir: "{{ eos_config_dir }}"
             structured_config_dir: "{{ structured_dir }}"
             device_list: "{{ ansible_play_hosts_all }}"
             workspace:
-              name: "{{ cv_common_pattern }}-{{ r }}-converge"
-              description: "{{ (cv_common_pattern + '-' + r + '-converge') | upper }}"
+              name: "{{ cv_common_pattern }}_{{ r }}_converge"
+              description: "{{ (cv_common_pattern + '_' + r + '_converge') | upper }}"
               requested_state: "abandoned"
             return_details: true
           register: cv_deploy_results
@@ -99,7 +103,7 @@
               - cv_deploy_results.workspace.requested_state == "abandoned"
               - cv_deploy_results.workspace.state == "abandoned"
               - cv_deploy_results.failed is true
-              - cv_deploy_results.warnings == []
+              - cv_deploy_results.warnings | default([]) | length == 0
               - cv_deploy_results.errors | length == 1
               - "'Failed to build workspace' in cv_deploy_results.errors[0]"
               - "'device build error' in cv_deploy_results.errors[0]"
@@ -126,10 +130,10 @@
           ansible.builtin.import_role:
             name: arista.avd.cv_deploy
           vars:
-            cv_workspace_name: "{{ cv_common_pattern }}-{{ r }}-cleanup"
-            cv_workspace_description: "{{ cv_common_pattern + '-' + r + '-cleanup' | upper }}"
-            cv_change_control_name: "{{ cv_common_pattern }}-{{ r }}-cleanup"
-            cv_change_control_description: "{{ cv_common_pattern + '-' + r + '-cleanup' | upper }}"
+            cv_workspace_name: "{{ cv_common_pattern }}_{{ r }}_cleanup"
+            cv_workspace_description: "{{ (cv_common_pattern + '_' + r + '_cleanup') | upper }}"
+            cv_change_control_name: "{{ cv_common_pattern }}_{{ r }}_cleanup"
+            cv_change_control_description: "{{ (cv_common_pattern + '_' + r + '_cleanup') | upper }}"
             cv_register_detailed_results: true
             cv_devices: "{{ ansible_play_hosts_all }}"
             eos_config_dir: "{{ playbook_dir }}/intended/configs/base_configs"

--- a/ansible_collections/arista/avd/extensions/molecule/cv_deploy/no_duplicated_devices.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/cv_deploy/no_duplicated_devices.yml
@@ -162,7 +162,7 @@
             that:
               # errors and warnings
               - cv_deploy_results.errors == []
-              - cv_deploy_results.warnings == []
+              - cv_deploy_results.warnings | default([]) | length == 0
 
       always:
 


### PR DESCRIPTION
## Change Summary

Adjust `cv_deploy` CI workflow to make sure tasks that call `cv_workflow` plugin directly pass explicit Proxy settings from ENV variables

## Related Issue(s)

N/A

## Component(s) name

`arista.avd.cv_deploy`

## Proposed changes
- Explicitly pass proxy-related parameters to `cv_workflow`
- Unify syntax of the tasks in `invalid_config` workflow

## How to test
`cv_deploy` molecule scenario
 
## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [ ] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
