### PR TITLE
Refactor(eos_designs): Move inband mgmt vlan to network services

### DIFF
--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1A.yml
@@ -1768,6 +1768,7 @@ vlan_interfaces:
   ip_address: 10.10.10.6/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -1791,7 +1792,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF1B.yml
@@ -1768,6 +1768,7 @@ vlan_interfaces:
   ip_address: 10.10.10.7/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -1791,7 +1792,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF2A.yml
@@ -10662,6 +10662,7 @@ vlan_interfaces:
   ip_address: 10.10.10.8/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -10680,7 +10681,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3A.yml
@@ -3467,6 +3467,7 @@ vlan_interfaces:
   ip_address: 10.10.10.9/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -3490,7 +3491,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3B.yml
@@ -3467,6 +3467,7 @@ vlan_interfaces:
   ip_address: 10.10.10.10/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -3490,7 +3491,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3C.yml
@@ -3366,6 +3366,7 @@ vlan_interfaces:
   ip_address: 10.10.10.11/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -3384,7 +3385,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3D.yml
@@ -3366,6 +3366,7 @@ vlan_interfaces:
   ip_address: 10.10.10.12/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -3384,7 +3385,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/LEAF3E.yml
@@ -3366,6 +3366,7 @@ vlan_interfaces:
   ip_address: 10.10.10.13/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -3384,7 +3385,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE1.yml
@@ -314,6 +314,8 @@ vlan_interfaces:
   ip_virtual_router_addresses:
   - 10.10.10.1
   mtu: 1500
+  metadata:
+    tenant: MY_FABRIC
 vlan_internal_order:
   allocation: ascending
   range:
@@ -359,7 +361,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
+++ b/ansible_collections/arista/avd/examples/campus-fabric/intended/structured_configs/SPINE2.yml
@@ -314,6 +314,8 @@ vlan_interfaces:
   ip_virtual_router_addresses:
   - 10.10.10.1
   mtu: 1500
+  metadata:
+    tenant: MY_FABRIC
 vlan_internal_order:
   allocation: ascending
   range:
@@ -359,7 +361,7 @@ vlans:
   tenant: MY_FABRIC
 - id: 10
   name: INBAND_MGMT
-  tenant: system
+  tenant: MY_FABRIC
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf1a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf1a.yml
@@ -512,6 +512,18 @@ vlan_interfaces:
   ip_address: 10.255.1.64/31
   mtu: 1500
   no_autostate: true
+- name: Vlan4085
+  description: Inband Management
+  shutdown: false
+  ip_address: 172.21.110.2/24
+  ip_virtual_router_addresses:
+  - 172.21.110.1
+  mtu: 1500
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan11
   description: VRF10_VLAN11
   shutdown: false
@@ -558,16 +570,6 @@ vlan_interfaces:
   metadata:
     tenant: TENANT1
     type: underlay_peering
-- name: Vlan4085
-  description: Inband Management
-  shutdown: false
-  ip_address: 172.21.110.2/24
-  ip_virtual_router_addresses:
-  - 172.21.110.1
-  mtu: 1500
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -584,6 +586,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -612,9 +617,6 @@ vlans:
 - id: 3402
   name: L2_VLAN3402
   tenant: TENANT1
-- id: 4085
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf1b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf1b.yml
@@ -557,6 +557,18 @@ vlan_interfaces:
   ip_address: 10.255.1.65/31
   mtu: 1500
   no_autostate: true
+- name: Vlan4085
+  description: Inband Management
+  shutdown: false
+  ip_address: 172.21.110.3/24
+  ip_virtual_router_addresses:
+  - 172.21.110.1
+  mtu: 1500
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan11
   description: VRF10_VLAN11
   shutdown: false
@@ -603,16 +615,6 @@ vlan_interfaces:
   metadata:
     tenant: TENANT1
     type: underlay_peering
-- name: Vlan4085
-  description: Inband Management
-  shutdown: false
-  ip_address: 172.21.110.3/24
-  ip_virtual_router_addresses:
-  - 172.21.110.1
-  mtu: 1500
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -629,6 +631,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -657,9 +662,6 @@ vlans:
 - id: 3402
   name: L2_VLAN3402
   tenant: TENANT1
-- id: 4085
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf1c.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf1c.yml
@@ -91,6 +91,7 @@ vlan_interfaces:
   ip_address: 172.21.110.4/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -98,6 +99,9 @@ vlan_internal_order:
     beginning: 1006
     ending: 1199
 vlans:
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -116,9 +120,7 @@ vlans:
 - id: 3402
   name: L2_VLAN3402
   tenant: TENANT1
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf2a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf2a.yml
@@ -491,6 +491,18 @@ vlan_interfaces:
   ip_address: 10.255.1.68/31
   mtu: 1500
   no_autostate: true
+- name: Vlan4085
+  description: Inband Management
+  shutdown: false
+  ip_address: 172.21.110.2/24
+  ip_virtual_router_addresses:
+  - 172.21.110.1
+  mtu: 1500
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan11
   description: VRF10_VLAN11
   shutdown: false
@@ -537,16 +549,6 @@ vlan_interfaces:
   metadata:
     tenant: TENANT1
     type: underlay_peering
-- name: Vlan4085
-  description: Inband Management
-  shutdown: false
-  ip_address: 172.21.110.2/24
-  ip_virtual_router_addresses:
-  - 172.21.110.1
-  mtu: 1500
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -563,6 +565,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -591,9 +596,6 @@ vlans:
 - id: 3402
   name: L2_VLAN3402
   tenant: TENANT1
-- id: 4085
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf2b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf2b.yml
@@ -491,6 +491,18 @@ vlan_interfaces:
   ip_address: 10.255.1.69/31
   mtu: 1500
   no_autostate: true
+- name: Vlan4085
+  description: Inband Management
+  shutdown: false
+  ip_address: 172.21.110.3/24
+  ip_virtual_router_addresses:
+  - 172.21.110.1
+  mtu: 1500
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan11
   description: VRF10_VLAN11
   shutdown: false
@@ -537,16 +549,6 @@ vlan_interfaces:
   metadata:
     tenant: TENANT1
     type: underlay_peering
-- name: Vlan4085
-  description: Inband Management
-  shutdown: false
-  ip_address: 172.21.110.3/24
-  ip_virtual_router_addresses:
-  - 172.21.110.1
-  mtu: 1500
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -563,6 +565,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -591,9 +596,6 @@ vlans:
 - id: 3402
   name: L2_VLAN3402
   tenant: TENANT1
-- id: 4085
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf2c.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-leaf2c.yml
@@ -91,6 +91,7 @@ vlan_interfaces:
   ip_address: 172.21.110.5/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -98,6 +99,9 @@ vlan_internal_order:
     beginning: 1006
     ending: 1199
 vlans:
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VRF10_VLAN11
   tenant: TENANT1
@@ -116,9 +120,7 @@ vlans:
 - id: 3402
   name: L2_VLAN3402
   tenant: TENANT1
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/digital_twin/digital_twin/intended/structured_configs/digital-twin-adjust-oob-mgmt-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/digital_twin/digital_twin/intended/structured_configs/digital-twin-adjust-oob-mgmt-3.yml
@@ -31,6 +31,7 @@ vlan_interfaces:
   ip_address: 192.168.1.3/32
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -40,8 +41,9 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBAND_MGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/digital_twin/intended/structured_configs/digital-twin-adjust-oob-mgmt-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/digital_twin/intended/structured_configs/digital-twin-adjust-oob-mgmt-3.yml
@@ -23,6 +23,7 @@ vlan_interfaces:
   ip_address: 192.168.1.3/32
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -32,8 +33,9 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBAND_MGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF1.yml
@@ -272,6 +272,7 @@ vlan_interfaces:
   ip_address: 172.23.254.4/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -295,7 +296,7 @@ vlans:
   tenant: L2LS_BGP
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: L2LS_BGP
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF2.yml
@@ -220,6 +220,7 @@ vlan_interfaces:
   ip_address: 172.23.254.5/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -243,7 +244,7 @@ vlans:
   tenant: L2LS_BGP
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: L2LS_BGP
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-LEAF3.yml
@@ -132,6 +132,7 @@ vlan_interfaces:
   ip_address: 172.23.254.6/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -144,7 +145,7 @@ vlans:
   tenant: L2LS_BGP
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: L2LS_BGP
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE1.yml
@@ -581,15 +581,6 @@ vlan_interfaces:
   ip_address_virtual: 10.1.220.1/24
   metadata:
     tenant: L2LS_BGP
-- name: Vlan3100
-  description: MLAG_L3_VRF_New_VRF
-  shutdown: false
-  vrf: New_VRF
-  ip_address: 192.168.254.0/31
-  mtu: 9214
-  metadata:
-    tenant: L2LS_BGP
-    type: underlay_peering
 - name: Vlan4092
   description: Inband Management
   shutdown: false
@@ -600,6 +591,17 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: L2LS_BGP
+- name: Vlan3100
+  description: MLAG_L3_VRF_New_VRF
+  shutdown: false
+  vrf: New_VRF
+  ip_address: 192.168.254.0/31
+  mtu: 9214
+  metadata:
+    tenant: L2LS_BGP
+    type: underlay_peering
 vlan_internal_order:
   allocation: ascending
   range:
@@ -623,14 +625,14 @@ vlans:
 - id: 220
   name: SVI_220
   tenant: L2LS_BGP
+- id: 4092
+  name: INBAND_MGMT
+  tenant: L2LS_BGP
 - id: 3100
   name: MLAG_L3_VRF_New_VRF
   trunk_groups:
   - MLAG
   tenant: L2LS_BGP
-- id: 4092
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/BGP-SPINE2.yml
@@ -558,15 +558,6 @@ vlan_interfaces:
   ip_address_virtual: 10.1.220.1/24
   metadata:
     tenant: L2LS_BGP
-- name: Vlan3100
-  description: MLAG_L3_VRF_New_VRF
-  shutdown: false
-  vrf: New_VRF
-  ip_address: 192.168.254.1/31
-  mtu: 9214
-  metadata:
-    tenant: L2LS_BGP
-    type: underlay_peering
 - name: Vlan4092
   description: Inband Management
   shutdown: false
@@ -577,6 +568,17 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: L2LS_BGP
+- name: Vlan3100
+  description: MLAG_L3_VRF_New_VRF
+  shutdown: false
+  vrf: New_VRF
+  ip_address: 192.168.254.1/31
+  mtu: 9214
+  metadata:
+    tenant: L2LS_BGP
+    type: underlay_peering
 vlan_internal_order:
   allocation: ascending
   range:
@@ -600,14 +602,14 @@ vlans:
 - id: 220
   name: SVI_220
   tenant: L2LS_BGP
+- id: 4092
+  name: INBAND_MGMT
+  tenant: L2LS_BGP
 - id: 3100
   name: MLAG_L3_VRF_New_VRF
   trunk_groups:
   - MLAG
   tenant: L2LS_BGP
-- id: 4092
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-LEAF1.yml
@@ -58,6 +58,7 @@ vlan_interfaces:
   ip_address: 172.23.254.4/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -70,7 +71,7 @@ vlans:
   tenant: L2LS_ISIS
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: L2LS_ISIS
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/ISIS-SPINE1.yml
@@ -97,6 +97,8 @@ vlan_interfaces:
   ip_virtual_router_addresses:
   - 172.23.254.1
   mtu: 1500
+  metadata:
+    tenant: L2LS_ISIS
 vlan_internal_order:
   allocation: ascending
   range:
@@ -108,7 +110,7 @@ vlans:
   tenant: L2LS_ISIS
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: L2LS_ISIS
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF1.yml
@@ -79,6 +79,7 @@ vlan_interfaces:
   ip_address: 172.23.254.4/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -86,12 +87,12 @@ vlan_internal_order:
     beginning: 1006
     ending: 1199
 vlans:
