### PR TITLE
Feat(eos_cli_config_gen): Add support for IP locking disablement on Port-channels

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -5948,6 +5948,10 @@ interface Port-Channel3
    switchport trunk group MLAG
    switchport
    no snmp trap link-change
+   !
+   address locking
+      address-family ipv4
+      address-family ipv6
    shape rate 200000 kbps
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2 rx-disabled
@@ -5961,6 +5965,7 @@ interface Port-Channel5
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
+   address locking ipv4
    ip verify unicast source reachable-via rx
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
@@ -6033,6 +6038,10 @@ interface Port-Channel10
    evpn ethernet-segment
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
+   !
+   address locking
+      address-family ipv4 disabled
+      address-family ipv6 disabled
    shape rate 50 percent
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
@@ -6086,6 +6095,7 @@ interface Port-Channel15
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
+   address locking ipv4 ipv6
    arp gratuitous accept
    mlag 15
    no ntp serve
@@ -6108,6 +6118,7 @@ interface Port-Channel16
    switchport
    switchport vlan translation out 23 dot1q-tunnel 22
    snmp trap link-change
+   address locking ipv6
    mlag 16
    switchport port-security violation protect log
    switchport port-security mac-address maximum 100
@@ -6151,6 +6162,11 @@ interface Port-Channel50
    evpn ethernet-segment
       identifier 0000:0000:0303:0202:0101
       route-target import 03:03:02:02:01:01
+   !
+   address locking
+      address-family ipv6
+      address-family ipv4 disabled
+      locked-address ipv4 enforcement disabled
    lacp system-id 0303.0202.0101
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -5948,10 +5948,6 @@ interface Port-Channel3
    switchport trunk group MLAG
    switchport
    no snmp trap link-change
-   !
-   address locking
-      address-family ipv4
-      address-family ipv6
    shape rate 200000 kbps
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2 rx-disabled
@@ -5965,7 +5961,9 @@ interface Port-Channel5
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
-   address locking ipv4
+   !
+   address locking
+      address-family ipv4 disabled
    ip verify unicast source reachable-via rx
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
@@ -6038,10 +6036,6 @@ interface Port-Channel10
    evpn ethernet-segment
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
-   !
-   address locking
-      address-family ipv4 disabled
-      address-family ipv6 disabled
    shape rate 50 percent
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
@@ -6095,7 +6089,6 @@ interface Port-Channel15
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
-   address locking ipv4 ipv6
    arp gratuitous accept
    mlag 15
    no ntp serve
@@ -6118,7 +6111,6 @@ interface Port-Channel16
    switchport
    switchport vlan translation out 23 dot1q-tunnel 22
    snmp trap link-change
-   address locking ipv6
    mlag 16
    switchport port-security violation protect log
    switchport port-security mac-address maximum 100
@@ -6162,11 +6154,6 @@ interface Port-Channel50
    evpn ethernet-segment
       identifier 0000:0000:0303:0202:0101
       route-target import 03:03:02:02:01:01
-   !
-   address locking
-      address-family ipv6
-      address-family ipv4 disabled
-      locked-address ipv4 enforcement disabled
    lacp system-id 0303.0202.0101
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -5961,9 +5961,6 @@ interface Port-Channel5
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
-   !
-   address locking
-      address-family ipv4 disabled
    ip verify unicast source reachable-via rx
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
@@ -5979,6 +5976,9 @@ interface Port-Channel5
    ip igmp host-proxy version 2
    l2 mtu 8000
    l2 mru 8000
+   !
+   address locking
+      address-family ipv4 disabled
    mlag 5
    ntp serve
    ip ospf authentication-key 8a <removed>

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1984,9 +1984,6 @@ interface Port-Channel5
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
-   !
-   address locking
-      address-family ipv4 disabled
    ip verify unicast source reachable-via rx
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
@@ -2002,6 +1999,9 @@ interface Port-Channel5
    ip igmp host-proxy version 2
    l2 mtu 8000
    l2 mru 8000
+   !
+   address locking
+      address-family ipv4 disabled
    mlag 5
    ntp serve
    ip ospf authentication-key 8a $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1971,6 +1971,10 @@ interface Port-Channel3
    switchport trunk group MLAG
    switchport
    no snmp trap link-change
+   !
+   address locking
+      address-family ipv4
+      address-family ipv6
    shape rate 200000 kbps
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2 rx-disabled
@@ -1984,6 +1988,7 @@ interface Port-Channel5
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
+   address locking ipv4
    ip verify unicast source reachable-via rx
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
@@ -2056,6 +2061,10 @@ interface Port-Channel10
    evpn ethernet-segment
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
+   !
+   address locking
+      address-family ipv4 disabled
+      address-family ipv6 disabled
    shape rate 50 percent
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
@@ -2109,6 +2118,7 @@ interface Port-Channel15
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
+   address locking ipv4 ipv6
    arp gratuitous accept
    mlag 15
    no ntp serve
@@ -2131,6 +2141,7 @@ interface Port-Channel16
    switchport
    switchport vlan translation out 23 dot1q-tunnel 22
    snmp trap link-change
+   address locking ipv6
    mlag 16
    switchport port-security violation protect log
    switchport port-security mac-address maximum 100
@@ -2174,6 +2185,11 @@ interface Port-Channel50
    evpn ethernet-segment
       identifier 0000:0000:0303:0202:0101
       route-target import 03:03:02:02:01:01
