### PR TITLE
CI: Remove black and isort config from pyproject (unused tools)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,14 +15,6 @@ molecule = [
     "molecule-plugins[docker]>=23.4.0",
 ]
 
-[tool.black]
-# Black has been replaced with Ruff.
-force-exclude = '''.*'''
-
-[tool.isort]
-# Isort has been replaced with Ruff.
-skip_glob = ["**/*"]
-
 [tool.ruff]
 line-length = 160
 extend-exclude = [


### PR DESCRIPTION
## Change Summary

cf title

## Component(s) name

`ci`