### PR TITLE
CI: Add schemas.json.gz to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 /python-avd/pyavd/_eos_cli_config_gen/schema/__init__.py  linguist-generated=true -merge -diff
 /python-avd/pyavd/_eos_designs/schema/__init__.py linguist-generated=true -merge -diff
 /python-avd/pyavd/_eos_designs/eos_designs_facts/schema/protocol.py linguist-generated=true -merge -diff
+/python-avd/pyavd/_schema/schemas.json.gz linguist-generated=true -merge -diff
 
 # Showing generated tables in PR diff by default by count as generated and automatically use the latest file on merge
 /ansible_collections/arista/avd/roles/eos_cli_config_gen/docs/tables/*  linguist-generated=true -merge diff


### PR DESCRIPTION
Add schemas.json.gz to .gitattributes to avoid constant merge conflicts since this is a binary file.