### PR TITLE
Fix(eos_cli_config_gen): Address wrong config order for SNMP Engine ID and remote users

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -2302,6 +2302,8 @@ mcs client
 | local | 424242424242424242 | - | - |
 | remote | 6172697374615F6970 | 1.1.1.1 | - |
 | remote | DEADBEEFCAFE123456 | 2.2.2.2 | 1337 |
+| remote | 424242424242DEAD | 42.42.42.42 | - |
+| remote | 424242424242DEAD6666 | 42.42.42.42 | 666 |
 
 #### SNMP ACLs
 
@@ -2396,9 +2398,6 @@ snmp-server community <removed> view VW-READ rw ipv6 SNMP-MGMT SNMP-MGMT
 snmp-server community <removed> ro
 snmp-server group GRP-READ-ONLY v3 priv read v3read
 snmp-server group GRP-READ-WRITE v3 auth read v3read write v3write
-snmp-server user REMOTE-USER-IP-LOCALIZED GRP-REMOTE remote 42.42.42.42 v3 localized DEADBEEFCAFE123456 auth sha <removed>
-snmp-server user REMOTE-USER-IP-ONLY GRP-REMOTE remote 42.42.42.42 v3
-snmp-server user REMOTE-USER-IP-PORT GRP-REMOTE remote 42.42.42.42 udp-port 666 v3
 snmp-server user USER-READ-AUTH-NO-PRIV GRP-READ-ONLY v3 auth sha <removed>
 snmp-server user USER-READ-AUTH-NO-PRIV-LOC GRP-READ-ONLY v3 localized 424242424242424242 auth sha <removed>
 snmp-server user USER-READ-AUTH-PRIV GRP-READ-ONLY v3 auth sha <removed> priv aes <removed>
@@ -2408,12 +2407,17 @@ snmp-server user USER-READ-NO-AUTH-NO-PRIV-LOC GRP-READ-ONLY v3
 snmp-server user USER-WRITE GRP-READ-WRITE v3 auth sha <removed> priv aes <removed>
 snmp-server engineID remote 1.1.1.1 6172697374615F6970
 snmp-server engineID remote 2.2.2.2 udp-port 1337 DEADBEEFCAFE123456
-snmp-server host 10.6.75.99 vrf MGMT version 3 auth USER-READ-AUTH-NO-PRIV
-snmp-server host 10.6.75.99 vrf MGMT version 3 auth USER-WRITE
+snmp-server engineID remote 42.42.42.42 424242424242DEAD
+snmp-server engineID remote 42.42.42.42 udp-port 666 424242424242DEAD6666
+snmp-server user REMOTE-USER-IP-LOCALIZED GRP-REMOTE remote 42.42.42.42 v3 localized DEADBEEFCAFE123456 auth sha <removed>
+snmp-server user REMOTE-USER-IP-ONLY GRP-REMOTE remote 42.42.42.42 v3
+snmp-server user REMOTE-USER-IP-PORT GRP-REMOTE remote 42.42.42.42 udp-port 666 v3
 snmp-server host 10.6.75.100 vrf MGMT version 3 priv USER-READ-AUTH-PRIV
 snmp-server host 10.6.75.121 vrf MGMT version 1 <removed>
 snmp-server host 10.6.75.121 vrf MGMT version 2c <removed>
 snmp-server host 10.6.75.122 vrf MGMT version 2c <removed>
+snmp-server host 10.6.75.99 vrf MGMT version 3 auth USER-READ-AUTH-NO-PRIV
+snmp-server host 10.6.75.99 vrf MGMT version 3 auth USER-WRITE
 snmp-server enable traps
 snmp-server enable traps bgp
 no snmp-server enable traps bgp arista-backward-transition

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1273,9 +1273,6 @@ snmp-server community SNMP-COMMUNITY-2 view VW-READ rw ipv6 SNMP-MGMT SNMP-MGMT
 snmp-server community SNMP-COMMUNITY-3 ro
 snmp-server group GRP-READ-ONLY v3 priv read v3read
 snmp-server group GRP-READ-WRITE v3 auth read v3read write v3write