+- id: 4092
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 100
   name: L2VLAN_100
   tenant: L2LS_L2ONLY
-- id: 4092
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/L2ONLY-LEAF2.yml
@@ -79,6 +79,7 @@ vlan_interfaces:
   ip_address: 172.23.254.5/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -86,12 +87,12 @@ vlan_internal_order:
     beginning: 1006
     ending: 1199
 vlans:
+- id: 4092
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 100
   name: L2VLAN_100
   tenant: L2LS_L2ONLY
-- id: 4092
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF1.yml
@@ -79,6 +79,7 @@ vlan_interfaces:
   ip_address: 172.23.254.4/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -91,7 +92,7 @@ vlans:
   tenant: L2LS_OSPF
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: L2LS_OSPF
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-LEAF2.yml
@@ -79,6 +79,7 @@ vlan_interfaces:
   ip_address: 172.23.254.5/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -91,7 +92,7 @@ vlans:
   tenant: L2LS_OSPF
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: L2LS_OSPF
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE1.yml
@@ -162,6 +162,8 @@ vlan_interfaces:
   ip_virtual_router_addresses:
   - 172.23.254.1
   mtu: 1500
+  metadata:
+    tenant: L2LS_OSPF
 vlan_internal_order:
   allocation: ascending
   range:
@@ -178,7 +180,7 @@ vlans:
   tenant: L2LS_OSPF
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: L2LS_OSPF
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-l2ls/intended/structured_configs/OSPF-SPINE2.yml
@@ -167,6 +167,8 @@ vlan_interfaces:
   ip_virtual_router_addresses:
   - 172.23.254.1
   mtu: 1500
+  metadata:
+    tenant: L2LS_OSPF
 vlan_internal_order:
   allocation: ascending
   range:
