### PR TITLE
Refactor(pyavd): Ensure the primary-key is first in AvdModel under an AvdIndexedList

### DIFF
--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/inet-cloud.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/inet-cloud.yml
@@ -15,8 +15,8 @@ daemon_terminattr:
   disable_aaa: false
   smashexcludes: ale,flexCounter,hardware,kni,pulse,strata
 dhcp_servers:
-- disabled: false
-  vrf: default
+- vrf: default
+  disabled: false
   lease_time_ipv4:
     days: 6
     hours: 23

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/pf1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/pf1.yml
@@ -501,28 +501,28 @@ router_adaptive_virtual_topology:
   - name: BLUE
     policy: BLUE-POLICY
     profiles:
-    - name: BLUE-POLICY-VIDEO
-      id: 2
-    - name: BLUE-POLICY-VOICE
-      id: 3
-    - name: BLUE-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: BLUE-POLICY-VIDEO
+    - id: 3
+      name: BLUE-POLICY-VOICE
+    - id: 1
+      name: BLUE-POLICY-DEFAULT
   - name: RED
     policy: RED-POLICY
     profiles:
-    - name: RED-POLICY-CRITICAL-SECRET-DATA
-      id: 2
-    - name: RED-POLICY-NORMAL-DATA
-      id: 3
-    - name: RED-POLICY-NOT-SO-IMPORTANT-DATA
-      id: 4
+    - id: 2
+      name: RED-POLICY-CRITICAL-SECRET-DATA
+    - id: 3
+      name: RED-POLICY-NORMAL-DATA
+    - id: 4
+      name: RED-POLICY-NOT-SO-IMPORTANT-DATA
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/pf2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/pf2.yml
@@ -501,28 +501,28 @@ router_adaptive_virtual_topology:
   - name: BLUE
     policy: BLUE-POLICY
     profiles:
-    - name: BLUE-POLICY-VIDEO
-      id: 2
-    - name: BLUE-POLICY-VOICE
-      id: 3
-    - name: BLUE-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: BLUE-POLICY-VIDEO
+    - id: 3
+      name: BLUE-POLICY-VOICE
+    - id: 1
+      name: BLUE-POLICY-DEFAULT
   - name: RED
     policy: RED-POLICY
     profiles:
-    - name: RED-POLICY-CRITICAL-SECRET-DATA
-      id: 2
-    - name: RED-POLICY-NORMAL-DATA
-      id: 3
-    - name: RED-POLICY-NOT-SO-IMPORTANT-DATA
-      id: 4
+    - id: 2
+      name: RED-POLICY-CRITICAL-SECRET-DATA
+    - id: 3
+      name: RED-POLICY-NORMAL-DATA
+    - id: 4
+      name: RED-POLICY-NOT-SO-IMPORTANT-DATA
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border1.yml
@@ -124,10 +124,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 5000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-border2.yml
@@ -124,10 +124,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 5000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan1.yml
@@ -567,28 +567,28 @@ router_adaptive_virtual_topology:
   - name: BLUE
     policy: BLUE-POLICY
     profiles:
-    - name: BLUE-POLICY-VIDEO
-      id: 2
-    - name: BLUE-POLICY-VOICE
-      id: 3
-    - name: BLUE-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: BLUE-POLICY-VIDEO
+    - id: 3
+      name: BLUE-POLICY-VOICE
+    - id: 1
+      name: BLUE-POLICY-DEFAULT
   - name: RED
     policy: RED-POLICY
     profiles:
-    - name: RED-POLICY-CRITICAL-SECRET-DATA
-      id: 2
-    - name: RED-POLICY-NORMAL-DATA
-      id: 3
-    - name: RED-POLICY-NOT-SO-IMPORTANT-DATA
-      id: 4
+    - id: 2
+      name: RED-POLICY-CRITICAL-SECRET-DATA
+    - id: 3
+      name: RED-POLICY-NORMAL-DATA
+    - id: 4
+      name: RED-POLICY-NOT-SO-IMPORTANT-DATA
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site1-wan2.yml
@@ -568,28 +568,28 @@ router_adaptive_virtual_topology:
   - name: BLUE
     policy: BLUE-POLICY
     profiles:
-    - name: BLUE-POLICY-VIDEO
-      id: 2
-    - name: BLUE-POLICY-VOICE
-      id: 3
-    - name: BLUE-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: BLUE-POLICY-VIDEO
+    - id: 3
+      name: BLUE-POLICY-VOICE
+    - id: 1
+      name: BLUE-POLICY-DEFAULT
   - name: RED
     policy: RED-POLICY
     profiles:
-    - name: RED-POLICY-CRITICAL-SECRET-DATA
-      id: 2
-    - name: RED-POLICY-NORMAL-DATA
-      id: 3
-    - name: RED-POLICY-NOT-SO-IMPORTANT-DATA
-      id: 4
+    - id: 2
+      name: RED-POLICY-CRITICAL-SECRET-DATA
+    - id: 3
+      name: RED-POLICY-NORMAL-DATA
+    - id: 4
+      name: RED-POLICY-NOT-SO-IMPORTANT-DATA
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-leaf1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-leaf1.yml
@@ -83,10 +83,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 5000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-leaf2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-leaf2.yml
@@ -83,10 +83,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 5000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan1.yml
@@ -448,28 +448,28 @@ router_adaptive_virtual_topology:
   - name: BLUE
     policy: BLUE-POLICY
     profiles:
-    - name: BLUE-POLICY-VIDEO
-      id: 2
-    - name: BLUE-POLICY-VOICE
-      id: 3
-    - name: BLUE-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: BLUE-POLICY-VIDEO
+    - id: 3
+      name: BLUE-POLICY-VOICE
+    - id: 1
+      name: BLUE-POLICY-DEFAULT
   - name: RED
     policy: RED-POLICY
     profiles:
-    - name: RED-POLICY-CRITICAL-SECRET-DATA
-      id: 2
-    - name: RED-POLICY-NORMAL-DATA
-      id: 3
-    - name: RED-POLICY-NOT-SO-IMPORTANT-DATA
-      id: 4
+    - id: 2
+      name: RED-POLICY-CRITICAL-SECRET-DATA
+    - id: 3
+      name: RED-POLICY-NORMAL-DATA
+    - id: 4
+      name: RED-POLICY-NOT-SO-IMPORTANT-DATA
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site2-wan2.yml
@@ -496,28 +496,28 @@ router_adaptive_virtual_topology:
   - name: BLUE
     policy: BLUE-POLICY
     profiles:
-    - name: BLUE-POLICY-VIDEO
-      id: 2
-    - name: BLUE-POLICY-VOICE
-      id: 3
-    - name: BLUE-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: BLUE-POLICY-VIDEO
+    - id: 3
+      name: BLUE-POLICY-VOICE
+    - id: 1
+      name: BLUE-POLICY-DEFAULT
   - name: RED
     policy: RED-POLICY
     profiles:
-    - name: RED-POLICY-CRITICAL-SECRET-DATA
-      id: 2
-    - name: RED-POLICY-NORMAL-DATA
-      id: 3
-    - name: RED-POLICY-NOT-SO-IMPORTANT-DATA
-      id: 4
+    - id: 2
+      name: RED-POLICY-CRITICAL-SECRET-DATA
+    - id: 3
+      name: RED-POLICY-NORMAL-DATA
+    - id: 4
+      name: RED-POLICY-NOT-SO-IMPORTANT-DATA
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site3-leaf1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site3-leaf1.yml
@@ -37,10 +37,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 5000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site3-wan1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site3-wan1.yml
@@ -422,26 +422,26 @@ router_adaptive_virtual_topology:
   - name: BLUE
     policy: BLUE-POLICY
     profiles:
