### PR TITLE
Fix(eos_cli_config_gen): Do not generate blank LLDP settings table

### DIFF
--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/lldp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/lldp.j2
@@ -25,7 +25,13 @@
 | {{ tlv.name | arista.avd.default('-') }} | {{ tlv.transmit | arista.avd.default('-') }} |
 {%         endfor %}
 {%     endif %}
-{%     if ethernet_interfaces is arista.avd.defined %}
+{%     set lldp_settings = [] %}
+{%     for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
+{%         if ethernet_interface.lldp.transmit is arista.avd.defined or ethernet_interface.lldp.receive is arista.avd.defined %}
+{%             do lldp_settings.append(ethernet_interface) %}
+{%         endif %}
+{%     endfor %}
+{%     if lldp_settings | length > 0 %}
 
 #### LLDP Interface Settings
 {%         if lldp.run is arista.avd.defined(false) %}
@@ -35,7 +41,7 @@ LLDP is **disabled** globally. Local interface configs will not apply.
 
 | Interface | Transmit | Receive |
 | --------- | -------- | ------- |
-{%         for ethernet_interface in ethernet_interfaces | arista.avd.natural_sort('name') %}
+{%         for ethernet_interface in lldp_settings | arista.avd.natural_sort('name') %}
 {%             if ethernet_interface.lldp.transmit is arista.avd.defined or ethernet_interface.lldp.receive is arista.avd.defined %}
 | {{ ethernet_interface.name }} | {{ ethernet_interface.lldp.transmit | arista.avd.default('-') }} | {{ ethernet_interface.lldp.receive | arista.avd.default('-') }} |
 {%             endif %}

--- a/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/lldp.j2
+++ b/python-avd/pyavd/_eos_cli_config_gen/j2templates/documentation/lldp.j2
@@ -41,10 +41,8 @@ LLDP is **disabled** globally. Local interface configs will not apply.
 
 | Interface | Transmit | Receive |
 | --------- | -------- | ------- |
-{%         for ethernet_interface in lldp_settings | arista.avd.natural_sort('name') %}
-{%             if ethernet_interface.lldp.transmit is arista.avd.defined or ethernet_interface.lldp.receive is arista.avd.defined %}
+{%         for ethernet_interface in lldp_settings %}
 | {{ ethernet_interface.name }} | {{ ethernet_interface.lldp.transmit | arista.avd.default('-') }} | {{ ethernet_interface.lldp.receive | arista.avd.default('-') }} |
-{%             endif %}
 {%         endfor %}
 {%     endif %}
 


### PR DESCRIPTION
## Change Summary

Do not generate blank LLDP settings table

## Related Issue(s)

Fixes #6299 

## Component(s) name

`arista.avd.eos_cli_config_gen`

## Proposed changes
Updated doc template to avoid generating blank LLDP settings table

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
