### PR TITLE
Refactor(eos_designs)!: Render RR-OVERLAY-PEERS peer group only when there are some peers

### DIFF
--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE1-RR1.yml
@@ -145,9 +145,9 @@ router_bgp:
     neighbor_default:
       encapsulation: mpls
     peer_groups:
-    - name: RR-OVERLAY-PEERS
-      activate: true
     - name: MPLS-OVERLAY-PEERS
+      activate: true
+    - name: RR-OVERLAY-PEERS
       activate: true
   address_family_ipv4:
     peer_groups:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs-mpls-isis-sr-ldp/intended/structured_configs/SITE2-RR1.yml
@@ -145,9 +145,9 @@ router_bgp:
     neighbor_default:
       encapsulation: mpls
     peer_groups:
-    - name: RR-OVERLAY-PEERS
-      activate: true
     - name: MPLS-OVERLAY-PEERS
+      activate: true
+    - name: RR-OVERLAY-PEERS
       activate: true
   address_family_ipv4:
     peer_groups:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-2.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-2.cfg
@@ -115,12 +115,6 @@ router bgp 65001
    neighbor MLAG-IPv4-VRFS-PEER route-map RM-MLAG-PEER-IN in
    neighbor MLAG-IPv4-VRFS-PEER send-community
    neighbor MLAG-IPv4-VRFS-PEER maximum-routes 12003
-   neighbor RR-OVERLAY-PEERS peer group
-   neighbor RR-OVERLAY-PEERS remote-as 65001
-   neighbor RR-OVERLAY-PEERS update-source Loopback0
-   neighbor RR-OVERLAY-PEERS description Description for rr_overlay_peers via structured_config
-   neighbor RR-OVERLAY-PEERS send-community
-   neighbor RR-OVERLAY-PEERS maximum-routes 0
    neighbor 192.168.252.206 peer group IPv4-UNDERLAY-PEERS
    neighbor 192.168.252.206 remote-as 65001
    neighbor 192.168.252.206 description bgp-peer-groups-3_Ethernet2
@@ -138,9 +132,5 @@ router bgp 65001
       neighbor IPv4-UNDERLAY-PEERS activate
       neighbor MLAG-IPv4-UNDERLAY-PEER activate
       neighbor MLAG-IPv4-VRFS-PEER activate
-      no neighbor RR-OVERLAY-PEERS activate
-   !
-   address-family vpn-ipv4
-      neighbor RR-OVERLAY-PEERS activate
 !
 end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-4.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/bgp-peer-groups-4.cfg
@@ -1,0 +1,76 @@
+!
+no enable password
+no aaa root
+!
+vlan internal order ascending range 1006 1199
+!
+transceiver qsfp default-mode 4x10G
+!
+service routing protocols model multi-agent
+!
+hostname bgp-peer-groups-4
+!
+vrf instance MGMT
+!
+interface Loopback0
+   description ROUTER_ID
+   no shutdown
+   ip address 192.168.255.115/32
+   node-segment ipv4 index 207
+   isis enable CORE
+   isis passive
+!
+ip routing
+no ip routing vrf MGMT
+!
+ip route vrf MGMT 0.0.0.0/0 192.168.0.1
+!
+mpls ip
+!
+router bfd
+   multihop interval 300 min-rx 300 multiplier 3
+!
+router bgp 65001
+   router-id 192.168.255.115
+   update wait-install
+   no bgp default ipv4-unicast
+   bgp cluster-id 192.168.255.115
+   maximum-paths 4
+   neighbor MPLS-OVERLAY-PEERS peer group
+   neighbor MPLS-OVERLAY-PEERS remote-as 65001
+   neighbor MPLS-OVERLAY-PEERS update-source Loopback0
+   neighbor MPLS-OVERLAY-PEERS description Description for mpls_overlay_peers via structured_config
+   neighbor MPLS-OVERLAY-PEERS route-reflector-client
+   neighbor MPLS-OVERLAY-PEERS send-community
+   neighbor MPLS-OVERLAY-PEERS maximum-routes 0
+   neighbor RR-OVERLAY-PEERS peer group
+   neighbor RR-OVERLAY-PEERS remote-as 65001
+   neighbor RR-OVERLAY-PEERS update-source Loopback0
+   neighbor RR-OVERLAY-PEERS description Description for rr_overlay_peers via structured_config
+   neighbor RR-OVERLAY-PEERS send-community
+   neighbor RR-OVERLAY-PEERS maximum-routes 0
+   neighbor 192.168.255.112 peer group RR-OVERLAY-PEERS
+   neighbor 192.168.255.112 description bgp-peer-groups-2_Loopback0
+   !
+   address-family evpn
+      neighbor default encapsulation mpls next-hop-self source-interface Loopback0
+      neighbor MPLS-OVERLAY-PEERS activate
+      neighbor RR-OVERLAY-PEERS activate
+   !
+   address-family ipv4
+      no neighbor MPLS-OVERLAY-PEERS activate
+      no neighbor RR-OVERLAY-PEERS activate
+!
+router isis CORE
+   net 49.0001.1921.6825.5115.00
+   router-id ipv4 192.168.255.115
+   is-type level-1-2
+   log-adjacency-changes
+   !
+   address-family ipv4 unicast
+      maximum-paths 4
+   !
+   segment-routing mpls
+      no shutdown
+!
+end

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn_overlay_mpls_route_reflectors2_ibgp.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn_overlay_mpls_route_reflectors2_ibgp.cfg
@@ -65,7 +65,6 @@ router bgp 65233
    address-family evpn
       neighbor default encapsulation mpls
       neighbor MPLS-OVERLAY-PEERS activate