@@ -183,7 +185,7 @@ vlans:
   tenant: L2LS_OSPF
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: L2LS_OSPF
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/documentation/devices/DC2-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/documentation/devices/DC2-POD1-LEAF2A.md
@@ -22,7 +22,6 @@
   - [Ethernet Interfaces](#ethernet-interfaces)
   - [Port-Channel Interfaces](#port-channel-interfaces)
   - [Loopback Interfaces](#loopback-interfaces)
-  - [VLAN Interfaces](#vlan-interfaces)
   - [VXLAN Interface](#vxlan-interface)
 - [Routing](#routing)
   - [Service Routing Protocols Model](#service-routing-protocols-model)
@@ -260,32 +259,6 @@ interface Loopback1
    description VXLAN_TUNNEL_SOURCE
    no shutdown
    ip address 172.18.210.4/32
-```
-
-### VLAN Interfaces
-
-#### VLAN Interfaces Summary
-
-| Interface | Description | VRF |  MTU | Shutdown |
-| --------- | ----------- | --- | ---- | -------- |
-| Vlan4092 | Inband Management | default | - | False |
-
-##### IPv4
-
-| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | ACL In | ACL Out |
-| --------- | --- | ---------- | ------------------ | ------------------------- | ------ | ------- |
-| Vlan4092 |  default  |  172.21.210.2/24  |  -  |  172.21.210.1  |  -  |  -  |
-
-#### VLAN Interfaces Device Configuration
-
-```eos
-!
-interface Vlan4092
-   description Inband Management
-   no shutdown
-   ip address 172.21.210.2/24
-   ip attached-host route export 19
-   ip virtual-router address 172.21.210.1
 ```
 
 ### VXLAN Interface

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/configs/DC2-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/configs/DC2-POD1-LEAF2A.cfg
@@ -67,13 +67,6 @@ interface Management1
    vrf MGMT
    ip address 192.168.1.24/24
 !
-interface Vlan4092
-   description Inband Management
-   no shutdown
-   ip address 172.21.210.2/24
-   ip attached-host route export 19
-   ip virtual-router address 172.21.210.1
-!
 interface Vxlan1
    description DC2-POD1-LEAF2A_VTEP
    vxlan source-interface Loopback1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -87,6 +87,7 @@ vlan_interfaces:
   ip_address: 172.21.110.4/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -96,7 +97,7 @@ vlan_internal_order:
 vlans:
 - id: 4085
   name: L2LEAF_INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -132,6 +132,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.21.110.5/24
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -144,6 +145,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -174,9 +178,6 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -132,6 +132,7 @@ vlan_interfaces:
   ip_address: 172.21.110.6/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -144,6 +145,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -174,9 +178,6 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -271,6 +271,8 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 vlan_internal_order:
   allocation: ascending
   range:
@@ -279,7 +281,7 @@ vlan_internal_order:
 vlans:
 - id: 4085
   name: L2LEAF_INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -884,6 +884,17 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.20.110.3/31
   no_autostate: true
+- name: Vlan4085
+  description: L2LEAF_INBAND_MGMT
+  shutdown: false
+  ip_address: 172.21.110.3/24
+  ip_virtual_router_addresses:
+  - 172.21.110.1
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan110
   description: set from structured_config on svi (was Tenant_A_OP_Zone_1)
   shutdown: false
@@ -957,15 +968,6 @@ vlan_interfaces:
     tags:
     - opzone
     - web
-- name: Vlan4085
-  description: L2LEAF_INBAND_MGMT
-  shutdown: false
-  ip_address: 172.21.110.3/24
-  ip_virtual_router_addresses:
-  - 172.21.110.1
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -977,6 +979,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -1007,9 +1012,6 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -851,6 +851,17 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.20.110.2/31
   no_autostate: true
+- name: Vlan4085
+  description: L2LEAF_INBAND_MGMT
+  shutdown: false
+  ip_address: 172.21.110.2/24
+  ip_virtual_router_addresses:
+  - 172.21.110.1
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan110
   description: set from structured_config on svi for DC1.POD1.LEAF2A (was Tenant_A_OP_Zone_1)
   shutdown: false
@@ -924,15 +935,6 @@ vlan_interfaces:
     tags:
     - opzone
     - web
-- name: Vlan4085
-  description: L2LEAF_INBAND_MGMT
-  shutdown: false
-  ip_address: 172.21.110.2/24
-  ip_virtual_router_addresses:
-  - 172.21.110.1
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -944,6 +946,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -974,9 +979,6 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -77,6 +77,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.21.210.4/24
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -86,7 +87,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
@@ -77,6 +77,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.21.210.5/24
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -86,7 +87,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -354,6 +354,8 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 vlan_internal_order:
   allocation: ascending
   range:
@@ -362,7 +364,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/digital_twin/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -196,16 +196,6 @@ static_routes:
   prefix: 0.0.0.0/0
   next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
-vlan_interfaces:
-- name: Vlan4092
-  description: Inband Management
-  shutdown: false
-  ip_address: 172.21.210.2/24
-  ip_virtual_router_addresses:
-  - 172.21.210.1
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -214,7 +204,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/documentation/devices/DC2-POD1-LEAF2A.md
@@ -22,7 +22,6 @@
   - [Ethernet Interfaces](#ethernet-interfaces)
   - [Port-Channel Interfaces](#port-channel-interfaces)
   - [Loopback Interfaces](#loopback-interfaces)
-  - [VLAN Interfaces](#vlan-interfaces)
   - [VXLAN Interface](#vxlan-interface)
 - [Routing](#routing)
   - [Service Routing Protocols Model](#service-routing-protocols-model)
@@ -260,32 +259,6 @@ interface Loopback1
    description VXLAN_TUNNEL_SOURCE
    no shutdown
    ip address 172.18.210.4/32
-```
-
-### VLAN Interfaces
-
-#### VLAN Interfaces Summary
-
-| Interface | Description | VRF |  MTU | Shutdown |
-| --------- | ----------- | --- | ---- | -------- |
-| Vlan4092 | Inband Management | default | - | False |
-
-##### IPv4
-
-| Interface | VRF | IP Address | IP Address Virtual | IP Router Virtual Address | ACL In | ACL Out |
-| --------- | --- | ---------- | ------------------ | ------------------------- | ------ | ------- |
-| Vlan4092 |  default  |  172.21.210.2/24  |  -  |  172.21.210.1  |  -  |  -  |
-
-#### VLAN Interfaces Device Configuration
-
-```eos
-!
-interface Vlan4092
-   description Inband Management
-   no shutdown
-   ip address 172.21.210.2/24
-   ip attached-host route export 19
-   ip virtual-router address 172.21.210.1
 ```
 
 ### VXLAN Interface

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/configs/DC2-POD1-LEAF2A.cfg
@@ -67,13 +67,6 @@ interface Management1
    vrf MGMT
    ip address 192.168.1.24/24
 !
-interface Vlan4092
-   description Inband Management
-   no shutdown
-   ip address 172.21.210.2/24
-   ip attached-host route export 19
-   ip virtual-router address 172.21.210.1
-!
 interface Vxlan1
    description DC2-POD1-LEAF2A_VTEP
    vxlan source-interface Loopback1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF1A.yml
@@ -82,6 +82,7 @@ vlan_interfaces:
   ip_address: 172.21.110.4/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -91,7 +92,7 @@ vlan_internal_order:
 vlans:
 - id: 4085
   name: L2LEAF_INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2A.yml
@@ -124,6 +124,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.21.110.5/24
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -136,6 +137,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -166,9 +170,6 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-L2LEAF2B.yml
@@ -125,6 +125,7 @@ vlan_interfaces:
   ip_address: 172.21.110.6/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -137,6 +138,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -167,9 +171,6 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF1A.yml
@@ -264,6 +264,8 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 vlan_internal_order:
   allocation: ascending
   range:
@@ -272,7 +274,7 @@ vlan_internal_order:
 vlans:
 - id: 4085
   name: L2LEAF_INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1-POD1-LEAF2B.yml
@@ -877,6 +877,17 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.20.110.3/31
   no_autostate: true
+- name: Vlan4085
+  description: L2LEAF_INBAND_MGMT
+  shutdown: false
+  ip_address: 172.21.110.3/24
+  ip_virtual_router_addresses:
+  - 172.21.110.1
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan110
   description: set from structured_config on svi (was Tenant_A_OP_Zone_1)
   shutdown: false
@@ -950,15 +961,6 @@ vlan_interfaces:
     tags:
     - opzone
     - web
-- name: Vlan4085
-  description: L2LEAF_INBAND_MGMT
-  shutdown: false
-  ip_address: 172.21.110.3/24
-  ip_virtual_router_addresses:
-  - 172.21.110.1
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -970,6 +972,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -1000,9 +1005,6 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC1.POD1.LEAF2A.yml
@@ -844,6 +844,17 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.20.110.2/31
   no_autostate: true
+- name: Vlan4085
+  description: L2LEAF_INBAND_MGMT
+  shutdown: false
+  ip_address: 172.21.110.2/24
+  ip_virtual_router_addresses:
+  - 172.21.110.1
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan110
   description: set from structured_config on svi for DC1.POD1.LEAF2A (was Tenant_A_OP_Zone_1)
   shutdown: false
@@ -917,15 +928,6 @@ vlan_interfaces:
     tags:
     - opzone
     - web
-- name: Vlan4085
-  description: L2LEAF_INBAND_MGMT
-  shutdown: false
-  ip_address: 172.21.110.2/24
-  ip_virtual_router_addresses:
-  - 172.21.110.1
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -937,6 +939,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4085
+  name: L2LEAF_INBAND_MGMT
+  tenant: inband_mgmt
 - id: 110
   name: Tenant_A_OP_Zone_1
   tenant: Tenant_A
@@ -967,9 +972,6 @@ vlans:
 - id: 2601
   name: l2vlan_with_no_vxlan
   tenant: Tenant_A
-- id: 4085
-  name: L2LEAF_INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF1A.yml
@@ -70,6 +70,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.21.210.4/24
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -79,7 +80,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-L2LEAF2A.yml
@@ -70,6 +70,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 172.21.210.5/24
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -79,7 +80,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF1A.yml
@@ -347,6 +347,8 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 vlan_internal_order:
   allocation: ascending
   range:
@@ -355,7 +357,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-twodc-5stage-clos/intended/structured_configs/DC2-POD1-LEAF2A.yml
@@ -189,16 +189,6 @@ static_routes:
   prefix: 0.0.0.0/0
   next_hop: 192.168.1.254
 transceiver_qsfp_default_mode_4x10: true
-vlan_interfaces:
-- name: Vlan4092
-  description: Inband Management
-  shutdown: false
-  ip_address: 172.21.210.2/24
-  ip_virtual_router_addresses:
-  - 172.21.210.1
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -207,7 +197,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only-vrf.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-ipv6-only-vrf.cfg
@@ -19,6 +19,8 @@ ip name-server vrf INBANDMGMT 8.8.8.8
 vlan 107
    name INBAND_MGMT
 !
+vrf instance INBANDMGMT
+!
 vrf instance MGMT
 !
 interface Port-Channel1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-ipv6-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/inband-mgmt-parent-ipv6-2.cfg
@@ -24,6 +24,10 @@ vlan 106
 vlan 107
    name INBAND_MGMT
 !
+vlan 3665
+   name MLAG_L3_VRF_INBANDMGMT
+   trunk group MLAG
+!
 vlan 4093
    name MLAG_L3
    trunk group MLAG
@@ -175,6 +179,13 @@ interface Vlan107
    ipv6 address 2a00:107::3/64
    ipv6 virtual-router address 2a00:107::1
 !
+interface Vlan3665
+   description MLAG_L3_VRF_INBANDMGMT
+   no shutdown
+   mtu 9214
+   vrf INBANDMGMT
+   ip address 100.64.1.9/31
+!
 interface Vlan4093
    description MLAG_L3
    no shutdown
@@ -197,11 +208,17 @@ interface Vxlan1
 ip virtual-router mac-address 00:1c:73:00:dc:01
 !
 ip routing
+ip routing vrf INBANDMGMT
 no ip routing vrf MGMT
 !
 ip prefix-list PL-LOOPBACKS-EVPN-OVERLAY
    seq 10 permit 10.0.255.0/24 eq 32
    seq 20 permit 10.0.254.0/24 eq 32
+!
+ip prefix-list PL-MLAG-PEER-VRFS
+   seq 10 permit 100.64.1.8/31
+!
+ipv6 unicast-routing vrf INBANDMGMT
 !
 mlag configuration
    domain-id inband-mgmt-parents-ipv6
@@ -217,6 +234,11 @@ ntp server vrf MGMT pool.ntp.org
 !
 route-map RM-CONN-2-BGP permit 10
    match ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+!
+route-map RM-CONN-2-BGP-VRFS deny 10
+   match ip address prefix-list PL-MLAG-PEER-VRFS
+!
+route-map RM-CONN-2-BGP-VRFS permit 20
 !
 route-map RM-MLAG-PEER-IN permit 10
    description Make routes learned over MLAG Peer-link less preferred on spines to ensure optimal routing

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-2.yml
@@ -101,6 +101,7 @@ vlan_interfaces:
   ip_address: 192.168.1.2/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -110,8 +111,9 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBAND_MGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/aaa-settings-3.yml
@@ -120,6 +120,7 @@ vlan_interfaces:
   ip_address: 192.168.1.2/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -129,8 +130,9 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBAND_MGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-settings.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-settings.yml
@@ -89,6 +89,7 @@ vlan_interfaces:
   ip_address: 172.17.0.2/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -98,8 +99,9 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBAND_MGMT_VRF
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-2.yml
@@ -37,6 +37,7 @@ vlan_interfaces:
   ip_address: 192.168.1.2/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -46,8 +47,9 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBAND_MGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/dns-settings-3.yml
@@ -48,6 +48,7 @@ vlan_interfaces:
   ip_address: 192.168.1.2/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -57,8 +58,9 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBAND_MGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf1.yml
@@ -80,6 +80,7 @@ vlan_interfaces:
   ip_address: 10.254.254.4/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -92,7 +93,7 @@ vlans:
   tenant: FLOW_TRACKING
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf2.yml
@@ -80,6 +80,7 @@ vlan_interfaces:
   ip_address: 10.254.254.5/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -92,7 +93,7 @@ vlans:
   tenant: FLOW_TRACKING
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf3.yml
@@ -426,6 +426,8 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 vlan_internal_order:
   allocation: ascending
   range:
@@ -452,7 +454,7 @@ vlans:
   tenant: FLOW_TRACKING
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf4.yml
@@ -426,6 +426,8 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 vlan_internal_order:
   allocation: ascending
   range:
@@ -452,7 +454,7 @@ vlans:
   tenant: FLOW_TRACKING
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-ips.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-ips.yml
@@ -89,7 +89,7 @@ vlan_internal_order:
 vlans:
 - id: 105
   name: INBAND_MGMT
-  tenant: INBAND_MGMT_TESTS
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-ips.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-ips.yml
@@ -79,6 +79,7 @@ vlan_interfaces:
   ipv6_address: 2a00:105::123/64
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -88,7 +89,7 @@ vlan_internal_order:
 vlans:
 - id: 105
   name: INBAND_MGMT
-  tenant: system
+  tenant: INBAND_MGMT_TESTS
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-subnets.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-dualstack-subnets.yml
@@ -79,6 +79,7 @@ vlan_interfaces:
   ipv6_address: 2a00:104::7/64
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -88,7 +89,7 @@ vlan_internal_order:
 vlans:
 - id: 104
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ip.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ip.yml
@@ -72,6 +72,7 @@ vlan_interfaces:
   ip_address: 192.168.103.22/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -81,8 +82,9 @@ vlan_internal_order:
 vlans:
 - id: 103
   name: MYVLANNAME
-  tenant: system
+  tenant: INBAND_MGMT_TESTS
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBANDMGMT
+  tenant: INBAND_MGMT_TESTS

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only-vrf.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only-vrf.yml
@@ -77,6 +77,7 @@ vlan_interfaces:
   ipv6_address: 2a00:107::a/64
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -86,7 +87,9 @@ vlan_internal_order:
 vlans:
 - id: 107
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
+- name: INBANDMGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-ipv6-only.yml
@@ -75,6 +75,7 @@ vlan_interfaces:
   ipv6_address: 2a00:106::9/64
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -84,7 +85,7 @@ vlan_internal_order:
 vlans:
 - id: 106
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-a.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-a.yml
@@ -251,6 +251,7 @@ vlan_interfaces:
   ip_address: 192.168.101.22/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -265,7 +266,7 @@ vlans:
   tenant: system
 - id: 101
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-b.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-mlag-b.yml
@@ -251,6 +251,7 @@ vlan_interfaces:
   ip_address: 192.168.101.23/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -265,7 +266,7 @@ vlans:
   tenant: system
 - id: 101
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-dualstack1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-dualstack1.yml
@@ -379,6 +379,25 @@ vlan_interfaces:
   ip_address: 100.64.0.4/31
   mtu: 9214
   no_autostate: true
+- name: Vlan104
+  description: Inband Management
+  shutdown: false
+  ip_address: 192.168.104.2/24
+  ip_virtual_router_addresses:
+  - 192.168.104.1
+  ipv6_enable: true
+  ipv6_address: 2a00:104::2/64
+  ipv6_virtual_router_addresses:
+  - 2a00:104::1
+  mtu: 1500
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  ipv6_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan105
   description: Inband_management_vlan_ipv6
   shutdown: true
@@ -401,23 +420,6 @@ vlan_interfaces:
   metadata:
     tenant: INBAND_MGMT_TESTS
     type: underlay_peering
-- name: Vlan104
-  description: Inband Management
-  shutdown: false
-  ip_address: 192.168.104.2/24
-  ip_virtual_router_addresses:
-  - 192.168.104.1
-  ipv6_enable: true
-  ipv6_address: 2a00:104::2/64
-  ipv6_virtual_router_addresses:
-  - 2a00:104::1
-  mtu: 1500
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
-  ipv6_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -434,6 +436,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 104
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 105
   name: Inband_management_vlan_ipv6
   tenant: INBAND_MGMT_TESTS
@@ -442,9 +447,6 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: INBAND_MGMT_TESTS
-- id: 104
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-dualstack2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-dualstack2.yml
@@ -379,6 +379,25 @@ vlan_interfaces:
   ip_address: 100.64.0.5/31
   mtu: 9214
   no_autostate: true
+- name: Vlan104
+  description: Inband Management
+  shutdown: false
+  ip_address: 192.168.104.3/24
+  ip_virtual_router_addresses:
+  - 192.168.104.1
+  ipv6_enable: true
+  ipv6_address: 2a00:104::3/64
+  ipv6_virtual_router_addresses:
+  - 2a00:104::1
+  mtu: 1500
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  ipv6_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan105
   description: Inband_management_vlan_ipv6
   shutdown: true
@@ -401,23 +420,6 @@ vlan_interfaces:
   metadata:
     tenant: INBAND_MGMT_TESTS
     type: underlay_peering
-- name: Vlan104
-  description: Inband Management
-  shutdown: false
-  ip_address: 192.168.104.3/24
-  ip_virtual_router_addresses:
-  - 192.168.104.1
-  ipv6_enable: true
-  ipv6_address: 2a00:104::3/64
-  ipv6_virtual_router_addresses:
-  - 2a00:104::1
-  mtu: 1500
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
-  ipv6_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -434,6 +436,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 104
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 105
   name: Inband_management_vlan_ipv6
   tenant: INBAND_MGMT_TESTS
@@ -442,9 +447,6 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: INBAND_MGMT_TESTS
-- id: 104
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-ipv6-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-ipv6-1.yml
@@ -349,6 +349,8 @@ vlan_interfaces:
   ipv6_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan107
   description: Inband Management
   shutdown: false
@@ -360,6 +362,8 @@ vlan_interfaces:
   ipv6_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 vlan_internal_order:
   allocation: ascending
   range:
@@ -378,10 +382,10 @@ vlans:
   tenant: system
 - id: 106
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 - id: 107
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-ipv6-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-ipv6-2.yml
@@ -235,6 +235,10 @@ prefix_lists:
     action: permit 10.0.255.0/24 eq 32
   - sequence: 20
     action: permit 10.0.254.0/24 eq 32
+- name: PL-MLAG-PEER-VRFS
+  sequence_numbers:
+  - sequence: 10
+    action: permit 100.64.1.8/31
 route_maps:
 - name: RM-MLAG-PEER-IN
   sequence_numbers:
@@ -249,6 +253,14 @@ route_maps:
     type: permit
     match:
     - ip address prefix-list PL-LOOPBACKS-EVPN-OVERLAY
+- name: RM-CONN-2-BGP-VRFS
+  sequence_numbers:
+  - sequence: 10
+    type: deny
+    match:
+    - ip address prefix-list PL-MLAG-PEER-VRFS
+  - sequence: 20
+    type: permit
 router_bfd:
   multihop:
     interval: 300
@@ -337,6 +349,8 @@ vlan_interfaces:
   ipv6_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan107
   description: Inband Management
   shutdown: false
@@ -349,6 +363,17 @@ vlan_interfaces:
   ipv6_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
+- name: Vlan3665
+  description: MLAG_L3_VRF_INBANDMGMT
+  shutdown: false
+  vrf: INBANDMGMT
+  ip_address: 100.64.1.9/31
+  mtu: 9214
+  metadata:
+    tenant: inband_mgmt
+    type: underlay_peering
 vlan_internal_order:
   allocation: ascending
   range:
@@ -367,14 +392,22 @@ vlans:
   tenant: system
 - id: 106
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 - id: 107
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
+- id: 3665
+  name: MLAG_L3_VRF_INBANDMGMT
+  trunk_groups:
+  - MLAG
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBANDMGMT
+  ip_routing: true
+  ipv6_routing: true
+  tenant: inband_mgmt
 vxlan_interface:
   vxlan1:
     description: inband-mgmt-parent-ipv6-2_VTEP

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-vrf.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent-vrf.yml
@@ -276,6 +276,8 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: INBAND_MGMT_TESTS
 - name: Vlan102
   description: Inband Management
   shutdown: false
@@ -287,6 +289,8 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: INBAND_MGMT_TESTS
 vlan_internal_order:
   allocation: ascending
   range:
@@ -298,10 +302,10 @@ vlans:
   tenant: INBAND_MGMT_TESTS
 - id: 101
   name: INBAND_MGMT
-  tenant: system
+  tenant: INBAND_MGMT_TESTS
 - id: 102
   name: INBAND_MGMT
-  tenant: system
+  tenant: INBAND_MGMT_TESTS
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-parent.yml
@@ -291,13 +291,6 @@ router_bgp:
 service_routing_protocols_model: multi-agent
 transceiver_qsfp_default_mode_4x10: true
 vlan_interfaces:
-- name: Vlan103
-  description: Inband management vlan
-  shutdown: true
-  vrf: INBANDMGMT
-  ip_address: 192.168.103.1/24
-  metadata:
-    tenant: INBAND_MGMT_TESTS
 - name: Vlan101
   description: Inband Management
   shutdown: false
@@ -308,6 +301,8 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan102
   description: Inband Management
   shutdown: false
@@ -318,21 +313,30 @@ vlan_interfaces:
   ip_attached_host_route_export:
     enabled: true
     distance: 19
+  metadata:
+    tenant: inband_mgmt
+- name: Vlan103
+  description: Inband management vlan
+  shutdown: true
+  vrf: INBANDMGMT
+  ip_address: 192.168.103.1/24
+  metadata:
+    tenant: INBAND_MGMT_TESTS
 vlan_internal_order:
   allocation: ascending
   range:
     beginning: 1006
     ending: 1199
 vlans:
+- id: 101
+  name: INBAND_MGMT
+  tenant: inband_mgmt
+- id: 102
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 103
   name: Inband management vlan
   tenant: INBAND_MGMT_TESTS
-- id: 101
-  name: INBAND_MGMT
-  tenant: system
-- id: 102
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-per-interface-mtu-false.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-per-interface-mtu-false.yml
@@ -40,6 +40,7 @@ vlan_interfaces:
   shutdown: false
   ip_address: 192.168.103.22/24
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -49,7 +50,7 @@ vlan_internal_order:
 vlans:
 - id: 108
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet-vrf.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet-vrf.yml
@@ -76,6 +76,7 @@ vlan_interfaces:
   ip_address: 192.168.102.5/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -85,8 +86,9 @@ vlan_internal_order:
 vlans:
 - id: 102
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBANDMGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/inband-mgmt-subnet.yml
@@ -74,6 +74,7 @@ vlan_interfaces:
   ip_address: 192.168.101.7/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -83,7 +84,7 @@ vlan_internal_order:
 vlans:
 - id: 101
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ntp-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ntp-settings-2.yml
@@ -28,6 +28,7 @@ vlan_interfaces:
   ip_address: 192.168.1.2/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -37,8 +38,9 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false
 - name: INBAND_MGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
@@ -86,12 +86,12 @@ vlan_internal_order:
     beginning: 1006
     ending: 1199
 vlans:
-- id: 4092
-  name: INBAND_MGMT
-  tenant: inband_mgmt
 - id: 11
   name: VLAN11
   tenant: SFLOW
+- id: 4092
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf1.yml
@@ -78,6 +78,7 @@ vlan_interfaces:
   ip_address: 10.254.254.4/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -85,12 +86,12 @@ vlan_internal_order:
     beginning: 1006
     ending: 1199
 vlans:
+- id: 4092
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VLAN11
   tenant: SFLOW
-- id: 4092
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
@@ -86,12 +86,12 @@ vlan_internal_order:
     beginning: 1006
     ending: 1199
 vlans:
-- id: 4092
-  name: INBAND_MGMT
-  tenant: inband_mgmt
 - id: 11
   name: VLAN11
   tenant: SFLOW
+- id: 4092
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-l2-leaf2.yml
@@ -78,6 +78,7 @@ vlan_interfaces:
   ip_address: 10.254.254.5/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -85,12 +86,12 @@ vlan_internal_order:
     beginning: 1006
     ending: 1199
 vlans:
+- id: 4092
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VLAN11
   tenant: SFLOW
-- id: 4092
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf3.yml
@@ -372,6 +372,18 @@ vlan_interfaces:
   ip_address: 10.254.1.72/31
   mtu: 9214
   no_autostate: true
+- name: Vlan4092
+  description: Inband Management
+  shutdown: false
+  ip_address: 10.254.254.2/24
+  ip_virtual_router_addresses:
+  - 10.254.254.1
+  mtu: 1500
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan11
   description: VLAN11
   shutdown: false
@@ -387,16 +399,6 @@ vlan_interfaces:
   metadata:
     tenant: SFLOW
     type: underlay_peering
-- name: Vlan4092
-  description: Inband Management
-  shutdown: false
-  ip_address: 10.254.254.2/24
-  ip_virtual_router_addresses:
-  - 10.254.254.1
-  mtu: 1500
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -413,6 +415,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4092
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VLAN11
   tenant: SFLOW
@@ -421,9 +426,6 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: SFLOW
-- id: 4092
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/sflow-tests-leaf4.yml
@@ -372,6 +372,18 @@ vlan_interfaces:
   ip_address: 10.254.1.73/31
   mtu: 9214
   no_autostate: true
+- name: Vlan4092
+  description: Inband Management
+  shutdown: false
+  ip_address: 10.254.254.3/24
+  ip_virtual_router_addresses:
+  - 10.254.254.1
+  mtu: 1500
+  ip_attached_host_route_export:
+    enabled: true
+    distance: 19
+  metadata:
+    tenant: inband_mgmt
 - name: Vlan11
   description: VLAN11
   shutdown: false
@@ -387,16 +399,6 @@ vlan_interfaces:
   metadata:
     tenant: SFLOW
     type: underlay_peering
-- name: Vlan4092
-  description: Inband Management
-  shutdown: false
-  ip_address: 10.254.254.3/24
-  ip_virtual_router_addresses:
-  - 10.254.254.1
-  mtu: 1500
-  ip_attached_host_route_export:
-    enabled: true
-    distance: 19
 vlan_internal_order:
   allocation: ascending
   range:
@@ -413,6 +415,9 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: system
+- id: 4092
+  name: INBAND_MGMT
+  tenant: inband_mgmt
 - id: 11
   name: VLAN11
   tenant: SFLOW
@@ -421,9 +426,6 @@ vlans:
   trunk_groups:
   - MLAG
   tenant: SFLOW
-- id: 4092
-  name: INBAND_MGMT
-  tenant: system
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/snmp-settings-2.yml
@@ -54,6 +54,7 @@ vlan_interfaces:
   ip_address: 192.168.0.1/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -63,7 +64,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/source-interfaces.yml
@@ -38,6 +38,7 @@ vlan_interfaces:
   ip_address: 10.20.30.40/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -47,8 +48,9 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: default
   ip_routing: false
 - name: INBANDMGMT
+  tenant: inband_mgmt

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ssh-settings-2.yml
@@ -25,6 +25,7 @@ vlan_interfaces:
   ip_address: 192.168.0.1/24
   mtu: 1500
   metadata:
+    tenant: inband_mgmt
     type: inband_mgmt
 vlan_internal_order:
   allocation: ascending
@@ -34,7 +35,7 @@ vlan_internal_order:
 vlans:
 - id: 4092
   name: INBAND_MGMT
-  tenant: system
+  tenant: inband_mgmt
 vrfs:
 - name: MGMT
   ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/INBAND_MGMT_TESTS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/INBAND_MGMT_TESTS.yml
@@ -16,17 +16,16 @@ default_node_types:
     node_type: l2leaf
 
 default_interfaces:
-  - types: [ spine ]
-    platforms: [ default ]
-    downlink_interfaces: [ Ethernet1-10 ]
-  - types: [ l3leaf, l2leaf ]
-    platforms: [ default ]
-    uplink_interfaces: [ Ethernet1-10 ]
-    mlag_interfaces: [ Ethernet11-20 ]
-    downlink_interfaces: [ Ethernet21-30 ]
+  - types: [spine]
+    platforms: [default]
+    downlink_interfaces: [Ethernet1-10]
+  - types: [l3leaf, l2leaf]
+    platforms: [default]
+    uplink_interfaces: [Ethernet1-10]
+    mlag_interfaces: [Ethernet11-20]
+    downlink_interfaces: [Ethernet21-30]
     # Test for setting mlag interfaces speed via default_interfaces
     mlag_interfaces_speed: forced 100gfull
-
 default_mgmt_method: inband
 
 cv_settings:
@@ -142,6 +141,7 @@ l2leaf:
     - name: inband-mgmt-dualstack-ips
       inband_mgmt_vlan: 105
       uplink_switches: [inband-mgmt-parent-dualstack1, inband-mgmt-parent-dualstack2]
+      # TODO: this is weird behavior to have not inband_mgmt_vrf defined here when the SVI is in the VRF in tenants.
       inband_mgmt_ip: 192.168.105.22/24
       inband_mgmt_gateway: 192.168.105.1
       inband_mgmt_ipv6_address: 2a00:105::123/64

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
@@ -49,6 +49,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_attached_host_route_export</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_attached_host_route_export") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_attached_host_route_export.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_attached_host_route_export.distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_attached_host_route_export</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_attached_host_route_export") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_attached_host_route_export.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_attached_host_route_export.distance") | Integer |  |  | Min: 1<br>Max: 255 | Administrative distance for generated routes. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_length</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ipv6_attached_host_route_export.prefix_length") | Integer |  |  | Min: 0<br>Max: 128 | Prefix length for generated routes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
@@ -84,7 +91,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].bgp.raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the VLAN interface in the final EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].structured_config") | Dictionary |  |  |  | Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].evpn_l2_multi_domain") | Boolean |  |  |  | Explicitly extend SVI to remote EVPN domains.<br>Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.<br>Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles: true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].nodes.[].evpn_l2_multi_domain") | Boolean |  |  |  | Explicitly extend SVI to remote EVPN domains.<br>Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.<br>Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles: true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].enabled") | Boolean |  |  |  | Enable or disable interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].description") | String |  |  |  | SVI description. By default set to VLAN name.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;arp_gratuitous_accept</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].arp_gratuitous_accept") | Boolean |  |  |  | Accept gratuitous ARP. |
@@ -108,6 +115,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_attached_host_route_export</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_attached_host_route_export") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_attached_host_route_export.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_attached_host_route_export.distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_attached_host_route_export</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_attached_host_route_export") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_attached_host_route_export.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_attached_host_route_export.distance") | Integer |  |  | Min: 1<br>Max: 255 | Administrative distance for generated routes. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_length</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ipv6_attached_host_route_export.prefix_length") | Integer |  |  | Min: 0<br>Max: 128 | Prefix length for generated routes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
@@ -143,7 +157,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].bgp.raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the VLAN interface in the final EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].structured_config") | Dictionary |  |  |  | Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l2_multi_domain") | Boolean |  |  |  | Explicitly extend SVI to remote EVPN domains.<br>Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.<br>Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles: true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "<network_services_keys.name>.[].vrfs.[].svis.[].evpn_l2_multi_domain") | Boolean |  |  |  | Explicitly extend SVI to remote EVPN domains.<br>Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.<br>Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles: true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`. |
 
 === "YAML"
 
@@ -296,6 +310,17 @@
                     # Name of the IPv4 Access-list to be assigned in the egress direction.
                     # The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip".
                     ipv4_acl_out: <str>
+                    ip_attached_host_route_export:
+                      enabled: <bool; required>
+                      distance: <int; 1-255>
+                    ipv6_attached_host_route_export:
+                      enabled: <bool; required>
+
+                      # Administrative distance for generated routes.
+                      distance: <int; 1-255>
+
+                      # Prefix length for generated routes.
+                      prefix_length: <int; 0-128>
 
                     # IP helper for DHCP relay.
                     ip_helpers:
@@ -471,6 +496,17 @@
                 # Name of the IPv4 Access-list to be assigned in the egress direction.
                 # The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip".
                 ipv4_acl_out: <str>
+                ip_attached_host_route_export:
+                  enabled: <bool; required>
+                  distance: <int; 1-255>
+                ipv6_attached_host_route_export:
+                  enabled: <bool; required>
+
+                  # Administrative distance for generated routes.
+                  distance: <int; 1-255>
+
+                  # Prefix length for generated routes.
+                  prefix_length: <int; 0-128>
 
                 # IP helper for DHCP relay.
                 ip_helpers:

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
@@ -36,6 +36,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].nodes.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "svi_profiles.[].nodes.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "svi_profiles.[].nodes.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_attached_host_route_export</samp>](## "svi_profiles.[].nodes.[].ip_attached_host_route_export") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].ip_attached_host_route_export.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "svi_profiles.[].nodes.[].ip_attached_host_route_export.distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6_attached_host_route_export</samp>](## "svi_profiles.[].nodes.[].ipv6_attached_host_route_export") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].nodes.[].ipv6_attached_host_route_export.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "svi_profiles.[].nodes.[].ipv6_attached_host_route_export.distance") | Integer |  |  | Min: 1<br>Max: 255 | Administrative distance for generated routes. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_length</samp>](## "svi_profiles.[].nodes.[].ipv6_attached_host_route_export.prefix_length") | Integer |  |  | Min: 0<br>Max: 128 | Prefix length for generated routes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "svi_profiles.[].nodes.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "svi_profiles.[].nodes.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "svi_profiles.[].nodes.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
@@ -71,7 +78,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "svi_profiles.[].nodes.[].bgp.raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "svi_profiles.[].nodes.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the VLAN interface in the final EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "svi_profiles.[].nodes.[].structured_config") | Dictionary |  |  |  | Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "svi_profiles.[].nodes.[].evpn_l2_multi_domain") | Boolean |  |  |  | Explicitly extend SVI to remote EVPN domains.<br>Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.<br>Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles: true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "svi_profiles.[].nodes.[].evpn_l2_multi_domain") | Boolean |  |  |  | Explicitly extend SVI to remote EVPN domains.<br>Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.<br>Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles: true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;name</samp>](## "svi_profiles.[].name") | String |  |  |  | VLAN name. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].enabled") | Boolean |  |  |  | Enable or disable interface. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;description</samp>](## "svi_profiles.[].description") | String |  |  |  | SVI description. By default set to VLAN name.<br> |
@@ -96,6 +103,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;&lt;str&gt;</samp>](## "svi_profiles.[].ipv6_virtual_router_addresses.[]") | String |  |  |  | IPv6_address. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_in</samp>](## "svi_profiles.[].ipv4_acl_in") | String |  |  |  | Name of the IPv4 access-list to be assigned in the ingress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv4_acl_out</samp>](## "svi_profiles.[].ipv4_acl_out") | String |  |  |  | Name of the IPv4 Access-list to be assigned in the egress direction.<br>The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip". |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_attached_host_route_export</samp>](## "svi_profiles.[].ip_attached_host_route_export") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].ip_attached_host_route_export.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "svi_profiles.[].ip_attached_host_route_export.distance") | Integer |  |  | Min: 1<br>Max: 255 |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ipv6_attached_host_route_export</samp>](## "svi_profiles.[].ipv6_attached_host_route_export") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;enabled</samp>](## "svi_profiles.[].ipv6_attached_host_route_export.enabled") | Boolean | Required |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;distance</samp>](## "svi_profiles.[].ipv6_attached_host_route_export.distance") | Integer |  |  | Min: 1<br>Max: 255 | Administrative distance for generated routes. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;prefix_length</samp>](## "svi_profiles.[].ipv6_attached_host_route_export.prefix_length") | Integer |  |  | Min: 0<br>Max: 128 | Prefix length for generated routes. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;ip_helpers</samp>](## "svi_profiles.[].ip_helpers") | List, items: Dictionary |  |  |  | IP helper for DHCP relay. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;ip_helper</samp>](## "svi_profiles.[].ip_helpers.[].ip_helper") | String | Required, Unique |  |  | IPv4 DHCP server IP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;source_interface</samp>](## "svi_profiles.[].ip_helpers.[].source_interface") | String |  |  |  | Interface name to originate DHCP relay packets to DHCP server. |
@@ -131,7 +145,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "svi_profiles.[].bgp.raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the Router BGP, VLAN definition in the final EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;raw_eos_cli</samp>](## "svi_profiles.[].raw_eos_cli") | String |  |  |  | EOS CLI rendered directly on the VLAN interface in the final EOS configuration.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;structured_config</samp>](## "svi_profiles.[].structured_config") | Dictionary |  |  |  | Custom structured config added under vlan_interfaces.[name=<interface>] for eos_cli_config_gen.<br> |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "svi_profiles.[].evpn_l2_multi_domain") | Boolean |  |  |  | Explicitly extend SVI to remote EVPN domains.<br>Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.<br>Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles: true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;evpn_l2_multi_domain</samp>](## "svi_profiles.[].evpn_l2_multi_domain") | Boolean |  |  |  | Explicitly extend SVI to remote EVPN domains.<br>Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.<br>Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles: true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`. |
 
 === "YAML"
 