-    - name: BLUE-POLICY-VIDEO
-      id: 2
-    - name: BLUE-POLICY-VOICE
-      id: 3
-    - name: BLUE-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: BLUE-POLICY-VIDEO
+    - id: 3
+      name: BLUE-POLICY-VOICE
+    - id: 1
+      name: BLUE-POLICY-DEFAULT
   - name: RED
     policy: RED-POLICY
     profiles:
-    - name: RED-POLICY-NORMAL-DATA
-      id: 3
-    - name: RED-POLICY-NOT-SO-IMPORTANT-DATA
-      id: 4
+    - id: 3
+      name: RED-POLICY-NORMAL-DATA
+    - id: 4
+      name: RED-POLICY-NOT-SO-IMPORTANT-DATA
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site4-border1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site4-border1.yml
@@ -55,10 +55,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 5000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site4-border2.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site4-border2.yml
@@ -55,10 +55,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 5000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site4-wan1.yml
+++ b/ansible_collections/arista/avd/examples/cv-pathfinder/intended/structured_configs/site4-wan1.yml
@@ -436,28 +436,28 @@ router_adaptive_virtual_topology:
   - name: BLUE
     policy: BLUE-POLICY
     profiles:
-    - name: BLUE-POLICY-VIDEO
-      id: 2
-    - name: BLUE-POLICY-VOICE
-      id: 3
-    - name: BLUE-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: BLUE-POLICY-VIDEO
+    - id: 3
+      name: BLUE-POLICY-VOICE
+    - id: 1
+      name: BLUE-POLICY-DEFAULT
   - name: RED
     policy: RED-POLICY
     profiles:
-    - name: RED-POLICY-CRITICAL-SECRET-DATA
-      id: 2
-    - name: RED-POLICY-NORMAL-DATA
-      id: 3
-    - name: RED-POLICY-NOT-SO-IMPORTANT-DATA
-      id: 4
+    - id: 2
+      name: RED-POLICY-CRITICAL-SECRET-DATA
+    - id: 3
+      name: RED-POLICY-NORMAL-DATA
+    - id: 4
+      name: RED-POLICY-NOT-SO-IMPORTANT-DATA
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/Makefile
+++ b/ansible_collections/arista/avd/extensions/molecule/Makefile
@@ -17,7 +17,7 @@ test: ## Execute molecule "converge" sequence. Specify scenario name with `MOLEC
 
 .PHONY: converge
 converge: ## Execute molecule "converge" sequence. Specify scenario name with `MOLECULE=<scenario_name>` (default: `eos_cli_config_gen`) and Ansible options with `ANSIBLE_OPTIONS=<options>` (default: `--forks 5`).
-	cd .. && \
+	cd ../.. && \
 	molecule converge --scenario-name $(MOLECULE) -- $(ANSIBLE_OPTIONS)
 
 .PHONY: refresh-facts
@@ -25,8 +25,8 @@ refresh-facts: ## Run all "eos_designs" and "eos_cli_config_gen" molecule scenar
 	@while read -r MOLECULE_SCENARIO; do \
 		if [ -d "$$MOLECULE_SCENARIO" ]; then\
 			echo "Run scenario for "$$MOLECULE_SCENARIO && \
-			cd .. ; \
+			cd ../.. ; \
 			molecule converge --scenario-name $$MOLECULE_SCENARIO -- $(ANSIBLE_OPTIONS); \
-			cd ./molecule ; \
+			cd ./extensions/molecule ; \
 		fi \
 	done <MOLECULE_SCENARIOS.txt

--- a/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-wan1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-wan1.yml
@@ -374,10 +374,10 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-wan2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/anta_runner/intended/structured_configs/dc1-wan2.yml
@@ -396,10 +396,10 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/add-subnets-to-redistribution-in-default-vrf-with-sequence30.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/add-subnets-to-redistribution-in-default-vrf-with-sequence30.yml
@@ -227,10 +227,10 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1A1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1A1.yml
@@ -320,10 +320,10 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1B1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/asdot-for-wan-ha-transit1B1.yml
@@ -317,10 +317,10 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-1.yml
@@ -274,26 +274,26 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: CUSTOM-CP-POLICY
-      id: 254
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: CUSTOM-CP-POLICY
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: PROD
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-2.yml
@@ -389,26 +389,26 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: CUSTOM-CP-POLICY
-      id: 254
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: CUSTOM-CP-POLICY
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: PROD
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-edge-3.yml
@@ -335,26 +335,26 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: CUSTOM-CP-POLICY
-      id: 254
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: CUSTOM-CP-POLICY
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: PROD
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-custom-control-plane-policy-pathfinder-1.yml
@@ -460,26 +460,26 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: CUSTOM-CP-POLICY
-      id: 254
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: CUSTOM-CP-POLICY
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: PROD
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-custom-default-policy.yml
@@ -259,19 +259,19 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: PROD
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-default-policy.yml
@@ -248,20 +248,20 @@ router_adaptive_virtual_topology:
   - name: PROD
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-ipsec-for-wan-path-group.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-no-ipsec-for-wan-path-group.yml
@@ -322,19 +322,19 @@ router_adaptive_virtual_topology:
   - name: PROD
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-TEST
-      id: 42
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 42
+      name: DEFAULT-POLICY-TEST
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-TEST
-      id: 42
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 42
+      name: DEFAULT-POLICY-TEST
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-gateway-spine-uplink.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-gateway-spine-uplink.yml
@@ -307,30 +307,30 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: WAN-VRF-NO-AF
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-use-evpn-on-lan-no-overlay-on-lan.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-use-evpn-on-lan-no-overlay-on-lan.yml
@@ -298,30 +298,30 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: WAN-VRF-NO-AF
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-use-evpn-on-lan.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge-wan-use-evpn-on-lan.yml
@@ -307,30 +307,30 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: WAN-VRF-NO-AF
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge.yml
@@ -627,35 +627,35 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: ATTRACTED-VRF-FROM-UPLINK
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge1.yml
@@ -885,33 +885,33 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: ATTRACTED-VRF-FROM-UPLINK
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2A.yml
@@ -494,35 +494,35 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: ATTRACTED-VRF-FROM-UPLINK
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge2B.yml
@@ -477,35 +477,35 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: ATTRACTED-VRF-FROM-UPLINK
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge3A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge3A.yml
@@ -346,30 +346,30 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge3B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge3B.yml
@@ -345,30 +345,30 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4A.yml
@@ -374,30 +374,30 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-edge4B.yml
@@ -374,30 +374,30 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-metadata-with-no-default-vrf-in-wan-virtual-topologies.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-metadata-with-no-default-vrf-in-wan-virtual-topologies.yml
@@ -231,20 +231,20 @@ router_adaptive_virtual_topology:
   - name: PROD
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder.yml
@@ -612,53 +612,53 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: CUSTOM-VOICE-PROFILE-NAME
-      id: 42
-    - name: TRANSIT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 42
+      name: CUSTOM-VOICE-PROFILE-NAME
+    - id: 1
+      name: TRANSIT-AVT-POLICY-DEFAULT
   - name: ATTRACTED-VRF-FROM-UPLINK
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: WAN-VRF-NO-AF
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder1.yml
@@ -573,53 +573,53 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: CUSTOM-VOICE-PROFILE-NAME
-      id: 42
-    - name: TRANSIT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 42
+      name: CUSTOM-VOICE-PROFILE-NAME
+    - id: 1
+      name: TRANSIT-AVT-POLICY-DEFAULT
   - name: ATTRACTED-VRF-FROM-UPLINK
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: WAN-VRF-NO-AF
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-pathfinder2.yml
@@ -592,53 +592,53 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: CUSTOM-VOICE-PROFILE-NAME
-      id: 42
-    - name: TRANSIT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 42
+      name: CUSTOM-VOICE-PROFILE-NAME
+    - id: 1
+      name: TRANSIT-AVT-POLICY-DEFAULT
   - name: ATTRACTED-VRF-FROM-UPLINK
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: WAN-VRF-NO-AF
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1A.yml
@@ -505,42 +505,42 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: CUSTOM-VOICE-PROFILE-NAME
-      id: 42
-    - name: TRANSIT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 42
+      name: CUSTOM-VOICE-PROFILE-NAME
+    - id: 1
+      name: TRANSIT-AVT-POLICY-DEFAULT
   - name: ATTRACTED-VRF-FROM-UPLINK
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/cv-pathfinder-transit1B.yml
@@ -471,42 +471,42 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-AVT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-AVT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-AVT-POLICY-CONTROL-PLANE
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: PROD
     policy: PROD-AVT-POLICY
     profiles:
