### PR TITLE
Fix(eos_designs): Fix support for 'interface' keyword in custom descriptions for underlay ethernet interfaces

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1A.cfg
@@ -94,7 +94,7 @@ management api http-commands
       no shutdown
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet22
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet22
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -102,7 +102,7 @@ interface Ethernet1
    ip address 172.31.254.161/31
 !
 interface Ethernet2
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet22
+   description P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet22
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -110,7 +110,7 @@ interface Ethernet2
    ip address 172.31.254.163/31
 !
 interface Ethernet3
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet22
+   description P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet22
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -118,7 +118,7 @@ interface Ethernet3
    ip address 172.31.254.165/31
 !
 interface Ethernet4
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet22
+   description P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet22
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-BL1B.cfg
@@ -79,7 +79,7 @@ management api http-commands
       no shutdown
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet23
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet23
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -87,7 +87,7 @@ interface Ethernet1
    ip address 172.31.254.193/31
 !
 interface Ethernet2
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet23
+   description P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet23
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -95,7 +95,7 @@ interface Ethernet2
    ip address 172.31.254.195/31
 !
 interface Ethernet3
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet23
+   description P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet23
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -103,7 +103,7 @@ interface Ethernet3
    ip address 172.31.254.197/31
 !
 interface Ethernet4
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet23
+   description P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet23
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2A.cfg
@@ -67,7 +67,7 @@ management api http-commands
       no shutdown
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet24
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet24
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -75,7 +75,7 @@ interface Ethernet1
    ip address 172.31.254.225/31
 !
 interface Ethernet2
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet24
+   description P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet24
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -83,7 +83,7 @@ interface Ethernet2
    ip address 172.31.254.227/31
 !
 interface Ethernet3
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet24
+   description P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet24
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -91,7 +91,7 @@ interface Ethernet3
    ip address 172.31.254.229/31
 !
 interface Ethernet4
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet24
+   description P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet24
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-BL2B.cfg
@@ -65,7 +65,7 @@ management api http-commands
       no shutdown
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet25
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet25
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -73,7 +73,7 @@ interface Ethernet1
    ip address 172.31.255.1/31
 !
 interface Ethernet2
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet25
+   description P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet25
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -81,7 +81,7 @@ interface Ethernet2
    ip address 172.31.255.3/31
 !
 interface Ethernet3
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet25
+   description P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet25
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -89,7 +89,7 @@ interface Ethernet3
    ip address 172.31.255.5/31
 !
 interface Ethernet4
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet25
+   description P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet25
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1A.cfg
@@ -117,7 +117,7 @@ interface Port-Channel1151
    switchport
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet26
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet26
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -137,7 +137,7 @@ interface Ethernet1/16/1
    channel-group 1151 mode active
 !
 interface Ethernet2
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet26
+   description P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet26
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -145,7 +145,7 @@ interface Ethernet2
    ip address 172.31.255.35/31
 !
 interface Ethernet3
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet26
+   description P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet26
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -153,7 +153,7 @@ interface Ethernet3
    ip address 172.31.255.37/31
 !
 interface Ethernet4
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet26
+   description P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet26
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-CL1B.cfg
@@ -117,7 +117,7 @@ interface Port-Channel1311
    switchport
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet27
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet27
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -137,7 +137,7 @@ interface Ethernet1/32/1
    channel-group 1311 mode active
 !
 interface Ethernet2
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet27
+   description P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet27
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -145,7 +145,7 @@ interface Ethernet2
    ip address 172.31.255.67/31
 !
 interface Ethernet3
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet27
+   description P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet27
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -153,7 +153,7 @@ interface Ethernet3
    ip address 172.31.255.69/31
 !
 interface Ethernet4
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet27
+   description P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet27
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF1A.cfg
@@ -116,7 +116,7 @@ interface Ethernet9
    switchport
 !
 interface Ethernet27
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet1/1
+   description P2P_LINK_Ethernet27_TO_DC1-SPINE1_Ethernet1/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -124,7 +124,7 @@ interface Ethernet27
    ip address 172.31.254.1/31
 !
 interface Ethernet28
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet1/1/1
+   description P2P_LINK_Ethernet28_TO_DC1-SPINE2_Ethernet1/1/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -132,7 +132,7 @@ interface Ethernet28
    ip address 172.31.254.3/31
 !
 interface Ethernet29
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet1/1/1
+   description P2P_LINK_Ethernet29_TO_DC1-SPINE3_Ethernet1/1/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -140,7 +140,7 @@ interface Ethernet29
    ip address 172.31.254.5/31
 !
 interface Ethernet30
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet1/1
+   description P2P_LINK_Ethernet30_TO_DC1-SPINE4_Ethernet1/1
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2A.cfg
@@ -378,7 +378,7 @@ interface Ethernet32
    channel-group 32 mode active
 !
 interface Ethernet49/1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet3/1
+   description P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet3/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -388,7 +388,7 @@ interface Ethernet49/1
    link tracking group l2leaf-server02 upstream
 !
 interface Ethernet50/1
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet1/3/1
+   description P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet1/3/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -398,7 +398,7 @@ interface Ethernet50/1
    link tracking group l2leaf-server02 upstream
 !
 interface Ethernet51/1
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet1/4/1
+   description P2P_LINK_Ethernet51/1_TO_DC1-SPINE2_Ethernet1/4/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -408,7 +408,7 @@ interface Ethernet51/1
    link tracking group l2leaf-server02 upstream
 !
 interface Ethernet52/1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet4/1
+   description P2P_LINK_Ethernet52/1_TO_DC1-SPINE1_Ethernet4/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -418,7 +418,7 @@ interface Ethernet52/1
    link tracking group l2leaf-server02 upstream
 !
 interface Ethernet53/1
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet1/3/1
+   description P2P_LINK_Ethernet53/1_TO_DC1-SPINE3_Ethernet1/3/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -428,7 +428,7 @@ interface Ethernet53/1
    link tracking group l2leaf-server02 upstream
 !
 interface Ethernet54/1
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet3/1
+   description P2P_LINK_Ethernet54/1_TO_DC1-SPINE4_Ethernet3/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -438,7 +438,7 @@ interface Ethernet54/1
    link tracking group l2leaf-server02 upstream
 !
 interface Ethernet55/1
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet4/1
+   description P2P_LINK_Ethernet55/1_TO_DC1-SPINE4_Ethernet4/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -448,7 +448,7 @@ interface Ethernet55/1
    link tracking group l2leaf-server02 upstream
 !
 interface Ethernet56/1
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet1/4/1
+   description P2P_LINK_Ethernet56/1_TO_DC1-SPINE3_Ethernet1/4/1
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-LEAF2B.cfg
@@ -327,7 +327,7 @@ interface Ethernet31
    channel-group 30 mode active
 !
 interface Ethernet49/1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet5/1
+   description P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet5/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -336,7 +336,7 @@ interface Ethernet49/1
    link tracking group LT_GROUP1 upstream
 !
 interface Ethernet50/1
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet1/5/1
+   description P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet1/5/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -345,7 +345,7 @@ interface Ethernet50/1
    link tracking group LT_GROUP1 upstream
 !
 interface Ethernet51/1
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet1/6/1
+   description P2P_LINK_Ethernet51/1_TO_DC1-SPINE2_Ethernet1/6/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -354,7 +354,7 @@ interface Ethernet51/1
    link tracking group LT_GROUP1 upstream
 !
 interface Ethernet52/1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet6/1