@@ -240,6 +254,17 @@
             # Name of the IPv4 Access-list to be assigned in the egress direction.
             # The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip".
             ipv4_acl_out: <str>
+            ip_attached_host_route_export:
+              enabled: <bool; required>
+              distance: <int; 1-255>
+            ipv6_attached_host_route_export:
+              enabled: <bool; required>
+
+              # Administrative distance for generated routes.
+              distance: <int; 1-255>
+
+              # Prefix length for generated routes.
+              prefix_length: <int; 0-128>
 
             # IP helper for DHCP relay.
             ip_helpers:
@@ -418,6 +443,17 @@
         # Name of the IPv4 Access-list to be assigned in the egress direction.
         # The access-list must be defined under `ipv4_acls` and supports substitution of the field "interface_ip".
         ipv4_acl_out: <str>
+        ip_attached_host_route_export:
+          enabled: <bool; required>
+          distance: <int; 1-255>
+        ipv6_attached_host_route_export:
+          enabled: <bool; required>
+
+          # Administrative distance for generated routes.
+          distance: <int; 1-255>
+
+          # Prefix length for generated routes.
+          prefix_length: <int; 0-128>
 
         # IP helper for DHCP relay.
         ip_helpers:

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -20207,6 +20207,8 @@ class EosDesigns(EosDesignsRootModel):
                 "ipv6_virtual_router_addresses": {"type": Ipv6VirtualRouterAddresses},
                 "ipv4_acl_in": {"type": str},
                 "ipv4_acl_out": {"type": str},