-    - name: PROD-AVT-POLICY-VOICE
-      id: 2
-    - name: PROD-AVT-POLICY-VIDEO
-      id: 4
-    - name: PROD-AVT-POLICY-MPLS-ONLY
-      id: 5
-    - name: PROD-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 2
+      name: PROD-AVT-POLICY-VOICE
+    - id: 4
+      name: PROD-AVT-POLICY-VIDEO
+    - id: 5
+      name: PROD-AVT-POLICY-MPLS-ONLY
+    - id: 1
+      name: PROD-AVT-POLICY-DEFAULT
   - name: IT
     policy: DEFAULT-AVT-POLICY
     profiles:
-    - name: DEFAULT-AVT-POLICY-VIDEO
-      id: 3
-    - name: DEFAULT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 3
+      name: DEFAULT-AVT-POLICY-VIDEO
+    - id: 1
+      name: DEFAULT-AVT-POLICY-DEFAULT
   - name: TRANSIT
     policy: TRANSIT-AVT-POLICY
     profiles:
-    - name: CUSTOM-VOICE-PROFILE-NAME
-      id: 42
-    - name: TRANSIT-AVT-POLICY-DEFAULT
-      id: 1
+    - id: 42
+      name: CUSTOM-VOICE-PROFILE-NAME
+    - id: 1
+      name: TRANSIT-AVT-POLICY-DEFAULT
   - name: ATTRACTED-VRF-FROM-UPLINK
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ebgp-overlay-address-families-vpn-ipv4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/ebgp-overlay-address-families-vpn-ipv4.yml
@@ -206,10 +206,10 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf1.yml
@@ -28,10 +28,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 300000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf2.yml
@@ -28,10 +28,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 300000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-l2-leaf3.yml
@@ -39,10 +39,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER-10
+      record_export:
         on_inactive_timeout: 50020
         on_interval: 300321
-      name: FLOW-TRACKER-10
       exporters:
       - name: ayush_exporter
         collectors:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-leaf2.yml
@@ -122,20 +122,20 @@ flow_tracking:
       ipv6: true
       threshold_minimum: 1332
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER-3
+      record_export:
         on_inactive_timeout: 50000
         on_interval: 300331
-      name: FLOW-TRACKER-3
       exporters:
       - name: ayush_exporter
         collectors:
         - host: 127.0.0.1
         local_interface: Loopback0
         template_interval: 40000
-    - record_export:
+    - name: FLOW-TRACKER-4
+      record_export:
         on_inactive_timeout: 50020
         on_interval: 300321
-      name: FLOW-TRACKER-4
       exporters:
       - name: ayush_exporter
         collectors:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-spine1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/flow-tracking-tests-spine1.yml
@@ -152,22 +152,22 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 50001
         on_interval: 300332
-      name: FLOW-TRACKER
       exporters:
       - name: ayush_exporter
         collectors:
         - host: 127.0.0.2
         local_interface: Loopback0
         template_interval: 40002
-    - table_size: 4331
+    - name: FLOW-TRACKER-1
+      table_size: 4331
       record_export:
         mpls: true
         on_inactive_timeout: 50000
         on_interval: 300331
-      name: FLOW-TRACKER-1
       exporters:
       - name: ayush_exporter
         collectors:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/network-services-l3-port-channels.yml
@@ -88,20 +88,20 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 300000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:
         - host: 127.0.0.1
         local_interface: Loopback0
         template_interval: 3600000
-    - record_export:
+    - name: FT_Test
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 300000
-      name: FT_Test
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-port-channels.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/node-type-l3-port-channels.yml
@@ -417,10 +417,10 @@ router_adaptive_virtual_topology:
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_l2leaf.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_l2leaf.yml
@@ -39,10 +39,10 @@ flow_tracking:
   sampled:
     sample: 10000
     trackers:
-    - record_export:
+    - name: FLOW-TRACKER
+      record_export:
         on_inactive_timeout: 70000
         on_interval: 300000
-      name: FLOW-TRACKER
       exporters:
       - name: CV-TELEMETRY
         collectors:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router1.yml
@@ -229,15 +229,15 @@ router_adaptive_virtual_topology:
   - name: VRF1
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/uplink_lan_wan_router2.yml
@@ -243,15 +243,15 @@ router_adaptive_virtual_topology:
   - name: VRF1
     policy: DEFAULT-POLICY
     profiles:
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
   - name: default
     policy: DEFAULT-POLICY-WITH-CP
     profiles:
-    - name: DEFAULT-POLICY-CONTROL-PLANE
-      id: 254
-    - name: DEFAULT-POLICY-DEFAULT
-      id: 1
+    - id: 254
+      name: DEFAULT-POLICY-CONTROL-PLANE
+    - id: 1
+      name: DEFAULT-POLICY-DEFAULT
 router_bfd:
   multihop:
     interval: 300

--- a/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
+++ b/python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py
@@ -4409,11 +4409,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             class ReservationsItem(AvdModel):
                 """Subclass of AvdModel."""
 
-                _fields: ClassVar[dict] = {"ipv4_address": {"type": str}, "mac_address": {"type": str}, "hostname": {"type": str}}
-                ipv4_address: str | None
-                """Valid IPv4 address from the given subnet."""
+                _fields: ClassVar[dict] = {"mac_address": {"type": str}, "ipv4_address": {"type": str}, "hostname": {"type": str}}
                 mac_address: str
                 """Ethernet address in format - HHHH.HHHH.HHHH"""
+                ipv4_address: str | None
+                """Valid IPv4 address from the given subnet."""
                 hostname: str | None
 
                 if TYPE_CHECKING:
@@ -4421,8 +4421,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     def __init__(
                         self,
                         *,
-                        ipv4_address: str | None | UndefinedType = Undefined,
                         mac_address: str | UndefinedType = Undefined,
+                        ipv4_address: str | None | UndefinedType = Undefined,
                         hostname: str | None | UndefinedType = Undefined,
                     ) -> None:
                         """
@@ -4432,8 +4432,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         Subclass of AvdModel.
 
                         Args:
-                            ipv4_address: Valid IPv4 address from the given subnet.
                             mac_address: Ethernet address in format - HHHH.HHHH.HHHH
+                            ipv4_address: Valid IPv4 address from the given subnet.
                             hostname: hostname
 
                         """