+   description P2P_LINK_Ethernet52/1_TO_DC1-SPINE1_Ethernet6/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -363,7 +363,7 @@ interface Ethernet52/1
    link tracking group LT_GROUP1 upstream
 !
 interface Ethernet53/1
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet1/5/1
+   description P2P_LINK_Ethernet53/1_TO_DC1-SPINE3_Ethernet1/5/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -372,7 +372,7 @@ interface Ethernet53/1
    link tracking group LT_GROUP1 upstream
 !
 interface Ethernet54/1
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet5/1
+   description P2P_LINK_Ethernet54/1_TO_DC1-SPINE4_Ethernet5/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -381,7 +381,7 @@ interface Ethernet54/1
    link tracking group LT_GROUP1 upstream
 !
 interface Ethernet55/1
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet6/1
+   description P2P_LINK_Ethernet55/1_TO_DC1-SPINE4_Ethernet6/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -390,7 +390,7 @@ interface Ethernet55/1
    link tracking group LT_GROUP1 upstream
 !
 interface Ethernet56/1
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet1/6/1
+   description P2P_LINK_Ethernet56/1_TO_DC1-SPINE3_Ethernet1/6/1
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE1.cfg
@@ -41,7 +41,7 @@ management api http-commands
       no shutdown
 !
 interface Ethernet1/1
-   description P2P_LINK_TO_DC1-LEAF1A_Ethernet27
+   description P2P_LINK_Ethernet1/1_TO_DC1-LEAF1A_Ethernet27
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -49,7 +49,7 @@ interface Ethernet1/1
    ip address 172.31.254.0/31
 !
 interface Ethernet3/1
-   description P2P_LINK_TO_DC1-LEAF2A_Ethernet49/1
+   description P2P_LINK_Ethernet3/1_TO_DC1-LEAF2A_Ethernet49/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -57,7 +57,7 @@ interface Ethernet3/1
    ip address 172.31.254.32/31
 !
 interface Ethernet4/1
-   description P2P_LINK_TO_DC1-LEAF2A_Ethernet52/1
+   description P2P_LINK_Ethernet4/1_TO_DC1-LEAF2A_Ethernet52/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -65,7 +65,7 @@ interface Ethernet4/1
    ip address 172.31.254.38/31
 !
 interface Ethernet5/1
-   description P2P_LINK_TO_DC1-LEAF2B_Ethernet49/1
+   description P2P_LINK_Ethernet5/1_TO_DC1-LEAF2B_Ethernet49/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -73,7 +73,7 @@ interface Ethernet5/1
    ip address 172.31.254.64/31
 !
 interface Ethernet6/1
-   description P2P_LINK_TO_DC1-LEAF2B_Ethernet52/1
+   description P2P_LINK_Ethernet6/1_TO_DC1-LEAF2B_Ethernet52/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -81,7 +81,7 @@ interface Ethernet6/1
    ip address 172.31.254.70/31
 !
 interface Ethernet7/1
-   description P2P_LINK_TO_DC1-SVC3A_Ethernet49/1
+   description P2P_LINK_Ethernet7/1_TO_DC1-SVC3A_Ethernet49/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -89,7 +89,7 @@ interface Ethernet7/1
    ip address 172.31.254.96/31
 !
 interface Ethernet9/1
-   description P2P_LINK_TO_DC1-SVC3B_Ethernet49/1
+   description P2P_LINK_Ethernet9/1_TO_DC1-SVC3B_Ethernet49/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -97,7 +97,7 @@ interface Ethernet9/1
    ip address 172.31.254.128/31
 !
 interface Ethernet18
-   description P2P_LINK_TO_MLAG-OSPF-L3LEAF1A_Ethernet1
+   description P2P_LINK_Ethernet18_TO_MLAG-OSPF-L3LEAF1A_Ethernet1
    no shutdown
    mtu 1500
    speed forced 40gfull
@@ -113,7 +113,7 @@ interface Ethernet19
    ip address 10.10.101.0/31
 !
 interface Ethernet20
-   description P2P_LINK_TO_MH-LEAF1B_Ethernet1
+   description P2P_LINK_Ethernet20_TO_MH-LEAF1B_Ethernet1
    no shutdown
    mtu 1500
    speed forced 40gfull
@@ -121,7 +121,7 @@ interface Ethernet20
    ip address 10.10.101.2/31
 !
 interface Ethernet21
-   description P2P_LINK_TO_MH-LEAF2A_Ethernet1
+   description P2P_LINK_Ethernet21_TO_MH-LEAF2A_Ethernet1
    no shutdown
    mtu 1500
    speed forced 40gfull
@@ -129,7 +129,7 @@ interface Ethernet21
    ip address 10.10.101.4/31
 !
 interface Ethernet22
-   description P2P_LINK_TO_DC1-BL1A_Ethernet1
+   description P2P_LINK_Ethernet22_TO_DC1-BL1A_Ethernet1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -137,7 +137,7 @@ interface Ethernet22
    ip address 172.31.254.160/31
 !
 interface Ethernet23
-   description P2P_LINK_TO_DC1-BL1B_Ethernet1
+   description P2P_LINK_Ethernet23_TO_DC1-BL1B_Ethernet1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -145,7 +145,7 @@ interface Ethernet23
    ip address 172.31.254.192/31
 !
 interface Ethernet24
-   description P2P_LINK_TO_DC1-BL2A_Ethernet1
+   description P2P_LINK_Ethernet24_TO_DC1-BL2A_Ethernet1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -153,7 +153,7 @@ interface Ethernet24
    ip address 172.31.254.224/31
 !
 interface Ethernet25
-   description P2P_LINK_TO_DC1-BL2B_Ethernet1
+   description P2P_LINK_Ethernet25_TO_DC1-BL2B_Ethernet1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -161,7 +161,7 @@ interface Ethernet25
    ip address 172.31.255.0/31
 !
 interface Ethernet26
-   description P2P_LINK_TO_DC1-CL1A_Ethernet1
+   description P2P_LINK_Ethernet26_TO_DC1-CL1A_Ethernet1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -169,7 +169,7 @@ interface Ethernet26
    ip address 172.31.255.32/31
 !
 interface Ethernet27
-   description P2P_LINK_TO_DC1-CL1B_Ethernet1
+   description P2P_LINK_Ethernet27_TO_DC1-CL1B_Ethernet1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -177,7 +177,7 @@ interface Ethernet27
    ip address 172.31.255.64/31
 !
 interface Ethernet28
-   description P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet49/1
+   description P2P_LINK_Ethernet28_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet49/1
    shutdown
    mtu 1500
    speed 100g-2
@@ -185,7 +185,7 @@ interface Ethernet28
    ip address 172.31.255.128/31
 !
 interface Ethernet29
-   description P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet49/1
+   description P2P_LINK_Ethernet29_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet49/1
    shutdown
    mtu 1500
    speed forced 100gfull
@@ -193,7 +193,7 @@ interface Ethernet29
    ip address 172.31.255.160/31
 !
 interface Ethernet220
-   description P2P_LINK_TO_MLAG-OSPF-L3LEAF1B_Ethernet1
+   description P2P_LINK_Ethernet220_TO_MLAG-OSPF-L3LEAF1B_Ethernet1
    no shutdown
    mtu 1500
    speed forced 40gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE2.cfg
@@ -43,7 +43,7 @@ management api http-commands
       no shutdown
 !
 interface Ethernet1/1/1
-   description P2P_LINK_TO_DC1-LEAF1A_Ethernet28
+   description P2P_LINK_Ethernet1/1/1_TO_DC1-LEAF1A_Ethernet28
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -51,7 +51,7 @@ interface Ethernet1/1/1
    ip address 172.31.254.2/31
 !
 interface Ethernet1/3/1
-   description P2P_LINK_TO_DC1-LEAF2A_Ethernet50/1
+   description P2P_LINK_Ethernet1/3/1_TO_DC1-LEAF2A_Ethernet50/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -59,7 +59,7 @@ interface Ethernet1/3/1
    ip address 172.31.254.34/31
 !
 interface Ethernet1/4/1