+   !
+   address locking
+      address-family ipv6
+      address-family ipv4 disabled
+      locked-address ipv4 enforcement disabled
    lacp system-id 0303.0202.0101
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -1971,10 +1971,6 @@ interface Port-Channel3
    switchport trunk group MLAG
    switchport
    no snmp trap link-change
-   !
-   address locking
-      address-family ipv4
-      address-family ipv6
    shape rate 200000 kbps
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2 rx-disabled
@@ -1988,7 +1984,9 @@ interface Port-Channel5
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
-   address locking ipv4
+   !
+   address locking
+      address-family ipv4 disabled
    ip verify unicast source reachable-via rx
    ip igmp host-proxy
    ip igmp host-proxy 239.0.0.1
@@ -2061,10 +2059,6 @@ interface Port-Channel10
    evpn ethernet-segment
       identifier 0000:0000:0404:0404:0303
       route-target import 04:04:03:03:02:02
-   !
-   address locking
-      address-family ipv4 disabled
-      address-family ipv6 disabled
    shape rate 50 percent
    isis enable EVPN_UNDERLAY
    isis authentication mode sha key-id 2
@@ -2118,7 +2112,6 @@ interface Port-Channel15
    switchport trunk allowed vlan 110,201
    switchport mode trunk
    switchport
-   address locking ipv4 ipv6
    arp gratuitous accept
    mlag 15
    no ntp serve
@@ -2141,7 +2134,6 @@ interface Port-Channel16
    switchport
    switchport vlan translation out 23 dot1q-tunnel 22
    snmp trap link-change
-   address locking ipv6
    mlag 16
    switchport port-security violation protect log
    switchport port-security mac-address maximum 100
@@ -2185,11 +2177,6 @@ interface Port-Channel50
    evpn ethernet-segment
       identifier 0000:0000:0303:0202:0101
       route-target import 03:03:02:02:01:01
-   !
-   address locking
-      address-family ipv6
-      address-family ipv4 disabled
-      locked-address ipv4 enforcement disabled
    lacp system-id 0303.0202.0101
    isis enable EVPN_UNDERLAY
    isis authentication mode shared-secret profile profile1 algorithm sha-1 rx-disabled

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -76,7 +76,7 @@ port_channel_interfaces:
     ospf_authentication_key: $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
     ospf_authentication_key_type: "8a"
     address_locking:
-      ipv4: true
+      ipv4: false
 
   - name: Port-Channel15
     comment: |
@@ -123,9 +123,6 @@ port_channel_interfaces:
     traffic_policy:
       input: BLUE-C1-POLICY
       output: BLUE-C2-POLICY
-    address_locking:
-      ipv4: true
-      ipv6: true
 
   - name: Port-Channel16
     comment: testing single line comment
@@ -161,9 +158,6 @@ port_channel_interfaces:
       backup_link:
         interface: Port-Channel100
         prefer_vlan: 20
-    address_locking:
-      ipv4: false
-      ipv6: true
 
   - name: Port-Channel3
     description: MLAG_PEER_DC1-LEAF1B_Po3
@@ -188,10 +182,6 @@ port_channel_interfaces:
         sha:
           key_id: 2
         rx_disabled: true
-    address_locking:
-      address_family:
-        ipv4: true
-        ipv6: true
 
   - name: Port-Channel10
     description: SRV01_bond0
@@ -214,10 +204,6 @@ port_channel_interfaces:
         mode: sha
         sha:
           key_id: 2
-    address_locking:
-      address_family:
-        ipv4: false
-        ipv6: false
 
   - name: Port-Channel50
     description: SRV-POD03_PortChanne1
@@ -239,11 +225,6 @@ port_channel_interfaces:
           profile: profile1
           algorithm: sha-1
         rx_disabled: true
-    address_locking:
-      ipv4_enforcement_disabled: true
-      address_family:
-        ipv4: false
-        ipv6: true
 
   - name: Port-Channel51
     description: ipv6_prefix

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -75,6 +75,8 @@ port_channel_interfaces:
     # test for ospf_authentication_key_type: "8a"
     ospf_authentication_key: $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
     ospf_authentication_key_type: "8a"
+    address_locking:
+      ipv4: true
 
   - name: Port-Channel15
     comment: |
@@ -121,6 +123,9 @@ port_channel_interfaces:
     traffic_policy:
       input: BLUE-C1-POLICY
       output: BLUE-C2-POLICY
+    address_locking:
+      ipv4: true
+      ipv6: true
 
   - name: Port-Channel16
     comment: testing single line comment
@@ -156,6 +161,9 @@ port_channel_interfaces:
       backup_link:
         interface: Port-Channel100
         prefer_vlan: 20
+    address_locking:
+      ipv4: false
+      ipv6: true
 
   - name: Port-Channel3
     description: MLAG_PEER_DC1-LEAF1B_Po3
@@ -180,6 +188,10 @@ port_channel_interfaces:
         sha:
           key_id: 2
         rx_disabled: true
+    address_locking:
+      address_family:
+        ipv4: true
+        ipv6: true
 
   - name: Port-Channel10
     description: SRV01_bond0
@@ -202,6 +214,10 @@ port_channel_interfaces:
         mode: sha
         sha:
           key_id: 2
+    address_locking:
+      address_family:
+        ipv4: false
+        ipv6: false
 
   - name: Port-Channel50
     description: SRV-POD03_PortChanne1
