### PR TITLE
Doc(eos_designs): Remove duplicate mgmt interface-table

### DIFF
--- a/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
+++ b/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.md
@@ -818,12 +818,6 @@ The following underlay routing protocols are supported:
 ansible_collections/arista/avd/roles/eos_designs/docs/tables/fabric-settings.md
 --8<--
 
-## Management interface settings
-
---8<--
-ansible_collections/arista/avd/roles/eos_designs/docs/tables/management-interface-settings.md
---8<--
-
 ## BFD settings
 
 --8<--


### PR DESCRIPTION
## Change Summary

Remove duplicate management interface settigns. The table already is present in Management Settings -> Management Interface

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Remove table from the list 

Already present [here](https://avd.arista.com/devel/ansible_collections/arista/avd/roles/eos_designs/docs/input-variables.html#management-interface)

## How to test
Run pre-commit 
Review documentation 

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