-   description P2P_LINK_TO_DC1-LEAF2A_Ethernet51/1
+   description P2P_LINK_Ethernet1/4/1_TO_DC1-LEAF2A_Ethernet51/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -67,7 +67,7 @@ interface Ethernet1/4/1
    ip address 172.31.254.36/31
 !
 interface Ethernet1/5/1
-   description P2P_LINK_TO_DC1-LEAF2B_Ethernet50/1
+   description P2P_LINK_Ethernet1/5/1_TO_DC1-LEAF2B_Ethernet50/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -75,7 +75,7 @@ interface Ethernet1/5/1
    ip address 172.31.254.66/31
 !
 interface Ethernet1/6/1
-   description P2P_LINK_TO_DC1-LEAF2B_Ethernet51/1
+   description P2P_LINK_Ethernet1/6/1_TO_DC1-LEAF2B_Ethernet51/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -83,7 +83,7 @@ interface Ethernet1/6/1
    ip address 172.31.254.68/31
 !
 interface Ethernet1/7/1
-   description P2P_LINK_TO_DC1-SVC3A_Ethernet50/1
+   description P2P_LINK_Ethernet1/7/1_TO_DC1-SVC3A_Ethernet50/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -91,7 +91,7 @@ interface Ethernet1/7/1
    ip address 172.31.254.98/31
 !
 interface Ethernet1/9/1
-   description P2P_LINK_TO_DC1-SVC3B_Ethernet50/1
+   description P2P_LINK_Ethernet1/9/1_TO_DC1-SVC3B_Ethernet50/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -99,7 +99,7 @@ interface Ethernet1/9/1
    ip address 172.31.254.130/31
 !
 interface Ethernet22
-   description P2P_LINK_TO_DC1-BL1A_Ethernet2
+   description P2P_LINK_Ethernet22_TO_DC1-BL1A_Ethernet2
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -107,7 +107,7 @@ interface Ethernet22
    ip address 172.31.254.162/31
 !
 interface Ethernet23
-   description P2P_LINK_TO_DC1-BL1B_Ethernet2
+   description P2P_LINK_Ethernet23_TO_DC1-BL1B_Ethernet2
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -115,7 +115,7 @@ interface Ethernet23
    ip address 172.31.254.194/31
 !
 interface Ethernet24
-   description P2P_LINK_TO_DC1-BL2A_Ethernet2
+   description P2P_LINK_Ethernet24_TO_DC1-BL2A_Ethernet2
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -123,7 +123,7 @@ interface Ethernet24
    ip address 172.31.254.226/31
 !
 interface Ethernet25
-   description P2P_LINK_TO_DC1-BL2B_Ethernet2
+   description P2P_LINK_Ethernet25_TO_DC1-BL2B_Ethernet2
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -131,7 +131,7 @@ interface Ethernet25
    ip address 172.31.255.2/31
 !
 interface Ethernet26
-   description P2P_LINK_TO_DC1-CL1A_Ethernet2
+   description P2P_LINK_Ethernet26_TO_DC1-CL1A_Ethernet2
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -139,7 +139,7 @@ interface Ethernet26
    ip address 172.31.255.34/31
 !
 interface Ethernet27
-   description P2P_LINK_TO_DC1-CL1B_Ethernet2
+   description P2P_LINK_Ethernet27_TO_DC1-CL1B_Ethernet2
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -147,7 +147,7 @@ interface Ethernet27
    ip address 172.31.255.66/31
 !
 interface Ethernet28
-   description P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet50/1
+   description P2P_LINK_Ethernet28_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet50/1
    shutdown
    mtu 1500
    speed 100g-2
@@ -155,7 +155,7 @@ interface Ethernet28
    ip address 172.31.255.130/31
 !
 interface Ethernet29
-   description P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet50/1
+   description P2P_LINK_Ethernet29_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet50/1
    shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE3.cfg
@@ -41,7 +41,7 @@ management api http-commands
       no shutdown
 !
 interface Ethernet1/1/1
-   description P2P_LINK_TO_DC1-LEAF1A_Ethernet29
+   description P2P_LINK_Ethernet1/1/1_TO_DC1-LEAF1A_Ethernet29
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -49,7 +49,7 @@ interface Ethernet1/1/1
    ip address 172.31.254.4/31
 !
 interface Ethernet1/3/1
-   description P2P_LINK_TO_DC1-LEAF2A_Ethernet53/1
+   description P2P_LINK_Ethernet1/3/1_TO_DC1-LEAF2A_Ethernet53/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -57,7 +57,7 @@ interface Ethernet1/3/1
    ip address 172.31.254.40/31
 !
 interface Ethernet1/4/1
-   description P2P_LINK_TO_DC1-LEAF2A_Ethernet56/1
+   description P2P_LINK_Ethernet1/4/1_TO_DC1-LEAF2A_Ethernet56/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -65,7 +65,7 @@ interface Ethernet1/4/1
    ip address 172.31.254.46/31
 !
 interface Ethernet1/5/1
-   description P2P_LINK_TO_DC1-LEAF2B_Ethernet53/1
+   description P2P_LINK_Ethernet1/5/1_TO_DC1-LEAF2B_Ethernet53/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -73,7 +73,7 @@ interface Ethernet1/5/1
    ip address 172.31.254.72/31
 !
 interface Ethernet1/6/1
-   description P2P_LINK_TO_DC1-LEAF2B_Ethernet56/1
+   description P2P_LINK_Ethernet1/6/1_TO_DC1-LEAF2B_Ethernet56/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -81,7 +81,7 @@ interface Ethernet1/6/1
    ip address 172.31.254.78/31
 !
 interface Ethernet1/7/1
-   description P2P_LINK_TO_DC1-SVC3A_Ethernet51/1
+   description P2P_LINK_Ethernet1/7/1_TO_DC1-SVC3A_Ethernet51/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -89,7 +89,7 @@ interface Ethernet1/7/1
    ip address 172.31.254.100/31
 !
 interface Ethernet1/9/1
-   description P2P_LINK_TO_DC1-SVC3B_Ethernet51/1
+   description P2P_LINK_Ethernet1/9/1_TO_DC1-SVC3B_Ethernet51/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -97,7 +97,7 @@ interface Ethernet1/9/1
    ip address 172.31.254.132/31
 !
 interface Ethernet22
-   description P2P_LINK_TO_DC1-BL1A_Ethernet3
+   description P2P_LINK_Ethernet22_TO_DC1-BL1A_Ethernet3
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -105,7 +105,7 @@ interface Ethernet22
    ip address 172.31.254.164/31
 !
 interface Ethernet23
-   description P2P_LINK_TO_DC1-BL1B_Ethernet3
+   description P2P_LINK_Ethernet23_TO_DC1-BL1B_Ethernet3
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -113,7 +113,7 @@ interface Ethernet23
    ip address 172.31.254.196/31
 !
 interface Ethernet24
-   description P2P_LINK_TO_DC1-BL2A_Ethernet3
+   description P2P_LINK_Ethernet24_TO_DC1-BL2A_Ethernet3
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -121,7 +121,7 @@ interface Ethernet24
    ip address 172.31.254.228/31
 !
 interface Ethernet25
-   description P2P_LINK_TO_DC1-BL2B_Ethernet3
+   description P2P_LINK_Ethernet25_TO_DC1-BL2B_Ethernet3
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -129,7 +129,7 @@ interface Ethernet25
    ip address 172.31.255.4/31
 !
 interface Ethernet26
-   description P2P_LINK_TO_DC1-CL1A_Ethernet3
+   description P2P_LINK_Ethernet26_TO_DC1-CL1A_Ethernet3
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -137,7 +137,7 @@ interface Ethernet26
    ip address 172.31.255.36/31
 !
 interface Ethernet27
