### PR TITLE
CI: Pyo3 bump to 0.26.0 to support both Python 3.14 and pyo3-log 0.13.1

### DIFF
--- a/rust/passwords/Cargo.toml
+++ b/rust/passwords/Cargo.toml
@@ -5,12 +5,12 @@ edition = "2024"
 license.workspace = true
 
 [build-dependencies]
-pyo3-build-config = { version = "0.24.2"}
+pyo3-build-config = { version = "0.26.0"}
 
 [dependencies]
 sha-crypt = { version = "0.5.0", default-features = false }
 derive_more = { version = "2.0.1", features = ["display", "from"] }
-pyo3 = { version = "0.24.2", "features" = ["extension-module", "abi3"] }
+pyo3 = { version = "0.26.0", "features" = ["extension-module", "abi3"] }
 
 [lib]
 crate-type = ["cdylib", "lib"]

--- a/rust/validation/Cargo.toml
+++ b/rust/validation/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2024"
 license.workspace = true
 
 [build-dependencies]
-pyo3-build-config = { version = "0.24.2"}
+pyo3-build-config = { version = "0.26.0"}
 
 [dependencies]
 avdschema = { path = "../avdschema" }
@@ -13,8 +13,8 @@ derive_more = { version = "2.0.1", features = ["display", "from"] }
 included_store = { path = "../included_store", optional = true }
 log = { version = "0.4.26", optional = true }
 ordermap = { version = "0.5.4", features = ["serde"] }
-pyo3 = { version = "0.24.1", features = ["abi3", "extension-module"], optional = true }
-pyo3-log = { version = "0.12.1", optional = true }
+pyo3 = { version = "0.26.0", features = ["abi3", "extension-module"], optional = true }
+pyo3-log = { version = "0.13.1", optional = true }
 regex = { version = "1.11.1" }
 serde = { version = "1.0.217", features = ["derive"] }
 serde_json = { version = "1.0.135", features = [


### PR DESCRIPTION
## Change Summary

CI is failing on macos14 image because our current version of pyo3 (0.24.21) does not support python 3.14.

This PR bump pyo3 across our two crates (validation and passwor)

## Related Issue(s)

CI

## Component(s) name

`rust`

## Proposed changes

* bump pyo3 to 0.26.0 (cf next line to understand why we don't pick 0.27.1 which is the latest)
* bump pyo3-log to 0.13.1 - this is the latest release and it requires pyo3 0.26.0

## How to test

CI should be 🍏 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