-      neighbor RR-OVERLAY-PEERS activate
    !
    address-family ipv4
       no neighbor MPLS-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn_overlay_mpls_route_reflectors2_ibgp.cfg
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/configs/evpn_overlay_mpls_route_reflectors2_ibgp.cfg
@@ -60,12 +60,6 @@ router bgp 65233
    neighbor MPLS-OVERLAY-PEERS route-reflector-client
    neighbor MPLS-OVERLAY-PEERS send-community
    neighbor MPLS-OVERLAY-PEERS maximum-routes 0
-   neighbor RR-OVERLAY-PEERS peer group
-   neighbor RR-OVERLAY-PEERS remote-as 65233
-   neighbor RR-OVERLAY-PEERS update-source Loopback0
-   neighbor RR-OVERLAY-PEERS bfd
-   neighbor RR-OVERLAY-PEERS send-community
-   neighbor RR-OVERLAY-PEERS maximum-routes 0
    redistribute connected route-map RM-CONN-2-BGP
    !
    address-family evpn
@@ -75,7 +69,6 @@ router bgp 65233
    !
    address-family ipv4
       no neighbor MPLS-OVERLAY-PEERS activate
-      no neighbor RR-OVERLAY-PEERS activate
    !
    address-family rt-membership
       neighbor MPLS-OVERLAY-PEERS activate

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-2.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-2.yml
@@ -127,15 +127,6 @@ router_bgp:
     bfd: false
     send_community: all
     maximum_routes: 0
-  - name: RR-OVERLAY-PEERS
-    metadata:
-      type: mpls
-    remote_as: '65001'
-    description: Description for rr_overlay_peers via structured_config
-    update_source: Loopback0
-    bfd: false
-    send_community: all
-    maximum_routes: 0
   neighbors:
   - ip_address: 192.168.253.204
     peer_group: MLAG-IPv4-UNDERLAY-PEER
@@ -171,12 +162,6 @@ router_bgp:
       activate: true
     - name: EVPN-OVERLAY-PEERS
       activate: false
