### PR TITLE
CI(pyavd-utils): Fix pyright warnings

### DIFF
--- a/.github/workflows/pull-request-management.yml
+++ b/.github/workflows/pull-request-management.yml
@@ -145,8 +145,9 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: Install pyavd and Ansible requirements
+        # Adding pyavd-utils as editable to force a build of the .so files. The pyavd-utils is already added to the python path in the pyright config.
         run: |
-          pip install -r ansible_collections/arista/avd/requirements-dev.txt --upgrade
+          pip install -r ansible_collections/arista/avd/requirements-dev.txt -e pyavd-utils/ --upgrade
       - name: PyRight static type checker
         # Specific SHA as allowed by github org admins
         uses: jakebailey/pyright-action@6cabc0f01c4994be48fd45cd9dbacdd6e1ee6e5e

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,6 +145,7 @@ extraPaths = [
   "python-avd",
   "pyavd-utils"
 ]
+reportMissingImports = "error"
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,7 @@ exclude = [
   "python-avd/pyavd/_eos_designs/eos_designs_facts/schema/protocol.py",
   "python-avd/pyavd/_eos_designs/j2templates/compiled_templates",
   "python-avd/pyavd/_eos_designs/schema/__init__.py",
+  ".tox",
 ]
 pythonVersion = "3.10"
 # This is to direct pyright where to look for schema_tools


### PR DESCRIPTION
- Fix pyright warnings caused by missing .so files for python-utils
- Elevate such warnings to errors so it blocks the CI
- ignore .tox in pyright - only relevant for local use where running tox first can trigger lots of errors from other libraries installed inside the tox venvs.