### PR TITLE
Test: Add howto molecule scenario to MOLECULE_SCENARIOS.txt

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/MOLECULE_SCENARIOS.txt
+++ b/ansible_collections/arista/avd/extensions/molecule/MOLECULE_SCENARIOS.txt
@@ -19,3 +19,4 @@ example-l2ls-fabric
 example-single-dc-l3ls
 example-single-dc-l3ls-ipv6
 example-cv-pathfinder
+howto


### PR DESCRIPTION
## Change Summary

Since the `howto` molecule scenario was not included in MOLECULE_SCENARIOS.txt, `make refresh-facts` was not running `howto` scenario.
To fix this, including `howto` scenario in MOLECULE_SCENARIOS.txt

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.<role-name>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