-    - name: RR-OVERLAY-PEERS
-      activate: false
-  address_family_vpn_ipv4:
-    peer_groups:
-    - name: RR-OVERLAY-PEERS
-      activate: true
 service_routing_protocols_model: multi-agent
 spanning_tree:
   no_spanning_tree_vlan: '4094'

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/bgp-peer-groups-4.yml
@@ -1,0 +1,106 @@
+aaa_root:
+  disabled: true
+config_end: true
+enable_password:
+  disabled: true
+hostname: bgp-peer-groups-4
+ip_igmp_snooping:
+  globally_enabled: true
+ip_routing: true
+loopback_interfaces:
+- name: Loopback0
+  description: ROUTER_ID
+  shutdown: false
+  ip_address: 192.168.255.115/32
+  isis_enable: CORE
+  isis_passive: true
+  node_segment:
+    ipv4_index: 207
+metadata:
+  is_deployed: true
+  fabric_name: EOS_DESIGNS_UNIT_TESTS
+mpls:
+  ip: true
+router_bfd:
+  multihop:
+    interval: 300
+    min_rx: 300
+    multiplier: 3
+router_bgp:
+  as: '65001'
+  router_id: 192.168.255.115
+  maximum_paths:
+    paths: 4
+  updates:
+    wait_install: true
+  bgp_cluster_id: 192.168.255.115
+  bgp:
+    default:
+      ipv4_unicast: false
+  peer_groups:
+  - name: MPLS-OVERLAY-PEERS
+    metadata:
+      type: mpls
+    remote_as: '65001'
+    description: Description for mpls_overlay_peers via structured_config
+    update_source: Loopback0
+    route_reflector_client: true
+    bfd: false
+    send_community: all
+    maximum_routes: 0
+  - name: RR-OVERLAY-PEERS
+    metadata:
+      type: mpls
+    remote_as: '65001'
+    description: Description for rr_overlay_peers via structured_config
+    update_source: Loopback0
+    bfd: false
+    send_community: all
+    maximum_routes: 0
+  neighbors:
+  - ip_address: 192.168.255.112
+    peer_group: RR-OVERLAY-PEERS
+    metadata:
+      peer: bgp-peer-groups-2
+    description: bgp-peer-groups-2_Loopback0
+  address_family_evpn:
+    neighbor_default:
+      encapsulation: mpls
+      next_hop_self_source_interface: Loopback0
+    peer_groups:
+    - name: MPLS-OVERLAY-PEERS
+      activate: true
+    - name: RR-OVERLAY-PEERS
+      activate: true
+  address_family_ipv4:
+    peer_groups:
+    - name: MPLS-OVERLAY-PEERS
+      activate: false
+    - name: RR-OVERLAY-PEERS
+      activate: false
+router_isis:
+  instance: CORE
+  net: 49.0001.1921.6825.5115.00
+  router_id: 192.168.255.115
+  is_type: level-1-2
+  log_adjacency_changes: true
+  address_family_ipv4:
+    enabled: true
+    maximum_paths: 4
+  segment_routing_mpls:
+    enabled: true
+    router_id: 192.168.255.115
+service_routing_protocols_model: multi-agent
+static_routes:
+- vrf: MGMT
+  prefix: 0.0.0.0/0
+  next_hop: 192.168.0.1
+transceiver_qsfp_default_mode_4x10: true
+vlan_internal_order:
+  allocation: ascending
+  range:
+    beginning: 1006
+    ending: 1199
+vrfs:
+- name: MGMT
+  ip_routing: false

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_overlay_mpls_route_reflectors2_ibgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_overlay_mpls_route_reflectors2_ibgp.yml
@@ -76,8 +76,6 @@ router_bgp:
     neighbor_default:
       encapsulation: mpls
     peer_groups:
-    - name: RR-OVERLAY-PEERS
-      activate: true
     - name: MPLS-OVERLAY-PEERS
       activate: true
   address_family_rtc:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_overlay_mpls_route_reflectors2_ibgp.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/intended/structured_configs/evpn_overlay_mpls_route_reflectors2_ibgp.yml
@@ -68,14 +68,6 @@ router_bgp:
     bfd: true
     send_community: all
     maximum_routes: 0
-  - name: RR-OVERLAY-PEERS
-    metadata:
-      type: mpls
-    remote_as: '65233'
-    update_source: Loopback0
-    bfd: true
-    send_community: all
-    maximum_routes: 0
   redistribute:
     connected:
       enabled: true
@@ -97,8 +89,6 @@ router_bgp:
   address_family_ipv4:
     peer_groups:
     - name: MPLS-OVERLAY-PEERS
-      activate: false
-    - name: RR-OVERLAY-PEERS
       activate: false
 service_routing_protocols_model: multi-agent
 transceiver_qsfp_default_mode_4x10: true

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/group_vars/BGP_PEER_GROUPS.yml
@@ -29,6 +29,16 @@ node_type_keys:
     default_overlay_address_families: [evpn]
     default_evpn_encapsulation: mpls
 
+default_node_types:
+  - match_hostnames:
+      - bgp-peer-groups-3
+      - bgp-peer-groups-4
+    node_type: pe
+  # All others are l3leaf
+  - match_hostnames:
+      - bgp-peer-groups-.*
+    node_type: l3leaf
+
 bgp_peer_groups:
   ipv4_underlay_peers:
     bfd: true