+                "ip_attached_host_route_export": {"type": EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport},
+                "ipv6_attached_host_route_export": {"type": EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport},
                 "ip_helpers": {"type": IpHelpers},
                 "static_routes": {"type": StaticRoutes},
                 "ipv6_static_routes": {"type": Ipv6StaticRoutes},
@@ -20306,6 +20308,8 @@ class EosDesigns(EosDesignsRootModel):
             The access-list must be defined
             under `ipv4_acls` and supports substitution of the field "interface_ip".
             """
+            ip_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport
+            ipv6_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport
             ip_helpers: IpHelpers
             """
             IP helper for DHCP relay.
@@ -20450,6 +20454,8 @@ class EosDesigns(EosDesignsRootModel):
                     ipv6_virtual_router_addresses: Ipv6VirtualRouterAddresses | UndefinedType = Undefined,
                     ipv4_acl_in: str | None | UndefinedType = Undefined,
                     ipv4_acl_out: str | None | UndefinedType = Undefined,
+                    ip_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport | UndefinedType = Undefined,
+                    ipv6_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport | UndefinedType = Undefined,
                     ip_helpers: IpHelpers | UndefinedType = Undefined,
                     static_routes: StaticRoutes | UndefinedType = Undefined,
                     ipv6_static_routes: Ipv6StaticRoutes | UndefinedType = Undefined,
@@ -20532,6 +20538,8 @@ class EosDesigns(EosDesignsRootModel):
                            Name of the IPv4 Access-list to be assigned in the egress direction.
                            The access-list must be defined
                            under `ipv4_acls` and supports substitution of the field "interface_ip".
+                        ip_attached_host_route_export: ip_attached_host_route_export
+                        ipv6_attached_host_route_export: ipv6_attached_host_route_export
                         ip_helpers:
                            IP helper for DHCP relay.
 
@@ -21188,6 +21196,8 @@ class EosDesigns(EosDesignsRootModel):
             "ipv6_virtual_router_addresses": {"type": Ipv6VirtualRouterAddresses},
             "ipv4_acl_in": {"type": str},
             "ipv4_acl_out": {"type": str},
+            "ip_attached_host_route_export": {"type": EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport},
+            "ipv6_attached_host_route_export": {"type": EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport},
             "ip_helpers": {"type": IpHelpers},
             "static_routes": {"type": StaticRoutes},
             "ipv6_static_routes": {"type": Ipv6StaticRoutes},
@@ -21303,6 +21313,8 @@ class EosDesigns(EosDesignsRootModel):
         The access-list must be defined
         under `ipv4_acls` and supports substitution of the field "interface_ip".
         """
+        ip_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport
+        ipv6_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport
         ip_helpers: IpHelpers
         """
         IP helper for DHCP relay.
@@ -21449,6 +21461,8 @@ class EosDesigns(EosDesignsRootModel):
                 ipv6_virtual_router_addresses: Ipv6VirtualRouterAddresses | UndefinedType = Undefined,
                 ipv4_acl_in: str | None | UndefinedType = Undefined,
                 ipv4_acl_out: str | None | UndefinedType = Undefined,
+                ip_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport | UndefinedType = Undefined,
+                ipv6_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport | UndefinedType = Undefined,
                 ip_helpers: IpHelpers | UndefinedType = Undefined,
                 static_routes: StaticRoutes | UndefinedType = Undefined,
                 ipv6_static_routes: Ipv6StaticRoutes | UndefinedType = Undefined,
@@ -21543,6 +21557,8 @@ class EosDesigns(EosDesignsRootModel):
                        Name of the IPv4 Access-list to be assigned in the egress direction.
                        The access-list must be defined
                        under `ipv4_acls` and supports substitution of the field "interface_ip".
+                    ip_attached_host_route_export: ip_attached_host_route_export
+                    ipv6_attached_host_route_export: ipv6_attached_host_route_export
                     ip_helpers:
                        IP helper for DHCP relay.
 
@@ -49441,6 +49457,8 @@ class EosDesigns(EosDesignsRootModel):
                                 "ipv6_virtual_router_addresses": {"type": Ipv6VirtualRouterAddresses},
                                 "ipv4_acl_in": {"type": str},
                                 "ipv4_acl_out": {"type": str},
+                                "ip_attached_host_route_export": {"type": EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport},
+                                "ipv6_attached_host_route_export": {"type": EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport},
                                 "ip_helpers": {"type": IpHelpers},
                                 "static_routes": {"type": StaticRoutes},
                                 "ipv6_static_routes": {"type": Ipv6StaticRoutes},
@@ -49550,6 +49568,8 @@ class EosDesigns(EosDesignsRootModel):
                             The access-list must be defined
                             under `ipv4_acls` and supports substitution of the field "interface_ip".
                             """
+                            ip_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport
+                            ipv6_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport
                             ip_helpers: IpHelpers
                             """
                             IP helper for DHCP relay.