-   description P2P_LINK_TO_DC1-CL1B_Ethernet3
+   description P2P_LINK_Ethernet27_TO_DC1-CL1B_Ethernet3
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -145,7 +145,7 @@ interface Ethernet27
    ip address 172.31.255.68/31
 !
 interface Ethernet28
-   description P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet51/1
+   description P2P_LINK_Ethernet28_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet51/1
    shutdown
    mtu 1500
    speed 100g-2
@@ -153,7 +153,7 @@ interface Ethernet28
    ip address 172.31.255.132/31
 !
 interface Ethernet29
-   description P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet51/1
+   description P2P_LINK_Ethernet29_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet51/1
    shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SPINE4.cfg
@@ -41,7 +41,7 @@ management api http-commands
       no shutdown
 !
 interface Ethernet1/1
-   description P2P_LINK_TO_DC1-LEAF1A_Ethernet30
+   description P2P_LINK_Ethernet1/1_TO_DC1-LEAF1A_Ethernet30
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -49,7 +49,7 @@ interface Ethernet1/1
    ip address 172.31.254.6/31
 !
 interface Ethernet3/1
-   description P2P_LINK_TO_DC1-LEAF2A_Ethernet54/1
+   description P2P_LINK_Ethernet3/1_TO_DC1-LEAF2A_Ethernet54/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -57,7 +57,7 @@ interface Ethernet3/1
    ip address 172.31.254.42/31
 !
 interface Ethernet4/1
-   description P2P_LINK_TO_DC1-LEAF2A_Ethernet55/1
+   description P2P_LINK_Ethernet4/1_TO_DC1-LEAF2A_Ethernet55/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -65,7 +65,7 @@ interface Ethernet4/1
    ip address 172.31.254.44/31
 !
 interface Ethernet5/1
-   description P2P_LINK_TO_DC1-LEAF2B_Ethernet54/1
+   description P2P_LINK_Ethernet5/1_TO_DC1-LEAF2B_Ethernet54/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -73,7 +73,7 @@ interface Ethernet5/1
    ip address 172.31.254.74/31
 !
 interface Ethernet6/1
-   description P2P_LINK_TO_DC1-LEAF2B_Ethernet55/1
+   description P2P_LINK_Ethernet6/1_TO_DC1-LEAF2B_Ethernet55/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -81,7 +81,7 @@ interface Ethernet6/1
    ip address 172.31.254.76/31
 !
 interface Ethernet7/1
-   description P2P_LINK_TO_DC1-SVC3A_Ethernet52/1
+   description P2P_LINK_Ethernet7/1_TO_DC1-SVC3A_Ethernet52/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -89,7 +89,7 @@ interface Ethernet7/1
    ip address 172.31.254.102/31
 !
 interface Ethernet9/1
-   description P2P_LINK_TO_DC1-SVC3B_Ethernet52/1
+   description P2P_LINK_Ethernet9/1_TO_DC1-SVC3B_Ethernet52/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -97,21 +97,21 @@ interface Ethernet9/1
    ip address 172.31.254.134/31
 !
 interface Ethernet16
-   description P2P_LINK_TO_CV-TOPOLOGY-LEAF3A_Ethernet1
+   description P2P_LINK_Ethernet16_TO_CV-TOPOLOGY-LEAF3A_Ethernet1
    no shutdown
    mtu 1500
    no switchport
    ip address 10.10.101.2/31
 !
 interface Ethernet17
-   description P2P_LINK_TO_CV-TOPOLOGY-LEAF3B_Ethernet1
+   description P2P_LINK_Ethernet17_TO_CV-TOPOLOGY-LEAF3B_Ethernet1
    no shutdown
    mtu 1500
    no switchport
    ip address 10.10.101.4/31
 !
 interface Ethernet20
-   description P2P_LINK_TO_CV-MLAG-OSPF-L3LEAF1A_Ethernet1
+   description P2P_LINK_Ethernet20_TO_CV-MLAG-OSPF-L3LEAF1A_Ethernet1
    no shutdown
    mtu 1500
    speed forced 40gfull
@@ -119,7 +119,7 @@ interface Ethernet20
    ip address 10.10.101.6/31
 !
 interface Ethernet21
-   description P2P_LINK_TO_CV-MLAG-OSPF-L3LEAF1B_Ethernet1
+   description P2P_LINK_Ethernet21_TO_CV-MLAG-OSPF-L3LEAF1B_Ethernet1
    no shutdown
    mtu 1500
    speed forced 40gfull
@@ -127,7 +127,7 @@ interface Ethernet21
    ip address 10.10.101.8/31
 !
 interface Ethernet22
-   description P2P_LINK_TO_DC1-BL1A_Ethernet4
+   description P2P_LINK_Ethernet22_TO_DC1-BL1A_Ethernet4
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -135,7 +135,7 @@ interface Ethernet22
    ip address 172.31.254.166/31
 !
 interface Ethernet23
-   description P2P_LINK_TO_DC1-BL1B_Ethernet4
+   description P2P_LINK_Ethernet23_TO_DC1-BL1B_Ethernet4
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -143,7 +143,7 @@ interface Ethernet23
    ip address 172.31.254.198/31
 !
 interface Ethernet24
-   description P2P_LINK_TO_DC1-BL2A_Ethernet4
+   description P2P_LINK_Ethernet24_TO_DC1-BL2A_Ethernet4
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -151,7 +151,7 @@ interface Ethernet24
    ip address 172.31.254.230/31
 !
 interface Ethernet25
-   description P2P_LINK_TO_DC1-BL2B_Ethernet4
+   description P2P_LINK_Ethernet25_TO_DC1-BL2B_Ethernet4
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -159,7 +159,7 @@ interface Ethernet25
    ip address 172.31.255.6/31
 !
 interface Ethernet26
-   description P2P_LINK_TO_DC1-CL1A_Ethernet4
+   description P2P_LINK_Ethernet26_TO_DC1-CL1A_Ethernet4
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -167,7 +167,7 @@ interface Ethernet26
    ip address 172.31.255.38/31
 !
 interface Ethernet27
-   description P2P_LINK_TO_DC1-CL1B_Ethernet4
+   description P2P_LINK_Ethernet27_TO_DC1-CL1B_Ethernet4
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -175,7 +175,7 @@ interface Ethernet27
    ip address 172.31.255.70/31
 !
 interface Ethernet28
-   description P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet52/1
+   description P2P_LINK_Ethernet28_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet52/1
    no shutdown
    mtu 1500
    speed 100g-2
@@ -183,7 +183,7 @@ interface Ethernet28
    ip address 172.31.255.134/31
 !
 interface Ethernet29
-   description P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet52/1
+   description P2P_LINK_Ethernet29_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet52/1
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3A.cfg
@@ -591,7 +591,7 @@ interface Ethernet43
    channel-group 43 mode active
 !
 interface Ethernet49/1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet7/1
+   description P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet7/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -601,7 +601,7 @@ interface Ethernet49/1
    link tracking group link-tracking-group02 upstream
 !
 interface Ethernet50/1
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet1/7/1
+   description P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet1/7/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -611,7 +611,7 @@ interface Ethernet50/1
    link tracking group link-tracking-group02 upstream
 !
 interface Ethernet51/1
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet1/7/1
+   description P2P_LINK_Ethernet51/1_TO_DC1-SPINE3_Ethernet1/7/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -621,7 +621,7 @@ interface Ethernet51/1
    link tracking group link-tracking-group02 upstream
 !
 interface Ethernet52/1
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet7/1
+   description P2P_LINK_Ethernet52/1_TO_DC1-SPINE4_Ethernet7/1
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1-SVC3B.cfg
@@ -550,7 +550,7 @@ interface Ethernet44
    channel-group 43 mode active
 !
 interface Ethernet49/1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet9/1
