### PR TITLE
Doc: Add Redhat AAP support text to Collection documentation

### DIFF
--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -98,7 +98,7 @@ You can also open an [issue](https://github.com/aristanetworks/avd/issues) to re
 ## Support
 
 - AVD is an open-source project maintained by a dedicated Arista engineering team. Customers can purchase TAC support for AVD through the [A-Care Service contract](https://avd.arista.com/stable/docs/support/support_overview.html). TAC support for AVD must be purchased separately.
-- As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP).
+- As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP) using the **Create issue** button on the top right corner.
 - Without a support contract AVD code can be used as-is, without any warranty and with best-effort problem resolution via [GitHub discussions board](https://github.com/aristanetworks/avd/discussions).
 
 ## Release Notes and Roadmap

--- a/ansible_collections/arista/avd/README.md
+++ b/ansible_collections/arista/avd/README.md
@@ -98,6 +98,7 @@ You can also open an [issue](https://github.com/aristanetworks/avd/issues) to re
 ## Support
 
 - AVD is an open-source project maintained by a dedicated Arista engineering team. Customers can purchase TAC support for AVD through the [A-Care Service contract](https://avd.arista.com/stable/docs/support/support_overview.html). TAC support for AVD must be purchased separately.
+- As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP).
 - Without a support contract AVD code can be used as-is, without any warranty and with best-effort problem resolution via [GitHub discussions board](https://github.com/aristanetworks/avd/discussions).
 
 ## Release Notes and Roadmap


### PR DESCRIPTION
## Change Summary


As Red Hat Ansible Certified Content, this collection is entitled to support through the Ansible Automation Platform (AAP).
Added text in the Ansible README.md to state this.

Note: I didn't update the main GitHub README, as this pertains only to the Ansible Collection.