### PR TITLE
Refactor(eos_cli_config_gen): Fixing Cli order for policy_maps.qos

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -13798,7 +13798,7 @@ class-map type pbr match-any aaa
 
 | Class Name | COS | DSCP | Traffic Class | Drop Precedence | Police Rate (Burst) -> Action |
 | ---------- | --- | ---- | ------------- | --------------- | ----------------------------- |
-| CM_REPLICATION_LD | - | af11 | 2 | 1 | 10 kbps (260 kbytes) -> drop-precedence<br> 30 kbps(270 kbytes) -> drop |
+| CM_REPLICATION_LD | 2 | af11 | 2 | 1 | 10 kbps (260 kbytes) -> drop-precedence<br> 30 kbps(270 kbytes) -> drop |
 | CM_REPLICATION_LD_2 | - | af11 | 2 | - | - |
 
 ##### PM_REPLICATION_LD2
@@ -13829,6 +13829,7 @@ class-map type pbr match-any aaa
 !
 policy-map type quality-of-service PM_REPLICATION_LD
    class CM_REPLICATION_LD
+      set cos 2
       set dscp af11
       set traffic-class 2
       set drop-precedence 1
@@ -13840,14 +13841,14 @@ policy-map type quality-of-service PM_REPLICATION_LD
 !
 policy-map type quality-of-service PM_REPLICATION_LD2
    class CM_REPLICATION_LD
-      set dscp af11
       set cos 4
+      set dscp af11
       police rate 30 kbps burst-size 280 bytes action set dscp af11 rate 1 mbps burst-size 270 bytes
 !
 policy-map type quality-of-service PM_REPLICATION_LD3
    class CM_REPLICATION_LD
-      set dscp af11
       set cos 6
+      set dscp af11
       police rate 10000 bps burst-size 260 kbytes
 !
 policy-map type quality-of-service pmap_test1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -5419,6 +5419,7 @@ policy-map type copp copp-system-policy
 !
 policy-map type quality-of-service PM_REPLICATION_LD
    class CM_REPLICATION_LD
+      set cos 2
       set dscp af11
       set traffic-class 2
       set drop-precedence 1
@@ -5430,14 +5431,14 @@ policy-map type quality-of-service PM_REPLICATION_LD
 !
 policy-map type quality-of-service PM_REPLICATION_LD2
    class CM_REPLICATION_LD
-      set dscp af11
       set cos 4
+      set dscp af11
       police rate 30 kbps burst-size 280 bytes action set dscp af11 rate 1 mbps burst-size 270 bytes
 !
 policy-map type quality-of-service PM_REPLICATION_LD3
    class CM_REPLICATION_LD
-      set dscp af11
       set cos 6
+      set dscp af11
       police rate 10000 bps burst-size 260 kbytes
 !
 policy-map type quality-of-service pmap_test1

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/policy-maps.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/policy-maps.yml
@@ -25,6 +25,7 @@ policy_maps:
             dscp: af11
             traffic_class: 2
             drop_precedence: 1
+            cos: 2
           police:
             rate: 10
             rate_unit: kbps

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/policy-maps-qos.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/policy-maps-qos.j2
@@ -12,10 +12,10 @@ policy-map type quality-of-service {{ policy_map.name }}
    !
 {%         endif %}
    class {{ class.name }}
-{%         for set in class.set | arista.avd.default([]) %}
-{%             set cli_set = set | replace('_','-') | lower %}
-{%             if cli_set in ['cos', 'dscp', 'traffic-class', 'drop-precedence'] %}
-      set {{ cli_set }} {{ class.set[set] }}
+{%         for key in ['cos', 'dscp', 'traffic_class', 'drop_precedence'] %}
+{%             if key in class.set %}
+{%                 set cli_set = key | replace('_','-') %}
+      set {{ cli_set }} {{ class.set[key] }}
 {%             endif %}
 {%         endfor %}
 {%         if class.police is arista.avd.defined %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/policy-maps-qos.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/policy-maps-qos.j2
@@ -12,12 +12,18 @@ policy-map type quality-of-service {{ policy_map.name }}
    !
 {%         endif %}
    class {{ class.name }}
-{%         for key in ['cos', 'dscp', 'traffic_class', 'drop_precedence'] %}
-{%             if key in class.set %}
-{%                 set cli_set = key | replace('_','-') %}
-      set {{ cli_set }} {{ class.set[key] }}
-{%             endif %}
-{%         endfor %}
+{%         if class.set.cos is arista.avd.defined %}
+      set cos {{ class.set.cos }}
+{%         endif %}
+{%         if class.set.dscp is arista.avd.defined %}
+      set dscp {{ class.set.dscp }}
+{%         endif %}
+{%         if class.set.traffic_class is arista.avd.defined %}
+      set traffic-class {{ class.set.traffic_class }}
+{%         endif %}
+{%         if class.set.drop_precedence is arista.avd.defined %}
+      set drop-precedence {{ class.set.drop_precedence }}
+{%         endif %}
 {%         if class.police is arista.avd.defined %}
 {%             set police_cli = "police rate " %}
 {%             if class.police.rate is arista.avd.defined and class.police.rate_burst_size is arista.avd.defined %}


### PR DESCRIPTION
## Change Summary

Iterating over the data keys instead of checking "if x is defined" and then "if y is defined". It makes the CLI order dependent on the data ordering.
Add a testcase to check the order when all 4 keys of are policy_maps.qos[].classes[].set defined

## Related Issue(s)

Fixes #

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Fixing j2 templates

## How to test
CI

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