+   description P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet9/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -558,7 +558,7 @@ interface Ethernet49/1
    ip address 172.31.254.129/31
 !
 interface Ethernet50/1
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet1/9/1
+   description P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet1/9/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -566,7 +566,7 @@ interface Ethernet50/1
    ip address 172.31.254.131/31
 !
 interface Ethernet51/1
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet1/9/1
+   description P2P_LINK_Ethernet51/1_TO_DC1-SPINE3_Ethernet1/9/1
    no shutdown
    mtu 1500
    speed forced 100gfull
@@ -574,7 +574,7 @@ interface Ethernet51/1
    ip address 172.31.254.133/31
 !
 interface Ethernet52/1
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet9/1
+   description P2P_LINK_Ethernet52/1_TO_DC1-SPINE4_Ethernet9/1
    no shutdown
    mtu 1500
    speed forced 100gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1A.cfg
@@ -180,28 +180,28 @@ interface Port-Channel571
    switchport
 !
 interface Ethernet49/1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet28
+   description P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet28
    no shutdown
    speed forced 100gfull
    no switchport
    ip address 172.31.255.129/31
 !
 interface Ethernet50/1
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet28
+   description P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet28
    no shutdown
    speed forced 100gfull
    no switchport
    ip address 172.31.255.131/31
 !
 interface Ethernet51/1
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet28
+   description P2P_LINK_Ethernet51/1_TO_DC1-SPINE3_Ethernet28
    no shutdown
    speed forced 100gfull
    no switchport
    ip address 172.31.255.133/31
 !
 interface Ethernet52/1
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet28
+   description P2P_LINK_Ethernet52/1_TO_DC1-SPINE4_Ethernet28
    no shutdown
    speed forced 100gfull
    no switchport

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/DC1_UNDEPLOYED_LEAF1B.cfg
@@ -180,28 +180,28 @@ interface Port-Channel571
    switchport
 !
 interface Ethernet49/1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet29
+   description P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet29
    no shutdown
    speed forced 100gfull
    no switchport
    ip address 172.31.255.161/31
 !
 interface Ethernet50/1
-   description P2P_LINK_TO_DC1-SPINE2_Ethernet29
+   description P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet29
    no shutdown
    speed forced 100gfull
    no switchport
    ip address 172.31.255.163/31
 !
 interface Ethernet51/1
-   description P2P_LINK_TO_DC1-SPINE3_Ethernet29
+   description P2P_LINK_Ethernet51/1_TO_DC1-SPINE3_Ethernet29
    no shutdown
    speed forced 100gfull
    no switchport
    ip address 172.31.255.165/31
 !
 interface Ethernet52/1
-   description P2P_LINK_TO_DC1-SPINE4_Ethernet29
+   description P2P_LINK_Ethernet52/1_TO_DC1-SPINE4_Ethernet29
    no shutdown
    speed forced 100gfull
    no switchport

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1A.cfg
@@ -214,7 +214,7 @@ interface Port-Channel22
    lacp system-id d716.1795.361e
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet19
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet19
    no shutdown
    mtu 1500
    speed forced 40gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF1B.cfg
@@ -214,7 +214,7 @@ interface Port-Channel22
    lacp system-id d716.1795.361e
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet20
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet20
    no shutdown
    mtu 1500
    speed forced 40gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MH-LEAF2A.cfg
@@ -69,7 +69,7 @@ interface Port-Channel2
    switchport
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet21
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet21
    no shutdown
    mtu 1500
    speed forced 40gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1A.cfg
@@ -54,7 +54,7 @@ interface Port-Channel5
    switchport
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet18
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet18
    no shutdown
    mtu 1500
    speed forced 40gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/MLAG-OSPF-L3LEAF1B.cfg
@@ -54,7 +54,7 @@ interface Port-Channel5
    switchport
 !
 interface Ethernet1
-   description P2P_LINK_TO_DC1-SPINE1_Ethernet220
+   description P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet220
    no shutdown
    mtu 1500
    speed forced 40gfull

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1A.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet22
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet22
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -29,7 +29,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet2
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet22
+  description: P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet22
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -41,7 +41,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet3
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet22
+  description: P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet22
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -53,7 +53,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet4
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet22
+  description: P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet22
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL1B.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet23
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet23
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -29,7 +29,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet2
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet23
+  description: P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet23
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -41,7 +41,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet3
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet23
+  description: P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet23
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -53,7 +53,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet4
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet23
+  description: P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet23
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2A.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet24
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet24
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -29,7 +29,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet2
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet24
+  description: P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet24
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -41,7 +41,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet3
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet24
+  description: P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet24
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -53,7 +53,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet4
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet24
+  description: P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet24
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-BL2B.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet25
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet25
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -29,7 +29,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet2
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet25
+  description: P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet25
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -41,7 +41,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet3
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet25
+  description: P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet25
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -53,7 +53,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet4
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet25
+  description: P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet25
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1A.yml
@@ -39,7 +39,7 @@ ethernet_interfaces:
     peer_interface: Ethernet1/16/1
     peer_type: mlag_peer
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet26
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet26
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -51,7 +51,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet2
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet26
+  description: P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet26
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -63,7 +63,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet3
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet26
+  description: P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet26
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -75,7 +75,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet4
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet26
+  description: P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet26
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-CL1B.yml
@@ -39,7 +39,7 @@ ethernet_interfaces:
     peer_interface: Ethernet1/32/1
     peer_type: mlag_peer
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet27
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet27
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -51,7 +51,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet2
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet27
+  description: P2P_LINK_Ethernet2_TO_DC1-SPINE2_Ethernet27
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -63,7 +63,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet3
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet27
+  description: P2P_LINK_Ethernet3_TO_DC1-SPINE3_Ethernet27
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -75,7 +75,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet4
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet27
+  description: P2P_LINK_Ethernet4_TO_DC1-SPINE4_Ethernet27
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF1A.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet27
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet1/1
+  description: P2P_LINK_Ethernet27_TO_DC1-SPINE1_Ethernet1/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -29,7 +29,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet28
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet1/1/1
+  description: P2P_LINK_Ethernet28_TO_DC1-SPINE2_Ethernet1/1/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -41,7 +41,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet29
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet1/1/1
+  description: P2P_LINK_Ethernet29_TO_DC1-SPINE3_Ethernet1/1/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -53,7 +53,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet30
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet1/1
+  description: P2P_LINK_Ethernet30_TO_DC1-SPINE4_Ethernet1/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2A.yml
@@ -99,7 +99,7 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
 - name: Ethernet49/1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet3/1
+  description: P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet3/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -116,7 +116,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet50/1
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet1/3/1
+  description: P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet1/3/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -133,7 +133,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet51/1
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet1/4/1
+  description: P2P_LINK_Ethernet51/1_TO_DC1-SPINE2_Ethernet1/4/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -150,7 +150,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet52/1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet4/1
+  description: P2P_LINK_Ethernet52/1_TO_DC1-SPINE1_Ethernet4/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -167,7 +167,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet53/1
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet1/3/1
+  description: P2P_LINK_Ethernet53/1_TO_DC1-SPINE3_Ethernet1/3/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -184,7 +184,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet54/1
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet3/1
+  description: P2P_LINK_Ethernet54/1_TO_DC1-SPINE4_Ethernet3/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -201,7 +201,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet55/1
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet4/1
+  description: P2P_LINK_Ethernet55/1_TO_DC1-SPINE4_Ethernet4/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -218,7 +218,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet56/1
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet1/4/1
+  description: P2P_LINK_Ethernet56/1_TO_DC1-SPINE3_Ethernet1/4/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-LEAF2B.yml
@@ -89,7 +89,7 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
 - name: Ethernet49/1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet5/1