-snmp-server user REMOTE-USER-IP-LOCALIZED GRP-REMOTE remote 42.42.42.42 v3 localized DEADBEEFCAFE123456 auth sha DEADBEEFCAFE123456ABC1234321AB1233456778
-snmp-server user REMOTE-USER-IP-ONLY GRP-REMOTE remote 42.42.42.42 v3
-snmp-server user REMOTE-USER-IP-PORT GRP-REMOTE remote 42.42.42.42 udp-port 666 v3
 snmp-server user USER-READ-AUTH-NO-PRIV GRP-READ-ONLY v3 auth sha clearPassword
 snmp-server user USER-READ-AUTH-NO-PRIV-LOC GRP-READ-ONLY v3 localized 424242424242424242 auth sha 8da526cd35b9ea9b42d819036f7fad058576ea0a
 snmp-server user USER-READ-AUTH-PRIV GRP-READ-ONLY v3 auth sha clearPassword priv aes clearPassword
@@ -1285,12 +1282,17 @@ snmp-server user USER-READ-NO-AUTH-NO-PRIV-LOC GRP-READ-ONLY v3
 snmp-server user USER-WRITE GRP-READ-WRITE v3 auth sha clearPassword priv aes clearPassword
 snmp-server engineID remote 1.1.1.1 6172697374615F6970
 snmp-server engineID remote 2.2.2.2 udp-port 1337 DEADBEEFCAFE123456
-snmp-server host 10.6.75.99 vrf MGMT version 3 auth USER-READ-AUTH-NO-PRIV
-snmp-server host 10.6.75.99 vrf MGMT version 3 auth USER-WRITE
+snmp-server engineID remote 42.42.42.42 424242424242DEAD
+snmp-server engineID remote 42.42.42.42 udp-port 666 424242424242DEAD6666
+snmp-server user REMOTE-USER-IP-LOCALIZED GRP-REMOTE remote 42.42.42.42 v3 localized DEADBEEFCAFE123456 auth sha DEADBEEFCAFE123456ABC1234321AB1233456778
+snmp-server user REMOTE-USER-IP-ONLY GRP-REMOTE remote 42.42.42.42 v3
+snmp-server user REMOTE-USER-IP-PORT GRP-REMOTE remote 42.42.42.42 udp-port 666 v3
 snmp-server host 10.6.75.100 vrf MGMT version 3 priv USER-READ-AUTH-PRIV
 snmp-server host 10.6.75.121 vrf MGMT version 1 SNMP-COMMUNITY-1
 snmp-server host 10.6.75.121 vrf MGMT version 2c SNMP-COMMUNITY-2
 snmp-server host 10.6.75.122 vrf MGMT version 2c SNMP-COMMUNITY-2
+snmp-server host 10.6.75.99 vrf MGMT version 3 auth USER-READ-AUTH-NO-PRIV
+snmp-server host 10.6.75.99 vrf MGMT version 3 auth USER-WRITE
 snmp-server enable traps
 snmp-server enable traps bgp
 no snmp-server enable traps bgp arista-backward-transition

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/snmp-server.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/snmp-server.yml
@@ -11,6 +11,12 @@ snmp_server:
       - id: DEADBEEFCAFE123456
         address: 2.2.2.2
         udp_port: 1337
