### PR TITLE
Refactor(eos_cli_config_gen): Fix j2 template for mac_access_list.entries

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/documentation/devices/host1.md
@@ -11979,6 +11979,8 @@ ipv6 access-list acl_qos_tc5_v6
 | - | permit any 02:00:00:12:34:56 00:00:00:00:00:00 |
 | - | deny any 02:00:00:ab:cd:ef 00:00:00:00:00:00 |
 
+##### TEST5
+
 #### MAC Access-lists Device Configuration
 
 ```eos
@@ -12002,6 +12004,8 @@ mac access-list TEST4
    remark A comment in the middle
    permit any 02:00:00:12:34:56 00:00:00:00:00:00
    deny any 02:00:00:ab:cd:ef 00:00:00:00:00:00
+!
+mac access-list TEST5
 ```
 
 ## VRF Instances

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/intended/configs/host1.cfg
@@ -5053,6 +5053,8 @@ mac access-list TEST4
    permit any 02:00:00:12:34:56 00:00:00:00:00:00
    deny any 02:00:00:ab:cd:ef 00:00:00:00:00:00
 !
+mac access-list TEST5
+!
 system control-plane
    tcp mss ceiling ipv4 1344 ipv6 1366
    ip access-group ingress default ingress_ipv4_acl

--- a/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/mac-access-lists.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_cli_config_gen/inventory/host_vars/host1/mac-access-lists.yml
@@ -28,3 +28,4 @@ mac_access_lists:
       - action: "remark A comment in the middle"
       - action: "permit any 02:00:00:12:34:56 00:00:00:00:00:00"
       - action: "deny any 02:00:00:ab:cd:ef 00:00:00:00:00:00"
+  - name: TEST5

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mac-access-lists.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/mac-access-lists.j2
@@ -16,12 +16,14 @@
 
 - ACL has counting mode `counters per-entry` enabled!
 {%         endif %}
+{%         if mac_access_list.entries is arista.avd.defined %}
 
 | Sequence | Action |
 | -------- | ------ |
-{%         for acl_entry in mac_access_list.entries %}
+{%             for acl_entry in mac_access_list.entries %}
 | {{ acl_entry.sequence | arista.avd.default('-') }} | {{ acl_entry.action }} |
-{%         endfor %}
+{%             endfor %}
+{%         endif %}
 {%     endfor %}
 
 #### MAC Access-lists Device Configuration

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/mac-access-lists.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/eos/mac-access-lists.j2
@@ -10,7 +10,7 @@ mac access-list {{ mac_access_list.name }}
 {%     if mac_access_list.counters_per_entry is arista.avd.defined(true) %}
    counters per-entry
 {%     endif %}
-{%     for acl_entry in mac_access_list.entries %}
+{%     for acl_entry in mac_access_list.entries | arista.avd.default([]) %}
 {%         set acl_string = '' %}
 {%         if acl_entry.sequence is arista.avd.defined %}
 {%             set acl_string = acl_string ~ acl_entry.sequence ~ ' ' %}


### PR DESCRIPTION
## Change Summary

Fix j2 template for mac_access_list.entries.
mac_access_list.entries is not a required key.  But arista.avd.default is not written while iterating the list. This will break when entries are not set. This is fixed in this PR.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Fix j2 template for mac_access_list.entries.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