+  description: P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet5/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -104,7 +104,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet50/1
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet1/5/1
+  description: P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet1/5/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -119,7 +119,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet51/1
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet1/6/1
+  description: P2P_LINK_Ethernet51/1_TO_DC1-SPINE2_Ethernet1/6/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -134,7 +134,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet52/1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet6/1
+  description: P2P_LINK_Ethernet52/1_TO_DC1-SPINE1_Ethernet6/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -149,7 +149,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet53/1
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet1/5/1
+  description: P2P_LINK_Ethernet53/1_TO_DC1-SPINE3_Ethernet1/5/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -164,7 +164,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet54/1
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet5/1
+  description: P2P_LINK_Ethernet54/1_TO_DC1-SPINE4_Ethernet5/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -179,7 +179,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet55/1
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet6/1
+  description: P2P_LINK_Ethernet55/1_TO_DC1-SPINE4_Ethernet6/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -194,7 +194,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet56/1
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet1/6/1
+  description: P2P_LINK_Ethernet56/1_TO_DC1-SPINE3_Ethernet1/6/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE1.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1/1
-  description: P2P_LINK_TO_DC1-LEAF1A_Ethernet27
+  description: P2P_LINK_Ethernet1/1_TO_DC1-LEAF1A_Ethernet27
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -29,7 +29,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet3/1
-  description: P2P_LINK_TO_DC1-LEAF2A_Ethernet49/1
+  description: P2P_LINK_Ethernet3/1_TO_DC1-LEAF2A_Ethernet49/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -41,7 +41,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet4/1
-  description: P2P_LINK_TO_DC1-LEAF2A_Ethernet52/1
+  description: P2P_LINK_Ethernet4/1_TO_DC1-LEAF2A_Ethernet52/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -53,7 +53,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet5/1
-  description: P2P_LINK_TO_DC1-LEAF2B_Ethernet49/1
+  description: P2P_LINK_Ethernet5/1_TO_DC1-LEAF2B_Ethernet49/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -65,7 +65,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet6/1
-  description: P2P_LINK_TO_DC1-LEAF2B_Ethernet52/1
+  description: P2P_LINK_Ethernet6/1_TO_DC1-LEAF2B_Ethernet52/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -77,7 +77,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet7/1
-  description: P2P_LINK_TO_DC1-SVC3A_Ethernet49/1
+  description: P2P_LINK_Ethernet7/1_TO_DC1-SVC3A_Ethernet49/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -89,7 +89,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet9/1
-  description: P2P_LINK_TO_DC1-SVC3B_Ethernet49/1
+  description: P2P_LINK_Ethernet9/1_TO_DC1-SVC3B_Ethernet49/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -101,7 +101,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet18
-  description: P2P_LINK_TO_MLAG-OSPF-L3LEAF1A_Ethernet1
+  description: P2P_LINK_Ethernet18_TO_MLAG-OSPF-L3LEAF1A_Ethernet1
   shutdown: false
   speed: forced 40gfull
   mtu: 1500
@@ -125,7 +125,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet20
-  description: P2P_LINK_TO_MH-LEAF1B_Ethernet1
+  description: P2P_LINK_Ethernet20_TO_MH-LEAF1B_Ethernet1
   shutdown: false
   speed: forced 40gfull
   mtu: 1500
@@ -137,7 +137,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet21
-  description: P2P_LINK_TO_MH-LEAF2A_Ethernet1
+  description: P2P_LINK_Ethernet21_TO_MH-LEAF2A_Ethernet1
   shutdown: false
   speed: forced 40gfull
   mtu: 1500
@@ -149,7 +149,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet22
-  description: P2P_LINK_TO_DC1-BL1A_Ethernet1
+  description: P2P_LINK_Ethernet22_TO_DC1-BL1A_Ethernet1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -161,7 +161,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet23
-  description: P2P_LINK_TO_DC1-BL1B_Ethernet1
+  description: P2P_LINK_Ethernet23_TO_DC1-BL1B_Ethernet1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -173,7 +173,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet24
-  description: P2P_LINK_TO_DC1-BL2A_Ethernet1
+  description: P2P_LINK_Ethernet24_TO_DC1-BL2A_Ethernet1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -185,7 +185,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet25
-  description: P2P_LINK_TO_DC1-BL2B_Ethernet1
+  description: P2P_LINK_Ethernet25_TO_DC1-BL2B_Ethernet1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -197,7 +197,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet26
-  description: P2P_LINK_TO_DC1-CL1A_Ethernet1
+  description: P2P_LINK_Ethernet26_TO_DC1-CL1A_Ethernet1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -209,7 +209,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet27
-  description: P2P_LINK_TO_DC1-CL1B_Ethernet1
+  description: P2P_LINK_Ethernet27_TO_DC1-CL1B_Ethernet1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -221,7 +221,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet28
-  description: P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet49/1
+  description: P2P_LINK_Ethernet28_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet49/1
   shutdown: true
   speed: 100g-2
   mtu: 1500
@@ -233,7 +233,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet29
-  description: P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet49/1
+  description: P2P_LINK_Ethernet29_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet49/1
   shutdown: true
   speed: forced 100gfull
   mtu: 1500
@@ -245,7 +245,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet220
-  description: P2P_LINK_TO_MLAG-OSPF-L3LEAF1B_Ethernet1
+  description: P2P_LINK_Ethernet220_TO_MLAG-OSPF-L3LEAF1B_Ethernet1
   shutdown: false
   speed: forced 40gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE2.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1/1/1
-  description: P2P_LINK_TO_DC1-LEAF1A_Ethernet28
+  description: P2P_LINK_Ethernet1/1/1_TO_DC1-LEAF1A_Ethernet28
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -29,7 +29,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/3/1
-  description: P2P_LINK_TO_DC1-LEAF2A_Ethernet50/1
+  description: P2P_LINK_Ethernet1/3/1_TO_DC1-LEAF2A_Ethernet50/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -41,7 +41,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/4/1
-  description: P2P_LINK_TO_DC1-LEAF2A_Ethernet51/1
+  description: P2P_LINK_Ethernet1/4/1_TO_DC1-LEAF2A_Ethernet51/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -53,7 +53,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/5/1
-  description: P2P_LINK_TO_DC1-LEAF2B_Ethernet50/1
+  description: P2P_LINK_Ethernet1/5/1_TO_DC1-LEAF2B_Ethernet50/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -65,7 +65,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/6/1
-  description: P2P_LINK_TO_DC1-LEAF2B_Ethernet51/1
+  description: P2P_LINK_Ethernet1/6/1_TO_DC1-LEAF2B_Ethernet51/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -77,7 +77,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/7/1
-  description: P2P_LINK_TO_DC1-SVC3A_Ethernet50/1
+  description: P2P_LINK_Ethernet1/7/1_TO_DC1-SVC3A_Ethernet50/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -89,7 +89,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/9/1
-  description: P2P_LINK_TO_DC1-SVC3B_Ethernet50/1
+  description: P2P_LINK_Ethernet1/9/1_TO_DC1-SVC3B_Ethernet50/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -101,7 +101,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet22
-  description: P2P_LINK_TO_DC1-BL1A_Ethernet2
+  description: P2P_LINK_Ethernet22_TO_DC1-BL1A_Ethernet2
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -113,7 +113,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet23
-  description: P2P_LINK_TO_DC1-BL1B_Ethernet2
+  description: P2P_LINK_Ethernet23_TO_DC1-BL1B_Ethernet2
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -125,7 +125,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet24
-  description: P2P_LINK_TO_DC1-BL2A_Ethernet2
+  description: P2P_LINK_Ethernet24_TO_DC1-BL2A_Ethernet2
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -137,7 +137,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet25
-  description: P2P_LINK_TO_DC1-BL2B_Ethernet2
+  description: P2P_LINK_Ethernet25_TO_DC1-BL2B_Ethernet2
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -149,7 +149,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet26
-  description: P2P_LINK_TO_DC1-CL1A_Ethernet2
+  description: P2P_LINK_Ethernet26_TO_DC1-CL1A_Ethernet2
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -161,7 +161,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet27
-  description: P2P_LINK_TO_DC1-CL1B_Ethernet2
+  description: P2P_LINK_Ethernet27_TO_DC1-CL1B_Ethernet2
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -173,7 +173,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet28
-  description: P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet50/1
+  description: P2P_LINK_Ethernet28_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet50/1
   shutdown: true
   speed: 100g-2
   mtu: 1500