@@ -74,7 +84,6 @@ bgp_peer_groups:
     # Custom structured config added under router_bgp.peer_groups.<name> for eos_cli_config_gen
     structured_config:
       description: Description for ipvpn_gateway_peers via structured_config
-type: l3leaf
 mgmt_gateway: 192.168.0.1
 overlay_routing_protocol: ibgp
 bgp_as: 65001
@@ -142,6 +151,16 @@ pe:
           mpls_overlay_role: client
           ipvpn_gateway:
             enabled: true
+    - group: bgp-peer-group-rr-overlay-peer
+      # Adding another RR to test the rr_overlay_peers
+      # To trigger the peer-group generation, overlay_routing_protocol needs to be set to ibgp which is done in host_vars
+      nodes:
+        - name: bgp-peer-groups-4
+          mpls_route_reflectors: [bgp-peer-groups-2]
+          id: 107
+          bgp_as: 107
+          evpn_role: server
+          mpls_overlay_role: server
 
 # MPLS Beta code is hardcoded to look for this dictionary.
 rr:

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/bgp-peer-groups-4.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/host_vars/bgp-peer-groups-4.yml
@@ -1,0 +1,4 @@
+---
+# Setting overlay_routing_protocol to ibgp to trigger generation of the RR peer group
+# This device is seen as a server with peers
+overlay_routing_protocol: ibgp

--- a/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/hosts.yml
+++ b/ansible_collections/arista/avd/extensions/molecule/eos_designs_unit_tests/inventory/hosts.yml
@@ -255,7 +255,7 @@ all:
             bgp-peer-groups-1:
             bgp-peer-groups-2:
             bgp-peer-groups-3:
-              type: pe
+            bgp-peer-groups-4:
             bgp-peer-groups-ipv6-1:
         EVPN_PREVENT_READVERTISE_TO_SERVER:
           hosts:

--- a/python-avd/pyavd/_eos_designs/structured_config/overlay/router_bgp.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/overlay/router_bgp.py
@@ -11,6 +11,7 @@ from pyavd._eos_designs.schema import EosDesigns
 from pyavd._eos_designs.structured_config.structured_config_generator import structured_config_contributor
 from pyavd._errors import AristaAvdError, AristaAvdInvalidInputsError
 from pyavd._utils import AvdStringFormatter, default, strip_empties_from_dict
+from pyavd._utils.run_once import run_once_method
 from pyavd.j2filters import natural_sort
 
 if TYPE_CHECKING:
@@ -124,12 +125,6 @@ class RouterBgpMixin(Protocol):
                     evpn_overlay_peer_group.route_reflector_client = True
                 peer_groups.append(evpn_overlay_peer_group)
 
-            # RR Overlay peer group rendered either for MPLS route servers
-            if self._is_mpls_server is True:
-                rr_overlay_peer_group = self._generate_base_peer_group("mpls", "rr_overlay_peers")
-                rr_overlay_peer_group.remote_as = self.shared_utils.formatted_bgp_as
-                peer_groups.append(rr_overlay_peer_group)
-
         # Always render the WAN routers
         # TODO: probably should move from overlay
         if self.shared_utils.is_wan_router:
@@ -185,12 +180,8 @@ class RouterBgpMixin(Protocol):
         ):
             peer_groups.append_new(name=self.inputs.bgp_peer_groups.evpn_overlay_core.name, activate=False)
 
-        if self.shared_utils.overlay_routing_protocol == "ibgp":
-            if self.shared_utils.overlay_mpls is True:
-                peer_groups.append_new(name=self.inputs.bgp_peer_groups.mpls_overlay_peers.name, activate=False)
-
-            if self._is_mpls_server is True:
-                peer_groups.append_new(name=self.inputs.bgp_peer_groups.rr_overlay_peers.name, activate=False)
+        if self.shared_utils.overlay_routing_protocol == "ibgp" and self.shared_utils.overlay_mpls is True:
+            peer_groups.append_new(name=self.inputs.bgp_peer_groups.mpls_overlay_peers.name, activate=False)
 
         if self.shared_utils.overlay_ipvpn_gateway is True:
             peer_groups.append_new(name=self.inputs.bgp_peer_groups.ipvpn_gateway_peers.name, activate=False)
@@ -264,9 +255,6 @@ class RouterBgpMixin(Protocol):
                 self.structured_config.router_bgp.address_family_evpn.neighbor_default.encapsulation = "mpls"
                 if self.shared_utils.overlay_ler is True:
                     self.structured_config.router_bgp.address_family_evpn.neighbor_default.next_hop_self_source_interface = "Loopback0"