@@ -49695,6 +49715,8 @@ class EosDesigns(EosDesignsRootModel):
                                     ipv6_virtual_router_addresses: Ipv6VirtualRouterAddresses | UndefinedType = Undefined,
                                     ipv4_acl_in: str | None | UndefinedType = Undefined,
                                     ipv4_acl_out: str | None | UndefinedType = Undefined,
+                                    ip_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport | UndefinedType = Undefined,
+                                    ipv6_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport | UndefinedType = Undefined,
                                     ip_helpers: IpHelpers | UndefinedType = Undefined,
                                     static_routes: StaticRoutes | UndefinedType = Undefined,
                                     ipv6_static_routes: Ipv6StaticRoutes | UndefinedType = Undefined,
@@ -49783,6 +49805,8 @@ class EosDesigns(EosDesignsRootModel):
                                            Name of the IPv4 Access-list to be assigned in the egress direction.
                                            The access-list must be defined
                                            under `ipv4_acls` and supports substitution of the field "interface_ip".
+                                        ip_attached_host_route_export: ip_attached_host_route_export
+                                        ipv6_attached_host_route_export: ipv6_attached_host_route_export
                                         ip_helpers:
                                            IP helper for DHCP relay.
 
@@ -50451,6 +50475,8 @@ class EosDesigns(EosDesignsRootModel):
                             "ipv6_virtual_router_addresses": {"type": Ipv6VirtualRouterAddresses},
                             "ipv4_acl_in": {"type": str},
                             "ipv4_acl_out": {"type": str},
+                            "ip_attached_host_route_export": {"type": EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport},
+                            "ipv6_attached_host_route_export": {"type": EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport},
                             "ip_helpers": {"type": IpHelpers},
                             "static_routes": {"type": StaticRoutes},
                             "ipv6_static_routes": {"type": Ipv6StaticRoutes},
@@ -50590,6 +50616,8 @@ class EosDesigns(EosDesignsRootModel):
                         The access-list must be defined
                         under `ipv4_acls` and supports substitution of the field "interface_ip".
                         """
+                        ip_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport
+                        ipv6_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport
                         ip_helpers: IpHelpers
                         """
                         IP helper for DHCP relay.
@@ -50739,6 +50767,8 @@ class EosDesigns(EosDesignsRootModel):
                                 ipv6_virtual_router_addresses: Ipv6VirtualRouterAddresses | UndefinedType = Undefined,
                                 ipv4_acl_in: str | None | UndefinedType = Undefined,
                                 ipv4_acl_out: str | None | UndefinedType = Undefined,
+                                ip_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.IpAttachedHostRouteExport | UndefinedType = Undefined,
+                                ipv6_attached_host_route_export: EosCliConfigGen.VlanInterfacesItem.Ipv6AttachedHostRouteExport | UndefinedType = Undefined,
                                 ip_helpers: IpHelpers | UndefinedType = Undefined,
                                 static_routes: StaticRoutes | UndefinedType = Undefined,
                                 ipv6_static_routes: Ipv6StaticRoutes | UndefinedType = Undefined,
@@ -50849,6 +50879,8 @@ class EosDesigns(EosDesignsRootModel):
                                        Name of the IPv4 Access-list to be assigned in the egress direction.
                                        The access-list must be defined
                                        under `ipv4_acls` and supports substitution of the field "interface_ip".
+                                    ip_attached_host_route_export: ip_attached_host_route_export
+                                    ipv6_attached_host_route_export: ipv6_attached_host_route_export
                                     ip_helpers:
                                        IP helper for DHCP relay.
 

--- a/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/eos_designs.schema.yml
@@ -12861,6 +12861,12 @@ $defs:
         type: str
         convert_types:
         - int
+      ip_attached_host_route_export:
+        type: dict
+        $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/ip_attached_host_route_export
+      ipv6_attached_host_route_export:
+        type: dict
+        $ref: eos_cli_config_gen#/keys/vlan_interfaces/items/keys/ipv6_attached_host_route_export
       ip_helpers:
         type: list
         primary_key: ip_helper
@@ -13156,9 +13162,7 @@ $defs:
           Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.
 
           Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles:
-          true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`.
-
-          '
+          true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`.'
   virtual_topology:
     type: dict
     keys:

--- a/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
+++ b/python-avd/pyavd/_eos_designs/schema/schema_fragments/defs_svi_settings.schema.yml
@@ -1,3 +1,4 @@
+---
 # Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
@@ -108,6 +109,12 @@ $defs:
         type: str
         convert_types:
           - int
+      ip_attached_host_route_export:
+        type: dict
+        $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/ip_attached_host_route_export"
+      ipv6_attached_host_route_export:
+        type: dict
+        $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items/keys/ipv6_attached_host_route_export"
       ip_helpers:
         type: list
         primary_key: ip_helper
@@ -362,7 +369,7 @@ $defs:
         $ref: "eos_cli_config_gen#/keys/vlan_interfaces/items"
       evpn_l2_multi_domain:
         type: bool
-        description: |
+        description: |-
           Explicitly extend SVI to remote EVPN domains.
           Overrides `<network_services_key>[].evpn_l2_multi_domain` and `<network_services_key>[].vrfs[].evpn_l2_multi_domain`.
           Not supported in conjunction with EVPN vlan aware bundles. i.e. `evpn_vlan_aware_bundles: true` or `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle`.

--- a/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from functools import cached_property
+from ipaddress import ip_network
 from typing import TYPE_CHECKING, Literal, Protocol, cast, overload
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
@@ -42,6 +43,8 @@ class FilteredTenantsMixin(Protocol):
 
         filtered_tenants = EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServices()
         filter_tenants = self.node_config.filter.tenants
+        all_vlans: set[int] = set()
+        """Keeping a set of all vlans injected to check at the end if we must inject inband_management vlan."""
         for network_services_key in self.inputs._dynamic_keys.network_services:
             for original_tenant in network_services_key.value:
                 if original_tenant.name not in filter_tenants and "all" not in filter_tenants:
@@ -49,9 +52,13 @@ class FilteredTenantsMixin(Protocol):
                 tenant = original_tenant._deepcopy()
                 tenant._internal_data.context = f"{network_services_key.key}"
                 tenant.l2vlans = self.filtered_l2vlans(tenant)
+                # TODO: can consider updating this as we go along.
+                all_vlans.update(l2vlan.id for l2vlan in tenant.l2vlans)
                 tenant.vrfs = self.filtered_vrfs(tenant)
+                all_vlans.update(svi.id for vrf in tenant.vrfs for svi in vrf.svis)
                 filtered_tenants.append(tenant)
 
