### PR TITLE
Doc(eos_designs): Fix incorrect variable name for mlag description in custom interface description example

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/custom_modules/custom_interface_descriptions_with_data.py
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/custom_modules/custom_interface_descriptions_with_data.py
@@ -80,7 +80,7 @@ class CustomAvdInterfaceDescriptions(AvdInterfaceDescriptions):
 
         Available data:
             - mlag_peer
-            - peer_channel_group_id
+            - mlag_port_channel_id
             - mpls_overlay_role
             - mpls_lsr
             - overlay_routing_protocol


### PR DESCRIPTION
## Change Summary

Fix incorrect variable name in the docstring of the MLAG peer-link Port-Channel interface description example.

The comment referenced peer_channel_group_id, which does not exist.

Updated to mlag_port_channel_id, which matches the actual implementation.

## Related Issue(s)

Fixes #6101

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
- Corrected the docstring in `CustomAvdInterfaceDescriptions.mlag_port_channel_interface` to reference the correct variable: mlag_port_channel_id.

- No changes were made to the actual logic; this is purely a documentation fix to help contributors understand the available data fields.

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
