### PR TITLE
CI: Fix sonar coverage after moving .coverage to root

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -41,8 +41,7 @@ sonar.python.version=\
     3.13
 
 sonar.python.coverage.reportPaths=\
-    python-avd/coverage.xml,\
-    pyavd-utils/coverage.xml,\
+    coverage.xml,\
     ansible_collections/arista/avd/*coverage.xml
 
 sonar.coverage.exclusions=\


### PR DESCRIPTION
Fix sonar coverage after moving .coverage to root