+        # TODO: Make a separate method
         no_vrf_default = all("default" not in tenant.vrfs for tenant in filtered_tenants)
         if self.is_wan_router and no_vrf_default:
             filtered_tenants.append(
@@ -78,7 +85,79 @@ class FilteredTenantsMixin(Protocol):
                     raise AristaAvdError(msg)
                 break
 
+        # TODO: Make a separated method
+        if self.inband_management_parent_vlans or self.configure_inband_mgmt or self.configure_inband_mgmt_ipv6:
+            # First, look for any mgmt VRF defined in networks services named the same as inband_mgmt_vrf
+            mgmt_inband_tuple: (
+                tuple[
+                    EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem,
+                    EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem,
+                ]
+                | tuple[None, None]
+            ) = next(((vrf, tenant) for tenant in filtered_tenants for vrf in tenant.vrfs if self.node_config.inband_mgmt_vrf == vrf.name), (None, None))
+            # Looks like pyright is limited on this one... and does not understand properly if mgmt_inband_tuple != (None, None):
+            mgmt_inband_vrf, mgmt_inband_tenant = mgmt_inband_tuple
+            if mgmt_inband_vrf is not None and mgmt_inband_tenant is not None:
+                self.inject_management_vlans(mgmt_inband_vrf, mgmt_inband_tenant, all_vlans)
+                self.filtered_mgmt_inband_vrf = mgmt_inband_vrf
+                self.filtered_mgmt_inband_tenant = mgmt_inband_tenant
+            else:
+                # Using obtain to avoid name clash.
+                mgmt_inband_tenant = filtered_tenants.obtain("inband_mgmt")
+                mgmt_inband_vrf = mgmt_inband_tenant.vrfs.append_new(
+                    name=self.inband_mgmt_vrf or "default",
+                    vrf_id=666,
+                    address_families=EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.AddressFamilies(),
+                )
+                self.inject_management_vlans(mgmt_inband_vrf, mgmt_inband_tenant, all_vlans)
+                self.filtered_mgmt_inband_vrf = mgmt_inband_vrf
+                self.filtered_mgmt_inband_tenant = mgmt_inband_tenant
+                filtered_tenants.append(mgmt_inband_tenant)
+
         return filtered_tenants._natural_sorted()
+
+    filtered_mgmt_inband_vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem | None = None
+    filtered_mgmt_inband_tenant: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem | None = None
+
+    def inject_management_vlans(
+        self: SharedUtilsProtocol,
+        vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem,
+        tenant: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem,
+        all_vlans: set[int],
+    ) -> None:
+        """Return a tenant if any additional vlan has to be configured for inband management."""
+        if (self.configure_inband_mgmt or self.configure_inband_mgmt_ipv6) and self.node_config.inband_mgmt_vlan not in all_vlans:
+            _ = tenant.l2vlans.append_new(
+                id=self.node_config.inband_mgmt_vlan,
+                name=self.node_config.inband_mgmt_vlan_name,
+            )
+
+        for vlan, subnet in self.inband_management_parent_vlans.items():
+            if vlan not in all_vlans:
+                svi = vrf.svis.append_new(
+                    id=vlan,
+                    name=self.node_config.inband_mgmt_vlan_name,
+                    mtu=self.inband_mgmt_mtu,
+                    enabled=True,
+                    description=self.node_config.inband_mgmt_description,
+                    vxlan=False,
+                )
+                if subnet["ipv4"] is not None:
+                    network = ip_network(subnet["ipv4"], strict=False)
+                    ip = str(network[3]) if self.mlag_role == "secondary" else str(network[2])
+                    svi.ip_address = f"{ip}/{network.prefixlen}"
+                    svi.ip_virtual_router_addresses.append(str(network[1]))
+                    if self.underlay_routing_protocol == "ebgp":
+                        svi.ip_attached_host_route_export._update(enabled=True, distance=19)
+                if subnet["ipv6"] is not None:
+                    network = ip_network(subnet["ipv6"], strict=False)
+                    ip = str(network[3]) if self.mlag_role == "secondary" else str(network[2])
+                    svi.ipv6_address = f"{ip}/{network.prefixlen}"
+                    svi.ipv6_enable = True
+                    svi.ipv6_virtual_router_addresses.append(str(network[1]))
+                    if self.underlay_routing_protocol == "ebgp":
+                        svi.ipv6_attached_host_route_export._update(enabled=True, distance=19)
+                all_vlans.add(vlan)
 
     def filtered_l2vlans(
         self: SharedUtilsProtocol, tenant: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem

--- a/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/filtered_tenants.py
@@ -51,6 +51,7 @@ class FilteredTenantsMixin(Protocol):
                     continue
                 tenant = original_tenant._deepcopy()
                 tenant._internal_data.context = f"{network_services_key.key}"
+                tenant._internal_data.inband_mgmt = False
                 tenant.l2vlans = self.filtered_l2vlans(tenant)
                 # TODO: can consider updating this as we go along.
                 all_vlans.update(l2vlan.id for l2vlan in tenant.l2vlans)
@@ -58,80 +59,73 @@ class FilteredTenantsMixin(Protocol):
                 all_vlans.update(svi.id for vrf in tenant.vrfs for svi in vrf.svis)
                 filtered_tenants.append(tenant)
 
-        # TODO: Make a separate method
-        no_vrf_default = all("default" not in tenant.vrfs for tenant in filtered_tenants)
-        if self.is_wan_router and no_vrf_default:
-            filtered_tenants.append(
-                EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem(
-                    name="WAN_DEFAULT",
-                    vrfs=EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.Vrfs(
-                        [
-                            EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem(
-                                name="default",
-                                vrf_id=1,
-                            )
-                        ]
-                    ),
-                )
-            )
-        elif self.is_wan_router:
-            # It is enough to check only the first occurrence of default VRF as some other piece of code
-            # checks that if the VRF is in multiple tenants, the configuration is consistent.
-            for tenant in filtered_tenants:
-                if "default" not in tenant.vrfs:
-                    continue
-                if self.inputs.underlay_filter_peer_as:
-                    msg = "WAN configuration is not compatible with 'underlay_filter_peer_as'"
-                    raise AristaAvdError(msg)
-                break
+        # Inject default VRF for WAN routers if this is missing
+        self.ensure_defaut_vrf_for_wan(filtered_tenants)
 
-        # TODO: Make a separated method
-        if self.inband_management_parent_vlans or self.configure_inband_mgmt or self.configure_inband_mgmt_ipv6:
-            # First, look for any mgmt VRF defined in networks services named the same as inband_mgmt_vrf
-            mgmt_inband_tuple: (
-                tuple[
-                    EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem,
-                    EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem,
-                ]
-                | tuple[None, None]
-            ) = next(((vrf, tenant) for tenant in filtered_tenants for vrf in tenant.vrfs if self.node_config.inband_mgmt_vrf == vrf.name), (None, None))
-            # Looks like pyright is limited on this one... and does not understand properly if mgmt_inband_tuple != (None, None):
-            mgmt_inband_vrf, mgmt_inband_tenant = mgmt_inband_tuple
-            if mgmt_inband_vrf is not None and mgmt_inband_tenant is not None:
-                self.inject_management_vlans(mgmt_inband_vrf, mgmt_inband_tenant, all_vlans)
-                self.filtered_mgmt_inband_vrf = mgmt_inband_vrf
-                self.filtered_mgmt_inband_tenant = mgmt_inband_tenant
-            else:
-                # Using obtain to avoid name clash.
-                mgmt_inband_tenant = filtered_tenants.obtain("inband_mgmt")
-                mgmt_inband_vrf = mgmt_inband_tenant.vrfs.append_new(
-                    name=self.inband_mgmt_vrf or "default",
-                    vrf_id=666,
-                    address_families=EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.AddressFamilies(),
-                )
-                self.inject_management_vlans(mgmt_inband_vrf, mgmt_inband_tenant, all_vlans)
-                self.filtered_mgmt_inband_vrf = mgmt_inband_vrf
-                self.filtered_mgmt_inband_tenant = mgmt_inband_tenant
-                filtered_tenants.append(mgmt_inband_tenant)
+        self.ensure_inband_mgmt_vrf(filtered_tenants, all_vlans)
 
         return filtered_tenants._natural_sorted()
 
-    filtered_mgmt_inband_vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem | None = None
-    filtered_mgmt_inband_tenant: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem | None = None
+    @cached_property
+    def filtered_inband_mgmt_tenant(self: SharedUtilsProtocol) -> EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem | None:
+        for tenant in self.filtered_tenants:
+            if hasattr(tenant._internal_data, "inband_mgmt") and tenant._internal_data.inband_mgmt is True:
+                return tenant
+        return None
+
+    @cached_property
+    def filtered_inband_mgmt_vrf(self: SharedUtilsProtocol) -> EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem | None:
+        if self.filtered_inband_mgmt_tenant is None:
+            return None
+
+        for vrf in self.filtered_inband_mgmt_tenant.vrfs:
+            if hasattr(vrf._internal_data, "inband_mgmt") and vrf._internal_data.inband_mgmt is True:
+                return vrf
+        return None
+
+    def ensure_inband_mgmt_vrf(
+        self: SharedUtilsProtocol,
+        filtered_tenants: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServices,
+        all_vlans: set[int],
+    ) -> None:
+        """For devices where a child device requires its inband management VLAN to be configured, add a SVI."""
+        if not (self.inband_management_parent_vlans or self.configure_inband_mgmt or self.configure_inband_mgmt_ipv6):
+            return
+
+        # First, look for any mgmt VRF defined in networks services named the same as inband_mgmt_vrf
+        mgmt_inband_tuple: (
+            tuple[
+                EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem,
+                EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem,
+            ]
+            | tuple[None, None]
+        ) = next(((vrf, tenant) for tenant in filtered_tenants for vrf in tenant.vrfs if self.node_config.inband_mgmt_vrf == vrf.name), (None, None))
+        # Looks like pyright is limited on this one... and does not understand properly if mgmt_inband_tuple != (None, None):
+        mgmt_inband_vrf, mgmt_inband_tenant = mgmt_inband_tuple
+        if mgmt_inband_vrf is not None and mgmt_inband_tenant is not None:
+            mgmt_inband_vrf._internal_data.inband_mgmt = True
+            mgmt_inband_tenant._internal_data.inband_mgmt = True
+            self.inject_management_vlans(mgmt_inband_vrf, all_vlans)
+        # Using obtain to avoid name clash.
+        mgmt_inband_tenant = filtered_tenants.obtain("inband_mgmt")
+        mgmt_inband_tenant._internal_data.inband_mgmt = True
+        mgmt_inband_vrf = mgmt_inband_tenant.vrfs.append_new(
+            name=self.inband_mgmt_vrf or "default",
+            vrf_id=666,
+            address_families=EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem.AddressFamilies(),
+        )
+        mgmt_inband_vrf._internal_data.inband_mgmt = True
+        self.inject_management_vlans(mgmt_inband_vrf, all_vlans)
+        filtered_tenants.append(mgmt_inband_tenant)
 
     def inject_management_vlans(
         self: SharedUtilsProtocol,
         vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem,
-        tenant: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem,
         all_vlans: set[int],
     ) -> None:
         """Return a tenant if any additional vlan has to be configured for inband management."""
-        if (self.configure_inband_mgmt or self.configure_inband_mgmt_ipv6) and self.node_config.inband_mgmt_vlan not in all_vlans:
-            _ = tenant.l2vlans.append_new(
-                id=self.node_config.inband_mgmt_vlan,
-                name=self.node_config.inband_mgmt_vlan_name,
-            )
-
+        if not self.inband_management_parent_vlans:
+            return
         for vlan, subnet in self.inband_management_parent_vlans.items():
             if vlan not in all_vlans:
                 svi = vrf.svis.append_new(
@@ -158,6 +152,44 @@ class FilteredTenantsMixin(Protocol):
                     if self.underlay_routing_protocol == "ebgp":
                         svi.ipv6_attached_host_route_export._update(enabled=True, distance=19)
                 all_vlans.add(vlan)
+
+    def ensure_defaut_vrf_for_wan(self: SharedUtilsProtocol, filtered_tenants: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServices) -> None:
+        """
+        Ensure the VRF default is present in filtered tenants for WAN routers.
+
+        If not present, add it.
+        If present, make sure no incompatible configuration exists on the VRF:
+            * underlay_filter_peer_as
+
+        Raises:
+            AristaAvdError
+                If incompatible configuration is found.
+        """
+        no_vrf_default = all("default" not in tenant.vrfs for tenant in filtered_tenants)
+        if self.is_wan_router and no_vrf_default:
+            filtered_tenants.append(
+                EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem(
+                    name="WAN_DEFAULT",
+                    vrfs=EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.Vrfs(
+                        [
+                            EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem(
+                                name="default",
+                                vrf_id=1,
+                            )
+                        ]
+                    ),
+                )
+            )
+        elif self.is_wan_router:
+            # It is enough to check only the first occurrence of default VRF as some other piece of code
+            # checks that if the VRF is in multiple tenants, the configuration is consistent.
+            for tenant in filtered_tenants:
+                if "default" not in tenant.vrfs:
+                    continue
+                if self.inputs.underlay_filter_peer_as:
+                    msg = "WAN configuration is not compatible with 'underlay_filter_peer_as'"
+                    raise AristaAvdError(msg)
+                break
 
     def filtered_l2vlans(
         self: SharedUtilsProtocol, tenant: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem

--- a/python-avd/pyavd/_eos_designs/shared_utils/inband_management.py
+++ b/python-avd/pyavd/_eos_designs/shared_utils/inband_management.py
@@ -156,13 +156,14 @@ class InbandManagementMixin(Protocol):
         return None
 
     @cached_property
-    def inband_management_parent_vlans(self: SharedUtilsProtocol) -> dict:
+    def inband_management_parent_vlans(self: SharedUtilsProtocol) -> dict[int, dict[str, str | None]]:
+        """List of SVIs to configure on this switch to be allow downlink switches management VLANs."""
         if not self.underlay_router:
             return {}
 
         svis = {}
-        subnets = []
-        ipv6_subnets = []
+        subnets: list[str] = []
+        ipv6_subnets: list[str] = []
         for peer in self.switch_facts.downlink_switches:
             peer_facts = self.get_peer_facts(peer)
             if (vlan := peer_facts.inband_mgmt_vlan) is None:
@@ -173,11 +174,11 @@ class InbandManagementMixin(Protocol):
             if vlan not in svis:
                 svis[vlan] = {"ipv4": None, "ipv6": None}
 
-            if subnet not in subnets:
+            if subnet is not None and subnet not in subnets:
                 subnets.append(subnet)
                 svis[vlan]["ipv4"] = subnet
 
-            if ipv6_subnet not in ipv6_subnets:
+            if ipv6_subnet is not None and ipv6_subnet not in ipv6_subnets:
                 ipv6_subnets.append(ipv6_subnet)
                 svis[vlan]["ipv6"] = ipv6_subnet
 

--- a/python-avd/pyavd/_eos_designs/structured_config/inband_management/__init__.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/inband_management/__init__.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 
 from functools import cached_property
 from ipaddress import ip_network
-from typing import cast
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import StructuredConfigGenerator, structured_config_contributor
@@ -13,45 +12,6 @@ from pyavd._errors import AristaAvdInvalidInputsError
 
 
 class AvdStructuredConfigInbandManagement(StructuredConfigGenerator):
-    @structured_config_contributor
-    def vlans(self) -> None:
-        if not self.shared_utils.inband_management_parent_vlans and not (
-            self.shared_utils.configure_inband_mgmt or self.shared_utils.configure_inband_mgmt_ipv6
-        ):
-            return
-
-        if self.shared_utils.configure_inband_mgmt or self.shared_utils.configure_inband_mgmt_ipv6:
-            self.structured_config.vlans.append_new(
-                id=self.shared_utils.node_config.inband_mgmt_vlan, tenant="system", name=self.shared_utils.node_config.inband_mgmt_vlan_name
-            )
-            return
-        for svi in self.shared_utils.inband_management_parent_vlans:
-            self.structured_config.vlans.append_new(id=svi, tenant="system", name=self.shared_utils.node_config.inband_mgmt_vlan_name)
-
-    @structured_config_contributor
-    def vlan_interfaces(self) -> None:
-        """VLAN interfaces can be our own management interface and/or SVIs created on behalf of child switches using us as uplink_switch."""
-        if not self.shared_utils.inband_management_parent_vlans and not (
-            self.shared_utils.configure_inband_mgmt or self.shared_utils.configure_inband_mgmt_ipv6
-        ):
-            return
-
-        if self.shared_utils.configure_inband_mgmt or self.shared_utils.configure_inband_mgmt_ipv6:
-            self.structured_config.vlan_interfaces.append_new(
-                name=cast("str", self.shared_utils.inband_mgmt_interface),
-                description=self.shared_utils.node_config.inband_mgmt_description,
-                shutdown=False,
-                mtu=self.shared_utils.inband_mgmt_mtu,
-                vrf=self.shared_utils.inband_mgmt_vrf,
-                ip_address=self.shared_utils.inband_mgmt_ip,
-                ipv6_enable=None if not self.shared_utils.configure_inband_mgmt_ipv6 else True,
-                ipv6_address=self.shared_utils.inband_mgmt_ipv6_address,
-                metadata=EosCliConfigGen.VlanInterfacesItem.Metadata(type="inband_mgmt"),
-            )
-            return
-        for vlan, subnet in self.shared_utils.inband_management_parent_vlans.items():
-            self.structured_config.vlan_interfaces.append(self.get_parent_svi_cfg(vlan, subnet["ipv4"], subnet["ipv6"]))
-
     @cached_property
     def _inband_mgmt_ipv6_parent(self) -> bool:
         if self.shared_utils.inband_management_parent_vlans:
@@ -85,15 +45,6 @@ class AvdStructuredConfigInbandManagement(StructuredConfigGenerator):
         self.structured_config.ipv6_static_routes.append_new(
             prefix="::/0", next_hop=self.shared_utils.inband_mgmt_ipv6_gateway, vrf=self.shared_utils.inband_mgmt_vrf
         )
-
-    @structured_config_contributor
-    def vrfs(self) -> None:
-        if self.shared_utils.inband_mgmt_vrf is None:
-            return
-
-        if not self.shared_utils.inband_management_parent_vlans and not self.shared_utils.configure_inband_mgmt:
-            return
-        self.structured_config.vrfs.append_new(name=self.shared_utils.inband_mgmt_vrf)
 
     @structured_config_contributor
     def ip_virtual_router_mac_address(self) -> None:

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
@@ -32,7 +32,8 @@ class VlanInterfacesMixin(Protocol):
         Consist of svis and mlag peering vlans from filtered tenants
         """
         if not (self.shared_utils.network_services_l2 and self.shared_utils.network_services_l3):
-            self._set_l2_device_inband_mgmt_svi()
+            if not self.shared_utils.network_services_l3 and not self.shared_utils.underlay_router:
+                self._set_l2_device_inband_mgmt_svi()
             return
 
         for tenant in self.shared_utils.filtered_tenants:
@@ -67,18 +68,10 @@ class VlanInterfacesMixin(Protocol):
             )
             # TODO: this is not great we should do this someplace else
             vlan = self.structured_config.vlans.obtain(self.shared_utils.node_config.inband_mgmt_vlan)
+            # This works because it comes after network_services.
             vlan.name = self.shared_utils.node_config.inband_mgmt_vlan_name
-            # The following raises duplicate (as expected) when name is set
-            # But name must be set on the SVIs for other nodes so we need to override scenario on these
-            # devices.
-            # It could be done in filtered tenants but this looks weird.
-            # - self.structured_config.vlans.append(
-            # -    EosCliConfigGen.VlansItem(
-            # -        id=self.shared_utils.node_config.inband_mgmt_vlan,
-            # -        name=self.shared_utils.node_config.inband_mgmt_vlan_name,
-            # -    ),
-            # -    ignore_fields=("tenant",),
-            # -)
+            if self.shared_utils.filtered_inband_mgmt_tenant is not None:
+                vlan.tenant = self.shared_utils.filtered_inband_mgmt_tenant.name
 
     def _check_virtual_router_mac_address(self: AvdStructuredConfigNetworkServicesProtocol, variable: str) -> None:
         """Raise if virtual router mac address is required but missing, otherwise return None."""

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vlan_interfaces.py
@@ -3,7 +3,7 @@
 # that can be found in the LICENSE file.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, cast
 
 from pyavd._eos_cli_config_gen.schema import EosCliConfigGen
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
@@ -32,6 +32,7 @@ class VlanInterfacesMixin(Protocol):
         Consist of svis and mlag peering vlans from filtered tenants
         """
         if not (self.shared_utils.network_services_l2 and self.shared_utils.network_services_l3):
+            self._set_l2_device_inband_mgmt_svi()
             return
 
         for tenant in self.shared_utils.filtered_tenants:
@@ -45,6 +46,39 @@ class VlanInterfacesMixin(Protocol):
                     continue
 
                 self.structured_config.vlan_interfaces.append(self._get_vlan_interface_config_for_mlag_peering(vrf, tenant, vlan_id), ignore_fields=("tenant",))
+
+    def _set_l2_device_inband_mgmt_svi(self: AvdStructuredConfigNetworkServicesProtocol) -> None:
+        """
+        On devices without l2 or l3 services, there may be the inband mgmt svi to configure.
+
+        For other devices the SVI is injected in the filtered tenants by AVD.
+        """
+        if self.shared_utils.configure_inband_mgmt or self.shared_utils.configure_inband_mgmt_ipv6:
+            _ = self.structured_config.vlan_interfaces.append_new(
+                name=cast("str", self.shared_utils.inband_mgmt_interface),
+                description=self.shared_utils.node_config.inband_mgmt_description,
+                shutdown=False,
+                mtu=self.shared_utils.inband_mgmt_mtu,
+                vrf=self.shared_utils.inband_mgmt_vrf,
+                ip_address=self.shared_utils.inband_mgmt_ip,
+                ipv6_enable=None if not self.shared_utils.configure_inband_mgmt_ipv6 else True,
+                ipv6_address=self.shared_utils.inband_mgmt_ipv6_address,
+                metadata=EosCliConfigGen.VlanInterfacesItem.Metadata(type="inband_mgmt", tenant="inband_mgmt"),
+            )
+            # TODO: this is not great we should do this someplace else
+            vlan = self.structured_config.vlans.obtain(self.shared_utils.node_config.inband_mgmt_vlan)
+            vlan.name = self.shared_utils.node_config.inband_mgmt_vlan_name
+            # The following raises duplicate (as expected) when name is set
+            # But name must be set on the SVIs for other nodes so we need to override scenario on these
+            # devices.
+            # It could be done in filtered tenants but this looks weird.
+            # - self.structured_config.vlans.append(
+            # -    EosCliConfigGen.VlansItem(
+            # -        id=self.shared_utils.node_config.inband_mgmt_vlan,
+            # -        name=self.shared_utils.node_config.inband_mgmt_vlan_name,
+            # -    ),
+            # -    ignore_fields=("tenant",),
+            # -)
 
     def _check_virtual_router_mac_address(self: AvdStructuredConfigNetworkServicesProtocol, variable: str) -> None:
         """Raise if virtual router mac address is required but missing, otherwise return None."""
@@ -72,6 +106,8 @@ class VlanInterfacesMixin(Protocol):
             ip_address_secondaries=EosCliConfigGen.VlanInterfacesItem.IpAddressSecondaries(svi.ip_address_secondaries),
             ipv6_address=svi.ipv6_address,
             ipv6_enable=svi.ipv6_enable,
+            ip_attached_host_route_export=svi.ip_attached_host_route_export,
+            ipv6_attached_host_route_export=svi.ipv6_attached_host_route_export,
             arp_gratuitous_accept=svi.arp_gratuitous_accept,
             mtu=self.shared_utils.get_interface_mtu(interface_name, svi.mtu),
             eos_cli=svi.raw_eos_cli,

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vrfs.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vrfs.py
@@ -61,11 +61,11 @@ class VrfsMixin(Protocol):
         For other devices the VRF is injected in the filtered tenants by AVD.
         """
         if (self.shared_utils.configure_inband_mgmt or self.shared_utils.configure_inband_mgmt_ipv6) and (
-            vrf := self.shared_utils.filtered_mgmt_inband_vrf
+            vrf := self.shared_utils.filtered_inband_mgmt_vrf
         ) is not None:
             if vrf.name == "default":
                 return
-            tenant_name = self.shared_utils.filtered_mgmt_inband_tenant.name if self.shared_utils.filtered_mgmt_inband_tenant is not None else "inband_mgmt"
+            tenant_name = self.shared_utils.filtered_inband_mgmt_tenant.name if self.shared_utils.filtered_inband_mgmt_tenant is not None else "inband_mgmt"
             new_vrf = EosCliConfigGen.VrfsItem(name=vrf.name, tenant=tenant_name)
             if vrf.description:
                 new_vrf.description = vrf.description

--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/vrfs.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/vrfs.py
@@ -32,6 +32,7 @@ class VrfsMixin(Protocol):
         all Tenants deployed on this device.
         """
         if not self.shared_utils.network_services_l3:
+            self._set_l2_device_inband_mgmt_vrf()
             return
 
         for tenant in self.shared_utils.filtered_tenants:
@@ -44,8 +45,7 @@ class VrfsMixin(Protocol):
                 # MLAG IBGP Peering VLANs per VRF
                 if self.inputs.overlay_mlag_rfc5549 and self._mlag_ibgp_peering_enabled(vrf, tenant):
                     new_vrf._update(ip_routing_ipv6_interfaces=True, ipv6_routing=True)
-                else:
-                    new_vrf.ip_routing = True
+                new_vrf.ip_routing = True
 
                 if self._has_ipv6(vrf):
                     new_vrf.ipv6_routing = True
@@ -53,6 +53,23 @@ class VrfsMixin(Protocol):
                 if vrf.description:
                     new_vrf.description = vrf.description
                 self.structured_config.vrfs.append(new_vrf, ignore_fields=("tenant",))
+
+    def _set_l2_device_inband_mgmt_vrf(self: AvdStructuredConfigNetworkServicesProtocol) -> None:
+        """
+        On devices without l3 services, there may be the inband mgmt VRF to configure.
+
+        For other devices the VRF is injected in the filtered tenants by AVD.
+        """
+        if (self.shared_utils.configure_inband_mgmt or self.shared_utils.configure_inband_mgmt_ipv6) and (
+            vrf := self.shared_utils.filtered_mgmt_inband_vrf
+        ) is not None:
+            if vrf.name == "default":
+                return
+            tenant_name = self.shared_utils.filtered_mgmt_inband_tenant.name if self.shared_utils.filtered_mgmt_inband_tenant is not None else "inband_mgmt"
+            new_vrf = EosCliConfigGen.VrfsItem(name=vrf.name, tenant=tenant_name)
+            if vrf.description:
+                new_vrf.description = vrf.description
+            self.structured_config.vrfs.append(new_vrf, ignore_fields=("metadata",))
 
     def _has_ipv6(
         self: AvdStructuredConfigNetworkServicesProtocol, vrf: EosDesigns._DynamicKeys.DynamicNetworkServicesItem.NetworkServicesItem.VrfsItem

--- a/python-avd/pyavd/_schema/models/avd_base.py
+++ b/python-avd/pyavd/_schema/models/avd_base.py
@@ -23,6 +23,7 @@ class InternalData:
         "evpn_l3_multicast_enabled",
         "evpn_l3_multicast_evpn_peg_transit",
         "evpn_l3_multicast_group_ip",
+        "inband_mgmt",
         "interface",
         "interfaces",
         "pim_rp_addresses",
@@ -35,6 +36,7 @@ class InternalData:
     evpn_l3_multicast_enabled: bool | None
     evpn_l3_multicast_evpn_peg_transit: bool | None
     evpn_l3_multicast_group_ip: str | None
+    inband_mgmt: bool | None
     interface: str
     interfaces: list
     pim_rp_addresses: list[dict]


### PR DESCRIPTION
## Change Summary

Preparation of #5981 - refactor how inband_mgmt vlan, vlan interface and vrf are being generated.

TODO: explore statuc routes

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

* inject the SVIs/L2VLANS/VRFS/tenants in filtered tenants where needed for parent vlans
* move generation of structured config to network_services

## How to test

* molecule should pass

## Checklist

### User Checklist

Two changes to discuss
- [ ] one I believe is a fix as the VRF was not generated earlier
- [ ] the second one is adding some MLAG config that requires investigation

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
