### PR TITLE
Refactor(eos_designs): Remove deleted key `destination_address_prefix` from code

### DIFF
--- a/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
+++ b/python-avd/pyavd/_eos_designs/structured_config/network_services/utils.py
@@ -97,7 +97,7 @@ class UtilsMixin(Protocol):
                 continue
 
             for static_route in static_routes:
-                vrf_default_ipv4_static_routes.add(static_route.prefix or static_route.destination_address_prefix)
+                vrf_default_ipv4_static_routes.add(static_route.prefix)
 
             vrf_default_redistribute_static = default(tenant.vrfs["default"].redistribute_static, vrf_default_redistribute_static)
 


### PR DESCRIPTION
## Change Summary

Remove deleted key `destination_address_prefix` from code.

## Related Issue(s)

Fixes #<ISSUE ID>

## Component(s) name

`arista.avd.eos_designs`

## Proposed changes
Remove deleted key `destination_address_prefix` from code.

## How to test
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->

## Checklist

### User Checklist

<!-- Add your own checklist using MD syntax and by replacing N/A -->
- N/A

### Repository Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code has been rebased from devel before I start
- [x] I have read the [**CONTRIBUTING**](https://avd.arista.com/stable/docs/contribution/overview.html) document.
- [x] My change requires a change to the documentation and documentation have been updated accordingly.
- [x] I have updated [molecule CI](https://github.com/aristanetworks/avd/tree/devel/ansible_collections/arista/avd/extensions/molecule) testing accordingly. (check the box if not applicable)