@@ -4627,11 +4627,11 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             class ReservationsItem(AvdModel):
                 """Subclass of AvdModel."""
 
-                _fields: ClassVar[dict] = {"ipv6_address": {"type": str}, "mac_address": {"type": str}, "hostname": {"type": str}}
-                ipv6_address: str | None
-                """Valid IPv6 address from the given subnet."""
+                _fields: ClassVar[dict] = {"mac_address": {"type": str}, "ipv6_address": {"type": str}, "hostname": {"type": str}}
                 mac_address: str
                 """Ethernet address in format - HHHH.HHHH.HHHH"""
+                ipv6_address: str | None
+                """Valid IPv6 address from the given subnet."""
                 hostname: str | None
 
                 if TYPE_CHECKING:
@@ -4639,8 +4639,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     def __init__(
                         self,
                         *,
-                        ipv6_address: str | None | UndefinedType = Undefined,
                         mac_address: str | UndefinedType = Undefined,
+                        ipv6_address: str | None | UndefinedType = Undefined,
                         hostname: str | None | UndefinedType = Undefined,
                     ) -> None:
                         """
@@ -4650,8 +4650,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         Subclass of AvdModel.
 
                         Args:
-                            ipv6_address: Valid IPv6 address from the given subnet.
                             mac_address: Ethernet address in format - HHHH.HHHH.HHHH
+                            ipv6_address: Valid IPv6 address from the given subnet.
                             hostname: hostname
 
                         """
@@ -4812,8 +4812,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
         Ipv6Subnets._item_type = Ipv6SubnetsItem
 
         _fields: ClassVar[dict] = {
-            "disabled": {"type": bool},
             "vrf": {"type": str},
+            "disabled": {"type": bool},
             "lease_time_ipv4": {"type": LeaseTimeIpv4},
             "lease_time_ipv6": {"type": LeaseTimeIpv6},
             "dns_domain_name_ipv4": {"type": str},
@@ -4826,9 +4826,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             "ipv6_subnets": {"type": Ipv6Subnets},
             "eos_cli": {"type": str},
         }
-        disabled: bool | None
         vrf: str
         """VRF in which to configure the DHCP server, use `default` to indicate default VRF."""
+        disabled: bool | None
         lease_time_ipv4: LeaseTimeIpv4
         """Subclass of AvdModel."""
         lease_time_ipv6: LeaseTimeIpv6