+      # These next two are needed to configure non localized remote users defined below
+      - id: 424242424242DEAD
+        address: 42.42.42.42
+      - id: 424242424242DEAD6666
+        address: 42.42.42.42
+        udp_port: 666
   contact: DC1_OPS
   location: DC1
   communities:

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/snmp-server.md
@@ -48,7 +48,7 @@
     | [<samp>&nbsp;&nbsp;users</samp>](## "snmp_server.users") | List, items: Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;-&nbsp;name</samp>](## "snmp_server.users.[].name") | String |  |  |  | Username. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;group</samp>](## "snmp_server.users.[].group") | String |  |  |  | Group name. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_address</samp>](## "snmp_server.users.[].remote_address") | String |  |  |  | Hostname or ip of remote engine.<br>The remote_address and udp_port are used for remote users.<br> |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;remote_address</samp>](## "snmp_server.users.[].remote_address") | String |  |  |  | Hostname or ip of remote engine.<br>The remote_address and udp_port are used for remote users.<br>A `snmp_server.engine_ids.remotes` entry with a matching address is required when this is set<br>and `localized` is not set.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;udp_port</samp>](## "snmp_server.users.[].udp_port") | Integer |  |  |  | udp_port will not be used if no remote_address is configured.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;version</samp>](## "snmp_server.users.[].version") | String |  |  | Valid Values:<br>- <code>v1</code><br>- <code>v2c</code><br>- <code>v3</code> |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;localized</samp>](## "snmp_server.users.[].localized") | String |  |  |  | Engine ID in hexadecimal for localizing auth and/or priv.<br> |
@@ -157,6 +157,8 @@
 
           # Hostname or ip of remote engine.
           # The remote_address and udp_port are used for remote users.
+          # A `snmp_server.engine_ids.remotes` entry with a matching address is required when this is set
+          # and `localized` is not set.
           remote_address: <str>
 
           # udp_port will not be used if no remote_address is configured.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/snmp-server.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/snmp-server.j2
@@ -104,72 +104,92 @@ snmp-server location {{ snmp_server.location }}
 {{ group_cli }}
 {%         endfor %}
 {%     endif %}
-{%     if snmp_server.users is arista.avd.defined %}
-{%         for user in snmp_server.users | arista.avd.natural_sort('name') %}
-{%             if user.name is arista.avd.defined %}
-{%                 set user_cli = "snmp-server user " ~ user.name %}
+{# First render local users #}
+{%     for user in snmp_server.users | arista.avd.natural_sort('name') | rejectattr("remote_address", "arista.avd.defined") %}
+{%         if user.name is arista.avd.defined %}
+{%             set user_cli = "snmp-server user " ~ user.name %}
+{%         endif %}
+{%         if user.group is arista.avd.defined %}
+{%             set user_cli = user_cli ~ " " ~ user.group %}
+{%         endif %}
+{%         if user.version is arista.avd.defined %}
+{%             set user_cli = user_cli ~ " " ~ user.version %}
+{%         endif %}
+{%         if user.auth is arista.avd.defined
+              and user.version is arista.avd.defined('v3')
+              and user.auth_passphrase is arista.avd.defined %}
+{%             if user.localized is arista.avd.defined %}
+{%                 set user_cli = user_cli ~ " localized " ~ user.localized %}
 {%             endif %}
-{%             if user.group is arista.avd.defined %}
-{%                 set user_cli = user_cli ~ " " ~ user.group %}
+{%             set user_cli = user_cli ~ " auth " ~ user.auth ~ " " ~ user.auth_passphrase | arista.avd.hide_passwords(hide_passwords) %}
+{%             if user.priv is arista.avd.defined
+                  and user.priv_passphrase is arista.avd.defined %}
+{%                 set user_cli = user_cli ~ " priv " ~ user.priv ~ " " ~ user.priv_passphrase | arista.avd.hide_passwords(hide_passwords) %}
 {%             endif %}
-{%             if user.remote_address is arista.avd.defined and user.version is arista.avd.defined('v3') %}
-{%                 set user_cli = user_cli ~ " remote " ~ user.remote_address %}
-{%                 if user.udp_port is arista.avd.defined %}
-{%                     set user_cli = user_cli ~ " udp-port " ~ user.udp_port %}
-{%                 endif %}
-{%             endif %}
-{%             if user.version is arista.avd.defined %}
-{%                 set user_cli = user_cli ~ " " ~ user.version %}
-{%             endif %}
-{%             if user.auth is arista.avd.defined
-                  and user.version is arista.avd.defined('v3')
-                  and user.auth_passphrase is arista.avd.defined %}
-{%                 if user.localized is arista.avd.defined %}
-{%                     set user_cli = user_cli ~ " localized " ~ user.localized %}
-{%                 endif %}
-{%                 set user_cli = user_cli ~ " auth " ~ user.auth ~ " " ~ user.auth_passphrase | arista.avd.hide_passwords(hide_passwords) %}
-{%                 if user.priv is arista.avd.defined
-                      and user.priv_passphrase is arista.avd.defined %}
-{%                     set user_cli = user_cli ~ " priv " ~ user.priv ~ " " ~ user.priv_passphrase | arista.avd.hide_passwords(hide_passwords) %}
-{%                 endif %}
-{%             endif %}
+{%         endif %}
 {{ user_cli }}
-{%         endfor %}
-{%     endif %}
-{%     if snmp_server.engine_ids.remotes is arista.avd.defined %}
-{%         for engine_id in snmp_server.engine_ids.remotes | arista.avd.natural_sort('address') %}
-{%             if engine_id.id is arista.avd.defined and engine_id.address is arista.avd.defined %}
-{%                 set remote_engine_ids_cli =  "snmp-server engineID remote " ~ engine_id.address %}
-{%                 if engine_id.udp_port is arista.avd.defined %}
-{%                     set remote_engine_ids_cli =  remote_engine_ids_cli ~ " udp-port " ~  engine_id.udp_port %}
-{%                 endif %}
-{%                 set remote_engine_ids_cli = remote_engine_ids_cli ~ " " ~ engine_id.id %}
+{%     endfor %}
+{%     for engine_id in snmp_server.engine_ids.remotes | arista.avd.natural_sort('address') %}
+{%         if engine_id.id is arista.avd.defined and engine_id.address is arista.avd.defined %}
+{%             set remote_engine_ids_cli =  "snmp-server engineID remote " ~ engine_id.address %}
+{%             if engine_id.udp_port is arista.avd.defined %}
+{%                 set remote_engine_ids_cli =  remote_engine_ids_cli ~ " udp-port " ~  engine_id.udp_port %}
+{%             endif %}
+{%             set remote_engine_ids_cli = remote_engine_ids_cli ~ " " ~ engine_id.id %}
 {{ remote_engine_ids_cli }}
+{%         endif %}
+{%     endfor %}
+{# Then render remote users #}
+{%     for user in snmp_server.users | arista.avd.natural_sort('name') | selectattr("remote_address", "arista.avd.defined") %}
+{%         if user.name is arista.avd.defined %}
+{%             set user_cli = "snmp-server user " ~ user.name %}
+{%         endif %}
+{%         if user.group is arista.avd.defined %}
+{%             set user_cli = user_cli ~ " " ~ user.group %}
+{%         endif %}
+{%         if user.remote_address is arista.avd.defined and user.version is arista.avd.defined('v3') %}
+{%             set user_cli = user_cli ~ " remote " ~ user.remote_address %}
+{%             if user.udp_port is arista.avd.defined %}
+{%                 set user_cli = user_cli ~ " udp-port " ~ user.udp_port %}
 {%             endif %}
-{%         endfor %}
-{%     endif %}
-{%     if snmp_server.hosts is arista.avd.defined %}
-{%         for host in snmp_server.hosts | arista.avd.natural_sort('host') %}
-{%             if host.host is arista.avd.defined %}
-{%                 set host_cli = "snmp-server host " ~ host.host %}
-{%                 if host.vrf is arista.avd.defined %}
-{%                     set host_cli = host_cli ~ " vrf " ~ host.vrf %}
-{%                 endif %}
-{%                 if host.users is arista.avd.defined
-                      and host.version | arista.avd.default('3') | string == '3' %}
-{%                     for user in host.users %}
-{%                         if user.username is arista.avd.defined
-                              and user.authentication_level is arista.avd.defined %}
+{%         endif %}
+{%         if user.version is arista.avd.defined %}
+{%             set user_cli = user_cli ~ " " ~ user.version %}
+{%         endif %}
+{%         if user.auth is arista.avd.defined
+              and user.version is arista.avd.defined('v3')
+              and user.auth_passphrase is arista.avd.defined %}
+{%             if user.localized is arista.avd.defined %}
+{%                 set user_cli = user_cli ~ " localized " ~ user.localized %}
+{%             endif %}
+{%             set user_cli = user_cli ~ " auth " ~ user.auth ~ " " ~ user.auth_passphrase | arista.avd.hide_passwords(hide_passwords) %}
+{%             if user.priv is arista.avd.defined
+                  and user.priv_passphrase is arista.avd.defined %}
+{%                 set user_cli = user_cli ~ " priv " ~ user.priv ~ " " ~ user.priv_passphrase | arista.avd.hide_passwords(hide_passwords) %}
+{%             endif %}
+{%         endif %}
+{{ user_cli }}
+{%     endfor %}
+{%     for host in snmp_server.hosts | arista.avd.default([]) | sort(attribute='host') %}
+{%         if host.host is arista.avd.defined %}
+{%             set host_cli = "snmp-server host " ~ host.host %}
+{%             if host.vrf is arista.avd.defined %}
+{%                 set host_cli = host_cli ~ " vrf " ~ host.vrf %}
+{%             endif %}
+{%             if host.users is arista.avd.defined
+                  and host.version | arista.avd.default('3') | string == '3' %}
+{%                 for user in host.users %}
+{%                     if user.username is arista.avd.defined
+                          and user.authentication_level is arista.avd.defined %}
 {{ host_cli }} version 3 {{ user.authentication_level }} {{ user.username }}
-{%                         endif %}
-{%                     endfor %}
-{%                 elif host.community is arista.avd.defined
-                        and host.version | arista.avd.default('2c') | string in ['1', '2c'] %}
+{%                     endif %}
+{%                 endfor %}
+{%             elif host.community is arista.avd.defined
+                    and host.version | arista.avd.default('2c') | string in ['1', '2c'] %}
 {{ host_cli }} version {{ host.version | arista.avd.default('2c') }} {{ host.community | arista.avd.hide_passwords(hide_passwords) }}
-{%                 endif %}
 {%             endif %}
-{%         endfor %}
-{%     endif %}
+{%         endif %}
+{%     endfor %}
 {%     if snmp_server.traps.enable is arista.avd.defined(true) %}
 snmp-server enable traps
 {%     elif snmp_server.traps.enable is arista.avd.defined(false) %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -62355,6 +62355,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             """
             Hostname or ip of remote engine.
             The remote_address and udp_port are used for remote users.
+            A
+            `snmp_server.engine_ids.remotes` entry with a matching address is required when this is set
+            and
+            `localized` is not set.
             """
             udp_port: int | None
             """udp_port will not be used if no remote_address is configured."""
@@ -62398,6 +62402,10 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         remote_address:
                            Hostname or ip of remote engine.
                            The remote_address and udp_port are used for remote users.
+                           A
+                           `snmp_server.engine_ids.remotes` entry with a matching address is required when this is set
+                           and
+                           `localized` is not set.
                         udp_port: udp_port will not be used if no remote_address is configured.
                         version: version
                         localized: Engine ID in hexadecimal for localizing auth and/or priv.

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -23419,6 +23419,11 @@ keys:
 
                 The remote_address and udp_port are used for remote users.
 
+                A `snmp_server.engine_ids.remotes` entry with a matching address is
+                required when this is set
+
+                and `localized` is not set.
+
                 '
             udp_port:
               type: int

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/snmp_server.schema.yml
@@ -1,4 +1,5 @@
-# Copyright (c) 2023-2024 Arista Networks, Inc.
+---
+# Copyright (c) 2023-2025 Arista Networks, Inc.
 # Use of this source code is governed by the Apache License 2.0
 # that can be found in the LICENSE file.
 # yaml-language-server: $schema=../../../_schema/avd_meta_schema.json
@@ -19,6 +20,7 @@ keys:
               - int
             description: |
               Engine ID in hexadecimal.
+          # TODO: AVD 6.0 - make the address required and maybe primary_key
           remotes:
             type: list
             items:
@@ -149,14 +151,18 @@ keys:
             notify:
               type: str
               description: Notify view.
+      # TODO: AVD 6.0, consider separating local and remote users in model.
       users:
         type: list
         items:
           type: dict
           keys:
+            # TODO: AVD 6.0, make this required.
+            # Cannot make it primary key because same user group can be defined with different version
             name:
               type: str
               description: Username.
+            # TODO: AVD 6.0, make group required
             group:
               type: str
               description: Group name.
@@ -165,12 +171,15 @@ keys:
               description: |
                 Hostname or ip of remote engine.
                 The remote_address and udp_port are used for remote users.
+                A `snmp_server.engine_ids.remotes` entry with a matching address is required when this is set
+                and `localized` is not set.
             udp_port:
               type: int
               convert_types:
                 - str
               description: |
                 udp_port will not be used if no remote_address is configured.
+            # TODO: AVD 6.0, make version required
             version:
               type: str
               valid_values: ["v1", "v2c", "v3"]


### PR DESCRIPTION
Cherry-pick of #6042