@@ -223,6 +239,11 @@ port_channel_interfaces:
           profile: profile1
           algorithm: sha-1
         rx_disabled: true
+    address_locking:
+      ipv4_enforcement_disabled: true
+      address_family:
+        ipv4: false
+        ipv6: true
 
   - name: Port-Channel51
     description: ipv6_prefix

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/port-channel-interfaces.yml
@@ -76,7 +76,8 @@ port_channel_interfaces:
     ospf_authentication_key: $kUVyoj7FVQ//yw9D2lbqjA==$kxxohBiofI46IX3pw18KYQ==$DOOM0l9uU4TrQt2kyA7XCKtjUA==
     ospf_authentication_key_type: "8a"
     address_locking:
-      ipv4: false
+      address_family:
+        ipv4: false
 
   - name: Port-Channel15
     comment: |

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -21,6 +21,13 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;l2_mru</samp>](## "port_channel_interfaces.[].l2_mru") | Integer |  |  | Min: 68<br>Max: 65535 | "l2_mru" should only be defined for platforms supporting the "l2 mru" CLI.<br> |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;arp_gratuitous_accept</samp>](## "port_channel_interfaces.[].arp_gratuitous_accept") | Boolean |  |  |  | Accept gratuitous ARP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "port_channel_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;address_locking</samp>](## "port_channel_interfaces.[].address_locking") | Dictionary |  |  |  |  |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "port_channel_interfaces.[].address_locking.ipv4") | Boolean |  |  |  | Enable address locking for IPv4.<br>For EOS version 4.31 and above, the `address_family.ipv4` parameter should be used instead. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "port_channel_interfaces.[].address_locking.ipv6") | Boolean |  |  |  | Enable address locking for IPv6.<br>For EOS version 4.31 and above, the `address_family.ipv6` parameter should be used instead. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family</samp>](## "port_channel_interfaces.[].address_locking.address_family") | Dictionary |  |  |  | Configure address locking per address family.<br>The `address_locking.ipv4/ipv6` and `address_locking.address_family.ipv4/ipv6` are mutually exclusive and `address_locking.address_family.ipv4/ipv6` take precedence.<br>Introduced in EOS 4.31.0F. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "port_channel_interfaces.[].address_locking.address_family.ipv4") | Boolean |  |  |  | Enable/disable address locking for IPv4. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "port_channel_interfaces.[].address_locking.address_family.ipv6") | Boolean |  |  |  | Enable/disable address locking for IPv6. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_enforcement_disabled</samp>](## "port_channel_interfaces.[].address_locking.ipv4_enforcement_disabled") | Boolean |  |  |  | Disable enforcement for IPv4 locked addresses. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q</samp>](## "port_channel_interfaces.[].encapsulation_dot1q") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q.vlan") | Integer | Required |  | Min: 1<br>Max: 4094 | VLAD ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Inner VLAN ID. This setting can only be applied to sub-interfaces on EOS. |
@@ -510,6 +517,29 @@
         # Accept gratuitous ARP.
         arp_gratuitous_accept: <bool>
         snmp_trap_link_change: <bool>
+        address_locking:
+
+          # Enable address locking for IPv4.
+          # For EOS version 4.31 and above, the `address_family.ipv4` parameter should be used instead.
+          ipv4: <bool>
+
+          # Enable address locking for IPv6.
+          # For EOS version 4.31 and above, the `address_family.ipv6` parameter should be used instead.
+          ipv6: <bool>
+
+          # Configure address locking per address family.
+          # The `address_locking.ipv4/ipv6` and `address_locking.address_family.ipv4/ipv6` are mutually exclusive and `address_locking.address_family.ipv4/ipv6` take precedence.
+          # Introduced in EOS 4.31.0F.
+          address_family:
+
+            # Enable/disable address locking for IPv4.
+            ipv4: <bool>
+
+            # Enable/disable address locking for IPv6.
+            ipv6: <bool>
+
+          # Disable enforcement for IPv4 locked addresses.
+          ipv4_enforcement_disabled: <bool>
         encapsulation_dot1q:
 
           # VLAD ID.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -22,7 +22,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;arp_gratuitous_accept</samp>](## "port_channel_interfaces.[].arp_gratuitous_accept") | Boolean |  |  |  | Accept gratuitous ARP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "port_channel_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;address_locking</samp>](## "port_channel_interfaces.[].address_locking") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family</samp>](## "port_channel_interfaces.[].address_locking.address_family") | Dictionary |  |  |  | Configure address locking per address family.<br>Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family</samp>](## "port_channel_interfaces.[].address_locking.address_family") | Dictionary |  |  |  | Configure address locking per address family.<br>Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "port_channel_interfaces.[].address_locking.address_family.ipv4") | Boolean |  |  |  | Enable/disable address locking for IPv4. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q</samp>](## "port_channel_interfaces.[].encapsulation_dot1q") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q.vlan") | Integer | Required |  | Min: 1<br>Max: 4094 | VLAD ID. |
@@ -516,7 +516,7 @@
         address_locking:
 
           # Configure address locking per address family.
-          # Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported
+          # Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported.
           address_family:
 
             # Enable/disable address locking for IPv4.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -22,12 +22,8 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;arp_gratuitous_accept</samp>](## "port_channel_interfaces.[].arp_gratuitous_accept") | Boolean |  |  |  | Accept gratuitous ARP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "port_channel_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;address_locking</samp>](## "port_channel_interfaces.[].address_locking") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "port_channel_interfaces.[].address_locking.ipv4") | Boolean |  |  |  | Enable address locking for IPv4.<br>For EOS version 4.31 and above, the `address_family.ipv4` parameter should be used instead. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "port_channel_interfaces.[].address_locking.ipv6") | Boolean |  |  |  | Enable address locking for IPv6.<br>For EOS version 4.31 and above, the `address_family.ipv6` parameter should be used instead. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family</samp>](## "port_channel_interfaces.[].address_locking.address_family") | Dictionary |  |  |  | Configure address locking per address family.<br>The `address_locking.ipv4/ipv6` and `address_locking.address_family.ipv4/ipv6` are mutually exclusive and `address_locking.address_family.ipv4/ipv6` take precedence.<br>Introduced in EOS 4.31.0F. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family</samp>](## "port_channel_interfaces.[].address_locking.address_family") | Dictionary |  |  |  | Configure address locking per address family.<br>Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "port_channel_interfaces.[].address_locking.address_family.ipv4") | Boolean |  |  |  | Enable/disable address locking for IPv4. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv6</samp>](## "port_channel_interfaces.[].address_locking.address_family.ipv6") | Boolean |  |  |  | Enable/disable address locking for IPv6. |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4_enforcement_disabled</samp>](## "port_channel_interfaces.[].address_locking.ipv4_enforcement_disabled") | Boolean |  |  |  | Disable enforcement for IPv4 locked addresses. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q</samp>](## "port_channel_interfaces.[].encapsulation_dot1q") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q.vlan") | Integer | Required |  | Min: 1<br>Max: 4094 | VLAD ID. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;inner_vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q.inner_vlan") | Integer |  |  | Min: 1<br>Max: 4094 | Inner VLAN ID. This setting can only be applied to sub-interfaces on EOS. |
@@ -519,27 +515,12 @@
         snmp_trap_link_change: <bool>
         address_locking:
 
-          # Enable address locking for IPv4.
-          # For EOS version 4.31 and above, the `address_family.ipv4` parameter should be used instead.
-          ipv4: <bool>
-
-          # Enable address locking for IPv6.
-          # For EOS version 4.31 and above, the `address_family.ipv6` parameter should be used instead.
-          ipv6: <bool>
-
           # Configure address locking per address family.
-          # The `address_locking.ipv4/ipv6` and `address_locking.address_family.ipv4/ipv6` are mutually exclusive and `address_locking.address_family.ipv4/ipv6` take precedence.
-          # Introduced in EOS 4.31.0F.
+          # Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported
           address_family:
 
             # Enable/disable address locking for IPv4.
             ipv4: <bool>
-
-            # Enable/disable address locking for IPv6.
-            ipv6: <bool>
-
-          # Disable enforcement for IPv4 locked addresses.
-          ipv4_enforcement_disabled: <bool>
         encapsulation_dot1q:
 
           # VLAD ID.

--- a/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
+++ b/ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/port-channel-interfaces.md
@@ -22,7 +22,7 @@
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;arp_gratuitous_accept</samp>](## "port_channel_interfaces.[].arp_gratuitous_accept") | Boolean |  |  |  | Accept gratuitous ARP. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;snmp_trap_link_change</samp>](## "port_channel_interfaces.[].snmp_trap_link_change") | Boolean |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;address_locking</samp>](## "port_channel_interfaces.[].address_locking") | Dictionary |  |  |  |  |
-    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family</samp>](## "port_channel_interfaces.[].address_locking.address_family") | Dictionary |  |  |  | Configure address locking per address family.<br>Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported. |
+    | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;address_family</samp>](## "port_channel_interfaces.[].address_locking.address_family") | Dictionary |  |  |  | Configure address locking per address family.<br>Introduced in EOS 4.31.0F. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;ipv4</samp>](## "port_channel_interfaces.[].address_locking.address_family.ipv4") | Boolean |  |  |  | Enable/disable address locking for IPv4. |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;encapsulation_dot1q</samp>](## "port_channel_interfaces.[].encapsulation_dot1q") | Dictionary |  |  |  |  |
     | [<samp>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;vlan</samp>](## "port_channel_interfaces.[].encapsulation_dot1q.vlan") | Integer | Required |  | Min: 1<br>Max: 4094 | VLAD ID. |
@@ -516,7 +516,7 @@
         address_locking:
 
           # Configure address locking per address family.
-          # Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported.
+          # Introduced in EOS 4.31.0F.
           address_family:
 
             # Enable/disable address locking for IPv4.

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -245,11 +245,6 @@ interface {{ port_channel_interface.name }}
 {%     elif port_channel_interface.snmp_trap_link_change is arista.avd.defined(true) %}
    snmp trap link-change
 {%     endif %}
-{%     if port_channel_interface.address_locking.address_family.ipv4 is arista.avd.defined(false) %}
-   !
-   address locking
-      address-family ipv4 disabled
-{%     endif %}
 {%     if port_channel_interface.vrf is arista.avd.defined %}
    vrf {{ port_channel_interface.vrf }}
 {%     endif %}
@@ -393,6 +388,11 @@ interface {{ port_channel_interface.name }}
 {%     endif %}
 {%     if port_channel_interface.lacp_id is arista.avd.defined %}
    lacp system-id {{ port_channel_interface.lacp_id }}
+{%     endif %}
+{%     if port_channel_interface.address_locking.address_family.ipv4 is arista.avd.defined(false) %}
+   !
+   address locking
+      address-family ipv4 disabled
 {%     endif %}
 {%     if port_channel_interface.mpls.ldp.igp_sync is arista.avd.defined(true) %}
    mpls ldp igp sync

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -245,33 +245,10 @@ interface {{ port_channel_interface.name }}
 {%     elif port_channel_interface.snmp_trap_link_change is arista.avd.defined(true) %}
    snmp trap link-change
 {%     endif %}
-{%     if port_channel_interface.address_locking.address_family.ipv4 is arista.avd.defined or port_channel_interface.address_locking.address_family.ipv6 is arista.avd.defined or port_channel_interface.address_locking.ipv4_enforcement_disabled is arista.avd.defined(true) %}
+{%     if port_channel_interface.address_locking.address_family.ipv4 is arista.avd.defined(false) %}
    !
    address locking
-{%         if port_channel_interface.address_locking.address_family.ipv4 is arista.avd.defined(true) %}
-      address-family ipv4
-{%         endif %}
-{%         if port_channel_interface.address_locking.address_family.ipv6 is arista.avd.defined(true) %}
-      address-family ipv6
-{%         endif %}
-{%         if port_channel_interface.address_locking.address_family.ipv4 is arista.avd.defined(false) %}
       address-family ipv4 disabled
-{%         endif %}
-{%         if port_channel_interface.address_locking.address_family.ipv6 is arista.avd.defined(false) %}
-      address-family ipv6 disabled
-{%         endif %}
-{%         if port_channel_interface.address_locking.ipv4_enforcement_disabled is arista.avd.defined(true) %}
-      locked-address ipv4 enforcement disabled
-{%         endif %}
-{%     elif port_channel_interface.address_locking.ipv4 is arista.avd.defined(true) or port_channel_interface.address_locking.ipv6 is arista.avd.defined(true) %}
-{%         set address_locking_cli = "address locking" %}
-{%         if port_channel_interface.address_locking.ipv4 is arista.avd.defined(true) %}
-{%             set address_locking_cli = address_locking_cli + " ipv4" %}
-{%         endif %}
-{%         if port_channel_interface.address_locking.ipv6 is arista.avd.defined(true) %}
-{%             set address_locking_cli = address_locking_cli + " ipv6" %}
-{%         endif %}
-   {{ address_locking_cli }}
 {%     endif %}
 {%     if port_channel_interface.vrf is arista.avd.defined %}
    vrf {{ port_channel_interface.vrf }}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/port-channel-interfaces.j2
@@ -245,6 +245,34 @@ interface {{ port_channel_interface.name }}
 {%     elif port_channel_interface.snmp_trap_link_change is arista.avd.defined(true) %}
    snmp trap link-change
 {%     endif %}
+{%     if port_channel_interface.address_locking.address_family.ipv4 is arista.avd.defined or port_channel_interface.address_locking.address_family.ipv6 is arista.avd.defined or port_channel_interface.address_locking.ipv4_enforcement_disabled is arista.avd.defined(true) %}
+   !
+   address locking
+{%         if port_channel_interface.address_locking.address_family.ipv4 is arista.avd.defined(true) %}
+      address-family ipv4
+{%         endif %}
+{%         if port_channel_interface.address_locking.address_family.ipv6 is arista.avd.defined(true) %}
+      address-family ipv6
+{%         endif %}
+{%         if port_channel_interface.address_locking.address_family.ipv4 is arista.avd.defined(false) %}
+      address-family ipv4 disabled
+{%         endif %}
+{%         if port_channel_interface.address_locking.address_family.ipv6 is arista.avd.defined(false) %}
+      address-family ipv6 disabled
+{%         endif %}
+{%         if port_channel_interface.address_locking.ipv4_enforcement_disabled is arista.avd.defined(true) %}
+      locked-address ipv4 enforcement disabled
+{%         endif %}
+{%     elif port_channel_interface.address_locking.ipv4 is arista.avd.defined(true) or port_channel_interface.address_locking.ipv6 is arista.avd.defined(true) %}
+{%         set address_locking_cli = "address locking" %}
+{%         if port_channel_interface.address_locking.ipv4 is arista.avd.defined(true) %}
+{%             set address_locking_cli = address_locking_cli + " ipv4" %}
+{%         endif %}
+{%         if port_channel_interface.address_locking.ipv6 is arista.avd.defined(true) %}
+{%             set address_locking_cli = address_locking_cli + " ipv6" %}
+{%         endif %}
+   {{ address_locking_cli }}
+{%     endif %}
 {%     if port_channel_interface.vrf is arista.avd.defined %}
    vrf {{ port_channel_interface.vrf }}
 {%     endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -29462,15 +29462,13 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             class AddressFamily(AvdModel):
                 """Subclass of AvdModel."""
 
-                _fields: ClassVar[dict] = {"ipv4": {"type": bool}, "ipv6": {"type": bool}}
+                _fields: ClassVar[dict] = {"ipv4": {"type": bool}}
                 ipv4: bool | None
                 """Enable/disable address locking for IPv4."""
-                ipv6: bool | None
-                """Enable/disable address locking for IPv6."""
 
                 if TYPE_CHECKING:
 
-                    def __init__(self, *, ipv4: bool | None | UndefinedType = Undefined, ipv6: bool | None | UndefinedType = Undefined) -> None:
+                    def __init__(self, *, ipv4: bool | None | UndefinedType = Undefined) -> None:
                         """
                         AddressFamily.
 
@@ -29479,52 +29477,22 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                         Args:
                             ipv4: Enable/disable address locking for IPv4.
-                            ipv6: Enable/disable address locking for IPv6.
 
                         """
 
-            _fields: ClassVar[dict] = {
-                "ipv4": {"type": bool},
-                "ipv6": {"type": bool},
-                "address_family": {"type": AddressFamily},
-                "ipv4_enforcement_disabled": {"type": bool},
-            }
-            ipv4: bool | None
-            """
-            Enable address locking for IPv4.
-            For EOS version 4.31 and above, the `address_family.ipv4` parameter
-            should be used instead.
-            """
-            ipv6: bool | None
-            """
-            Enable address locking for IPv6.
-            For EOS version 4.31 and above, the `address_family.ipv6` parameter
-            should be used instead.
-            """
+            _fields: ClassVar[dict] = {"address_family": {"type": AddressFamily}}
             address_family: AddressFamily
             """
             Configure address locking per address family.
-            The `address_locking.ipv4/ipv6` and
-            `address_locking.address_family.ipv4/ipv6` are mutually exclusive and
-            `address_locking.address_family.ipv4/ipv6` take precedence.
-            Introduced in EOS 4.31.0F.
+            Introduced in EOS 4.31.0F, on port-channel interfaces
+            only IPv4 disablement is supported
 
-            Subclass of
-            AvdModel.
+            Subclass of AvdModel.
             """
-            ipv4_enforcement_disabled: bool | None
-            """Disable enforcement for IPv4 locked addresses."""
 
             if TYPE_CHECKING:
 
-                def __init__(
-                    self,
-                    *,
-                    ipv4: bool | None | UndefinedType = Undefined,
-                    ipv6: bool | None | UndefinedType = Undefined,
-                    address_family: AddressFamily | UndefinedType = Undefined,
-                    ipv4_enforcement_disabled: bool | None | UndefinedType = Undefined,
-                ) -> None:
+                def __init__(self, *, address_family: AddressFamily | UndefinedType = Undefined) -> None:
                     """
                     AddressLocking.
 
@@ -29532,24 +29500,12 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Subclass of AvdModel.
 
                     Args:
-                        ipv4:
-                           Enable address locking for IPv4.
-                           For EOS version 4.31 and above, the `address_family.ipv4` parameter
-                           should be used instead.
-                        ipv6:
-                           Enable address locking for IPv6.
-                           For EOS version 4.31 and above, the `address_family.ipv6` parameter
-                           should be used instead.
                         address_family:
                            Configure address locking per address family.
-                           The `address_locking.ipv4/ipv6` and
-                           `address_locking.address_family.ipv4/ipv6` are mutually exclusive and
-                           `address_locking.address_family.ipv4/ipv6` take precedence.
-                           Introduced in EOS 4.31.0F.
+                           Introduced in EOS 4.31.0F, on port-channel interfaces
+                           only IPv4 disablement is supported
 
-                           Subclass of
-                           AvdModel.
-                        ipv4_enforcement_disabled: Disable enforcement for IPv4 locked addresses.
+                           Subclass of AvdModel.
 
                     """
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -29485,7 +29485,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             """
             Configure address locking per address family.
             Introduced in EOS 4.31.0F, on port-channel interfaces
-            only IPv4 disablement is supported
+            only IPv4 disablement is supported.
 
             Subclass of AvdModel.
             """
@@ -29503,7 +29503,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         address_family:
                            Configure address locking per address family.
                            Introduced in EOS 4.31.0F, on port-channel interfaces
-                           only IPv4 disablement is supported
+                           only IPv4 disablement is supported.
 
                            Subclass of AvdModel.
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -29456,6 +29456,103 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
                     """
 
+        class AddressLocking(AvdModel):
+            """Subclass of AvdModel."""
+
+            class AddressFamily(AvdModel):
+                """Subclass of AvdModel."""
+
+                _fields: ClassVar[dict] = {"ipv4": {"type": bool}, "ipv6": {"type": bool}}
+                ipv4: bool | None
+                """Enable/disable address locking for IPv4."""
+                ipv6: bool | None
+                """Enable/disable address locking for IPv6."""
+
+                if TYPE_CHECKING:
+
+                    def __init__(self, *, ipv4: bool | None | UndefinedType = Undefined, ipv6: bool | None | UndefinedType = Undefined) -> None:
+                        """
+                        AddressFamily.
+
+
+                        Subclass of AvdModel.
+
+                        Args:
+                            ipv4: Enable/disable address locking for IPv4.
+                            ipv6: Enable/disable address locking for IPv6.
+
+                        """
+
+            _fields: ClassVar[dict] = {
+                "ipv4": {"type": bool},
+                "ipv6": {"type": bool},
+                "address_family": {"type": AddressFamily},
+                "ipv4_enforcement_disabled": {"type": bool},
+            }
+            ipv4: bool | None
+            """
+            Enable address locking for IPv4.
+            For EOS version 4.31 and above, the `address_family.ipv4` parameter
+            should be used instead.
+            """
+            ipv6: bool | None
+            """
+            Enable address locking for IPv6.
+            For EOS version 4.31 and above, the `address_family.ipv6` parameter
+            should be used instead.
+            """
+            address_family: AddressFamily
+            """
+            Configure address locking per address family.
+            The `address_locking.ipv4/ipv6` and
+            `address_locking.address_family.ipv4/ipv6` are mutually exclusive and
+            `address_locking.address_family.ipv4/ipv6` take precedence.
+            Introduced in EOS 4.31.0F.
+
+            Subclass of
+            AvdModel.
+            """
+            ipv4_enforcement_disabled: bool | None
+            """Disable enforcement for IPv4 locked addresses."""
+
+            if TYPE_CHECKING:
+
+                def __init__(
+                    self,
+                    *,
+                    ipv4: bool | None | UndefinedType = Undefined,
+                    ipv6: bool | None | UndefinedType = Undefined,
+                    address_family: AddressFamily | UndefinedType = Undefined,
+                    ipv4_enforcement_disabled: bool | None | UndefinedType = Undefined,
+                ) -> None:
+                    """
+                    AddressLocking.
+
+
+                    Subclass of AvdModel.
+
+                    Args:
+                        ipv4:
+                           Enable address locking for IPv4.
+                           For EOS version 4.31 and above, the `address_family.ipv4` parameter
+                           should be used instead.
+                        ipv6:
+                           Enable address locking for IPv6.
+                           For EOS version 4.31 and above, the `address_family.ipv6` parameter
+                           should be used instead.
+                        address_family:
+                           Configure address locking per address family.
+                           The `address_locking.ipv4/ipv6` and
+                           `address_locking.address_family.ipv4/ipv6` are mutually exclusive and
+                           `address_locking.address_family.ipv4/ipv6` take precedence.
+                           Introduced in EOS 4.31.0F.
+
+                           Subclass of
+                           AvdModel.
+                        ipv4_enforcement_disabled: Disable enforcement for IPv4 locked addresses.
+
+                    """
+
         class EncapsulationDot1q(AvdModel):
             """Subclass of AvdModel."""
 
@@ -33768,6 +33865,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "l2_mru": {"type": int},
             "arp_gratuitous_accept": {"type": bool},
             "snmp_trap_link_change": {"type": bool},
+            "address_locking": {"type": AddressLocking},
             "encapsulation_dot1q": {"type": EncapsulationDot1q},
             "vrf": {"type": str},
             "encapsulation_vlan": {"type": EncapsulationVlan},
@@ -33861,6 +33959,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         arp_gratuitous_accept: bool | None
         """Accept gratuitous ARP."""
         snmp_trap_link_change: bool | None
+        address_locking: AddressLocking
+        """Subclass of AvdModel."""
         encapsulation_dot1q: EncapsulationDot1q
         """Subclass of AvdModel."""
         vrf: str | None
@@ -34027,6 +34127,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 l2_mru: int | None | UndefinedType = Undefined,
                 arp_gratuitous_accept: bool | None | UndefinedType = Undefined,
                 snmp_trap_link_change: bool | None | UndefinedType = Undefined,
+                address_locking: AddressLocking | UndefinedType = Undefined,
                 encapsulation_dot1q: EncapsulationDot1q | UndefinedType = Undefined,
                 vrf: str | None | UndefinedType = Undefined,
                 encapsulation_vlan: EncapsulationVlan | UndefinedType = Undefined,
@@ -34121,6 +34222,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     l2_mru: "l2_mru" should only be defined for platforms supporting the "l2 mru" CLI.
                     arp_gratuitous_accept: Accept gratuitous ARP.
                     snmp_trap_link_change: snmp_trap_link_change
+                    address_locking: Subclass of AvdModel.
                     encapsulation_dot1q: Subclass of AvdModel.
                     vrf: VRF name.
                     encapsulation_vlan:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -29484,8 +29484,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             address_family: AddressFamily
             """
             Configure address locking per address family.
-            Introduced in EOS 4.31.0F, on port-channel interfaces
-            only IPv4 disablement is supported.
+            Introduced in EOS 4.31.0F.
 
             Subclass of AvdModel.
             """
@@ -29502,8 +29501,7 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Args:
                         address_family:
                            Configure address locking per address family.
-                           Introduced in EOS 4.31.0F, on port-channel interfaces
-                           only IPv4 disablement is supported.
+                           Introduced in EOS 4.31.0F.
 
                            Subclass of AvdModel.
 

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -11693,8 +11693,7 @@ keys:
             address_family:
               description: 'Configure address locking per address family.
 
-                Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement
-                is supported.'
+                Introduced in EOS 4.31.0F.'
               type: dict
               keys:
                 ipv4:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -11690,37 +11690,16 @@ keys:
         address_locking:
           type: dict
           keys:
-            ipv4:
-              type: bool
-              description: 'Enable address locking for IPv4.
-
-                For EOS version 4.31 and above, the `address_family.ipv4` parameter
-                should be used instead.'
-            ipv6:
-              type: bool
-              description: 'Enable address locking for IPv6.
-
-                For EOS version 4.31 and above, the `address_family.ipv6` parameter
-                should be used instead.'
             address_family:
               description: 'Configure address locking per address family.
 
-                The `address_locking.ipv4/ipv6` and `address_locking.address_family.ipv4/ipv6`
-                are mutually exclusive and `address_locking.address_family.ipv4/ipv6`
-                take precedence.
-
-                Introduced in EOS 4.31.0F.'
+                Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement
+                is supported'
               type: dict
               keys:
                 ipv4:
                   type: bool
                   description: Enable/disable address locking for IPv4.
-                ipv6:
-                  type: bool
-                  description: Enable/disable address locking for IPv6.
-            ipv4_enforcement_disabled:
-              type: bool
-              description: Disable enforcement for IPv4 locked addresses.
         encapsulation_dot1q:
           type: dict
           keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -11687,6 +11687,40 @@ keys:
           description: Accept gratuitous ARP.
         snmp_trap_link_change:
           type: bool
+        address_locking:
+          type: dict
+          keys:
+            ipv4:
+              type: bool
+              description: 'Enable address locking for IPv4.
+
+                For EOS version 4.31 and above, the `address_family.ipv4` parameter
+                should be used instead.'
+            ipv6:
+              type: bool
+              description: 'Enable address locking for IPv6.
+
+                For EOS version 4.31 and above, the `address_family.ipv6` parameter
+                should be used instead.'
+            address_family:
+              description: 'Configure address locking per address family.
+
+                The `address_locking.ipv4/ipv6` and `address_locking.address_family.ipv4/ipv6`
+                are mutually exclusive and `address_locking.address_family.ipv4/ipv6`
+                take precedence.
+
+                Introduced in EOS 4.31.0F.'
+              type: dict
+              keys:
+                ipv4:
+                  type: bool
+                  description: Enable/disable address locking for IPv4.
+                ipv6:
+                  type: bool
+                  description: Enable/disable address locking for IPv6.
+            ipv4_enforcement_disabled:
+              type: bool
+              description: Disable enforcement for IPv4 locked addresses.
         encapsulation_dot1q:
           type: dict
           keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/eos_cli_config_gen.schema.yml
@@ -11694,7 +11694,7 @@ keys:
               description: 'Configure address locking per address family.
 
                 Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement
-                is supported'
+                is supported.'
               type: dict
               keys:
                 ipv4:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -57,6 +57,35 @@ keys:
           description: Accept gratuitous ARP.
         snmp_trap_link_change:
           type: bool
+        address_locking:
+          type: dict
+          keys:
+            ipv4:
+              type: bool
+              description: |-
+                Enable address locking for IPv4.
+                For EOS version 4.31 and above, the `address_family.ipv4` parameter should be used instead.
+            ipv6:
+              type: bool
+              description: |-
+                Enable address locking for IPv6.
+                For EOS version 4.31 and above, the `address_family.ipv6` parameter should be used instead.
+            address_family:
+              description: |-
+                Configure address locking per address family.
+                The `address_locking.ipv4/ipv6` and `address_locking.address_family.ipv4/ipv6` are mutually exclusive and `address_locking.address_family.ipv4/ipv6` take precedence.
+                Introduced in EOS 4.31.0F.
+              type: dict
+              keys:
+                ipv4:
+                  type: bool
+                  description: Enable/disable address locking for IPv4.
+                ipv6:
+                  type: bool
+                  description: Enable/disable address locking for IPv6.
+            ipv4_enforcement_disabled:
+              type: bool
+              description: Disable enforcement for IPv4 locked addresses.
         encapsulation_dot1q:
           type: dict
           keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -60,32 +60,15 @@ keys:
         address_locking:
           type: dict
           keys:
-            ipv4:
-              type: bool
-              description: |-
-                Enable address locking for IPv4.
-                For EOS version 4.31 and above, the `address_family.ipv4` parameter should be used instead.
-            ipv6:
-              type: bool
-              description: |-
-                Enable address locking for IPv6.
-                For EOS version 4.31 and above, the `address_family.ipv6` parameter should be used instead.
             address_family:
               description: |-
                 Configure address locking per address family.
-                The `address_locking.ipv4/ipv6` and `address_locking.address_family.ipv4/ipv6` are mutually exclusive and `address_locking.address_family.ipv4/ipv6` take precedence.
-                Introduced in EOS 4.31.0F.
+                Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported
               type: dict
               keys:
                 ipv4:
                   type: bool
                   description: Enable/disable address locking for IPv4.
-                ipv6:
-                  type: bool
-                  description: Enable/disable address locking for IPv6.
-            ipv4_enforcement_disabled:
-              type: bool
-              description: Disable enforcement for IPv4 locked addresses.
         encapsulation_dot1q:
           type: dict
           keys:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -63,7 +63,7 @@ keys:
             address_family:
               description: |-
                 Configure address locking per address family.
-                Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported
+                Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported.
               type: dict
               keys:
                 ipv4:

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/schema_fragments/port_channel_interfaces.schema.yml
@@ -63,7 +63,7 @@ keys:
             address_family:
               description: |-
                 Configure address locking per address family.
-                Introduced in EOS 4.31.0F, on port-channel interfaces only IPv4 disablement is supported.
+                Introduced in EOS 4.31.0F.
               type: dict
               keys:
                 ipv4:


### PR DESCRIPTION
## Change Summary

Allow support for IP locking disablement on Port-channel interfaces:  https://github.com/aristanetworks/avd/issues/6138

## Related Issue(s)

Fixes #6138 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes

```
port_channel_interfaces
  - name: <str; required; unique>
    address_locking:
      address_family:
        ipv4: <bool>
```

## How to test
Molecule tested

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
