### PR TITLE
Doc(eos_designs): network services navigation refactor

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
@@ -1482,8 +1482,6 @@ for granular deployment of network services to the fabric leveraging the tenant 
 - This allows for the reuse of SVI/VLAN IDs across the fabric.
 - An error will be returned at runtime in case of duplicate or conflicting SVI/VLAN IDs or VNIs targeted towards the same device.
 
-### Settings
-
 The supported network services for each tenant cover:
 
 - VRFs
@@ -1509,31 +1507,31 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services.md
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/new-network-services-bgp-vrf-config.md
 --8<--
 
-#### VRFs
+### VRFs
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
 --8<--
 
-##### SVIs
+#### SVIs
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
 --8<--
 
-##### L3 interfaces
+#### L3 interfaces
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
 --8<--
 
-##### L3 port-channels
+#### L3 port-channels
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
 --8<--
 
-##### Loopbacks
+#### Loopbacks
 
 Loopbacks are usually configured with `vtep_diagnostic` which supports IP pools etc.
 
@@ -1544,13 +1542,13 @@ IP addresses on individual nodes.
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-loopbacks-settings.md
 --8<--
 
-##### BGP
+#### BGP
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
 --8<--
 
-##### OSPF
+#### OSPF
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
@@ -1574,7 +1572,7 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-po
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md
 --8<--
 
-### SVI profiles settings
+### SVI profiles
 
 SVI profiles can be leveraged to share common settings between SVIs.
 
@@ -1593,7 +1591,7 @@ SVI profiles can be leveraged to share common settings between SVIs.
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/svi-profiles.md
 --8<--
 
-### EVPN VLAN aware bundles settings
+### EVPN VLAN aware bundles
 
 EVPN VLAN aware bundles referenced by name in `<network_services_key>[].evpn_vlan_bundle` or `<network_services_key>[].vrfs[].svis[].evpn_vlan_bundle` or `<network_services_key>[].l2vlans[].evpn_vlan_bundle`.
 
@@ -1603,7 +1601,7 @@ An EVPN VLAN aware bundle will only be configured if at least one VLAN is associ
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/evpn-vlan-bundles.md
 --8<--
 
-### Network services keys settings
+### Network services keys
 
 Network Services can be grouped by using separate keys.
 

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
@@ -1482,7 +1482,7 @@ for granular deployment of network services to the fabric leveraging the tenant 
 - This allows for the reuse of SVI/VLAN IDs across the fabric.
 - An error will be returned at runtime in case of duplicate or conflicting SVI/VLAN IDs or VNIs targeted towards the same device.
 
-### Network services settings
+### Settings
 
 The supported network services for each tenant cover:
 
@@ -1509,31 +1509,31 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services.md
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/new-network-services-bgp-vrf-config.md
 --8<--
 
-#### Network services VRFs configuration
+#### VRFs
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
 --8<--
 
-#### Network services VRF SVIs configuration
+#### VRF SVIs
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
 --8<--
 
-#### Network services VRF L3 Interfaces configuration
+#### VRF L3 Interfaces
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
 --8<--
 
-#### Network services VRF L3 Port-Channels configuration
+#### VRF L3 Port-Channels
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
 --8<--
 
-#### Network services VRF Loopbacks configuration
+#### VRF Loopbacks
 
 Loopbacks are usually configured with `vtep_diagnostic` which supports IP pools etc.
 
@@ -1544,31 +1544,31 @@ IP addresses on individual nodes.
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-loopbacks-settings.md
 --8<--
 
-#### Network services VRF BGP configuration
+#### VRF BGP
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
 --8<--
 
-#### Network services VRF OSPF configuration
+#### VRF OSPF
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
 --8<--
 
-#### Network services L2 VLANs configuration
+#### L2 VLANs
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-l2vlans-settings.md
 --8<--
 
-#### Network services point-to-point services configuration
+#### Point-to-point services
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-point-to-point-services-settings.md
 --8<--
 
-#### Network services multicast configuration
+#### Multicast
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
@@ -1515,25 +1515,25 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/new-network-service
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-settings.md
 --8<--
 
-#### VRF SVIs
+##### SVIs
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-svis-settings.md
 --8<--
 
-#### VRF L3 Interfaces
+##### L3 interfaces
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-interfaces-settings.md
 --8<--
 
-#### VRF L3 Port-Channels
+##### L3 port-channels
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-l3-port-channel-settings.md
 --8<--
 
-#### VRF Loopbacks
+##### Loopbacks
 
 Loopbacks are usually configured with `vtep_diagnostic` which supports IP pools etc.
 
@@ -1544,13 +1544,13 @@ IP addresses on individual nodes.
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-loopbacks-settings.md
 --8<--
 
-#### VRF BGP
+##### BGP
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-bgp-settings.md
 --8<--
 
-#### VRF OSPF
+##### OSPF
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
@@ -1497,7 +1497,7 @@ The supported network services for each tenant cover:
 
 Typically services within each tenant share common VNI ranges and MAC VRF assignment pattern.
 
-The keys used to define network services are configurable using [`network_services_keys`](#network-services-keys-settings).
+The keys used to define network services are configurable using [`network_services_keys`](#network-services-keys).
 The default available keys is `tenants`.
 
 --8<--

--- a/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/data-models.md
@@ -1487,6 +1487,7 @@ The supported network services for each tenant cover:
 - VRFs
   - SVIs
   - L3 Interfaces
+  - L3 Port-Channels
   - Loopbacks
   - BGP routing
   - OSPF routing
@@ -1501,10 +1502,6 @@ The default available keys is `tenants`.
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services.md
---8<--
-
---8<--
-ansible_collections/arista/avd/roles/eos_designs/docs/tables/new-network-services-bgp-vrf-config.md
 --8<--
 
 ### VRFs
@@ -1554,19 +1551,19 @@ ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vr
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-vrfs-ospf-settings.md
 --8<--
 
-#### L2 VLANs
+### L2 VLANs
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-l2vlans-settings.md
 --8<--
 
-#### Point-to-point services
+### Point-to-point services
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-point-to-point-services-settings.md
 --8<--
 
-#### Multicast
+### Multicast
 
 --8<--
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/network-services-multicast-settings.md


### PR DESCRIPTION
## Change Summary

Simplify navigation title fro network services

## Component(s) name

`arista.avd.eos_config`

## Proposed changes
Modify navigation title for network services setttings 
Current navigation
```
Network Services
  Network services settings
    Network services VRFs configuration
    Network services VRF SVIs configuration
    Network services VRF L3 Interfaces configuration
    Network services VRF L3 Port-Channels configuration
    Network services VRF Loopbacks configuration
    Network services VRF BGP configuration
    Network services VRF OSPF configuration
    Network services L2 VLANs configuration
    Network services point-to-point services configuration
    Network services multicast configuration
  SVI profiles settings
  EVPN VLAN aware bundles settings
  Network services keys settings
```

Proposed navigation
```
Network Services
  VRFs
    SVIs
    L3 interfaces
    L3 port-channels
    Loopbacks
    BGP
    VRF OSPF
  L2 VLANs
  Point-to-point services
  Multicast
  SVI Profiles
  EVPN VLAN aware bundles
  Network services keys
```

## How to test
Review documentation site (input variables)
Run pre-commit

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
