### PR TITLE
Doc: Fix wrong docstring for secure_hash j2filter

### DIFF
--- a/python-avd/pyavd/j2filters/secure_hash.py
+++ b/python-avd/pyavd/j2filters/secure_hash.py
@@ -12,7 +12,7 @@ def sha512_password(clear_password: str, salt: str) -> str:
 
     Args:
         clear_password: The cleartext password provided by the user that will be hashed.
-        salt: Salt value to be used when creating password hash. A randomly generated salt will be used unless the user specifies one.
+        salt: Salt value to be used when creating password hash.
 
     Returns:
         The SHA-512 password hash.


### PR DESCRIPTION
## Change Summary

Salt is mandatory

## Related Issue(s)

from the field testing 6.0.0-dev4

## Component(s) name

`pyavd`

## Proposed changes

correct the docsrting

## How to test
nothing

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