@@ -4863,8 +4863,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             def __init__(
                 self,
                 *,
-                disabled: bool | None | UndefinedType = Undefined,
                 vrf: str | UndefinedType = Undefined,
+                disabled: bool | None | UndefinedType = Undefined,
                 lease_time_ipv4: LeaseTimeIpv4 | UndefinedType = Undefined,
                 lease_time_ipv6: LeaseTimeIpv6 | UndefinedType = Undefined,
                 dns_domain_name_ipv4: str | None | UndefinedType = Undefined,
@@ -4884,8 +4884,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 Subclass of AvdModel.
 
                 Args:
-                    disabled: disabled
                     vrf: VRF in which to configure the DHCP server, use `default` to indicate default VRF.
+                    disabled: disabled
                     lease_time_ipv4: Subclass of AvdModel.
                     lease_time_ipv6: Subclass of AvdModel.
                     dns_domain_name_ipv4: dns_domain_name_ipv4
@@ -13715,17 +13715,17 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 Exporters._item_type = ExportersItem
 
                 _fields: ClassVar[dict] = {
+                    "name": {"type": str},
                     "table_size": {"type": int},
                     "record_export": {"type": RecordExport},
-                    "name": {"type": str},
                     "exporters": {"type": Exporters},
                 }
+                name: str
+                """Tracker Name."""
                 table_size: int | None
                 """Maximum number of entries in flow table."""
                 record_export: RecordExport
                 """Subclass of AvdModel."""
-                name: str
-                """Tracker Name."""
                 exporters: Exporters
                 """Subclass of AvdIndexedList with `ExportersItem` items. Primary key is `name` (`str`)."""
 
@@ -13734,9 +13734,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     def __init__(
                         self,
                         *,
+                        name: str | UndefinedType = Undefined,
                         table_size: int | None | UndefinedType = Undefined,
                         record_export: RecordExport | UndefinedType = Undefined,
-                        name: str | UndefinedType = Undefined,
                         exporters: Exporters | UndefinedType = Undefined,
                     ) -> None:
                         """
@@ -13746,9 +13746,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         Subclass of AvdModel.
 
                         Args:
+                            name: Tracker Name.
                             table_size: Maximum number of entries in flow table.
                             record_export: Subclass of AvdModel.
-                            name: Tracker Name.
                             exporters: Subclass of AvdIndexedList with `ExportersItem` items. Primary key is `name` (`str`).
 
                         """
@@ -38043,15 +38043,15 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
             class ProfilesItem(AvdModel):
                 """Subclass of AvdModel."""
 
-                _fields: ClassVar[dict] = {"name": {"type": str}, "id": {"type": int}}
-                name: str | None
-                """AVT profile name."""
+                _fields: ClassVar[dict] = {"id": {"type": int}, "name": {"type": str}}
                 id: int
                 """Unique ID for this AVT (per VRF)."""
+                name: str | None
+                """AVT profile name."""
 
                 if TYPE_CHECKING:
 
-                    def __init__(self, *, name: str | None | UndefinedType = Undefined, id: int | UndefinedType = Undefined) -> None:
+                    def __init__(self, *, id: int | UndefinedType = Undefined, name: str | None | UndefinedType = Undefined) -> None:
                         """
                         ProfilesItem.
 
@@ -38059,8 +38059,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                         Subclass of AvdModel.
 
                         Args:
-                            name: AVT profile name.
                             id: Unique ID for this AVT (per VRF).
+                            name: AVT profile name.
 
                         """
 
@@ -60406,9 +60406,9 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
 
             Networks._item_type = str
 
-            _fields: ClassVar[dict] = {"enabled": {"type": bool}, "vrf": {"type": str}, "metric_default": {"type": int}, "networks": {"type": Networks}}
-            enabled: bool | None
+            _fields: ClassVar[dict] = {"vrf": {"type": str}, "enabled": {"type": bool}, "metric_default": {"type": int}, "networks": {"type": Networks}}
             vrf: str
+            enabled: bool | None
             metric_default: int | None
             """Set default metric for the routes."""
             networks: Networks
@@ -60419,8 +60419,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                 def __init__(
                     self,
                     *,
-                    enabled: bool | None | UndefinedType = Undefined,
                     vrf: str | UndefinedType = Undefined,
+                    enabled: bool | None | UndefinedType = Undefined,
                     metric_default: int | None | UndefinedType = Undefined,
                     networks: Networks | UndefinedType = Undefined,
                 ) -> None:
@@ -60431,8 +60431,8 @@ class EosCliConfigGen(EosCliConfigGenRootModel):
                     Subclass of AvdModel.
 
                     Args:
-                        enabled: enabled
                         vrf: vrf
+                        enabled: enabled
                         metric_default: Set default metric for the routes.
                         networks: Subclass of AvdList with `str` items.
 

--- a/python-avd/pyavd/_eos_designs/eos_designs_facts/schema/protocol.py
+++ b/python-avd/pyavd/_eos_designs/eos_designs_facts/schema/protocol.py
@@ -952,8 +952,8 @@ class EosDesignsFactsProtocol(Protocol):
                     """
 
         _fields: ClassVar[dict] = {
-            "interfaces": {"type": Interfaces},
             "name": {"type": str},
+            "interfaces": {"type": Interfaces},
             "id": {"type": int},
             "description": {"type": str},
             "ipsec": {"type": Ipsec},
@@ -962,10 +962,10 @@ class EosDesignsFactsProtocol(Protocol):
             "excluded_from_default_policy": {"type": bool, "default": False},
             "dps_keepalive": {"type": DpsKeepalive},
         }
-        interfaces: Interfaces
-        """Subclass of AvdList with `InterfacesItem` items."""
         name: str
         """Path-group name."""
+        interfaces: Interfaces
+        """Subclass of AvdList with `InterfacesItem` items."""
         id: int
         """
         Path-group id.
@@ -1020,8 +1020,8 @@ class EosDesignsFactsProtocol(Protocol):
             def __init__(
                 self,
                 *,
-                interfaces: Interfaces | UndefinedType = Undefined,
                 name: str | UndefinedType = Undefined,
+                interfaces: Interfaces | UndefinedType = Undefined,
                 id: int | UndefinedType = Undefined,
                 description: str | None | UndefinedType = Undefined,
                 ipsec: Ipsec | UndefinedType = Undefined,
@@ -1037,8 +1037,8 @@ class EosDesignsFactsProtocol(Protocol):
                 Subclass of AvdModel.
 
                 Args:
-                    interfaces: Subclass of AvdList with `InterfacesItem` items.
                     name: Path-group name.
+                    interfaces: Subclass of AvdList with `InterfacesItem` items.
                     id:
                        Path-group id.
                        Required until an auto ID algorithm is implemented.

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -8248,8 +8248,8 @@ class EosDesigns(EosDesignsRootModel):
                         """
 
             _fields: ClassVar[dict] = {
-                "profile": {"type": str},
                 "name": {"type": str},
+                "profile": {"type": str},
                 "description": {"type": str},
                 "ip_address": {"type": str},
                 "dhcp_ip": {"type": str},
@@ -8277,14 +8277,14 @@ class EosDesigns(EosDesignsRootModel):
                 "flow_tracking": {"type": FlowTracking},
                 "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
             }
-            profile: str | None
-            """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
             name: str
             """
             Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
             For a
             subinterface, the parent physical interface is automatically created.
             """
+            profile: str | None
+            """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
             description: str | None
             """
             Interface description.
@@ -8439,8 +8439,8 @@ class EosDesigns(EosDesignsRootModel):
                 def __init__(
                     self,
                     *,
-                    profile: str | None | UndefinedType = Undefined,
                     name: str | UndefinedType = Undefined,
+                    profile: str | None | UndefinedType = Undefined,
                     description: str | None | UndefinedType = Undefined,
                     ip_address: str | None | UndefinedType = Undefined,
                     dhcp_ip: str | None | UndefinedType = Undefined,
@@ -8475,11 +8475,11 @@ class EosDesigns(EosDesignsRootModel):
                     Subclass of AvdModel.
 
                     Args:
-                        profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                         name:
                            Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                            For a
                            subinterface, the parent physical interface is automatically created.
+                        profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                         description:
                            Interface description.
                            If not set a default description will be configured with '[<peer>[
@@ -13304,8 +13304,8 @@ class EosDesigns(EosDesignsRootModel):
                         """
 
             _fields: ClassVar[dict] = {
-                "profile": {"type": str},
                 "name": {"type": str},
+                "profile": {"type": str},
                 "description": {"type": str},
                 "ip_address": {"type": str},
                 "dhcp_ip": {"type": str},
@@ -13333,14 +13333,14 @@ class EosDesigns(EosDesignsRootModel):
                 "flow_tracking": {"type": FlowTracking},
                 "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
             }
-            profile: str | None
-            """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
             name: str
             """
             Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
             For a
             subinterface, the parent physical interface is automatically created.
             """
+            profile: str | None
+            """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
             description: str | None
             """
             Interface description.
@@ -13495,8 +13495,8 @@ class EosDesigns(EosDesignsRootModel):
                 def __init__(
                     self,
                     *,
-                    profile: str | None | UndefinedType = Undefined,
                     name: str | UndefinedType = Undefined,
+                    profile: str | None | UndefinedType = Undefined,
                     description: str | None | UndefinedType = Undefined,
                     ip_address: str | None | UndefinedType = Undefined,
                     dhcp_ip: str | None | UndefinedType = Undefined,
@@ -13531,11 +13531,11 @@ class EosDesigns(EosDesignsRootModel):
                     Subclass of AvdModel.
 
                     Args:
-                        profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                         name:
                            Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                            For a
                            subinterface, the parent physical interface is automatically created.
+                        profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                         description:
                            Interface description.
                            If not set a default description will be configured with '[<peer>[
@@ -14546,10 +14546,10 @@ class EosDesigns(EosDesignsRootModel):
                     """
 
         _fields: ClassVar[dict] = {
+            "name": {"type": str},
             "profile": {"type": str},
             "type": {"type": str},
             "mlag_group": {"type": str},
-            "name": {"type": str},
             "downlink_pools": {"type": DownlinkPools},
             "id": {"type": int},
             "platform": {"type": str},
@@ -14677,6 +14677,8 @@ class EosDesigns(EosDesignsRootModel):
             "digital_twin": {"type": DigitalTwin},
             "validation_profile": {"type": str},
         }
+        name: str
+        """The Node Name is used as "hostname"."""
         profile: str | None
         """
         Inherit settings from a profile defined under `device_profiles`.
@@ -14698,8 +14700,6 @@ class EosDesigns(EosDesignsRootModel):
         creating MLAG Pairs, for port-channel descriptions on peers and for MLAG domain-id (unless
         mlag_domain_id is set).
         """
-        name: str
-        """The Node Name is used as "hostname"."""
         downlink_pools: DownlinkPools
         """
         IPv4 pools used for links to downlink switches. Set this on the parent switch. Cannot be combined
@@ -15592,10 +15592,10 @@ class EosDesigns(EosDesignsRootModel):
             def __init__(
                 self,
                 *,
+                name: str | UndefinedType = Undefined,
                 profile: str | None | UndefinedType = Undefined,
                 type: str | None | UndefinedType = Undefined,
                 mlag_group: str | None | UndefinedType = Undefined,
-                name: str | UndefinedType = Undefined,
                 downlink_pools: DownlinkPools | UndefinedType = Undefined,
                 id: int | None | UndefinedType = Undefined,
                 platform: str | None | UndefinedType = Undefined,
@@ -15730,6 +15730,7 @@ class EosDesigns(EosDesignsRootModel):
                 Subclass of AvdModel.
 
                 Args:
+                    name: The Node Name is used as "hostname".
                     profile:
                        Inherit settings from a profile defined under `device_profiles`.
                        Max two levels of profile
@@ -15745,7 +15746,6 @@ class EosDesigns(EosDesignsRootModel):
                        The group is used for
                        creating MLAG Pairs, for port-channel descriptions on peers and for MLAG domain-id (unless
                        mlag_domain_id is set).
-                    name: The Node Name is used as "hostname".
                     downlink_pools:
                        IPv4 pools used for links to downlink switches. Set this on the parent switch. Cannot be combined
                        with `uplink_ipv4_pool` set on the downlink switch.
@@ -24898,12 +24898,14 @@ class EosDesigns(EosDesignsRootModel):
             KeyType: TypeAlias = Literal["0", "7", "8a"]
             HashAlgorithm: TypeAlias = Literal["md5", "sha1"]
             _fields: ClassVar[dict] = {
+                "id": {"type": int},
                 "key": {"type": str},
                 "cleartext_key": {"type": str},
                 "key_type": {"type": str},
-                "id": {"type": int},
                 "hash_algorithm": {"type": str},
             }
+            id: int
+            """Key identifier."""
             key: str | None
             """
             Authentication provided using the `key_type` format.
@@ -24924,8 +24926,6 @@ class EosDesigns(EosDesignsRootModel):
             Key type of the `key`.
             Does not have any influence on `cleartext_key`.
             """
-            id: int
-            """Key identifier."""
             hash_algorithm: HashAlgorithm
 
             if TYPE_CHECKING:
@@ -24933,10 +24933,10 @@ class EosDesigns(EosDesignsRootModel):
                 def __init__(
                     self,
                     *,
+                    id: int | UndefinedType = Undefined,
                     key: str | None | UndefinedType = Undefined,
                     cleartext_key: str | None | UndefinedType = Undefined,
                     key_type: KeyType | None | UndefinedType = Undefined,
-                    id: int | UndefinedType = Undefined,
                     hash_algorithm: HashAlgorithm | UndefinedType = Undefined,
                 ) -> None:
                     """
@@ -24946,6 +24946,7 @@ class EosDesigns(EosDesignsRootModel):
                     Subclass of AvdModel.
 
                     Args:
+                        id: Key identifier.
                         key:
                            Authentication provided using the `key_type` format.
                            Will be rendered as such.
@@ -24960,7 +24961,6 @@ class EosDesigns(EosDesignsRootModel):
                         key_type:
                            Key type of the `key`.
                            Does not have any influence on `cleartext_key`.
-                        id: Key identifier.
                         hash_algorithm: hash_algorithm
 
                     """
@@ -36391,8 +36391,8 @@ class EosDesigns(EosDesignsRootModel):
                                     """
 
                         _fields: ClassVar[dict] = {
-                            "profile": {"type": str},
                             "name": {"type": str},
+                            "profile": {"type": str},
                             "description": {"type": str},
                             "ip_address": {"type": str},
                             "dhcp_ip": {"type": str},
@@ -36420,14 +36420,14 @@ class EosDesigns(EosDesignsRootModel):
                             "flow_tracking": {"type": FlowTracking},
                             "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
-                        profile: str | None
-                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         name: str
                         """
                         Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                         For a
                         subinterface, the parent physical interface is automatically created.
                         """
+                        profile: str | None
+                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         description: str | None
                         """
                         Interface description.
@@ -36582,8 +36582,8 @@ class EosDesigns(EosDesignsRootModel):
                             def __init__(
                                 self,
                                 *,
-                                profile: str | None | UndefinedType = Undefined,
                                 name: str | UndefinedType = Undefined,
+                                profile: str | None | UndefinedType = Undefined,
                                 description: str | None | UndefinedType = Undefined,
                                 ip_address: str | None | UndefinedType = Undefined,
                                 dhcp_ip: str | None | UndefinedType = Undefined,
@@ -36618,11 +36618,11 @@ class EosDesigns(EosDesignsRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     name:
                                        Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                                        For a
                                        subinterface, the parent physical interface is automatically created.
+                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     description:
                                        Interface description.
                                        If not set a default description will be configured with '[<peer>[
@@ -41431,8 +41431,8 @@ class EosDesigns(EosDesignsRootModel):
                                         """
 
                             _fields: ClassVar[dict] = {
-                                "profile": {"type": str},
                                 "name": {"type": str},
+                                "profile": {"type": str},
                                 "description": {"type": str},
                                 "ip_address": {"type": str},
                                 "dhcp_ip": {"type": str},
@@ -41460,14 +41460,14 @@ class EosDesigns(EosDesignsRootModel):
                                 "flow_tracking": {"type": FlowTracking},
                                 "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
-                            profile: str | None
-                            """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                             name: str
                             """
                             Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                             For a
                             subinterface, the parent physical interface is automatically created.
                             """
+                            profile: str | None
+                            """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                             description: str | None
                             """
                             Interface description.
@@ -41622,8 +41622,8 @@ class EosDesigns(EosDesignsRootModel):
                                 def __init__(
                                     self,
                                     *,
-                                    profile: str | None | UndefinedType = Undefined,
                                     name: str | UndefinedType = Undefined,
+                                    profile: str | None | UndefinedType = Undefined,
                                     description: str | None | UndefinedType = Undefined,
                                     ip_address: str | None | UndefinedType = Undefined,
                                     dhcp_ip: str | None | UndefinedType = Undefined,
@@ -41658,11 +41658,11 @@ class EosDesigns(EosDesignsRootModel):
                                     Subclass of AvdModel.
 
                                     Args:
-                                        profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                         name:
                                            Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                                            For a
                                            subinterface, the parent physical interface is automatically created.
+                                        profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                         description:
                                            Interface description.
                                            If not set a default description will be configured with '[<peer>[
@@ -46412,8 +46412,8 @@ class EosDesigns(EosDesignsRootModel):
                                     """
 
                         _fields: ClassVar[dict] = {
-                            "profile": {"type": str},
                             "name": {"type": str},
+                            "profile": {"type": str},
                             "description": {"type": str},
                             "ip_address": {"type": str},
                             "dhcp_ip": {"type": str},
@@ -46441,14 +46441,14 @@ class EosDesigns(EosDesignsRootModel):
                             "flow_tracking": {"type": FlowTracking},
                             "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
-                        profile: str | None
-                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         name: str
                         """
                         Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                         For a
                         subinterface, the parent physical interface is automatically created.
                         """
+                        profile: str | None
+                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         description: str | None
                         """
                         Interface description.
@@ -46603,8 +46603,8 @@ class EosDesigns(EosDesignsRootModel):
                             def __init__(
                                 self,
                                 *,
-                                profile: str | None | UndefinedType = Undefined,
                                 name: str | UndefinedType = Undefined,
+                                profile: str | None | UndefinedType = Undefined,
                                 description: str | None | UndefinedType = Undefined,
                                 ip_address: str | None | UndefinedType = Undefined,
                                 dhcp_ip: str | None | UndefinedType = Undefined,
@@ -46639,11 +46639,11 @@ class EosDesigns(EosDesignsRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     name:
                                        Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                                        For a
                                        subinterface, the parent physical interface is automatically created.
+                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     description:
                                        Interface description.
                                        If not set a default description will be configured with '[<peer>[
@@ -51467,8 +51467,8 @@ class EosDesigns(EosDesignsRootModel):
                                     """
 
                         _fields: ClassVar[dict] = {
-                            "profile": {"type": str},
                             "name": {"type": str},
+                            "profile": {"type": str},
                             "description": {"type": str},
                             "ip_address": {"type": str},
                             "dhcp_ip": {"type": str},
@@ -51496,14 +51496,14 @@ class EosDesigns(EosDesignsRootModel):
                             "flow_tracking": {"type": FlowTracking},
                             "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
-                        profile: str | None
-                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         name: str
                         """
                         Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                         For a
                         subinterface, the parent physical interface is automatically created.
                         """
+                        profile: str | None
+                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         description: str | None
                         """
                         Interface description.
@@ -51658,8 +51658,8 @@ class EosDesigns(EosDesignsRootModel):
                             def __init__(
                                 self,
                                 *,
-                                profile: str | None | UndefinedType = Undefined,
                                 name: str | UndefinedType = Undefined,
+                                profile: str | None | UndefinedType = Undefined,
                                 description: str | None | UndefinedType = Undefined,
                                 ip_address: str | None | UndefinedType = Undefined,
                                 dhcp_ip: str | None | UndefinedType = Undefined,
@@ -51694,11 +51694,11 @@ class EosDesigns(EosDesignsRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     name:
                                        Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                                        For a
                                        subinterface, the parent physical interface is automatically created.
+                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     description:
                                        Interface description.
                                        If not set a default description will be configured with '[<peer>[
@@ -68767,8 +68767,8 @@ class EosDesigns(EosDesignsRootModel):
                                     """
 
                         _fields: ClassVar[dict] = {
-                            "profile": {"type": str},
                             "name": {"type": str},
+                            "profile": {"type": str},
                             "description": {"type": str},
                             "ip_address": {"type": str},
                             "dhcp_ip": {"type": str},
@@ -68796,14 +68796,14 @@ class EosDesigns(EosDesignsRootModel):
                             "flow_tracking": {"type": FlowTracking},
                             "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
-                        profile: str | None
-                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         name: str
                         """
                         Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                         For a
                         subinterface, the parent physical interface is automatically created.
                         """
+                        profile: str | None
+                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         description: str | None
                         """
                         Interface description.
@@ -68958,8 +68958,8 @@ class EosDesigns(EosDesignsRootModel):
                             def __init__(
                                 self,
                                 *,
-                                profile: str | None | UndefinedType = Undefined,
                                 name: str | UndefinedType = Undefined,
+                                profile: str | None | UndefinedType = Undefined,
                                 description: str | None | UndefinedType = Undefined,
                                 ip_address: str | None | UndefinedType = Undefined,
                                 dhcp_ip: str | None | UndefinedType = Undefined,
@@ -68994,11 +68994,11 @@ class EosDesigns(EosDesignsRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     name:
                                        Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                                        For a
                                        subinterface, the parent physical interface is automatically created.
+                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     description:
                                        Interface description.
                                        If not set a default description will be configured with '[<peer>[
@@ -73807,8 +73807,8 @@ class EosDesigns(EosDesignsRootModel):
                                         """
 
                             _fields: ClassVar[dict] = {
-                                "profile": {"type": str},
                                 "name": {"type": str},
+                                "profile": {"type": str},
                                 "description": {"type": str},
                                 "ip_address": {"type": str},
                                 "dhcp_ip": {"type": str},
@@ -73836,14 +73836,14 @@ class EosDesigns(EosDesignsRootModel):
                                 "flow_tracking": {"type": FlowTracking},
                                 "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                             }
-                            profile: str | None
-                            """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                             name: str
                             """
                             Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                             For a
                             subinterface, the parent physical interface is automatically created.
                             """
+                            profile: str | None
+                            """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                             description: str | None
                             """
                             Interface description.
@@ -73998,8 +73998,8 @@ class EosDesigns(EosDesignsRootModel):
                                 def __init__(
                                     self,
                                     *,
-                                    profile: str | None | UndefinedType = Undefined,
                                     name: str | UndefinedType = Undefined,
+                                    profile: str | None | UndefinedType = Undefined,
                                     description: str | None | UndefinedType = Undefined,
                                     ip_address: str | None | UndefinedType = Undefined,
                                     dhcp_ip: str | None | UndefinedType = Undefined,
@@ -74034,11 +74034,11 @@ class EosDesigns(EosDesignsRootModel):
                                     Subclass of AvdModel.
 
                                     Args:
-                                        profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                         name:
                                            Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                                            For a
                                            subinterface, the parent physical interface is automatically created.
+                                        profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                         description:
                                            Interface description.
                                            If not set a default description will be configured with '[<peer>[
@@ -78788,8 +78788,8 @@ class EosDesigns(EosDesignsRootModel):
                                     """
 
                         _fields: ClassVar[dict] = {
-                            "profile": {"type": str},
                             "name": {"type": str},
+                            "profile": {"type": str},
                             "description": {"type": str},
                             "ip_address": {"type": str},
                             "dhcp_ip": {"type": str},
@@ -78817,14 +78817,14 @@ class EosDesigns(EosDesignsRootModel):
                             "flow_tracking": {"type": FlowTracking},
                             "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
-                        profile: str | None
-                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         name: str
                         """
                         Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                         For a
                         subinterface, the parent physical interface is automatically created.
                         """
+                        profile: str | None
+                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         description: str | None
                         """
                         Interface description.
@@ -78979,8 +78979,8 @@ class EosDesigns(EosDesignsRootModel):
                             def __init__(
                                 self,
                                 *,
-                                profile: str | None | UndefinedType = Undefined,
                                 name: str | UndefinedType = Undefined,
+                                profile: str | None | UndefinedType = Undefined,
                                 description: str | None | UndefinedType = Undefined,
                                 ip_address: str | None | UndefinedType = Undefined,
                                 dhcp_ip: str | None | UndefinedType = Undefined,
@@ -79015,11 +79015,11 @@ class EosDesigns(EosDesignsRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     name:
                                        Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                                        For a
                                        subinterface, the parent physical interface is automatically created.
+                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     description:
                                        Interface description.
                                        If not set a default description will be configured with '[<peer>[
@@ -83843,8 +83843,8 @@ class EosDesigns(EosDesignsRootModel):
                                     """
 
                         _fields: ClassVar[dict] = {
-                            "profile": {"type": str},
                             "name": {"type": str},
+                            "profile": {"type": str},
                             "description": {"type": str},
                             "ip_address": {"type": str},
                             "dhcp_ip": {"type": str},
@@ -83872,14 +83872,14 @@ class EosDesigns(EosDesignsRootModel):
                             "flow_tracking": {"type": FlowTracking},
                             "structured_config": {"type": EosCliConfigGen.EthernetInterfacesItem},
                         }
-                        profile: str | None
-                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         name: str
                         """
                         Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                         For a
                         subinterface, the parent physical interface is automatically created.
                         """
+                        profile: str | None
+                        """L3 interface profile name. Profile defined under `l3_interface_profiles`."""
                         description: str | None
                         """
                         Interface description.
@@ -84034,8 +84034,8 @@ class EosDesigns(EosDesignsRootModel):
                             def __init__(
                                 self,
                                 *,
-                                profile: str | None | UndefinedType = Undefined,
                                 name: str | UndefinedType = Undefined,
+                                profile: str | None | UndefinedType = Undefined,
                                 description: str | None | UndefinedType = Undefined,
                                 ip_address: str | None | UndefinedType = Undefined,
                                 dhcp_ip: str | None | UndefinedType = Undefined,
@@ -84070,11 +84070,11 @@ class EosDesigns(EosDesignsRootModel):
                                 Subclass of AvdModel.
 
                                 Args:
-                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     name:
                                        Ethernet interface name like 'Ethernet2' or subinterface name like 'Ethernet2.42'.
                                        For a
                                        subinterface, the parent physical interface is automatically created.
+                                    profile: L3 interface profile name. Profile defined under `l3_interface_profiles`.
                                     description:
                                        Interface description.
                                        If not set a default description will be configured with '[<peer>[

--- a/python-avd/pyavd/_eos_designs/schema/__init__.py
+++ b/python-avd/pyavd/_eos_designs/schema/__init__.py
@@ -491,10 +491,10 @@ class EosDesigns(EosDesignsRootModel):
             PasswordType: TypeAlias = Literal["sha512"]
             Shell: TypeAlias = Literal["/bin/bash", "/bin/sh", "/sbin/nologin"]
             _fields: ClassVar[dict] = {
+                "name": {"type": str},
                 "sha512_password": {"type": str},
                 "cleartext_password": {"type": str},
                 "password_type": {"type": str, "default": "sha512"},
-                "name": {"type": str},
                 "disabled": {"type": bool},
                 "privilege": {"type": int},
                 "role": {"type": str},
@@ -503,6 +503,8 @@ class EosDesigns(EosDesignsRootModel):
                 "secondary_ssh_key": {"type": str},
                 "shell": {"type": str},
             }
+            name: str
+            """Username."""
             sha512_password: str | None
             """
             SHA512 Hash of Password.
@@ -519,8 +521,6 @@ class EosDesigns(EosDesignsRootModel):
             """
             password_type: PasswordType
             """Default value: `"sha512"`"""
-            name: str
-            """Username."""
             disabled: bool | None
             """
             If true, the user will be removed and all other settings are ignored.
@@ -546,10 +546,10 @@ class EosDesigns(EosDesignsRootModel):
                 def __init__(
                     self,
                     *,
+                    name: str | UndefinedType = Undefined,
                     sha512_password: str | None | UndefinedType = Undefined,
                     cleartext_password: str | None | UndefinedType = Undefined,
                     password_type: PasswordType | UndefinedType = Undefined,
-                    name: str | UndefinedType = Undefined,
                     disabled: bool | None | UndefinedType = Undefined,
                     privilege: int | None | UndefinedType = Undefined,
                     role: str | None | UndefinedType = Undefined,
@@ -565,6 +565,7 @@ class EosDesigns(EosDesignsRootModel):
                     Subclass of AvdModel.
 
                     Args:
+                        name: Username.
                         sha512_password:
                            SHA512 Hash of Password.
                            Takes precedence over `cleartext_password`.
@@ -576,7 +577,6 @@ class EosDesigns(EosDesignsRootModel):
                            This variable is sensitive and
                            SHOULD be configured using some vault mechanism.
                         password_type: password_type
-                        name: Username.
                         disabled:
                            If true, the user will be removed and all other settings are ignored.
                            Useful for removing the

--- a/python-avd/schema_tools/generate_classes/class_src_gen.py
+++ b/python-avd/schema_tools/generate_classes/class_src_gen.py
@@ -5,17 +5,15 @@ from __future__ import annotations
 
 from functools import cached_property
 from keyword import iskeyword
-from typing import TYPE_CHECKING, Generic, TypeVar
-
-from schema_tools.metaschema.meta_schema_model import AvdSchemaDict
+from typing import TYPE_CHECKING, Generic, TypeVar, cast
 
 from .src_generators import ClassVarSrc, FieldSrc, FieldTypeHintSrc, ListSrc, LiteralSrc, ModelSrc, SrcData
 from .utils import generate_class_name, generate_class_name_from_ref
 
 if TYPE_CHECKING:
-    from schema_tools.metaschema.meta_schema_model import AvdSchemaBool, AvdSchemaInt, AvdSchemaList, AvdSchemaStr
+    from schema_tools.metaschema.meta_schema_model import AvdSchemaBool, AvdSchemaDict, AvdSchemaInt, AvdSchemaList, AvdSchemaStr
 
-    T = TypeVar("T", bound="AvdSchemaBool | AvdSchemaDict | AvdSchemaInt | AvdSchemaList | AvdSchemaStr")
+T = TypeVar("T", bound="AvdSchemaBool | AvdSchemaDict | AvdSchemaInt | AvdSchemaList | AvdSchemaStr")
 
 
 class SrcGenBase(Generic[T]):
@@ -225,8 +223,10 @@ class SrcGenList(SrcGenBase["AvdSchemaList"]):
         item_classes = []
 
         # Ensure that the items for lists with primary key always have the primary key as the first key:
-        if self.schema.primary_key and isinstance(self.schema.items, AvdSchemaDict) and self.schema.items.keys:
-            self.schema.items.keys = {self.schema.primary_key: self.schema.items.keys[self.schema.primary_key]} | self.schema.items.keys
+        if self.schema.primary_key:
+            self.schema.items = cast("AvdSchemaDict", self.schema.items)
+            if self.schema.items.keys:
+                self.schema.items.keys = {self.schema.primary_key: self.schema.items.keys[self.schema.primary_key]} | self.schema.items.keys
 
         fieldsrc = self.schema.items._generate_class_src(f"{self.get_class_name()}Item")
         item_classes.append(fieldsrc.cls)

--- a/python-avd/schema_tools/generate_classes/class_src_gen.py
+++ b/python-avd/schema_tools/generate_classes/class_src_gen.py
@@ -219,6 +219,11 @@ class SrcGenList(SrcGenBase):
             return None
 
         item_classes = []
+
+        # Ensure that the items for lists with primary key always have the primary key as the first key:
+        if self.schema.primary_key and self.schema.items.keys:
+            self.schema.items.keys = {self.schema.primary_key: self.schema.items.keys[self.schema.primary_key]} | self.schema.items.keys
+
         fieldsrc = self.schema.items._generate_class_src(f"{self.get_class_name()}Item")
         item_classes.append(fieldsrc.cls)
         if fieldsrc.item_classes:

--- a/python-avd/schema_tools/generate_classes/class_src_gen.py
+++ b/python-avd/schema_tools/generate_classes/class_src_gen.py
@@ -7,19 +7,15 @@ from functools import cached_property
 from keyword import iskeyword
 from typing import TYPE_CHECKING, Generic, TypeVar
 
+from schema_tools.metaschema.meta_schema_model import AvdSchemaDict
+
 from .src_generators import ClassVarSrc, FieldSrc, FieldTypeHintSrc, ListSrc, LiteralSrc, ModelSrc, SrcData
 from .utils import generate_class_name, generate_class_name_from_ref
 
 if TYPE_CHECKING:
-    from schema_tools.metaschema.meta_schema_model import (
-        AvdSchemaBool,
-        AvdSchemaDict,
-        AvdSchemaInt,
-        AvdSchemaList,
-        AvdSchemaStr,
-    )
+    from schema_tools.metaschema.meta_schema_model import AvdSchemaBool, AvdSchemaInt, AvdSchemaList, AvdSchemaStr
 
-T = TypeVar("T", bound="AvdSchemaBool | AvdSchemaDict | AvdSchemaInt | AvdSchemaList | AvdSchemaStr")
+    T = TypeVar("T", bound="AvdSchemaBool | AvdSchemaDict | AvdSchemaInt | AvdSchemaList | AvdSchemaStr")
 
 
 class SrcGenBase(Generic[T]):
@@ -229,7 +225,7 @@ class SrcGenList(SrcGenBase["AvdSchemaList"]):
         item_classes = []
 
         # Ensure that the items for lists with primary key always have the primary key as the first key:
-        if self.schema.primary_key and self.schema.items.keys:
+        if self.schema.primary_key and isinstance(self.schema.items, AvdSchemaDict) and self.schema.items.keys:
             self.schema.items.keys = {self.schema.primary_key: self.schema.items.keys[self.schema.primary_key]} | self.schema.items.keys
 
         fieldsrc = self.schema.items._generate_class_src(f"{self.get_class_name()}Item")


### PR DESCRIPTION
## Change Summary

<!-- Enter short PR description -->
Ensure the primary-key is first in AvdModel under an AvdIndexedList

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

When generating schema classes move the primary key to the top of the items dict.
This ensures we serialize it consistently.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

Reran molecules and observe the changes to structured config.
No config changes.

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