@@ -185,7 +185,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet29
-  description: P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet50/1
+  description: P2P_LINK_Ethernet29_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet50/1
   shutdown: true
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE3.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1/1/1
-  description: P2P_LINK_TO_DC1-LEAF1A_Ethernet29
+  description: P2P_LINK_Ethernet1/1/1_TO_DC1-LEAF1A_Ethernet29
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -29,7 +29,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/3/1
-  description: P2P_LINK_TO_DC1-LEAF2A_Ethernet53/1
+  description: P2P_LINK_Ethernet1/3/1_TO_DC1-LEAF2A_Ethernet53/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -41,7 +41,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/4/1
-  description: P2P_LINK_TO_DC1-LEAF2A_Ethernet56/1
+  description: P2P_LINK_Ethernet1/4/1_TO_DC1-LEAF2A_Ethernet56/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -53,7 +53,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/5/1
-  description: P2P_LINK_TO_DC1-LEAF2B_Ethernet53/1
+  description: P2P_LINK_Ethernet1/5/1_TO_DC1-LEAF2B_Ethernet53/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -65,7 +65,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/6/1
-  description: P2P_LINK_TO_DC1-LEAF2B_Ethernet56/1
+  description: P2P_LINK_Ethernet1/6/1_TO_DC1-LEAF2B_Ethernet56/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -77,7 +77,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/7/1
-  description: P2P_LINK_TO_DC1-SVC3A_Ethernet51/1
+  description: P2P_LINK_Ethernet1/7/1_TO_DC1-SVC3A_Ethernet51/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -89,7 +89,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet1/9/1
-  description: P2P_LINK_TO_DC1-SVC3B_Ethernet51/1
+  description: P2P_LINK_Ethernet1/9/1_TO_DC1-SVC3B_Ethernet51/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -101,7 +101,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet22
-  description: P2P_LINK_TO_DC1-BL1A_Ethernet3
+  description: P2P_LINK_Ethernet22_TO_DC1-BL1A_Ethernet3
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -113,7 +113,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet23
-  description: P2P_LINK_TO_DC1-BL1B_Ethernet3
+  description: P2P_LINK_Ethernet23_TO_DC1-BL1B_Ethernet3
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -125,7 +125,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet24
-  description: P2P_LINK_TO_DC1-BL2A_Ethernet3
+  description: P2P_LINK_Ethernet24_TO_DC1-BL2A_Ethernet3
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -137,7 +137,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet25
-  description: P2P_LINK_TO_DC1-BL2B_Ethernet3
+  description: P2P_LINK_Ethernet25_TO_DC1-BL2B_Ethernet3
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -149,7 +149,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet26
-  description: P2P_LINK_TO_DC1-CL1A_Ethernet3
+  description: P2P_LINK_Ethernet26_TO_DC1-CL1A_Ethernet3
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -161,7 +161,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet27
-  description: P2P_LINK_TO_DC1-CL1B_Ethernet3
+  description: P2P_LINK_Ethernet27_TO_DC1-CL1B_Ethernet3
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -173,7 +173,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet28
-  description: P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet51/1
+  description: P2P_LINK_Ethernet28_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet51/1
   shutdown: true
   speed: 100g-2
   mtu: 1500
@@ -185,7 +185,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet29
-  description: P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet51/1
+  description: P2P_LINK_Ethernet29_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet51/1
   shutdown: true
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SPINE4.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1/1
-  description: P2P_LINK_TO_DC1-LEAF1A_Ethernet30
+  description: P2P_LINK_Ethernet1/1_TO_DC1-LEAF1A_Ethernet30
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -29,7 +29,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet3/1
-  description: P2P_LINK_TO_DC1-LEAF2A_Ethernet54/1
+  description: P2P_LINK_Ethernet3/1_TO_DC1-LEAF2A_Ethernet54/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -41,7 +41,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet4/1
-  description: P2P_LINK_TO_DC1-LEAF2A_Ethernet55/1
+  description: P2P_LINK_Ethernet4/1_TO_DC1-LEAF2A_Ethernet55/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -53,7 +53,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet5/1
-  description: P2P_LINK_TO_DC1-LEAF2B_Ethernet54/1
+  description: P2P_LINK_Ethernet5/1_TO_DC1-LEAF2B_Ethernet54/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -65,7 +65,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet6/1
-  description: P2P_LINK_TO_DC1-LEAF2B_Ethernet55/1
+  description: P2P_LINK_Ethernet6/1_TO_DC1-LEAF2B_Ethernet55/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -77,7 +77,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet7/1
-  description: P2P_LINK_TO_DC1-SVC3A_Ethernet52/1
+  description: P2P_LINK_Ethernet7/1_TO_DC1-SVC3A_Ethernet52/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -89,7 +89,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet9/1
-  description: P2P_LINK_TO_DC1-SVC3B_Ethernet52/1
+  description: P2P_LINK_Ethernet9/1_TO_DC1-SVC3B_Ethernet52/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -101,7 +101,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet16
-  description: P2P_LINK_TO_CV-TOPOLOGY-LEAF3A_Ethernet1
+  description: P2P_LINK_Ethernet16_TO_CV-TOPOLOGY-LEAF3A_Ethernet1
   shutdown: false
   mtu: 1500
   ip_address: 10.10.101.2/31
@@ -112,7 +112,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet17
-  description: P2P_LINK_TO_CV-TOPOLOGY-LEAF3B_Ethernet1
+  description: P2P_LINK_Ethernet17_TO_CV-TOPOLOGY-LEAF3B_Ethernet1
   shutdown: false
   mtu: 1500
   ip_address: 10.10.101.4/31
@@ -123,7 +123,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet20
-  description: P2P_LINK_TO_CV-MLAG-OSPF-L3LEAF1A_Ethernet1
+  description: P2P_LINK_Ethernet20_TO_CV-MLAG-OSPF-L3LEAF1A_Ethernet1
   shutdown: false
   speed: forced 40gfull
   mtu: 1500
@@ -135,7 +135,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet21
-  description: P2P_LINK_TO_CV-MLAG-OSPF-L3LEAF1B_Ethernet1
+  description: P2P_LINK_Ethernet21_TO_CV-MLAG-OSPF-L3LEAF1B_Ethernet1
   shutdown: false
   speed: forced 40gfull
   mtu: 1500