-
-                if self._is_mpls_server is True:
-                    peer_groups.append_new(name=self.inputs.bgp_peer_groups.rr_overlay_peers.name, activate=True)
 
             # TODO: this is written for matching either evpn_mpls or evpn_vlxan based for iBGP see if we cannot make this better.
             if self.shared_utils.overlay_vtep is True and self.shared_utils.evpn_role == "client" and overlay_peer_group:
@@ -414,12 +402,8 @@ class RouterBgpMixin(Protocol):
         if self.shared_utils.overlay_ipvpn_gateway:
             af_vpn.peer_groups.append_new(name=self.inputs.bgp_peer_groups.ipvpn_gateway_peers.name, activate=True)
 
-        if self.shared_utils.overlay_routing_protocol == "ibgp":
-            if self.shared_utils.overlay_mpls:
-                af_vpn.peer_groups.append_new(name=self.inputs.bgp_peer_groups.mpls_overlay_peers.name, activate=True)
-
-            if self.shared_utils.mpls_overlay_role == "server":
-                af_vpn.peer_groups.append_new(name=self.inputs.bgp_peer_groups.rr_overlay_peers.name, activate=True)
+        if self.shared_utils.overlay_routing_protocol == "ibgp" and self.shared_utils.overlay_mpls:
+            af_vpn.peer_groups.append_new(name=self.inputs.bgp_peer_groups.mpls_overlay_peers.name, activate=True)
 
         if self.shared_utils.overlay_dpath:
             af_vpn.domain_identifier = self.shared_utils.node_config.ipvpn_gateway.ipvpn_domain_id
@@ -684,6 +668,7 @@ class RouterBgpMixin(Protocol):
                 overlay_peering_interface="Loopback0",
             )
             self.structured_config.router_bgp.neighbors.append(neighbor)
+            self._set_once_peer_group_rr_overlay_peers()
 
         for route_reflector_client in self.facts.mpls_route_reflector_clients:
             if route_reflector_client in self.facts.mpls_route_reflectors:
@@ -702,3 +687,27 @@ class RouterBgpMixin(Protocol):
                 overlay_peering_interface="Loopback0",
             )
             self.structured_config.router_bgp.neighbors.append(neighbor)
+            self._set_once_peer_group_rr_overlay_peers()
+
+    @run_once_method
+    def _set_once_peer_group_rr_overlay_peers(self: AvdStructuredConfigOverlayProtocol) -> None:
+        """Add rr_overlay_peers peer group to structured_config."""
+        peer_group = self._generate_base_peer_group("mpls", "rr_overlay_peers")
+        peer_group.remote_as = self.shared_utils.formatted_bgp_as
+        self.structured_config.router_bgp.peer_groups.append(peer_group)
+
+        # Disable the peer group for IPv4 address-family
+        self.structured_config.router_bgp.address_family_ipv4.peer_groups.append_new(name=self.inputs.bgp_peer_groups.rr_overlay_peers.name, activate=False)
+        # Activate in AF vpn-ipv4 and vpn-ipv6 if we are a mpls server
+        if self.shared_utils.mpls_overlay_role == "server":
+            if self.shared_utils.overlay_vpn_ipv4:
+                self.structured_config.router_bgp.address_family_vpn_ipv4.peer_groups.append_new(
+                    name=self.inputs.bgp_peer_groups.rr_overlay_peers.name, activate=True
+                )
+            if self.shared_utils.overlay_vpn_ipv6:
+                self.structured_config.router_bgp.address_family_vpn_ipv6.peer_groups.append_new(
+                    name=self.inputs.bgp_peer_groups.rr_overlay_peers.name, activate=True
+                )
+        # Activate in AF evpn if overlay_evpn_mpls is True and overlay_evpn_vxlan is not True
+        if self.shared_utils.overlay_evpn_mpls is True and self.shared_utils.overlay_evpn_vxlan is not True:
+            self.structured_config.router_bgp.address_family_evpn.peer_groups.append_new(name=self.inputs.bgp_peer_groups.rr_overlay_peers.name, activate=True)


### PR DESCRIPTION
## Change Summary

cf title

## Related Issue(s)

Fixes #6423 

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes

* move to set_once pattern
* render peer group when rendering a peer in the peer group

## How to test

added molecule test

## Checklist

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