@@ -147,7 +147,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet22
-  description: P2P_LINK_TO_DC1-BL1A_Ethernet4
+  description: P2P_LINK_Ethernet22_TO_DC1-BL1A_Ethernet4
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -159,7 +159,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet23
-  description: P2P_LINK_TO_DC1-BL1B_Ethernet4
+  description: P2P_LINK_Ethernet23_TO_DC1-BL1B_Ethernet4
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -171,7 +171,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet24
-  description: P2P_LINK_TO_DC1-BL2A_Ethernet4
+  description: P2P_LINK_Ethernet24_TO_DC1-BL2A_Ethernet4
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -183,7 +183,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet25
-  description: P2P_LINK_TO_DC1-BL2B_Ethernet4
+  description: P2P_LINK_Ethernet25_TO_DC1-BL2B_Ethernet4
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -195,7 +195,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet26
-  description: P2P_LINK_TO_DC1-CL1A_Ethernet4
+  description: P2P_LINK_Ethernet26_TO_DC1-CL1A_Ethernet4
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -207,7 +207,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet27
-  description: P2P_LINK_TO_DC1-CL1B_Ethernet4
+  description: P2P_LINK_Ethernet27_TO_DC1-CL1B_Ethernet4
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -219,7 +219,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet28
-  description: P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet52/1
+  description: P2P_LINK_Ethernet28_TO_DC1_UNDEPLOYED_LEAF1A_Ethernet52/1
   shutdown: false
   speed: 100g-2
   mtu: 1500
@@ -231,7 +231,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet29
-  description: P2P_LINK_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet52/1
+  description: P2P_LINK_Ethernet29_TO_DC1_UNDEPLOYED_LEAF1B_Ethernet52/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3A.yml
@@ -61,7 +61,7 @@ ethernet_interfaces:
     peer_interface: Ethernet1
     peer_type: l2leaf
 - name: Ethernet49/1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet7/1
+  description: P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet7/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -78,7 +78,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet50/1
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet1/7/1
+  description: P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet1/7/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -95,7 +95,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet51/1
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet1/7/1
+  description: P2P_LINK_Ethernet51/1_TO_DC1-SPINE3_Ethernet1/7/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -112,7 +112,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet52/1
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet7/1
+  description: P2P_LINK_Ethernet52/1_TO_DC1-SPINE4_Ethernet7/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1-SVC3B.yml
@@ -61,7 +61,7 @@ ethernet_interfaces:
     peer_interface: Ethernet2
     peer_type: l2leaf
 - name: Ethernet49/1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet9/1
+  description: P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet9/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -73,7 +73,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet50/1
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet1/9/1
+  description: P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet1/9/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -85,7 +85,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet51/1
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet1/9/1
+  description: P2P_LINK_Ethernet51/1_TO_DC1-SPINE3_Ethernet1/9/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500
@@ -97,7 +97,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet52/1
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet9/1
+  description: P2P_LINK_Ethernet52/1_TO_DC1-SPINE4_Ethernet9/1
   shutdown: false
   speed: forced 100gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1A.yml
@@ -39,7 +39,7 @@ ethernet_interfaces:
     peer_interface: Ethernet58/1
     peer_type: mlag_peer
 - name: Ethernet49/1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet28
+  description: P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet28
   shutdown: false
   speed: forced 100gfull
   ip_address: 172.31.255.129/31
@@ -50,7 +50,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet50/1
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet28
+  description: P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet28
   shutdown: false
   speed: forced 100gfull
   ip_address: 172.31.255.131/31
@@ -61,7 +61,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet51/1
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet28
+  description: P2P_LINK_Ethernet51/1_TO_DC1-SPINE3_Ethernet28
   shutdown: false
   speed: forced 100gfull
   ip_address: 172.31.255.133/31
@@ -72,7 +72,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet52/1
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet28
+  description: P2P_LINK_Ethernet52/1_TO_DC1-SPINE4_Ethernet28
   shutdown: false
   speed: forced 100gfull
   ip_address: 172.31.255.135/31

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/DC1_UNDEPLOYED_LEAF1B.yml
@@ -39,7 +39,7 @@ ethernet_interfaces:
     peer_interface: Ethernet58/1
     peer_type: mlag_peer
 - name: Ethernet49/1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet29
+  description: P2P_LINK_Ethernet49/1_TO_DC1-SPINE1_Ethernet29
   shutdown: false
   speed: forced 100gfull
   ip_address: 172.31.255.161/31
@@ -50,7 +50,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet50/1
-  description: P2P_LINK_TO_DC1-SPINE2_Ethernet29
+  description: P2P_LINK_Ethernet50/1_TO_DC1-SPINE2_Ethernet29
   shutdown: false
   speed: forced 100gfull
   ip_address: 172.31.255.163/31
@@ -61,7 +61,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet51/1
-  description: P2P_LINK_TO_DC1-SPINE3_Ethernet29
+  description: P2P_LINK_Ethernet51/1_TO_DC1-SPINE3_Ethernet29
   shutdown: false
   speed: forced 100gfull
   ip_address: 172.31.255.165/31
@@ -72,7 +72,7 @@ ethernet_interfaces:
   switchport:
     enabled: false
 - name: Ethernet52/1
-  description: P2P_LINK_TO_DC1-SPINE4_Ethernet29
+  description: P2P_LINK_Ethernet52/1_TO_DC1-SPINE4_Ethernet29
   shutdown: false
   speed: forced 100gfull
   ip_address: 172.31.255.167/31

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1A.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet19
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet19
   shutdown: false
   speed: forced 40gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF1B.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet20
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet20
   shutdown: false
   speed: forced 40gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MH-LEAF2A.yml
@@ -17,7 +17,7 @@ enable_password:
   disabled: true
 ethernet_interfaces:
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet21
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet21
   shutdown: false
   speed: forced 40gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1A.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet18
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet18
   shutdown: false
   speed: forced 40gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/MLAG-OSPF-L3LEAF1B.yml
@@ -37,7 +37,7 @@ ethernet_interfaces:
     peer_interface: Ethernet6
     peer_type: mlag_peer
 - name: Ethernet1
-  description: P2P_LINK_TO_DC1-SPINE1_Ethernet220
+  description: P2P_LINK_Ethernet1_TO_DC1-SPINE1_Ethernet220
   shutdown: false
   speed: forced 40gfull
   mtu: 1500

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/AVD_LAB.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/AVD_LAB.yml
@@ -20,7 +20,7 @@ mlag_peer_l3_vrf_svi_description: "MLAG_PEER_L3_iBGP: vrf {vrf}"
 mlag_peer_l3_vrf_vlan_name: "MLAG_iBGP_{vrf}"
 mlag_bgp_peer_description: "{mlag_peer}"
 overlay_bgp_peer_description: "{peer}"
-default_underlay_p2p_ethernet_description: "P2P_LINK_TO_{peer!u}_{peer_interface}{vrf?<_vrf_}"
+default_underlay_p2p_ethernet_description: "P2P_LINK_{interface}_TO_{peer!u}_{peer_interface}{vrf?<_vrf_}"
 default_underlay_p2p_port_channel_description: "P2P_LINK_TO_{peer}_{peer_interface}" # This is not actively used in this scenario. Included for completeness.
 underlay_l2_ethernet_description: "{peer!u}_{peer_interface}"
 underlay_l2_port_channel_description: "{peer_node_group_or_uppercase_peer}_Po{peer_port_channel_id}"

--- a/python-avd/pyavd/api/interface_descriptions/__init__.py
+++ b/python-avd/pyavd/api/interface_descriptions/__init__.py
@@ -98,6 +98,7 @@ class AvdInterfaceDescriptions(AvdFacts):
             **strip_null_from_data(
                 {
                     "peer": data.peer,
+                    "interface": data.interface,
                     "peer_interface": data.peer_interface,
                     "vrf": data.vrf,
                     "wan_carrier": data.wan_carrier,


### PR DESCRIPTION

## Change Summary

<!-- Enter short PR description -->
Fix support for 'interface' keyword in custom descriptions for underlay ethernet interfaces
## Related Issue(s)

Fixes #6363 

## Component(s) name

`arista.avd.eos_designs>`

## Proposed changes
<!--- Describe your changes in detail -->
<!--- Describe data model implemented for new features -->

- Honor the given interface field when rendering the AvdFormatter strings.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

- Updated molecule tests to exercise this

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
